### PR TITLE
Add IBKR data provider with yfinance-first fallback

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -91,6 +91,15 @@ scraping:
     afternoon: "12:35"
     close: "14:35"
 
+# --- IBKR data connection ---
+
+ibkr:
+  host: "127.0.0.1"
+  port: 4001          # 7497=TWS paper, 7496=TWS live, 4002=Gateway paper, 4001=Gateway live
+  client_id: 1
+  timeout: 30
+  readonly: true
+
 # --- LLM analysis ---
 
 llm:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pandas>=2.2",
     "numpy>=1.26",
     "yfinance>=1.2.0",
+    "ib_insync>=0.9.86",
     # Database
     "sqlalchemy>=2.0",
     "psycopg2-binary>=2.9",

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -25,20 +25,35 @@ def cli(ctx, config_path):
 @cli.command()
 @click.option("--symbol", default="MES", help="Symbol to fetch (MES, NQ, ES, GC)")
 @click.option("--data-dir", default="data/csv", help="Output directory for CSV files")
+@click.option(
+    "--provider", "provider_type", default="auto",
+    type=click.Choice(["auto", "ibkr", "yfinance"]),
+    help="Data source: auto (IBKR→yfinance fallback), ibkr, or yfinance",
+)
 @click.option("--plot/--no-plot", default=False, help="Run daytrade analysis + chart after fetch")
 @click.pass_context
-def fetch(ctx, symbol, data_dir, plot):
-    """Fetch latest data from yfinance and merge with existing CSVs."""
-    from rainier.data.yfinance_provider import fetch_symbol
+def fetch(ctx, symbol, data_dir, provider_type, plot):
+    """Fetch latest data and merge with existing CSVs."""
+    from rainier.data import get_provider
+    from rainier.data.persistence import save_candles
 
     data_path = Path(data_dir)
     tfs = [Timeframe.D1, Timeframe.H4, Timeframe.H1, Timeframe.M5]
 
-    click.echo(f"Fetching {symbol} data from yfinance...")
-    results = fetch_symbol(symbol, tfs, data_path)
+    source_label = {"auto": "yfinance (IBKR fallback)", "ibkr": "IBKR", "yfinance": "yfinance"}
+    click.echo(f"Fetching {symbol} data via {source_label[provider_type]}...")
 
-    for tf, count in results.items():
-        click.echo(f"  {tf.value}: {count} candles")
+    provider = get_provider(provider_type)
+    for tf in tfs:
+        try:
+            df = provider.get_candles(symbol, tf)
+            if df.empty:
+                click.echo(f"  {tf.value}: no data")
+                continue
+            count = save_candles(df, symbol, tf, data_path)
+            click.echo(f"  {tf.value}: {count} candles")
+        except Exception as e:
+            click.echo(f"  {tf.value}: ERROR - {e}")
 
     if plot:
         click.echo()

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -82,6 +82,14 @@ class RiskConfig(BaseModel):
     position_size_risk_pct: float = 0.01
 
 
+class IBKRConfig(BaseModel):
+    host: str = "127.0.0.1"
+    port: int = 7497  # 7497=TWS paper, 7496=TWS live, 4002=Gateway paper, 4001=Gateway live
+    client_id: int = 1
+    timeout: int = 30  # connection timeout in seconds
+    readonly: bool = True  # read-only API mode (no order submission)
+
+
 class DiscordConfig(BaseModel):
     webhook_url: str = ""
     enabled: bool = False
@@ -210,6 +218,9 @@ class Settings(BaseSettings):
     # Notifications
     notify: NotifyConfig = NotifyConfig()
 
+    # IBKR (Interactive Brokers) data connection
+    ibkr: IBKRConfig = IBKRConfig()
+
 
 class InstrumentConfig(BaseModel):
     symbol: str
@@ -218,6 +229,10 @@ class InstrumentConfig(BaseModel):
     tick_size: float = 0.25
     point_value: float = 1.0
     min_touches: int = 3
+    # IBKR contract fields
+    ib_symbol: str = ""  # IBKR symbol (defaults to symbol if empty)
+    ib_sec_type: str = "CONTFUT"  # CONTFUT, FUT, STK
+    ib_currency: str = "USD"
 
 
 def load_settings(config_path: Path | None = None) -> Settings:
@@ -257,6 +272,8 @@ def load_settings(config_path: Path | None = None) -> Settings:
         kwargs["llm"] = LLMAnalysisConfig(**yaml_config["llm"])
     if "notify" in yaml_config:
         kwargs["notify"] = NotifyConfig(**yaml_config["notify"])
+    if "ibkr" in yaml_config:
+        kwargs["ibkr"] = IBKRConfig(**yaml_config["ibkr"])
 
     return Settings(**kwargs)
 

