### PR TITLE
Add walk-forward cross-validation (Phase B)

### DIFF
--- a/src/rainier/backtest/engine.py
+++ b/src/rainier/backtest/engine.py
@@ -131,7 +131,7 @@ def run_backtest(
             closed_trades.append(record)
             equity_curve.append(capital)
 
-    return _compute_metrics(closed_trades, equity_curve, config)
+    return compute_metrics(closed_trades, equity_curve, config)
 
 
 # ---------------------------------------------------------------------------
@@ -305,7 +305,7 @@ def _close_trade(
 # ---------------------------------------------------------------------------
 
 
-def _compute_metrics(
+def compute_metrics(
     trades: list[TradeRecord],
     equity_curve: list[float],
     config: BacktestConfig,

--- a/src/rainier/backtest/walk_forward.py
+++ b/src/rainier/backtest/walk_forward.py
@@ -1,0 +1,282 @@
+"""Walk-forward cross-validation — out-of-sample backtesting.
+
+Splits data into sequential train/test windows. On each fold:
+  1. Train: run parameter sweep to find best params
+  2. Test: backtest with those params on unseen data (out-of-sample)
+
+Prevents overfitting by ensuring metrics come from data never seen during optimization.
+
+Dependency rule: imports only from core/ and backtest/.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from rainier.core.config import BacktestConfig, WalkForwardConfig
+from rainier.core.protocols import BacktestMetrics, TradeRecord
+from rainier.core.types import Timeframe
+
+from .engine import compute_metrics, run_backtest
+from .sweep import EmitterFactory, SweepParams, run_sweep
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WalkForwardFold:
+    """Results from a single train/test fold."""
+    fold_index: int
+    train_start: int  # bar index
+    train_end: int
+    test_start: int
+    test_end: int
+    best_params: SweepParams
+    in_sample_metrics: BacktestMetrics
+    oos_metrics: BacktestMetrics
+
+
+@dataclass
+class WalkForwardResult:
+    """Aggregate results from walk-forward cross-validation."""
+    folds: list[WalkForwardFold] = field(default_factory=list)
+    aggregate_oos: BacktestMetrics | None = None
+    aggregate_is: BacktestMetrics | None = None
+
+
+# ---------------------------------------------------------------------------
+# Window computation
+# ---------------------------------------------------------------------------
+
+
+def _compute_fold_boundaries(
+    n_bars: int,
+    wf_config: WalkForwardConfig,
+) -> list[tuple[int, int, int, int]]:
+    """Compute (train_start, train_end, test_start, test_end) for each fold.
+
+    Returns list of 4-tuples. train_end and test_end are exclusive (slice-style).
+    """
+    folds: list[tuple[int, int, int, int]] = []
+    fold = 0
+
+    while True:
+        if wf_config.mode == "rolling":
+            train_start = fold * wf_config.step_bars
+            train_end = train_start + wf_config.train_bars
+        else:  # anchored
+            train_start = 0
+            train_end = wf_config.train_bars + fold * wf_config.step_bars
+
+        test_start = train_end
+        test_end = test_start + wf_config.test_bars
+
+        if test_end > n_bars:
+            break
+
+        folds.append((train_start, train_end, test_start, test_end))
+        fold += 1
+
+    return folds
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_walk_forward(
+    df: pd.DataFrame,
+    symbol: str,
+    timeframe: Timeframe,
+    emitter_factory: EmitterFactory,
+    config: BacktestConfig | None = None,
+    wf_config: WalkForwardConfig | None = None,
+) -> WalkForwardResult:
+    """Run walk-forward cross-validation.
+
+    Args:
+        df: Full OHLCV dataset
+        symbol: Instrument symbol
+        timeframe: Bar timeframe
+        emitter_factory: Creates SignalEmitter for given (min_confidence, min_rr_ratio)
+        config: Backtest config (slippage, commission, etc.)
+        wf_config: Walk-forward config (window sizes, mode)
+
+    Returns:
+        WalkForwardResult with per-fold and aggregate metrics
+
+    Raises:
+        ValueError: If dataset is too small for even one fold
+    """
+    if config is None:
+        config = BacktestConfig()
+    if wf_config is None:
+        wf_config = WalkForwardConfig()
+
+    folds_bounds = _compute_fold_boundaries(len(df), wf_config)
+
+    if not folds_bounds:
+        min_needed = wf_config.train_bars + wf_config.test_bars
+        raise ValueError(
+            f"Dataset has {len(df)} bars, need at least {min_needed} "
+            f"for one fold (train={wf_config.train_bars}, test={wf_config.test_bars})"
+        )
+
+    result = WalkForwardResult()
+    all_oos_trades: list[TradeRecord] = []
+    all_is_trades: list[TradeRecord] = []
+    all_oos_equity_deltas: list[float] = []
+    all_is_equity_deltas: list[float] = []
+
+    # Metric name -> SweepResult attribute for best selection
+    metric_to_best = {
+        "sharpe_ratio": "best_by_sharpe",
+        "total_net_pnl": "best_by_pnl",
+        "profit_factor": "best_by_profit_factor",
+    }
+    best_attr = metric_to_best.get(wf_config.optimize_metric, "best_by_sharpe")
+
+    for fold_idx, (tr_start, tr_end, te_start, te_end) in enumerate(folds_bounds):
+        train_df = df.iloc[tr_start:tr_end].reset_index(drop=True)
+        test_df = df.iloc[te_start:te_end].reset_index(drop=True)
+
+        # --- Train: sweep to find best params ---
+        sweep_result = run_sweep(
+            train_df, symbol, timeframe, emitter_factory, config,
+        )
+
+        best_params: SweepParams | None = getattr(sweep_result, best_attr, None)
+        if best_params is None:
+            # Fallback: use first sweep params if no best found
+            best_params = SweepParams(
+                min_confidence=config.sweep_min_confidence[0],
+                min_rr_ratio=config.sweep_min_rr_ratio[0],
+            )
+
+        # In-sample metrics (best params on train data)
+        is_emitter = emitter_factory(best_params.min_confidence, best_params.min_rr_ratio)
+        is_metrics = run_backtest(train_df, symbol, timeframe, is_emitter, config)
+
+        # --- Test: evaluate best params out-of-sample ---
+        oos_emitter = emitter_factory(best_params.min_confidence, best_params.min_rr_ratio)
+        oos_metrics = run_backtest(test_df, symbol, timeframe, oos_emitter, config)
+
+        fold = WalkForwardFold(
+            fold_index=fold_idx,
+            train_start=tr_start,
+            train_end=tr_end,
+            test_start=te_start,
+            test_end=te_end,
+            best_params=best_params,
+            in_sample_metrics=is_metrics,
+            oos_metrics=oos_metrics,
+        )
+        result.folds.append(fold)
+
+        all_oos_trades.extend(oos_metrics.trades)
+        all_is_trades.extend(is_metrics.trades)
+
+        # Collect equity deltas for aggregation
+        if len(oos_metrics.equity_curve) > 1:
+            deltas = [
+                oos_metrics.equity_curve[i] - oos_metrics.equity_curve[i - 1]
+                for i in range(1, len(oos_metrics.equity_curve))
+            ]
+            all_oos_equity_deltas.extend(deltas)
+        if len(is_metrics.equity_curve) > 1:
+            deltas = [
+                is_metrics.equity_curve[i] - is_metrics.equity_curve[i - 1]
+                for i in range(1, len(is_metrics.equity_curve))
+            ]
+            all_is_equity_deltas.extend(deltas)
+
+    # --- Aggregate OOS metrics ---
+    oos_equity = [config.initial_capital]
+    for delta in all_oos_equity_deltas:
+        oos_equity.append(oos_equity[-1] + delta)
+    result.aggregate_oos = compute_metrics(all_oos_trades, oos_equity, config)
+
+    is_equity = [config.initial_capital]
+    for delta in all_is_equity_deltas:
+        is_equity.append(is_equity[-1] + delta)
+    result.aggregate_is = compute_metrics(all_is_trades, is_equity, config)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def format_walk_forward_report(result: WalkForwardResult) -> str:
+    """Format walk-forward results as a readable text report."""
+    lines = [
+        "=" * 100,
+        "WALK-FORWARD CROSS-VALIDATION RESULTS",
+        "=" * 100,
+        "",
+        f"{'Fold':>5} {'Train':>12} {'Test':>12} {'Conf':>6} {'R:R':>5} "
+        f"{'OOS Trades':>10} {'OOS WR':>8} {'OOS PnL':>12} {'OOS Sharpe':>10} "
+        f"{'IS PnL':>12}",
+        "-" * 100,
+    ]
+
+    for fold in result.folds:
+        oos = fold.oos_metrics
+        is_m = fold.in_sample_metrics
+        lines.append(
+            f"{fold.fold_index:>5} "
+            f"{fold.train_start:>5}-{fold.train_end:<5} "
+            f"{fold.test_start:>5}-{fold.test_end:<5} "
+            f"{fold.best_params.min_confidence:>6.2f} "
+            f"{fold.best_params.min_rr_ratio:>5.1f} "
+            f"{oos.total_trades:>10} "
+            f"{oos.win_rate:>7.1%} "
+            f"{oos.total_net_pnl:>+12,.2f} "
+            f"{oos.sharpe_ratio:>10.2f} "
+            f"{is_m.total_net_pnl:>+12,.2f}"
+        )
+
+    lines.append("=" * 100)
+    lines.append("")
+
+    # Aggregate comparison
+    if result.aggregate_oos and result.aggregate_is:
+        oos = result.aggregate_oos
+        is_m = result.aggregate_is
+        lines.append("AGGREGATE COMPARISON (In-Sample vs Out-of-Sample)")
+        lines.append("-" * 60)
+        lines.append(f"  {'':20} {'In-Sample':>15} {'OOS':>15}")
+        lines.append(f"  {'Total trades':20} {is_m.total_trades:>15} {oos.total_trades:>15}")
+        lines.append(f"  {'Win rate':20} {is_m.win_rate:>14.1%} {oos.win_rate:>14.1%}")
+        lines.append(
+            f"  {'Profit factor':20} {is_m.profit_factor:>15.2f} {oos.profit_factor:>15.2f}"
+        )
+        lines.append(
+            f"  {'Net P&L':20} {is_m.total_net_pnl:>+15,.2f} {oos.total_net_pnl:>+15,.2f}"
+        )
+        lines.append(
+            f"  {'Sharpe ratio':20} {is_m.sharpe_ratio:>15.2f} {oos.sharpe_ratio:>15.2f}"
+        )
+        lines.append(
+            f"  {'Max drawdown':20} {is_m.max_drawdown_pct:>14.2%} {oos.max_drawdown_pct:>14.2%}"
+        )
+
+        # Robustness ratio
+        if is_m.total_net_pnl != 0:
+            robustness = oos.total_net_pnl / is_m.total_net_pnl
+            lines.append(f"\n  Robustness ratio (OOS/IS P&L): {robustness:.2f}")
+            if robustness > 0.5:
+                lines.append("  → Strategy shows robustness (ratio > 0.5)")
+            elif robustness > 0:
+                lines.append("  → Strategy degrades out-of-sample (0 < ratio < 0.5)")
+            else:
+                lines.append("  → Strategy fails out-of-sample (negative OOS)")
+
+    return "\n".join(lines)

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -229,9 +229,17 @@ def chart(ctx, symbol, tf, csv_path, start, end, output_path):
 @click.option("--slippage", default=None, type=float, help="Override slippage pct (e.g. 0.0005)")
 @click.option("--commission", default=None, type=float, help="Override commission per side")
 @click.option("--trades", "show_trades", is_flag=True, default=False, help="Show per-trade log")
+@click.option("--walk-forward", "walk_forward", is_flag=True, default=False,
+              help="Run walk-forward cross-validation")
+@click.option("--wf-train-bars", default=500, type=int, help="Walk-forward training window size")
+@click.option("--wf-test-bars", default=100, type=int, help="Walk-forward test window size")
+@click.option("--wf-step-bars", default=100, type=int, help="Walk-forward step between folds")
+@click.option("--wf-mode", default="anchored", type=click.Choice(["anchored", "rolling"]),
+              help="Walk-forward window mode")
 @click.pass_context
 def backtest(ctx, symbol, tf, csv_path, start, end, capital, export_path, sweep,
-             slippage, commission, show_trades):
+             slippage, commission, show_trades, walk_forward, wf_train_bars, wf_test_bars,
+             wf_step_bars, wf_mode):
     """Run a backtest on historical data."""
     from rainier.backtest.engine import run_backtest
     from rainier.backtest.report import format_report, format_trade_log, plot_equity_curve
@@ -256,19 +264,41 @@ def backtest(ctx, symbol, tf, csv_path, start, end, capital, export_path, sweep,
     if commission is not None:
         bt_config.commission_per_trade = commission
 
-    if sweep:
+    def emitter_factory(min_conf: float, min_rr: float):
+        from rainier.core.config import ScorerConfig, SignalConfig
+        sig_config = SignalConfig(
+            scorer=ScorerConfig(min_confidence=min_conf),
+            min_rr_ratio=min_rr,
+        )
+        return PinBarSignalEmitter(settings.analysis, sig_config)
+
+    if walk_forward:
+        # Walk-forward cross-validation mode
+        from rainier.backtest.walk_forward import format_walk_forward_report, run_walk_forward
+        from rainier.core.config import WalkForwardConfig
+
+        wf_cfg = WalkForwardConfig(
+            train_bars=wf_train_bars,
+            test_bars=wf_test_bars,
+            step_bars=wf_step_bars,
+            mode=wf_mode,
+        )
+
+        click.echo(
+            f"Running walk-forward: {symbol} {tf}, {len(df)} candles, "
+            f"mode={wf_mode}, train={wf_train_bars}, test={wf_test_bars}, step={wf_step_bars}..."
+        )
+
+        wf_result = run_walk_forward(
+            df, symbol, timeframe, emitter_factory, bt_config, wf_cfg,
+        )
+        click.echo(format_walk_forward_report(wf_result))
+
+    elif sweep:
         # Parameter sweep mode
         from rainier.backtest.sweep import format_sweep_table, run_sweep
 
         click.echo(f"Running parameter sweep: {symbol} {tf}, {len(df)} candles...")
-
-        def emitter_factory(min_conf: float, min_rr: float):
-            from rainier.core.config import ScorerConfig, SignalConfig
-            sig_config = SignalConfig(
-                scorer=ScorerConfig(min_confidence=min_conf),
-                min_rr_ratio=min_rr,
-            )
-            return PinBarSignalEmitter(settings.analysis, sig_config)
 
         sweep_result = run_sweep(
             df, symbol, timeframe, emitter_factory, bt_config,

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -90,6 +90,14 @@ class BacktestConfig(BaseModel):
     )
 
 
+class WalkForwardConfig(BaseModel):
+    train_bars: int = 500
+    test_bars: int = 100
+    step_bars: int = 100  # how far to advance between folds
+    mode: str = "anchored"  # "anchored" or "rolling"
+    optimize_metric: str = "sharpe_ratio"  # metric to pick best params per fold
+
+
 class RiskConfig(BaseModel):
     max_positions: int = 3
     max_daily_loss: float = 1000.0

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -1,0 +1,257 @@
+"""Tests for walk-forward cross-validation."""
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytest
+
+from rainier.backtest.walk_forward import (
+    WalkForwardResult,
+    _compute_fold_boundaries,
+    format_walk_forward_report,
+    run_walk_forward,
+)
+from rainier.core.config import BacktestConfig, WalkForwardConfig
+from rainier.core.protocols import SignalEmitter
+from rainier.core.types import Direction, Signal, Timeframe
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_dataset(n_bars: int = 800) -> pd.DataFrame:
+    """Create a zigzag dataset long enough for walk-forward."""
+    rows = []
+    price = 100.0
+    base = datetime(2025, 1, 1)
+
+    for i in range(n_bars):
+        cycle = i % 40
+        move = 1.0 if cycle < 20 else -1.0
+
+        o = price
+        h = price + abs(move) + 1.0
+        low = price - abs(move) - 0.5
+        c = price + move
+
+        rows.append({
+            "timestamp": base + timedelta(hours=i),
+            "open": o, "high": h, "low": low, "close": c,
+            "volume": 1000.0 + (i % 10) * 100,
+        })
+        price = c
+
+    return pd.DataFrame(rows)
+
+
+class FakeEmitter:
+    """Emitter that generates a signal on every call."""
+
+    def emit(self, df: pd.DataFrame, symbol: str, timeframe: Timeframe) -> list[Signal]:
+        last_bar = df.iloc[-1]
+        return [
+            Signal(
+                symbol=symbol,
+                timeframe=timeframe,
+                direction=Direction.LONG,
+                entry_price=float(last_bar["close"]) - 0.5,
+                stop_loss=float(last_bar["close"]) - 5.0,
+                take_profit=float(last_bar["close"]) + 5.0,
+                confidence=0.75,
+                timestamp=pd.Timestamp(last_bar["timestamp"]).to_pydatetime(),
+            ),
+        ]
+
+
+def _fake_factory(min_conf: float, min_rr: float) -> SignalEmitter:
+    return FakeEmitter()
+
+
+class EmptyEmitter:
+    """Never emits signals."""
+
+    def emit(self, df: pd.DataFrame, symbol: str, timeframe: Timeframe) -> list[Signal]:
+        return []
+
+
+def _empty_factory(min_conf: float, min_rr: float) -> SignalEmitter:
+    return EmptyEmitter()
+
+
+# ---------------------------------------------------------------------------
+# Window splitting tests
+# ---------------------------------------------------------------------------
+
+
+class TestWindowSplitting:
+    def test_anchored_mode_boundaries(self):
+        wf = WalkForwardConfig(train_bars=200, test_bars=50, step_bars=50, mode="anchored")
+        folds = _compute_fold_boundaries(500, wf)
+
+        # Fold 0: train=[0,200), test=[200,250)
+        assert folds[0] == (0, 200, 200, 250)
+        # Fold 1: train=[0,250), test=[250,300) — anchored grows
+        assert folds[1] == (0, 250, 250, 300)
+        # All folds start at 0
+        assert all(f[0] == 0 for f in folds)
+
+    def test_rolling_mode_boundaries(self):
+        wf = WalkForwardConfig(train_bars=200, test_bars=50, step_bars=50, mode="rolling")
+        folds = _compute_fold_boundaries(500, wf)
+
+        # Fold 0: train=[0,200), test=[200,250)
+        assert folds[0] == (0, 200, 200, 250)
+        # Fold 1: train=[50,250), test=[250,300) — rolling slides
+        assert folds[1] == (50, 250, 250, 300)
+        # Train window is always 200 bars
+        assert all(f[1] - f[0] == 200 for f in folds)
+
+    def test_fold_count_anchored(self):
+        wf = WalkForwardConfig(train_bars=200, test_bars=100, step_bars=100, mode="anchored")
+        folds = _compute_fold_boundaries(600, wf)
+        # Fold 0: train=[0,200), test=[200,300)
+        # Fold 1: train=[0,300), test=[300,400)
+        # Fold 2: train=[0,400), test=[400,500)
+        # Fold 3: train=[0,500), test=[500,600)
+        assert len(folds) == 4
+
+    def test_fold_count_rolling(self):
+        wf = WalkForwardConfig(train_bars=200, test_bars=100, step_bars=100, mode="rolling")
+        folds = _compute_fold_boundaries(600, wf)
+        # Fold 0: train=[0,200), test=[200,300)
+        # Fold 1: train=[100,300), test=[300,400)
+        # Fold 2: train=[200,400), test=[400,500)
+        # Fold 3: train=[300,500), test=[500,600)
+        assert len(folds) == 4
+
+    def test_insufficient_data_returns_empty(self):
+        wf = WalkForwardConfig(train_bars=500, test_bars=100, step_bars=100)
+        folds = _compute_fold_boundaries(400, wf)
+        assert len(folds) == 0
+
+    def test_test_window_must_fit(self):
+        wf = WalkForwardConfig(train_bars=200, test_bars=100, step_bars=100)
+        # 299 bars: train fits (200), but test needs 100 more → 300 > 299
+        folds = _compute_fold_boundaries(299, wf)
+        assert len(folds) == 0
+
+    def test_exact_fit_produces_one_fold(self):
+        wf = WalkForwardConfig(train_bars=200, test_bars=100, step_bars=100)
+        folds = _compute_fold_boundaries(300, wf)
+        assert len(folds) == 1
+        assert folds[0] == (0, 200, 200, 300)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end walk-forward tests
+# ---------------------------------------------------------------------------
+
+
+class TestWalkForwardRunner:
+    def test_runs_with_fake_emitter(self):
+        df = _make_dataset(800)
+        wf_cfg = WalkForwardConfig(train_bars=200, test_bars=100, step_bars=100)
+        config = BacktestConfig(sr_recompute_interval=50)
+
+        result = run_walk_forward(
+            df, "TEST", Timeframe.H1, _fake_factory, config, wf_cfg,
+        )
+
+        assert isinstance(result, WalkForwardResult)
+        assert len(result.folds) > 0
+        assert result.aggregate_oos is not None
+        assert result.aggregate_is is not None
+
+    def test_fold_count_matches_expected(self):
+        df = _make_dataset(800)
+        wf_cfg = WalkForwardConfig(train_bars=300, test_bars=100, step_bars=100)
+
+        expected_folds = len(_compute_fold_boundaries(len(df), wf_cfg))
+        result = run_walk_forward(
+            df, "TEST", Timeframe.H1, _fake_factory, wf_config=wf_cfg,
+        )
+
+        assert len(result.folds) == expected_folds
+
+    def test_oos_trade_count_equals_sum_of_folds(self):
+        df = _make_dataset(800)
+        wf_cfg = WalkForwardConfig(train_bars=200, test_bars=100, step_bars=100)
+
+        result = run_walk_forward(
+            df, "TEST", Timeframe.H1, _fake_factory, wf_config=wf_cfg,
+        )
+
+        fold_trade_sum = sum(f.oos_metrics.total_trades for f in result.folds)
+        assert result.aggregate_oos.total_trades == fold_trade_sum
+
+    def test_insufficient_data_raises(self):
+        df = _make_dataset(100)
+        wf_cfg = WalkForwardConfig(train_bars=500, test_bars=200)
+
+        with pytest.raises(ValueError, match="need at least"):
+            run_walk_forward(
+                df, "TEST", Timeframe.H1, _fake_factory, wf_config=wf_cfg,
+            )
+
+    def test_empty_emitter_produces_zero_trades(self):
+        df = _make_dataset(800)
+        wf_cfg = WalkForwardConfig(train_bars=200, test_bars=100, step_bars=100)
+
+        result = run_walk_forward(
+            df, "TEST", Timeframe.H1, _empty_factory, wf_config=wf_cfg,
+        )
+
+        assert result.aggregate_oos.total_trades == 0
+        assert len(result.folds) > 0
+
+    def test_folds_have_best_params(self):
+        df = _make_dataset(800)
+        wf_cfg = WalkForwardConfig(train_bars=200, test_bars=100, step_bars=100)
+
+        result = run_walk_forward(
+            df, "TEST", Timeframe.H1, _fake_factory, wf_config=wf_cfg,
+        )
+
+        for fold in result.folds:
+            assert fold.best_params is not None
+            assert fold.best_params.min_confidence > 0
+            assert fold.best_params.min_rr_ratio > 0
+
+    def test_rolling_mode_works(self):
+        df = _make_dataset(800)
+        wf_cfg = WalkForwardConfig(
+            train_bars=200, test_bars=100, step_bars=100, mode="rolling",
+        )
+
+        result = run_walk_forward(
+            df, "TEST", Timeframe.H1, _fake_factory, wf_config=wf_cfg,
+        )
+
+        assert len(result.folds) > 0
+        assert result.aggregate_oos is not None
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+
+class TestWalkForwardReport:
+    def test_format_report_produces_output(self):
+        df = _make_dataset(800)
+        wf_cfg = WalkForwardConfig(train_bars=200, test_bars=100, step_bars=100)
+
+        result = run_walk_forward(
+            df, "TEST", Timeframe.H1, _fake_factory, wf_config=wf_cfg,
+        )
+
+        report = format_walk_forward_report(result)
+        assert "WALK-FORWARD" in report
+        assert "AGGREGATE" in report
+        assert "Robustness" in report
+
+    def test_format_empty_result(self):
+        result = WalkForwardResult()
+        report = format_walk_forward_report(result)
+        assert "WALK-FORWARD" in report


### PR DESCRIPTION
## Summary
- Adds walk-forward cross-validation to prevent overfitting in backtest parameter optimization
- Splits data into sequential train/test folds: sweeps best params on training window, evaluates on unseen test window
- Supports **anchored** (expanding train) and **rolling** (fixed-width sliding) window modes
- Reports per-fold OOS metrics + aggregate IS vs OOS comparison with robustness ratio

## Changes
- `src/rainier/backtest/walk_forward.py` — new module with `run_walk_forward()`, fold computation, and report formatting
- `src/rainier/core/config.py` — `WalkForwardConfig` (train_bars, test_bars, step_bars, mode, optimize_metric)
- `src/rainier/backtest/engine.py` — `_compute_metrics()` → `compute_metrics()` (public for OOS aggregation)
- `src/rainier/cli.py` — `--walk-forward`, `--wf-train-bars`, `--wf-test-bars`, `--wf-step-bars`, `--wf-mode` flags

## Usage
```bash
uv run rainier backtest --symbol MES --timeframe 1H --csv data/csv/MES_1H.csv \
  --walk-forward --wf-train-bars 500 --wf-test-bars 100 --wf-mode anchored
```

## Test plan
- [x] 16 tests in `tests/test_walk_forward.py`
- [x] Window splitting: anchored/rolling boundaries, fold count, edge cases
- [x] End-to-end: fake emitter through full pipeline, OOS trade count aggregation
- [x] Error handling: insufficient data raises ValueError
- [x] All 222 existing tests still pass