### PR TITLE
Fix cron jobs path + add Discord failure alerts

### DIFF
--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -1,10 +1,14 @@
 # Scheduled jobs — managed by `rainier jobs` CLI
-# Each job runs as a system cron entry tagged with its name.
-# Future: migrate to a long-running scheduler service.
+# Each job runs via cron-wrapper.sh which provides:
+#   - Timestamped logging ([START], [OK], [FAIL])
+#   - Discord alert on failure (if discord_on_failure: true)
 #
 # QU scraper requires Chrome with --remote-debugging-port=9222 to bypass bot
 # detection. Each scrape job starts Chrome headless before scraping and kills
 # it after, so Chrome only runs during the ~1-2 min each scrape takes.
+
+# Discord webhook for ops alerts (loaded from .env DISCORD_WEBHOOK_URL)
+discord_on_failure: true
 
 jobs:
   - name: fetch-mes

--- a/scripts/cron-wrapper.sh
+++ b/scripts/cron-wrapper.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Cron job wrapper — structured logging + Discord alert on failure.
+# Usage: cron-wrapper.sh <job-name> <log-file> <webhook-url> <command...>
+#
+# Example crontab entry:
+#   45 8 * * 1-5 /path/to/cron-wrapper.sh qu-morning /path/to/log.log https://discord.com/... "cd /proj && uv run rainier scrape qu ..."
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+UV="/Users/pinkbear/.local/bin/uv"
+
+JOB_NAME="$1"; shift
+LOG_FILE="$1"; shift
+WEBHOOK="$1"; shift
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+
+echo "$(ts) [START] $JOB_NAME" >> "$LOG_FILE"
+
+# Run command in subshell, capture output to temp file (avoids shell-escaping issues)
+TMPFILE=$(mktemp)
+( eval "$@" ) > "$TMPFILE" 2>&1
+RC=$?
+
+cat "$TMPFILE" >> "$LOG_FILE"
+
+if [ $RC -eq 0 ]; then
+    echo "$(ts) [OK] $JOB_NAME" >> "$LOG_FILE"
+else
+    echo "$(ts) [FAIL exit=$RC] $JOB_NAME" >> "$LOG_FILE"
+
+    # Send Discord alert via project Python (system python3 gets 403 from Discord)
+    if [ -n "$WEBHOOK" ]; then
+        cd "$PROJECT_DIR" && $UV run python3 - "$JOB_NAME" "$RC" "$WEBHOOK" "$TMPFILE" <<'PYEOF'
+import sys, json, httpx
+from datetime import datetime, timezone
+
+name, rc, webhook, tmpfile = sys.argv[1:5]
+with open(tmpfile) as f:
+    output = f.read()[-1500:]
+
+embed = {
+    "title": f"\u274c Cron Job Failed: {name}",
+    "description": (
+        f"**Exit code:** {rc}\n"
+        f"**Time:** {datetime.now().strftime('%Y-%m-%d %H:%M PT')}\n"
+        f"```\n{output}\n```"
+    ),
+    "color": 0xFF1744,
+    "timestamp": datetime.now(timezone.utc).isoformat(),
+}
+try:
+    r = httpx.post(webhook, json={"embeds": [embed]}, timeout=10)
+    r.raise_for_status()
+except Exception as e:
+    print(f"Discord notify failed: {e}", file=sys.stderr)
+PYEOF
+    fi
+fi
+
+rm -f "$TMPFILE"
+exit $RC

--- a/src/rainier/scheduler/jobs.py
+++ b/src/rainier/scheduler/jobs.py
@@ -10,6 +10,7 @@ import yaml  # type: ignore[import-untyped]
 
 JOB_TAG = "# rainier:"
 DEFAULT_CONFIG = Path("config/cron.yaml")
+WRAPPER_SCRIPT = Path("scripts/cron-wrapper.sh")
 
 
 def load_config(path: Path = DEFAULT_CONFIG) -> list[dict]:
@@ -17,6 +18,25 @@ def load_config(path: Path = DEFAULT_CONFIG) -> list[dict]:
     with open(path) as f:
         data = yaml.safe_load(f)
     return data.get("jobs", [])
+
+
+def _load_discord_on_failure(path: Path = DEFAULT_CONFIG) -> bool:
+    """Check if discord_on_failure is enabled in cron.yaml."""
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    return bool(data.get("discord_on_failure", False))
+
+
+def _load_discord_webhook(project_dir: Path) -> str:
+    """Load DISCORD_WEBHOOK_URL from .env file."""
+    env_file = project_dir / ".env"
+    if not env_file.exists():
+        return ""
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if line.startswith("DISCORD_WEBHOOK_URL=") and not line.startswith("#"):
+            return line.split("=", 1)[1].strip().strip('"').strip("'")
+    return ""
 
 
 def list_active() -> list[dict[str, str]]:
@@ -43,6 +63,11 @@ def sync(config_path: Path = DEFAULT_CONFIG, project_dir: Path | None = None) ->
     active = {j["name"]: j for j in list_active()}
     actions: dict[str, str] = {}
 
+    # Check if we should use the wrapper with Discord alerts
+    discord_on_failure = _load_discord_on_failure(config_path)
+    discord_webhook = _load_discord_webhook(project_dir) if discord_on_failure else ""
+    wrapper_path = project_dir / WRAPPER_SCRIPT
+
     # Remove jobs no longer in config (or disabled)
     config_names = {j["name"] for j in jobs if j.get("enabled", True)}
     for name in list(active):
@@ -61,12 +86,24 @@ def sync(config_path: Path = DEFAULT_CONFIG, project_dir: Path | None = None) ->
 
         log = job.get("log", "/dev/null")
         log_path = project_dir / log if not log.startswith("/") else Path(log)
+
         # Resolve bare "uv" to full path so cron (minimal PATH) can find it
         cmd = job["command"]
         uv_path = shutil.which("uv")
         if uv_path:
             cmd = cmd.replace("uv run", f"{uv_path} run")
-        command = f"cd {project_dir} && {cmd} >> {log_path} 2>&1"
+
+        # Build the cron command — use wrapper if available
+        inner_cmd = f"cd {project_dir} && {cmd}"
+        if wrapper_path.exists() and discord_webhook:
+            command = (
+                f"{wrapper_path} {name} {log_path} "
+                f"{discord_webhook} "
+                f'"{inner_cmd}"'
+            )
+        else:
+            command = f"{inner_cmd} >> {log_path} 2>&1"
+
         cron_line = f"{job['schedule']} {command} {JOB_TAG} {name}"
 
         existing_cmd = active[name]["command"] if name in active else ""


### PR DESCRIPTION
## Summary
- **Root cause**: All cron jobs pointed to `/projects/quant/` which doesn't exist — every scheduled scrape silently failed
- Added `scripts/cron-wrapper.sh` that wraps cron jobs with timestamped logging (`[START]`, `[OK]`, `[FAIL]`) and sends Discord alerts on failure
- Updated `jobs.py` to use the wrapper when `discord_on_failure: true` in `cron.yaml`

## Test plan
- [x] Tested wrapper with deliberate failure — Discord alert received in ops channel
- [x] Tested wrapper with success — clean `[OK]` log, no Discord noise
- [x] Verified `rainier jobs sync` generates correct crontab entries with new paths
- [x] Verified QU100 stock alerts still go to the stock channel webhook