--- a/src/rainier/data/__init__.py
+++ b/src/rainier/data/__init__.py
@@ -1,0 +1,28 @@
+"""Data providers for Rainier."""
+
+from __future__ import annotations
+
+
+def get_provider(provider_type: str = "auto"):
+    """Build a data provider.
+
+    Args:
+        provider_type: "ibkr", "yfinance", or "auto" (yfinance with IBKR fallback).
+    """
+    if provider_type == "ibkr":
+        from rainier.data.ibkr_provider import IBKRProvider
+
+        return IBKRProvider()
+    elif provider_type == "yfinance":
+        from rainier.data.yfinance_provider import YFinanceProvider
+
+        return YFinanceProvider()
+    else:  # "auto"
+        from rainier.data.fallback_provider import FallbackProvider
+        from rainier.data.ibkr_provider import IBKRProvider
+        from rainier.data.yfinance_provider import YFinanceProvider
+
+        return FallbackProvider(
+            primary=YFinanceProvider(),
+            fallback=IBKRProvider(),
+        )

--- a/src/rainier/data/fallback_provider.py
+++ b/src/rainier/data/fallback_provider.py
@@ -1,0 +1,66 @@
+"""Fallback data provider — tries primary, falls back to secondary on failure."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pandas as pd
+import structlog
+
+from rainier.core.types import Timeframe
+
+log = structlog.get_logger()
+
+
+def _provider_name(provider) -> str:
+    return type(provider).__name__.replace("Provider", "").lower()
+
+
+class FallbackProvider:
+    """Tries primary provider, falls back to secondary on failure or empty result."""
+
+    def __init__(self, primary, fallback):
+        self._primary = primary
+        self._fallback = fallback
+
+    def get_candles(
+        self,
+        symbol: str,
+        timeframe: Timeframe,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> pd.DataFrame:
+        primary_name = _provider_name(self._primary)
+        fallback_name = _provider_name(self._fallback)
+
+        try:
+            df = self._primary.get_candles(symbol, timeframe, start, end)
+            if not df.empty:
+                log.info(
+                    "data_source",
+                    provider=primary_name,
+                    symbol=symbol,
+                    tf=timeframe.value,
+                    rows=len(df),
+                )
+                return df
+        except Exception as exc:
+            log.warning(
+                "primary_provider_failed",
+                provider=primary_name,
+                symbol=symbol,
+                tf=timeframe.value,
+                error=str(exc),
+            )
+
+        # Fallback
+        log.info("falling_back", provider=fallback_name, symbol=symbol, tf=timeframe.value)
+        df = self._fallback.get_candles(symbol, timeframe, start, end)
+        log.info(
+            "data_source",
+            provider=fallback_name,
+            symbol=symbol,
+            tf=timeframe.value,
+            rows=len(df),
+        )
+        return df

--- a/src/rainier/data/ibkr_provider.py
+++ b/src/rainier/data/ibkr_provider.py
@@ -1,0 +1,175 @@
+"""IBKR data provider — fetches OHLCV via TWS/Gateway using ib_insync."""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from contextlib import contextmanager
+from datetime import datetime
+
+import pandas as pd
+import structlog
+
+from rainier.core.config import IBKRConfig, get_settings, load_watchlist
+from rainier.core.types import Timeframe
+
+log = structlog.get_logger()
+
+# Map Rainier timeframes to IBKR barSizeSetting
+TF_TO_IB_BAR_SIZE: dict[Timeframe, str] = {
+    Timeframe.M5: "5 mins",
+    Timeframe.H1: "1 hour",
+    Timeframe.H4: "4 hours",
+    Timeframe.D1: "1 day",
+}
+
+# Map Rainier timeframes to IBKR durationStr (how far back to fetch)
+TF_TO_IB_DURATION: dict[Timeframe, str] = {
+    Timeframe.M5: "20 D",
+    Timeframe.H1: "365 D",
+    Timeframe.H4: "365 D",
+    Timeframe.D1: "10 Y",
+}
+
+EMPTY_DF = pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
+
+
+class _RateLimiter:
+    """Simple sliding-window rate limiter for IBKR historical data requests."""
+
+    def __init__(self, max_requests: int = 55, window_seconds: int = 600):
+        self._timestamps: deque[float] = deque()
+        self._max = max_requests
+        self._window = window_seconds
+
+    def wait_if_needed(self) -> None:
+        now = time.time()
+        while self._timestamps and self._timestamps[0] < now - self._window:
+            self._timestamps.popleft()
+        if len(self._timestamps) >= self._max:
+            sleep_time = self._timestamps[0] + self._window - now + 1
+            log.info("ibkr_rate_limit_wait", seconds=round(sleep_time, 1))
+            time.sleep(sleep_time)
+        self._timestamps.append(time.time())
+
+
+_rate_limiter = _RateLimiter()
+
+
+class IBKRProvider:
+    """DataProvider implementation backed by Interactive Brokers TWS/Gateway."""
+
+    def __init__(self, config: IBKRConfig | None = None):
+        self._config = config or get_settings().ibkr
+        self._watchlist = load_watchlist()
+
+    @contextmanager
+    def _connection(self):
+        """Context manager for IB connection. Connect-per-fetch pattern."""
+        from ib_insync import IB
+
+        ib = IB()
+        try:
+            ib.connect(
+                self._config.host,
+                self._config.port,
+                clientId=self._config.client_id,
+                timeout=self._config.timeout,
+                readonly=self._config.readonly,
+            )
+            log.info("ibkr_connected", host=self._config.host, port=self._config.port)
+            yield ib
+        finally:
+            if ib.isConnected():
+                ib.disconnect()
+                log.debug("ibkr_disconnected")
+
+    def _make_contract(self, symbol: str):
+        """Build an ib_insync Contract from symbol + watchlist config."""
+        from ib_insync import ContFuture, Future, Stock
+
+        inst = self._watchlist.get(symbol)
+        ib_symbol = (inst.ib_symbol or symbol) if inst else symbol
+        exchange = (inst.exchange if inst else "CME") or "CME"
+        currency = (inst.ib_currency if inst else "USD") or "USD"
+        sec_type = (inst.ib_sec_type if inst else "CONTFUT") or "CONTFUT"
+
+        if sec_type == "CONTFUT":
+            return ContFuture(symbol=ib_symbol, exchange=exchange, currency=currency)
+        elif sec_type == "FUT":
+            return Future(symbol=ib_symbol, exchange=exchange, currency=currency)
+        elif sec_type == "STK":
+            return Stock(symbol=ib_symbol, exchange="SMART", currency=currency)
+        else:
+            return ContFuture(symbol=ib_symbol, exchange=exchange, currency=currency)
+
+    def get_candles(
+        self,
+        symbol: str,
+        timeframe: Timeframe,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> pd.DataFrame:
+        """Fetch historical bars from IBKR."""
+        from ib_insync import util
+
+        if timeframe not in TF_TO_IB_BAR_SIZE:
+            raise ValueError(f"Unsupported timeframe {timeframe} for IBKR")
+
+        contract = self._make_contract(symbol)
+        bar_size = TF_TO_IB_BAR_SIZE[timeframe]
+        duration = TF_TO_IB_DURATION[timeframe]
+
+        # If start is specified, calculate duration from start to now
+        end_dt = end or datetime.now()
+        if start:
+            delta = end_dt - start
+            days = max(delta.days, 1)
+            duration = f"{days} D"
+
+        _rate_limiter.wait_if_needed()
+
+        with self._connection() as ib:
+            ib.qualifyContracts(contract)
+            bars = ib.reqHistoricalData(
+                contract,
+                endDateTime=end_dt if end else "",
+                durationStr=duration,
+                barSizeSetting=bar_size,
+                whatToShow="TRADES",
+                useRTH=False,  # include extended hours
+                formatDate=1,
+                timeout=120,  # 2 min timeout for large requests
+            )
+
+        if not bars:
+            log.warning("ibkr_no_data", symbol=symbol, timeframe=timeframe.value)
+            return EMPTY_DF.copy()
+
+        df = util.df(bars)
+        return self._normalize(df)
+
+    def _normalize(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Convert ib_insync DataFrame to standard format."""
+        df = df.rename(columns={"date": "timestamp"})
+        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+        df = df[["timestamp", "open", "high", "low", "close", "volume"]]
+        return df.sort_values("timestamp").reset_index(drop=True)
+
+    def is_available(self) -> bool:
+        """Check if TWS/Gateway is reachable."""
+        from ib_insync import IB
+
+        try:
+            ib = IB()
+            ib.connect(
+                self._config.host,
+                self._config.port,
+                clientId=self._config.client_id + 100,  # different client_id for health check
+                timeout=5,
+                readonly=True,
+            )
+            ib.disconnect()
+            return True
+        except Exception:
+            return False

