### PR TITLE
Add regime detection and filtering (Phase B)

### DIFF
--- a/src/rainier/analysis/regime.py
+++ b/src/rainier/analysis/regime.py
@@ -1,0 +1,125 @@
+"""Market regime detection — classifies bars into trend/range/volatility states.
+
+Uses ATR percentile, SMA slope, and ADX to determine the current market regime.
+Pure analysis module — imports only from core/.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from rainier.analysis.pivots import compute_atr
+from rainier.core.config import RegimeConfig
+from rainier.core.types import MarketRegime
+
+
+class RegimeDetector:
+    """Classifies market regime using ATR percentile + SMA slope + ADX."""
+
+    def __init__(self, config: RegimeConfig | None = None) -> None:
+        self.config = config or RegimeConfig()
+
+    def detect(self, df: pd.DataFrame) -> pd.Series:
+        """Classify each bar into a MarketRegime.
+
+        Returns a Series of MarketRegime values with the same index as df.
+        """
+        cfg = self.config
+        n = len(df)
+
+        atr = compute_atr(df, period=cfg.atr_period)
+        adx = compute_adx(df, period=cfg.adx_period)
+        sma = df["close"].rolling(
+            window=min(cfg.sma_period, n), min_periods=1
+        ).mean()
+        sma_slope = sma.diff().fillna(0.0)
+
+        # ATR percentile rank over rolling window
+        atr_pct = atr.rolling(
+            window=min(cfg.atr_percentile_window, n), min_periods=1
+        ).apply(lambda x: pd.Series(x).rank(pct=True).iloc[-1], raw=False)
+        atr_pct = atr_pct.fillna(0.5)
+
+        regimes = []
+        for i in range(n):
+            atr_p = atr_pct.iloc[i] * 100  # 0-100 scale
+            adx_val = adx.iloc[i]
+            slope = sma_slope.iloc[i]
+
+            if atr_p > cfg.high_vol_percentile and adx_val < cfg.adx_trend_threshold:
+                regimes.append(MarketRegime.HIGH_VOLATILITY)
+            elif adx_val >= cfg.adx_trend_threshold and slope > 0:
+                regimes.append(MarketRegime.TRENDING_UP)
+            elif adx_val >= cfg.adx_trend_threshold and slope <= 0:
+                regimes.append(MarketRegime.TRENDING_DOWN)
+            else:
+                regimes.append(MarketRegime.RANGE_BOUND)
+
+        return pd.Series(regimes, index=df.index)
+
+    def detect_at(self, df: pd.DataFrame, bar_index: int) -> MarketRegime:
+        """Classify regime at a specific bar index."""
+        regimes = self.detect(df)
+        return regimes.iloc[min(bar_index, len(regimes) - 1)]
+
+
+# ---------------------------------------------------------------------------
+# ADX computation
+# ---------------------------------------------------------------------------
+
+
+def compute_adx(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Compute Average Directional Index (ADX).
+
+    ADX measures trend strength (0-100) regardless of direction.
+    High ADX (>25) = strong trend, Low ADX (<20) = weak/no trend.
+    """
+    high = df["high"]
+    low = df["low"]
+    close = df["close"]
+
+    # Directional movement
+    up_move = high.diff()
+    down_move = -low.diff()
+
+    plus_dm = pd.Series(
+        np.where((up_move > down_move) & (up_move > 0), up_move, 0.0),
+        index=df.index,
+    )
+    minus_dm = pd.Series(
+        np.where((down_move > up_move) & (down_move > 0), down_move, 0.0),
+        index=df.index,
+    )
+
+    # True range
+    tr1 = high - low
+    tr2 = (high - close.shift(1)).abs()
+    tr3 = (low - close.shift(1)).abs()
+    tr = pd.concat([tr1, tr2, tr3], axis=1).max(axis=1)
+
+    # Smoothed averages (Wilder's smoothing)
+    atr = tr.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+    smooth_plus = plus_dm.ewm(
+        alpha=1 / period, min_periods=period, adjust=False
+    ).mean()
+    smooth_minus = minus_dm.ewm(
+        alpha=1 / period, min_periods=period, adjust=False
+    ).mean()
+
+    # Directional indicators
+    plus_di = 100 * smooth_plus / atr
+    minus_di = 100 * smooth_minus / atr
+
+    # DX and ADX
+    di_sum = plus_di + minus_di
+    di_sum = di_sum.replace(0, np.nan)
+    dx = 100 * (plus_di - minus_di).abs() / di_sum
+    dx = dx.fillna(0.0)
+
+    adx = dx.ewm(
+        alpha=1 / period, min_periods=period, adjust=False
+    ).mean()
+    adx = adx.fillna(0.0)
+
+    return adx

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -236,10 +236,12 @@ def chart(ctx, symbol, tf, csv_path, start, end, output_path):
 @click.option("--wf-step-bars", default=100, type=int, help="Walk-forward step between folds")
 @click.option("--wf-mode", default="anchored", type=click.Choice(["anchored", "rolling"]),
               help="Walk-forward window mode")
