### PR TITLE
Add multi-symbol portfolio backtest (Phase B)

### DIFF
--- a/src/rainier/backtest/portfolio.py
+++ b/src/rainier/backtest/portfolio.py
@@ -1,0 +1,179 @@
+"""Multi-symbol portfolio backtest — runs backtest per symbol and aggregates.
+
+Dependency rule: imports only from core/ and backtest/.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import numpy as np
+import pandas as pd
+
+from rainier.core.config import BacktestConfig
+from rainier.core.protocols import BacktestMetrics, SignalEmitter
+from rainier.core.types import Timeframe
+
+from .engine import run_backtest
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SymbolResult:
+    """Per-symbol backtest result with allocation weight."""
+    symbol: str
+    metrics: BacktestMetrics
+    weight: float  # allocation weight (e.g., 0.33 for 3 symbols)
+
+
+@dataclass
+class PortfolioResult:
+    """Aggregate portfolio backtest results."""
+    symbol_results: list[SymbolResult] = field(default_factory=list)
+    combined_equity_curve: list[float] = field(default_factory=list)
+    total_net_pnl: float = 0.0
+    total_trades: int = 0
+    per_symbol_pnl: dict[str, float] = field(default_factory=dict)
+    portfolio_sharpe: float = 0.0
+    portfolio_max_drawdown_pct: float = 0.0
+    initial_capital: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_portfolio_backtest(
+    data: dict[str, pd.DataFrame],
+    timeframes: dict[str, Timeframe],
+    signal_emitter: SignalEmitter,
+    config: BacktestConfig | None = None,
+) -> PortfolioResult:
+    """Run backtest per symbol and aggregate portfolio metrics.
+
+    Args:
+        data: symbol -> OHLCV DataFrame
+        timeframes: symbol -> Timeframe
+        signal_emitter: Shared emitter (or per-symbol if wrapping)
+        config: Base backtest config (capital split equally)
+
+    Returns:
+        PortfolioResult with per-symbol and combined metrics
+    """
+    if config is None:
+        config = BacktestConfig()
+
+    symbols = list(data.keys())
+    n_symbols = len(symbols)
+    if n_symbols == 0:
+        return PortfolioResult(initial_capital=config.initial_capital)
+
+    # Equal capital allocation
+    per_symbol_capital = config.initial_capital / n_symbols
+    weight = 1.0 / n_symbols
+
+    result = PortfolioResult(initial_capital=config.initial_capital)
+    all_equity_deltas: list[list[float]] = []
+
+    for sym in symbols:
+        sym_config = config.model_copy()
+        sym_config.initial_capital = per_symbol_capital
+
+        tf = timeframes.get(sym, Timeframe.H1)
+        metrics = run_backtest(data[sym], sym, tf, signal_emitter, sym_config)
+
+        sym_result = SymbolResult(
+            symbol=sym, metrics=metrics, weight=weight,
+        )
+        result.symbol_results.append(sym_result)
+        result.per_symbol_pnl[sym] = metrics.total_net_pnl
+        result.total_trades += metrics.total_trades
+
+        # Collect equity deltas
+        if len(metrics.equity_curve) > 1:
+            deltas = [
+                metrics.equity_curve[i] - metrics.equity_curve[i - 1]
+                for i in range(1, len(metrics.equity_curve))
+            ]
+        else:
+            deltas = []
+        all_equity_deltas.append(deltas)
+
+    # Build combined equity curve
+    max_len = max(len(d) for d in all_equity_deltas) if all_equity_deltas else 0
+    combined = [config.initial_capital]
+    for i in range(max_len):
+        bar_delta = 0.0
+        for deltas in all_equity_deltas:
+            if i < len(deltas):
+                bar_delta += deltas[i]
+        combined.append(combined[-1] + bar_delta)
+
+    result.combined_equity_curve = combined
+    result.total_net_pnl = sum(result.per_symbol_pnl.values())
+
+    # Portfolio Sharpe
+    if len(combined) > 1:
+        returns = np.diff(combined) / np.array(combined[:-1])
+        if len(returns) > 0 and np.std(returns) > 0:
+            result.portfolio_sharpe = float(
+                np.mean(returns) / np.std(returns) * math.sqrt(252)
+            )
+
+    # Portfolio max drawdown
+    peak = combined[0]
+    max_dd_pct = 0.0
+    for eq in combined:
+        if eq > peak:
+            peak = eq
+        if peak > 0:
+            dd_pct = (peak - eq) / peak
+            if dd_pct > max_dd_pct:
+                max_dd_pct = dd_pct
+    result.portfolio_max_drawdown_pct = max_dd_pct
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def format_portfolio_report(result: PortfolioResult) -> str:
+    """Format portfolio results as a readable text report."""
+    lines = [
+        "=" * 80,
+        "PORTFOLIO BACKTEST RESULTS",
+        "=" * 80,
+        "",
+        f"  Initial capital: ${result.initial_capital:,.2f}",
+        f"  Symbols: {len(result.symbol_results)}",
+        f"  Total trades: {result.total_trades}",
+        f"  Total net P&L: ${result.total_net_pnl:+,.2f}",
+        f"  Portfolio Sharpe: {result.portfolio_sharpe:.2f}",
+        f"  Portfolio max DD: {result.portfolio_max_drawdown_pct:.2%}",
+        "",
+        "PER-SYMBOL BREAKDOWN",
+        "-" * 80,
+        f"  {'Symbol':<10} {'Weight':>7} {'Trades':>7} {'WinRate':>8} "
+        f"{'PF':>7} {'NetPnL':>12} {'Sharpe':>8} {'MaxDD':>8}",
+        "-" * 80,
+    ]
+
+    for sr in result.symbol_results:
+        m = sr.metrics
+        lines.append(
+            f"  {sr.symbol:<10} {sr.weight:>6.1%} {m.total_trades:>7} "
+            f"{m.win_rate:>7.1%} {m.profit_factor:>7.2f} "
+            f"{m.total_net_pnl:>+12,.2f} {m.sharpe_ratio:>8.2f} "
+            f"{m.max_drawdown_pct:>7.2%}"
+        )
+
+    lines.append("=" * 80)
+    return "\n".join(lines)

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -238,10 +238,13 @@ def chart(ctx, symbol, tf, csv_path, start, end, output_path):
               help="Walk-forward window mode")
 @click.option("--regime-filter", "regime_filter", default=None,
               help="Comma-separated regimes: trending_up,trending_down,range_bound,high_volatility")
+@click.option("--symbols", default=None, help="Comma-separated symbols for portfolio backtest")
+@click.option("--data-dir", "data_dir", default=None, type=click.Path(exists=True),
+              help="Directory with CSV files for portfolio mode")
 @click.pass_context
 def backtest(ctx, symbol, tf, csv_path, start, end, capital, export_path, sweep,
              slippage, commission, show_trades, walk_forward, wf_train_bars, wf_test_bars,
-             wf_step_bars, wf_mode, regime_filter):
+             wf_step_bars, wf_mode, regime_filter, symbols, data_dir):
     """Run a backtest on historical data."""
     from rainier.backtest.engine import run_backtest
     from rainier.backtest.report import format_report, format_trade_log, plot_equity_curve
@@ -289,6 +292,46 @@ def backtest(ctx, symbol, tf, csv_path, start, end, capital, export_path, sweep,
         return _wrap_with_regime(
             PinBarSignalEmitter(settings.analysis, sig_config)
         )
+
+    if symbols:
+        # Portfolio backtest mode
+        from rainier.backtest.portfolio import (
+            format_portfolio_report,
+            run_portfolio_backtest,
+        )
+        from rainier.data.csv_provider import CSVProvider as CSVProv
+
+        sym_list = [s.strip() for s in symbols.split(",")]
+        dir_path = Path(data_dir) if data_dir else Path(csv_path).parent
+
+        port_data: dict[str, pd.DataFrame] = {}
+        port_tfs: dict[str, Timeframe] = {}
+        prov = CSVProv(dir_path)
+        for sym in sym_list:
+            csv_file = dir_path / f"{sym}_{tf}.csv"
+            if not csv_file.exists():
+                click.echo(f"Warning: {csv_file} not found, skipping {sym}")
+                continue
+            port_data[sym] = prov._read_csv(csv_file, start_dt, end_dt)
+            port_tfs[sym] = timeframe
+
+        if not port_data:
+            click.echo("No data files found for portfolio backtest.")
+            return
+
+        emitter = _wrap_with_regime(
+            PinBarSignalEmitter(settings.analysis, settings.signal)
+        )
+        click.echo(
+            f"Running portfolio backtest: {list(port_data.keys())}, "
+            f"{tf}, {sum(len(d) for d in port_data.values())} total candles..."
+        )
+
+        port_result = run_portfolio_backtest(
+            port_data, port_tfs, emitter, bt_config,
+        )
+        click.echo(format_portfolio_report(port_result))
+        return
 
     if walk_forward:
         # Walk-forward cross-validation mode

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,200 @@
+"""Tests for multi-symbol portfolio backtest."""
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+
+from rainier.backtest.portfolio import (
+    PortfolioResult,
+    format_portfolio_report,
+    run_portfolio_backtest,
+)
+from rainier.core.config import BacktestConfig
+from rainier.core.types import Direction, Signal, Timeframe
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_dataset(n_bars: int = 200, seed_price: float = 100.0) -> pd.DataFrame:
+    rows = []
+    price = seed_price
+    base = datetime(2025, 1, 1)
+    for i in range(n_bars):
+        cycle = i % 40
+        move = 1.0 if cycle < 20 else -1.0
+        o = price
+        h = price + abs(move) + 1.0
+        low = price - abs(move) - 0.5
+        c = price + move
+        rows.append({
+            "timestamp": base + timedelta(hours=i),
+            "open": o, "high": h, "low": low, "close": c,
+            "volume": 1000.0 + (i % 10) * 100,
+        })
+        price = c
+    return pd.DataFrame(rows)
+
+
+class FakeEmitter:
+    def emit(self, df: pd.DataFrame, symbol: str, timeframe: Timeframe) -> list[Signal]:
+        last_bar = df.iloc[-1]
+        return [
+            Signal(
+                symbol=symbol,
+                timeframe=timeframe,
+                direction=Direction.LONG,
+                entry_price=float(last_bar["close"]) - 0.5,
+                stop_loss=float(last_bar["close"]) - 5.0,
+                take_profit=float(last_bar["close"]) + 5.0,
+                confidence=0.75,
+                timestamp=pd.Timestamp(last_bar["timestamp"]).to_pydatetime(),
+            ),
+        ]
+
+
+class EmptyEmitter:
+    def emit(self, df: pd.DataFrame, symbol: str, timeframe: Timeframe) -> list[Signal]:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPortfolioBacktest:
+    def test_single_symbol_runs(self):
+        df = _make_dataset(200)
+        data = {"MES": df}
+        tfs = {"MES": Timeframe.H1}
+        config = BacktestConfig(sr_recompute_interval=50)
+
+        result = run_portfolio_backtest(data, tfs, FakeEmitter(), config)
+
+        assert isinstance(result, PortfolioResult)
+        assert len(result.symbol_results) == 1
+        assert result.symbol_results[0].symbol == "MES"
+        assert result.initial_capital == config.initial_capital
+
+    def test_single_symbol_matches_standalone(self):
+        """Portfolio with 1 symbol should produce same metrics."""
+        from rainier.backtest.engine import run_backtest
+
+        df = _make_dataset(200)
+        config = BacktestConfig(sr_recompute_interval=50)
+        emitter = FakeEmitter()
+
+        # Standalone
+        standalone = run_backtest(df, "MES", Timeframe.H1, emitter, config)
+
+        # Portfolio (single symbol gets full capital)
+        emitter2 = FakeEmitter()
+        port = run_portfolio_backtest(
+            {"MES": df}, {"MES": Timeframe.H1}, emitter2, config,
+        )
+
+        assert port.symbol_results[0].metrics.total_trades == standalone.total_trades
+        assert abs(port.total_net_pnl - standalone.total_net_pnl) < 0.01
+
+    def test_multi_symbol_capital_split(self):
+        data = {
+            "MES": _make_dataset(200, 100.0),
+            "NQ": _make_dataset(200, 200.0),
+            "ES": _make_dataset(200, 150.0),
+        }
+        tfs = {s: Timeframe.H1 for s in data}
+        config = BacktestConfig(
+            initial_capital=300_000.0,
+            sr_recompute_interval=50,
+        )
+
+        result = run_portfolio_backtest(data, tfs, FakeEmitter(), config)
+
+        assert len(result.symbol_results) == 3
+        for sr in result.symbol_results:
+            assert sr.weight == 1.0 / 3
+            assert sr.metrics.initial_capital == 100_000.0
+
+    def test_pnl_aggregation(self):
+        data = {
+            "MES": _make_dataset(200, 100.0),
+            "NQ": _make_dataset(200, 200.0),
+        }
+        tfs = {s: Timeframe.H1 for s in data}
+        config = BacktestConfig(sr_recompute_interval=50)
+
+        result = run_portfolio_backtest(data, tfs, FakeEmitter(), config)
+
+        per_sym_sum = sum(result.per_symbol_pnl.values())
+        assert abs(result.total_net_pnl - per_sym_sum) < 0.01
+
+    def test_total_trades_aggregation(self):
+        data = {
+            "MES": _make_dataset(200, 100.0),
+            "NQ": _make_dataset(200, 200.0),
+        }
+        tfs = {s: Timeframe.H1 for s in data}
+        config = BacktestConfig(sr_recompute_interval=50)
+
+        result = run_portfolio_backtest(data, tfs, FakeEmitter(), config)
+
+        trade_sum = sum(sr.metrics.total_trades for sr in result.symbol_results)
+        assert result.total_trades == trade_sum
+
+    def test_combined_equity_curve_starts_at_capital(self):
+        data = {"MES": _make_dataset(200)}
+        tfs = {"MES": Timeframe.H1}
+        config = BacktestConfig(sr_recompute_interval=50)
+
+        result = run_portfolio_backtest(data, tfs, FakeEmitter(), config)
+
+        assert result.combined_equity_curve[0] == config.initial_capital
+
+    def test_empty_data_returns_empty_result(self):
+        config = BacktestConfig()
+        result = run_portfolio_backtest({}, {}, FakeEmitter(), config)
+
+        assert result.total_trades == 0
+        assert result.total_net_pnl == 0.0
+        assert len(result.symbol_results) == 0
+
+    def test_empty_emitter_zero_trades(self):
+        data = {"MES": _make_dataset(200)}
+        tfs = {"MES": Timeframe.H1}
+        config = BacktestConfig(sr_recompute_interval=50)
+
+        result = run_portfolio_backtest(data, tfs, EmptyEmitter(), config)
+
+        assert result.total_trades == 0
+
+    def test_different_data_lengths(self):
+        data = {
+            "MES": _make_dataset(200, 100.0),
+            "NQ": _make_dataset(300, 200.0),
+        }
+        tfs = {s: Timeframe.H1 for s in data}
+        config = BacktestConfig(sr_recompute_interval=50)
+
+        # Should not crash
+        result = run_portfolio_backtest(data, tfs, FakeEmitter(), config)
+        assert len(result.symbol_results) == 2
+
+
+class TestPortfolioReport:
+    def test_report_contains_key_sections(self):
+        data = {
+            "MES": _make_dataset(200, 100.0),
+            "NQ": _make_dataset(200, 200.0),
+        }
+        tfs = {s: Timeframe.H1 for s in data}
+        config = BacktestConfig(sr_recompute_interval=50)
+
+        result = run_portfolio_backtest(data, tfs, FakeEmitter(), config)
+        report = format_portfolio_report(result)
+
+        assert "PORTFOLIO" in report
+        assert "MES" in report
+        assert "NQ" in report
+        assert "PER-SYMBOL" in report


### PR DESCRIPTION
## Summary
- Runs backtest per symbol with equal capital allocation, aggregates into portfolio metrics
- Combined equity curve with portfolio-level Sharpe ratio and max drawdown
- Per-symbol breakdown in formatted report

## Changes
- `src/rainier/backtest/portfolio.py` — `run_portfolio_backtest()`, `PortfolioResult`, report formatting
- `src/rainier/cli.py` — `--symbols MES,NQ,ES` and `--data-dir` flags

## Usage
```bash
uv run rainier backtest --symbol MES --timeframe 1H --csv data/csv/MES_1H.csv \
  --symbols MES,NQ,ES --data-dir data/csv
```

## Test plan
- [x] 10 tests in `tests/test_portfolio.py`
- [x] Single symbol matches standalone backtest
- [x] Capital split verification (3 symbols = 1/3 each)
- [x] PnL and trade count aggregation
- [x] Different data lengths handled
- [x] Empty data edge case
- [x] All 216 existing tests still pass