--- a/src/rainier/data/persistence.py
+++ b/src/rainier/data/persistence.py
@@ -1,0 +1,81 @@
+"""Shared persistence utilities — CSV merge + database upsert for candle data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import structlog
+
+from rainier.core.types import Timeframe
+
+log = structlog.get_logger()
+
+
+def save_candles(
+    df: pd.DataFrame,
+    symbol: str,
+    timeframe: Timeframe,
+    data_dir: Path,
+) -> int:
+    """Save candles to CSV (merging with existing) and DB. Returns total row count."""
+    data_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = data_dir / f"{symbol}_{timeframe.value}.csv"
+    df = merge_with_existing(df, csv_path)
+    df.to_csv(csv_path, index=False)
+    persist_to_db(df, symbol, timeframe)
+    return len(df)
+
+
+def merge_with_existing(new_df: pd.DataFrame, csv_path: Path) -> pd.DataFrame:
+    """Merge new data with existing CSV, dedup on timestamp."""
+    if csv_path.exists():
+        existing = pd.read_csv(csv_path)
+        existing["timestamp"] = pd.to_datetime(existing["timestamp"], utc=True)
+        combined = pd.concat([existing, new_df], ignore_index=True)
+        combined = combined.drop_duplicates(subset="timestamp", keep="last")
+        combined = combined.sort_values("timestamp").reset_index(drop=True)
+        return combined
+    return new_df
+
+
+def persist_to_db(df: pd.DataFrame, symbol: str, tf: Timeframe) -> None:
+    """Upsert candle data into the CandleRecord table."""
+    try:
+        from sqlalchemy import select
+
+        from rainier.core.database import get_session
+        from rainier.core.models import CandleRecord
+
+        with get_session() as db:
+            for _, row in df.iterrows():
+                ts = row["timestamp"].to_pydatetime().replace(tzinfo=None)
+                existing = db.execute(
+                    select(CandleRecord).where(
+                        CandleRecord.symbol == symbol,
+                        CandleRecord.timeframe == tf.value,
+                        CandleRecord.timestamp == ts,
+                    )
+                ).scalar_one_or_none()
+
+                if existing:
+                    existing.open = float(row["open"])
+                    existing.high = float(row["high"])
+                    existing.low = float(row["low"])
+                    existing.close = float(row["close"])
+                    existing.volume = float(row["volume"])
+                else:
+                    db.add(CandleRecord(
+                        symbol=symbol,
+                        timeframe=tf.value,
+                        timestamp=ts,
+                        open=float(row["open"]),
+                        high=float(row["high"]),
+                        low=float(row["low"]),
+                        close=float(row["close"]),
+                        volume=float(row["volume"]),
+                    ))
+
+        log.info("db_persisted", symbol=symbol, timeframe=tf.value, rows=len(df))
+    except Exception as exc:
+        log.warning("db_persist_skipped", symbol=symbol, reason=str(exc))

--- a/src/rainier/data/yfinance_provider.py
+++ b/src/rainier/data/yfinance_provider.py
@@ -1,7 +1,8 @@
-"""Fetch OHLCV data from yfinance and save to CSV + database."""
+"""YFinance data provider — fetches OHLCV from Yahoo Finance."""
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -30,6 +31,43 @@ TF_TO_YF: dict[Timeframe, tuple[str, str]] = {
 }
 
 
+class YFinanceProvider:
+    """DataProvider implementation backed by yfinance."""
+
+    def get_candles(
+        self,
+        symbol: str,
+        timeframe: Timeframe,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> pd.DataFrame:
+        """Fetch candles from yfinance, return normalized DataFrame."""
+        ticker = SYMBOL_TO_TICKER.get(symbol, symbol)
+        if timeframe not in TF_TO_YF:
+            raise ValueError(f"Unsupported timeframe {timeframe} for yfinance")
+
+        yf_interval, yf_period = TF_TO_YF[timeframe]
+        raw = yf.Ticker(ticker).history(period=yf_period, interval=yf_interval)
+
+        if raw.empty:
+            log.warning("yfinance_no_data", symbol=symbol, timeframe=timeframe.value)
+            return pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
+
+        df = _normalize(raw)
+
+        # Resample 1h → 4h if needed
+        if timeframe == Timeframe.H4:
+            df = _resample_4h(df)
+
+        # Filter date range
+        if start:
+            df = df[df["timestamp"] >= pd.Timestamp(start, tz="UTC")]
+        if end:
+            df = df[df["timestamp"] <= pd.Timestamp(end, tz="UTC")]
+
+        return df.reset_index(drop=True)
+
+
 def fetch_symbol(
     symbol: str,
     timeframes: list[Timeframe],
@@ -38,38 +76,18 @@ def fetch_symbol(
     """Fetch data for a symbol across timeframes, merge with existing CSVs.
 
     Returns dict of {timeframe: total_rows} after merge.
