### PR TITLE
Fix QU100 scraper: use native click for login button

### DIFF
--- a/src/rainier/scrapers/qu/scraper.py
+++ b/src/rainier/scrapers/qu/scraper.py
@@ -234,7 +234,7 @@ class QUScraper(BaseScraper):
             login_btn = await page.query_selector("text=注册/登录")
             if login_btn:
                 self.log.info("cdp_clicking_login_button")
-                await page.evaluate("el => el.click()", login_btn)
+                await login_btn.click()
                 await page.wait_for_load_state(
                     "domcontentloaded", timeout=10000
                 )


### PR DESCRIPTION
## Summary
- `page.evaluate("el => el.click()")` crashes with "Execution context was destroyed" when the login button click triggers a page navigation
- Replaced with Playwright's native `login_btn.click()` which handles navigation gracefully
- All 4 daily QU100 scrapes have been failing since 2026-04-06 15:00 when session cookies expired

## Test plan
- [x] Ran scrape manually after fix — 200 records created, Discord notification sent
- [x] All 46 scraper/QU tests pass