+@click.option("--regime-filter", "regime_filter", default=None,
+              help="Comma-separated regimes: trending_up,trending_down,range_bound,high_volatility")
 @click.pass_context
 def backtest(ctx, symbol, tf, csv_path, start, end, capital, export_path, sweep,
              slippage, commission, show_trades, walk_forward, wf_train_bars, wf_test_bars,
-             wf_step_bars, wf_mode):
+             wf_step_bars, wf_mode, regime_filter):
     """Run a backtest on historical data."""
     from rainier.backtest.engine import run_backtest
     from rainier.backtest.report import format_report, format_trade_log, plot_equity_curve
@@ -264,13 +266,29 @@ def backtest(ctx, symbol, tf, csv_path, start, end, capital, export_path, sweep,
     if commission is not None:
         bt_config.commission_per_trade = commission
 
+    # Parse regime filter
+    regime_set = None
+    if regime_filter:
+        from rainier.core.types import MarketRegime
+        regime_set = {MarketRegime(r.strip()) for r in regime_filter.split(",")}
+        click.echo(f"Regime filter: {[r.value for r in regime_set]}")
+
+    def _wrap_with_regime(emitter):
+        if regime_set is None:
+            return emitter
+        from rainier.analysis.regime import RegimeDetector
+        from rainier.signals.regime_filter import RegimeFilter
+        return RegimeFilter(emitter, RegimeDetector(), regime_set)
+
     def emitter_factory(min_conf: float, min_rr: float):
         from rainier.core.config import ScorerConfig, SignalConfig
         sig_config = SignalConfig(
             scorer=ScorerConfig(min_confidence=min_conf),
             min_rr_ratio=min_rr,
         )
-        return PinBarSignalEmitter(settings.analysis, sig_config)
+        return _wrap_with_regime(
+            PinBarSignalEmitter(settings.analysis, sig_config)
+        )
 
     if walk_forward:
         # Walk-forward cross-validation mode
@@ -311,7 +329,9 @@ def backtest(ctx, symbol, tf, csv_path, start, end, capital, export_path, sweep,
             click.echo(f"\nSweep results saved to {out}")
     else:
         # Single backtest mode
-        emitter = PinBarSignalEmitter(settings.analysis, settings.signal)
+        emitter = _wrap_with_regime(
+            PinBarSignalEmitter(settings.analysis, settings.signal)
+        )
         click.echo(f"Running backtest: {symbol} {tf}, {len(df)} candles...")
 
         metrics = run_backtest(df, symbol, timeframe, emitter, bt_config)

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -98,6 +98,15 @@ class WalkForwardConfig(BaseModel):
     optimize_metric: str = "sharpe_ratio"  # metric to pick best params per fold
 
 
+class RegimeConfig(BaseModel):
+    sma_period: int = 50
+    atr_period: int = 14
+    atr_percentile_window: int = 100
+    high_vol_percentile: float = 80.0  # ATR above this = high_volatility
+    adx_period: int = 14
+    adx_trend_threshold: float = 25.0  # ADX above this = trending
+
+
 class RiskConfig(BaseModel):
     max_positions: int = 3
     max_daily_loss: float = 1000.0

--- a/src/rainier/core/types.py
+++ b/src/rainier/core/types.py
@@ -42,6 +42,13 @@ class SignalStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
+class MarketRegime(str, Enum):
+    TRENDING_UP = "trending_up"
+    TRENDING_DOWN = "trending_down"
+    RANGE_BOUND = "range_bound"
+    HIGH_VOLATILITY = "high_volatility"
+
+
 @dataclass(frozen=True, slots=True)
 class Candle:
     timestamp: datetime

--- a/src/rainier/features/extractor.py
+++ b/src/rainier/features/extractor.py
@@ -11,10 +11,12 @@ import numpy as np
 import pandas as pd
 
 from rainier.analysis.pivots import compute_atr
+from rainier.analysis.regime import RegimeDetector, compute_adx
 from rainier.core.types import (
     AnalysisResult,
     Direction,
     InsideBar,
+    MarketRegime,
     PinBar,
     SRLevel,
     SRRole,
@@ -61,6 +63,9 @@ class FeatureExtractor:
 
         # --- Rolling statistics ---
         features = self._add_rolling_features(features, df)
+
+        # --- Regime features ---
+        features = self._add_regime_features(features, df)
 
         # NaN policy: fill with defaults, then assert clean
         features = self._fill_defaults(features)
@@ -326,6 +331,33 @@ class FeatureExtractor:
         features["rolling_volatility_20"] = returns.rolling(
             window=20, min_periods=1
         ).std().fillna(0.0)
+
+        return features
+
+    # ------------------------------------------------------------------
+    # Regime features
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _add_regime_features(
+        features: pd.DataFrame, df: pd.DataFrame,
+    ) -> pd.DataFrame:
+        # Continuous features
+        atr = compute_atr(df, period=14)
+        atr_pct = atr.rolling(
+            window=min(100, len(df)), min_periods=1
+        ).apply(
+            lambda x: pd.Series(x).rank(pct=True).iloc[-1], raw=False
+        )
+        features["atr_percentile"] = atr_pct.fillna(0.5)
+        features["adx"] = compute_adx(df, period=14)
+
+        # One-hot regime classification
+        detector = RegimeDetector()
+        regimes = detector.detect(df)
+        for regime in MarketRegime:
+            col = f"regime_{regime.value}"
+            features[col] = (regimes == regime).astype(np.float64)
 
         return features
 

--- a/src/rainier/signals/regime_filter.py
+++ b/src/rainier/signals/regime_filter.py
@@ -1,0 +1,39 @@
+"""Regime-aware signal filter — wraps any SignalEmitter and drops signals
+when the current market regime is not in the allowed set.
+
+Satisfies the SignalEmitter protocol (decorator pattern).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from rainier.analysis.regime import RegimeDetector
+from rainier.core.protocols import SignalEmitter
+from rainier.core.types import MarketRegime, Signal, Timeframe
+
+
+class RegimeFilter:
+    """Wraps a SignalEmitter, only passing signals in allowed regimes."""
+
+    def __init__(
+        self,
+        inner: SignalEmitter,
+        detector: RegimeDetector,
+        allowed_regimes: set[MarketRegime],
+    ) -> None:
+        self._inner = inner
+        self._detector = detector
+        self._allowed = allowed_regimes
+
+    def emit(
+        self,
+        df: pd.DataFrame,
+        symbol: str,
+        timeframe: Timeframe,
+    ) -> list[Signal]:
+        """Emit signals only if current bar's regime is in allowed set."""
+        regime = self._detector.detect_at(df, len(df) - 1)
+        if regime not in self._allowed:
+            return []
+        return self._inner.emit(df, symbol, timeframe)

--- a/tests/test_regime.py
+++ b/tests/test_regime.py
@@ -1,0 +1,302 @@
+"""Tests for regime detection, filtering, and feature extraction."""
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+
+from rainier.analysis.regime import RegimeDetector, compute_adx
+from rainier.core.protocols import SignalEmitter
+from rainier.core.types import Direction, MarketRegime, Signal, Timeframe
+from rainier.signals.regime_filter import RegimeFilter
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_trending_up(n: int = 200) -> pd.DataFrame:
+    """Strong uptrend with steadily rising prices."""
+    base = datetime(2025, 1, 1)
+    rows = []
+    price = 100.0
+    for i in range(n):
+        move = 1.5 + np.random.uniform(0, 0.5)
+        o = price
+        h = price + move + 0.5
+        low = price - 0.3
+        c = price + move
+        rows.append({
+            "timestamp": base + timedelta(hours=i),
+            "open": o, "high": h, "low": low, "close": c,
+            "volume": 1000.0,
+        })
+        price = c
+    return pd.DataFrame(rows)
+
+
+def _make_trending_down(n: int = 200) -> pd.DataFrame:
+    """Strong downtrend with steadily falling prices."""
+    base = datetime(2025, 1, 1)
+    rows = []
+    price = 500.0
+    for i in range(n):
+        move = 1.5 + np.random.uniform(0, 0.5)
+        o = price
+        h = price + 0.3
+        low = price - move - 0.5
+        c = price - move
+        rows.append({
+            "timestamp": base + timedelta(hours=i),
+            "open": o, "high": h, "low": low, "close": c,
+            "volume": 1000.0,
+        })
+        price = c
+    return pd.DataFrame(rows)
+
+
+def _make_range_bound(n: int = 200) -> pd.DataFrame:
+    """Sideways choppy market oscillating around 100."""
+    base = datetime(2025, 1, 1)
+    rows = []
+    price = 100.0
+    for i in range(n):
+        move = np.sin(i * 0.3) * 0.5
+        o = price
+        h = price + 0.5
+        low = price - 0.5
+        c = price + move
+        rows.append({
+            "timestamp": base + timedelta(hours=i),
+            "open": o, "high": h, "low": low, "close": c,
+            "volume": 1000.0,
+        })
+        price = 100.0 + np.sin(i * 0.3) * 2  # mean-revert to 100
+    return pd.DataFrame(rows)
+
+
+def _make_high_volatility(n: int = 200) -> pd.DataFrame:
+    """Expanding range with no clear direction."""
+    base = datetime(2025, 1, 1)
+    rows = []
+    price = 100.0
+    for i in range(n):
+        # Volatility expands over time, direction alternates
+        vol = 0.5 + (i / n) * 5.0
+        move = vol * (1 if i % 2 == 0 else -1)
+        o = price
+        h = price + abs(move) + vol
+        low = price - abs(move) - vol
+        c = price + move * 0.1  # close near open (no trend)
+        rows.append({
+            "timestamp": base + timedelta(hours=i),
+            "open": o, "high": h, "low": low, "close": c,
+            "volume": 1000.0,
+        })
+        price = c
+    return pd.DataFrame(rows)
+
+
+class FakeEmitter:
+    """Always emits one signal."""
+
+    def emit(self, df: pd.DataFrame, symbol: str, timeframe: Timeframe) -> list[Signal]:
+        last_bar = df.iloc[-1]
+        return [
+            Signal(
+                symbol=symbol,
+                timeframe=timeframe,
+                direction=Direction.LONG,
+                entry_price=float(last_bar["close"]),
+                stop_loss=float(last_bar["close"]) - 5.0,
+                take_profit=float(last_bar["close"]) + 5.0,
+                confidence=0.8,
+                timestamp=pd.Timestamp(last_bar["timestamp"]).to_pydatetime(),
+            ),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# ADX computation
+# ---------------------------------------------------------------------------
+
+
+class TestADX:
+    def test_adx_returns_series(self):
+        df = _make_trending_up(100)
+        adx = compute_adx(df, period=14)
+        assert isinstance(adx, pd.Series)
+        assert len(adx) == len(df)
+
+    def test_adx_range_0_to_100(self):
+        df = _make_trending_up(200)
+        adx = compute_adx(df, period=14)
+        assert adx.min() >= 0
+        assert adx.max() <= 100
+
+    def test_adx_trending_higher_than_range(self):
+        trend_df = _make_trending_up(200)
+        range_df = _make_range_bound(200)
+        adx_trend = compute_adx(trend_df).iloc[-1]
+        adx_range = compute_adx(range_df).iloc[-1]
+        assert adx_trend > adx_range
+
+
+# ---------------------------------------------------------------------------
+# Regime detection
+# ---------------------------------------------------------------------------
+
+
+class TestRegimeDetector:
+    def test_detect_returns_series(self):
+        df = _make_trending_up(100)
+        detector = RegimeDetector()
+        regimes = detector.detect(df)
+        assert isinstance(regimes, pd.Series)
+        assert len(regimes) == len(df)
+
+    def test_all_values_are_market_regime(self):
+        df = _make_trending_up(100)
+        detector = RegimeDetector()
+        regimes = detector.detect(df)
+        for r in regimes:
+            assert isinstance(r, MarketRegime)
+
+    def test_trending_up_detected(self):
+        df = _make_trending_up(200)
+        detector = RegimeDetector()
+        regimes = detector.detect(df)
+        # Last bars should be trending up
+        last_regimes = regimes.iloc[-20:]
+        trending_up_count = (last_regimes == MarketRegime.TRENDING_UP).sum()
+        assert trending_up_count > 10, (
+            f"Expected mostly TRENDING_UP in uptrend tail, "
+            f"got {trending_up_count}/20"
+        )
+
+    def test_trending_down_detected(self):
+        df = _make_trending_down(200)
+        detector = RegimeDetector()
+        regimes = detector.detect(df)
+        last_regimes = regimes.iloc[-20:]
+        trending_down_count = (
+            last_regimes == MarketRegime.TRENDING_DOWN
+        ).sum()
+        assert trending_down_count > 10, (
+            f"Expected mostly TRENDING_DOWN in downtrend tail, "
+            f"got {trending_down_count}/20"
+        )
+
+    def test_detect_at_returns_single_regime(self):
+        df = _make_trending_up(100)
+        detector = RegimeDetector()
+        regime = detector.detect_at(df, len(df) - 1)
+        assert isinstance(regime, MarketRegime)
+
+
+# ---------------------------------------------------------------------------
+# Regime filter
+# ---------------------------------------------------------------------------
+
+
+class TestRegimeFilter:
+    def test_satisfies_signal_emitter_protocol(self):
+        inner = FakeEmitter()
+        detector = RegimeDetector()
+        filt = RegimeFilter(inner, detector, {MarketRegime.TRENDING_UP})
+        assert isinstance(filt, SignalEmitter)
+
+    def test_passes_signals_in_allowed_regime(self):
+        df = _make_trending_up(200)
+        inner = FakeEmitter()
+        detector = RegimeDetector()
+        # Allow all regimes — should pass through
+        filt = RegimeFilter(
+            inner, detector,
+            {r for r in MarketRegime},
+        )
+        signals = filt.emit(df, "TEST", Timeframe.H1)
+        assert len(signals) == 1
+
+    def test_blocks_signals_in_disallowed_regime(self):
+        df = _make_trending_up(200)
+        inner = FakeEmitter()
+        detector = RegimeDetector()
+        # Only allow range_bound — trending up data should be blocked
+        filt = RegimeFilter(
+            inner, detector,
+            {MarketRegime.RANGE_BOUND},
+        )
+        signals = filt.emit(df, "TEST", Timeframe.H1)
+        assert len(signals) == 0
+
+    def test_filter_wraps_inner_emitter(self):
+        """Verify inner emitter is called when regime matches."""
+        call_count = 0
+
+        class TrackingEmitter:
+            def emit(self, df, symbol, timeframe) -> list[Signal]:
+                nonlocal call_count
+                call_count += 1
+                return []
+
+        df = _make_trending_up(200)
+        detector = RegimeDetector()
+        filt = RegimeFilter(
+            TrackingEmitter(), detector,
+            {r for r in MarketRegime},  # allow all
+        )
+        filt.emit(df, "TEST", Timeframe.H1)
+        assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Feature extraction (regime features)
+# ---------------------------------------------------------------------------
+
+
+class TestRegimeFeatures:
+    def test_extractor_includes_regime_columns(self):
+        from rainier.analysis.analyzer import analyze
+        from rainier.features.extractor import FeatureExtractor
+
+        df = _make_trending_up(100)
+        result = analyze(df, "TEST", Timeframe.H1)
+        extractor = FeatureExtractor()
+        features = extractor.extract(result, df)
+
+        # Check regime columns exist
+        assert "atr_percentile" in features.columns
+        assert "adx" in features.columns
+        assert "regime_trending_up" in features.columns
+        assert "regime_trending_down" in features.columns
+        assert "regime_range_bound" in features.columns
+        assert "regime_high_volatility" in features.columns
+
+    def test_regime_one_hot_sums_to_one(self):
+        from rainier.analysis.analyzer import analyze
+        from rainier.features.extractor import FeatureExtractor
+
+        df = _make_trending_up(100)
+        result = analyze(df, "TEST", Timeframe.H1)
+        extractor = FeatureExtractor()
+        features = extractor.extract(result, df)
+
+        regime_cols = [
+            "regime_trending_up", "regime_trending_down",
+            "regime_range_bound", "regime_high_volatility",
+        ]
+        row_sums = features[regime_cols].sum(axis=1)
+        assert (row_sums == 1.0).all(), "Each bar should be exactly one regime"
+
+    def test_no_nan_in_regime_features(self):
+        from rainier.analysis.analyzer import analyze
+        from rainier.features.extractor import FeatureExtractor
+
+        df = _make_trending_up(100)
+        result = analyze(df, "TEST", Timeframe.H1)
+        extractor = FeatureExtractor()
+        features = extractor.extract(result, df)
+
+        assert features["atr_percentile"].isna().sum() == 0
+        assert features["adx"].isna().sum() == 0


### PR DESCRIPTION
## Summary
- Classifies market bars into 4 regimes: TRENDING_UP, TRENDING_DOWN, RANGE_BOUND, HIGH_VOLATILITY
- Uses ATR percentile + SMA slope + ADX (Average Directional Index) for classification
- `RegimeFilter` wraps any `SignalEmitter` — only passes signals when regime is favorable
- Adds 6 new ML features: `atr_percentile`, `adx`, and 4 regime one-hot columns

## Changes
- `core/types.py` — `MarketRegime` enum
- `core/config.py` — `RegimeConfig` (SMA period, ATR period, ADX threshold, etc.)
- `analysis/regime.py` — `RegimeDetector` class + `compute_adx()` function
- `signals/regime_filter.py` — `RegimeFilter` (SignalEmitter decorator pattern)
- `features/extractor.py` — regime one-hot + continuous features
- `cli.py` — `--regime-filter trending_up,range_bound` flag

## Usage
```bash
# Only trade when trending up or range bound
uv run rainier backtest --symbol MES --timeframe 1H --csv data/csv/MES_1H.csv \
  --regime-filter trending_up,range_bound
```

## Test plan
- [x] 15 tests in `tests/test_regime.py`
- [x] ADX computation: series shape, range 0-100, trending > range
- [x] Regime detection: correct classification on synthetic uptrend/downtrend data
- [x] RegimeFilter: protocol compliance, passes/blocks signals correctly
- [x] Feature extraction: regime columns present, one-hot sums to 1, no NaN
- [x] All 221 existing tests still pass