+    Backward-compatible wrapper around YFinanceProvider.
     """
-    ticker = SYMBOL_TO_TICKER.get(symbol)
-    if not ticker:
-        raise ValueError(f"Unknown symbol {symbol}. Known: {list(SYMBOL_TO_TICKER)}")
+    from rainier.data.persistence import save_candles
 
-    data_dir.mkdir(parents=True, exist_ok=True)
+    provider = YFinanceProvider()
     results: dict[Timeframe, int] = {}
 
     for tf in timeframes:
-        yf_interval, yf_period = TF_TO_YF[tf]
-        raw = yf.Ticker(ticker).history(period=yf_period, interval=yf_interval)
-
-        if raw.empty:
+        df = provider.get_candles(symbol, tf)
+        if df.empty:
             continue
-
-        df = _normalize(raw)
-
-        # Resample 1h → 4h if needed
-        if tf == Timeframe.H4:
-            df = _resample_4h(df)
-
-        # Merge with existing CSV
-        csv_path = data_dir / f"{symbol}_{tf.value}.csv"
-        df = _merge_with_existing(df, csv_path)
-
-        # Save to CSV
-        df.to_csv(csv_path, index=False)
-
-        # Save to database
-        _persist_to_db(df, symbol, tf)
-
-        results[tf] = len(df)
+        results[tf] = save_candles(df, symbol, tf, data_dir)
 
     return results
 
@@ -98,57 +116,3 @@ def _resample_4h(df: pd.DataFrame) -> pd.DataFrame:
         "volume": "sum",
     }).dropna()
     return resampled.reset_index()
-
-
-def _persist_to_db(df: pd.DataFrame, symbol: str, tf: Timeframe) -> None:
-    """Upsert candle data into the CandleRecord table."""
-    try:
-        from sqlalchemy import select
-
-        from rainier.core.database import get_session
-        from rainier.core.models import CandleRecord
-
-        with get_session() as db:
-            for _, row in df.iterrows():
-                ts = row["timestamp"].to_pydatetime().replace(tzinfo=None)
-                existing = db.execute(
-                    select(CandleRecord).where(
-                        CandleRecord.symbol == symbol,
-                        CandleRecord.timeframe == tf.value,
-                        CandleRecord.timestamp == ts,
-                    )
-                ).scalar_one_or_none()
-
-                if existing:
-                    existing.open = float(row["open"])
-                    existing.high = float(row["high"])
-                    existing.low = float(row["low"])
-                    existing.close = float(row["close"])
-                    existing.volume = float(row["volume"])
-                else:
-                    db.add(CandleRecord(
-                        symbol=symbol,
-                        timeframe=tf.value,
-                        timestamp=ts,
-                        open=float(row["open"]),
-                        high=float(row["high"]),
-                        low=float(row["low"]),
-                        close=float(row["close"]),
-                        volume=float(row["volume"]),
-                    ))
-
-        log.info("db_persisted", symbol=symbol, timeframe=tf.value, rows=len(df))
-    except Exception as exc:
-        log.warning("db_persist_skipped", symbol=symbol, reason=str(exc))
-
-
-def _merge_with_existing(new_df: pd.DataFrame, csv_path: Path) -> pd.DataFrame:
-    """Merge new data with existing CSV, dedup on timestamp."""
-    if csv_path.exists():
-        existing = pd.read_csv(csv_path)
-        existing["timestamp"] = pd.to_datetime(existing["timestamp"], utc=True)
-        combined = pd.concat([existing, new_df], ignore_index=True)
-        combined = combined.drop_duplicates(subset="timestamp", keep="last")
-        combined = combined.sort_values("timestamp").reset_index(drop=True)
-        return combined
-    return new_df

--- a/tests/test_fallback_provider.py
+++ b/tests/test_fallback_provider.py
@@ -1,0 +1,90 @@
+"""Tests for fallback data provider."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from rainier.core.types import Timeframe
+from rainier.data.fallback_provider import FallbackProvider
+
+
+@pytest.fixture
+def sample_df():
+    """Sample candle DataFrame."""
+    return pd.DataFrame([
+        {"timestamp": pd.Timestamp("2025-01-02 09:00:00", tz="UTC"),
+         "open": 5000.0, "high": 5010.0, "low": 4990.0, "close": 5005.0, "volume": 1000},
+        {"timestamp": pd.Timestamp("2025-01-02 10:00:00", tz="UTC"),
+         "open": 5005.0, "high": 5020.0, "low": 4995.0, "close": 5015.0, "volume": 1200},
+    ])
+
+
+@pytest.fixture
+def empty_df():
+    return pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
+
+
+class TestFallbackProvider:
+    def test_primary_success_no_fallback(self, sample_df):
+        primary = MagicMock()
+        fallback = MagicMock()
+        primary.get_candles.return_value = sample_df
+
+        provider = FallbackProvider(primary, fallback)
+        df = provider.get_candles("MES", Timeframe.H1)
+
+        assert len(df) == 2
+        primary.get_candles.assert_called_once_with("MES", Timeframe.H1, None, None)
+        fallback.get_candles.assert_not_called()
+
+    def test_primary_exception_triggers_fallback(self, sample_df):
+        primary = MagicMock()
+        fallback = MagicMock()
+        primary.get_candles.side_effect = ConnectionError("TWS not running")
+        fallback.get_candles.return_value = sample_df
+
+        provider = FallbackProvider(primary, fallback)
+        df = provider.get_candles("MES", Timeframe.H1)
+
+        assert len(df) == 2
+        primary.get_candles.assert_called_once()
+        fallback.get_candles.assert_called_once_with("MES", Timeframe.H1, None, None)
+
+    def test_primary_empty_triggers_fallback(self, empty_df, sample_df):
+        primary = MagicMock()
+        fallback = MagicMock()
+        primary.get_candles.return_value = empty_df
+        fallback.get_candles.return_value = sample_df
+
+        provider = FallbackProvider(primary, fallback)
+        df = provider.get_candles("MES", Timeframe.H1)
+
+        assert len(df) == 2
+        fallback.get_candles.assert_called_once()
+
+    def test_both_fail_raises(self, empty_df):
+        primary = MagicMock()
+        fallback = MagicMock()
+        primary.get_candles.side_effect = ConnectionError("TWS not running")
+        fallback.get_candles.side_effect = RuntimeError("yfinance down")
+
+        provider = FallbackProvider(primary, fallback)
+
+        with pytest.raises(RuntimeError, match="yfinance down"):
+            provider.get_candles("MES", Timeframe.H1)
+
+    def test_passes_start_end_to_providers(self, sample_df):
+        primary = MagicMock()
+        fallback = MagicMock()
+        primary.get_candles.return_value = sample_df
+
+        provider = FallbackProvider(primary, fallback)
+        start = datetime(2025, 1, 1)
+        end = datetime(2025, 1, 31)
+        provider.get_candles("MES", Timeframe.H1, start, end)
+
+        primary.get_candles.assert_called_once_with("MES", Timeframe.H1, start, end)

