### PR TITLE
Fix QU100 scraper: use text-based selectors for toggles

### DIFF
--- a/src/rainier/scrapers/qu/selectors.py
+++ b/src/rainier/scrapers/qu/selectors.py
@@ -26,14 +26,13 @@ QU100_CONTAINER = ".qu100"
 QU100_TABLE = ".ant-table"
 QU100_TABLE_ROW = ".ant-table-tbody tr.ant-table-row"
 
-# Top100/Bottom100 toggle — <span> elements inside .select-button
-# The second .select-button contains Top100/Bottom100 (first has Daily/Weekly)
-TOP100_BUTTON = ".select-button:nth-child(3) span:first-child"
-BOTTOM100_BUTTON = ".select-button:nth-child(3) span:last-child"
+# Top100/Bottom100 toggle — use text selectors (stable across DOM changes)
+TOP100_BUTTON = ".select-button span:text-is('前100')"
+BOTTOM100_BUTTON = ".select-button span:text-is('后100')"
 
 # Daily/Weekly toggle
-DAILY_BUTTON = ".select-button:nth-child(2) span:first-child"
-WEEKLY_BUTTON = ".select-button:nth-child(2) span:last-child"
+DAILY_BUTTON = ".select-button span:text-is('日线')"
+WEEKLY_BUTTON = ".select-button span:text-is('周线')"
 
 # Date picker (Ant Design)
 DATE_INPUT = ".ant-picker-input input"


### PR DESCRIPTION
## Summary
- QU100 scraper was failing on bottom100 with selector timeout (`.select-button:nth-child(3)` no longer matches after site DOM change)
- Switched Top100/Bottom100 and Daily/Weekly selectors from fragile `nth-child` CSS to Playwright text selectors (`span:text-is('前100')`) which are stable regardless of DOM order
- Also migrated `money_flow_snapshots` and `stock_capital_flow` DB tables from `stock_id` (int FK) to `symbol` (string) to match current ORM models

## Test plan
- [x] Verified new selectors find buttons on live site via CDP
- [x] Full scrape succeeded: 200 records (100 top + 100 bottom) in 2.1s
- [x] Data persisted to DB without errors