### PR TITLE
Fix CDP login: force fresh login when on signin page

### DIFF
--- a/src/rainier/scrapers/qu/auth.py
+++ b/src/rainier/scrapers/qu/auth.py
@@ -53,7 +53,7 @@ async def login(page: Page) -> None:
     await page.wait_for_url(
         lambda url: "signin" not in url, timeout=qu.timeout_ms
     )
-    await page.wait_for_load_state("networkidle", timeout=10000)
+    await page.wait_for_load_state("networkidle", timeout=30000)
 
     log.info("qu_login_success", url=page.url)
 

--- a/src/rainier/scrapers/qu/scraper.py
+++ b/src/rainier/scrapers/qu/scraper.py
@@ -167,10 +167,11 @@ class QUScraper(BaseScraper):
             await goto_with_retry(page, self._qu_config.url)
             await page.wait_for_load_state("networkidle", timeout=15000)
 
-        # Check if redirected to signin
+        # Check if redirected to signin — session is invalid regardless
+        # of file age (server may have expired it)
         if "signin" in (page.url or ""):
             self.log.info("cdp_needs_login", url=page.url)
-            await ensure_authenticated(page)
+            await login(page)
             await goto_with_retry(page, self._qu_config.url)
             return
 
@@ -187,7 +188,7 @@ class QUScraper(BaseScraper):
                 )
             if "signin" in (page.url or ""):
                 self.log.info("cdp_needs_login", url=page.url)
-                await ensure_authenticated(page)
+                await login(page)
                 await goto_with_retry(page, self._qu_config.url)
 
     # ------------------------------------------------------------------
@@ -210,6 +211,12 @@ class QUScraper(BaseScraper):
             if self.browser._is_cdp:
                 self.log.warning("cdp_wrong_page", url=current_url,
                                  hint="Navigate to QU100 page in Chrome first")
+            await goto_with_retry(page, self._qu_config.url)
+
+        # Safety net: if redirected to signin after navigation, force login
+        if "signin" in (page.url or ""):
+            self.log.info("scrape_forced_login", url=page.url)
+            await login(page)
             await goto_with_retry(page, self._qu_config.url)
 
         # Change date if requested (before initial search)


### PR DESCRIPTION
## Summary

- Fix silent scrape failures caused by stale server-side sessions in CDP mode
- `ensure_authenticated()` was trusting session file age and skipping login even when the browser was on the signin page
- Now calls `login()` directly when signin page is detected, regardless of file age
- Added safety net in `_scrape_qu100` to catch signin redirects after navigation
- Increased post-login networkidle timeout from 10s to 30s

## Root cause

When QU website expires the session server-side (but the local cookie file is < 12 hours old), the scraper would:
1. See "session valid" based on file age → skip login
2. Navigate to QU100 → get redirected to signin
3. Wait for `.ant-table` on the signin page → timeout
4. Fail silently (before Discord notification fix)

## Test plan

- [x] Tested with expired session: scraper detects signin, forces login, scrapes successfully
- [x] Post-scrape screener runs and sends results to Discord
- [x] Discord error notification fires on failure
- [x] DB cleanup: removed 108 duplicate rows, verified 0 remaining duplicates