--- a/tests/test_ibkr_provider.py
+++ b/tests/test_ibkr_provider.py
@@ -1,0 +1,159 @@
+"""Tests for IBKR data provider."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from rainier.core.config import IBKRConfig, InstrumentConfig
+from rainier.core.types import Timeframe
+from rainier.data.ibkr_provider import TF_TO_IB_BAR_SIZE, IBKRProvider
+
+
+@pytest.fixture
+def ibkr_config():
+    return IBKRConfig(host="127.0.0.1", port=7497, client_id=1, timeout=10, readonly=True)
+
+
+@pytest.fixture
+def sample_bars():
+    """Simulate ib_insync bar objects as a DataFrame (what util.df returns)."""
+    return pd.DataFrame([
+        {"date": "2025-01-02 09:00:00+00:00", "open": 5000.0, "high": 5010.0,
+         "low": 4990.0, "close": 5005.0, "volume": 1000, "barCount": 50, "average": 5002.0},
+        {"date": "2025-01-02 10:00:00+00:00", "open": 5005.0, "high": 5020.0,
+         "low": 4995.0, "close": 5015.0, "volume": 1200, "barCount": 60, "average": 5010.0},
+        {"date": "2025-01-02 11:00:00+00:00", "open": 5015.0, "high": 5025.0,
+         "low": 5000.0, "close": 5020.0, "volume": 900, "barCount": 45, "average": 5012.0},
+    ])
+
+
+class TestIBKRProviderContract:
+    """Test contract building from watchlist config."""
+
+    @patch("rainier.data.ibkr_provider.get_settings")
+    @patch("rainier.data.ibkr_provider.load_watchlist")
+    def test_make_contract_contfut(self, mock_watchlist, mock_settings, ibkr_config):
+        mock_settings.return_value.ibkr = ibkr_config
+        mock_watchlist.return_value = {
+            "MES": InstrumentConfig(
+                symbol="MES", exchange="CME", ib_sec_type="CONTFUT", ib_currency="USD",
+            ),
+        }
+        provider = IBKRProvider(config=ibkr_config)
+
+        with patch("ib_insync.ContFuture") as mock_cf:
+            mock_cf.return_value = MagicMock()
+            provider._make_contract("MES")
+            mock_cf.assert_called_once_with(symbol="MES", exchange="CME", currency="USD")
+
+    @patch("rainier.data.ibkr_provider.get_settings")
+    @patch("rainier.data.ibkr_provider.load_watchlist")
+    def test_make_contract_stock(self, mock_watchlist, mock_settings, ibkr_config):
+        mock_settings.return_value.ibkr = ibkr_config
+        mock_watchlist.return_value = {
+            "AAPL": InstrumentConfig(
+                symbol="AAPL", exchange="SMART", ib_sec_type="STK", ib_currency="USD",
+            ),
+        }
+        provider = IBKRProvider(config=ibkr_config)
+
+        with patch("ib_insync.Stock") as mock_stock:
+            mock_stock.return_value = MagicMock()
+            provider._make_contract("AAPL")
+            mock_stock.assert_called_once_with(symbol="AAPL", exchange="SMART", currency="USD")
+
+    @patch("rainier.data.ibkr_provider.get_settings")
+    @patch("rainier.data.ibkr_provider.load_watchlist")
+    def test_make_contract_unknown_defaults_contfut(
+        self, mock_watchlist, mock_settings, ibkr_config,
+    ):
+        mock_settings.return_value.ibkr = ibkr_config
+        mock_watchlist.return_value = {}
+        provider = IBKRProvider(config=ibkr_config)
+
+        with patch("ib_insync.ContFuture") as mock_cf:
+            mock_cf.return_value = MagicMock()
+            provider._make_contract("UNKNOWN")
+            mock_cf.assert_called_once_with(symbol="UNKNOWN", exchange="CME", currency="USD")
+
+
+class TestIBKRProviderNormalize:
+    """Test DataFrame normalization."""
+
+    @patch("rainier.data.ibkr_provider.get_settings")
+    @patch("rainier.data.ibkr_provider.load_watchlist")
+    def test_normalize_output_format(self, mock_watchlist, mock_settings, ibkr_config, sample_bars):
+        mock_settings.return_value.ibkr = ibkr_config
+        mock_watchlist.return_value = {}
+        provider = IBKRProvider(config=ibkr_config)
+
+        df = provider._normalize(sample_bars)
+
+        assert list(df.columns) == ["timestamp", "open", "high", "low", "close", "volume"]
+        assert len(df) == 3
+        assert df["timestamp"].dtype == "datetime64[ns, UTC]"
+        assert df["open"].iloc[0] == 5000.0
+        assert df["close"].iloc[-1] == 5020.0
+
+
+class TestIBKRProviderGetCandles:
+    """Test get_candles with mocked IB connection."""
+
+    @patch("rainier.data.ibkr_provider.get_settings")
+    @patch("rainier.data.ibkr_provider.load_watchlist")
+    def test_get_candles_success(self, mock_watchlist, mock_settings, ibkr_config, sample_bars):
+        mock_settings.return_value.ibkr = ibkr_config
+        mock_watchlist.return_value = {
+            "MES": InstrumentConfig(symbol="MES", exchange="CME"),
+        }
+
+        mock_bar = MagicMock()
+        mock_bars = [mock_bar, mock_bar, mock_bar]
+
+        provider = IBKRProvider(config=ibkr_config)
+
+        with patch.object(provider, "_connection") as mock_conn, \
+             patch("ib_insync.util") as mock_util:
+            mock_ib = MagicMock()
+            mock_conn.return_value.__enter__ = MagicMock(return_value=mock_ib)
+            mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+            mock_ib.reqHistoricalData.return_value = mock_bars
+            mock_util.df.return_value = sample_bars
+
+            df = provider.get_candles("MES", Timeframe.H1)
+
+            assert list(df.columns) == ["timestamp", "open", "high", "low", "close", "volume"]
+            assert len(df) == 3
+            mock_ib.qualifyContracts.assert_called_once()
+            mock_ib.reqHistoricalData.assert_called_once()
+
+    @patch("rainier.data.ibkr_provider.get_settings")
+    @patch("rainier.data.ibkr_provider.load_watchlist")
+    def test_get_candles_empty(self, mock_watchlist, mock_settings, ibkr_config):
+        mock_settings.return_value.ibkr = ibkr_config
+        mock_watchlist.return_value = {}
+
+        provider = IBKRProvider(config=ibkr_config)
+
+        with patch.object(provider, "_connection") as mock_conn:
+            mock_ib = MagicMock()
+            mock_conn.return_value.__enter__ = MagicMock(return_value=mock_ib)
+            mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+            mock_ib.reqHistoricalData.return_value = []
+
+            df = provider.get_candles("MES", Timeframe.H1)
+
+            assert df.empty
+            assert list(df.columns) == ["timestamp", "open", "high", "low", "close", "volume"]
+
+
+class TestTimeframeMapping:
+    """Test that all supported timeframes have IBKR mappings."""
+
+    def test_all_core_timeframes_mapped(self):
+        core_tfs = [Timeframe.M5, Timeframe.H1, Timeframe.H4, Timeframe.D1]
+        for tf in core_tfs:
+            assert tf in TF_TO_IB_BAR_SIZE, f"{tf} not mapped to IBKR bar size"

--- a/uv.lock
+++ b/uv.lock
@@ -523,6 +523,18 @@ wheels = [
 ]
 
 [[package]]
+name = "eventkit"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/1e/0fac4e45d71ace143a2673ec642701c3cd16f833a0e77a57fa6a40472696/eventkit-1.0.3.tar.gz", hash = "sha256:99497f6f3c638a50ff7616f2f8cd887b18bbff3765dc1bd8681554db1467c933", size = 28320, upload-time = "2023-12-11T11:41:35.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d9/7497d650b69b420e1a913329a843e16c715dac883750679240ef00a921e2/eventkit-1.0.3-py3-none-any.whl", hash = "sha256:0e199527a89aff9d195b9671ad45d2cc9f79ecda0900de8ecfb4c864d67ad6a2", size = 31837, upload-time = "2023-12-11T11:41:33.358Z" },
+]
+
+[[package]]
 name = "fastuuid"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -833,6 +845,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/15/eafc1c57bf0f8afffb243dcd4c0cceb785e956acc17bba4d9bf2ae21fc9c/huggingface_hub-1.7.2.tar.gz", hash = "sha256:7f7e294e9bbb822e025bdb2ada025fa4344d978175a7f78e824d86e35f7ab43b", size = 724684, upload-time = "2026-03-20T10:36:08.767Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/de/3ad061a05f74728927ded48c90b73521b9a9328c85d841bdefb30e01fb85/huggingface_hub-1.7.2-py3-none-any.whl", hash = "sha256:288f33a0a17b2a73a1359e2a5fd28d1becb2c121748c6173ab8643fb342c850e", size = 618036, upload-time = "2026-03-20T10:36:06.824Z" },
+]
+
+[[package]]
+name = "ib-insync"
+version = "0.9.86"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "eventkit" },
+    { name = "nest-asyncio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/bb/733d5c81c8c2f54e90898afc7ff3a99f4d53619e6917c848833f9cc1ab56/ib_insync-0.9.86.tar.gz", hash = "sha256:73af602ca2463f260999970c5bd937b1c4325e383686eff301743a4de08d381e", size = 69859, upload-time = "2023-07-02T12:43:31.968Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/f3/28ea87be30570f4d6b8fd24380d12fa74e59467ee003755e76aeb29082b8/ib_insync-0.9.86-py3-none-any.whl", hash = "sha256:a61fbe56ff405d93d211dad8238d7300de76dd6399eafc04c320470edec9a4a4", size = 72980, upload-time = "2023-07-02T12:43:29.928Z" },
 ]
 
 [[package]]
@@ -1225,6 +1250,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/b4/02a8add181b8d2cd5da3b667cd102ae536e8c9572ab1a130816d70a89edb/narwhals-2.18.0.tar.gz", hash = "sha256:1de5cee338bc17c338c6278df2c38c0dd4290499fcf70d75e0a51d5f22a6e960", size = 620222, upload-time = "2026-03-10T15:51:27.14Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/75/0b4a10da17a44cf13567d08a9c7632a285297e46253263f1ae119129d10a/narwhals-2.18.0-py3-none-any.whl", hash = "sha256:68378155ee706ac9c5b25868ef62ecddd62947b6df7801a0a156bc0a615d2d0d", size = 444865, upload-time = "2026-03-10T15:51:24.085Z" },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
 ]
 
 [[package]]
@@ -1956,6 +1990,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "click" },
     { name = "httpx" },
+    { name = "ib-insync" },
     { name = "kaleido" },
     { name = "litellm" },
     { name = "numpy" },
@@ -1991,6 +2026,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "click", specifier = ">=8.1" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "ib-insync", specifier = ">=0.9.86" },
     { name = "kaleido", specifier = "==0.2.1" },
     { name = "litellm", specifier = ">=1.40" },
     { name = "numpy", specifier = ">=1.26" },


### PR DESCRIPTION
- Add IBKRProvider using ib_insync for fetching futures/stock data from Interactive Brokers TWS/Gateway with rate limiting and connect-per-fetch
- Add FallbackProvider that tries yfinance first (faster), falls back to IBKR when yfinance fails or returns empty data
- Refactor yfinance_provider from standalone function to YFinanceProvider class implementing DataProvider protocol
- Extract shared CSV merge + DB persistence into data/persistence.py
- Add IBKRConfig to settings with host/port/client_id/timeout/readonly
- Extend InstrumentConfig with ib_symbol, ib_sec_type, ib_currency fields
- Add --provider flag to CLI fetch command (auto/ibkr/yfinance)
- Add get_provider() factory in data/__init__.py