### PR TITLE
fix: QU scraper race condition after post-login navigation

### DIFF
--- a/src/rainier/scrapers/qu/scraper.py
+++ b/src/rainier/scrapers/qu/scraper.py
@@ -243,8 +243,10 @@ class QUScraper(BaseScraper):
                 await login(page)
                 await goto_with_retry(page, self._qu_config.url)
 
-            # After login, click Search to load the table
-            search_btn = await page.query_selector(sel.SEARCH_BUTTON)
+            # After login, wait for React to render, then click Search
+            search_btn = await page.wait_for_selector(
+                sel.SEARCH_BUTTON, timeout=15000
+            )
             if search_btn:
                 await search_btn.click()
             await page.wait_for_selector(
@@ -283,7 +285,7 @@ class QUScraper(BaseScraper):
         # Change date if requested, then click Search to load data
         if target_date:
             await self._set_date(target_date)
-        search_btn = await page.query_selector(sel.SEARCH_BUTTON)
+        search_btn = await page.wait_for_selector(sel.SEARCH_BUTTON, timeout=15000)
         if search_btn:
             await search_btn.click()
 


### PR DESCRIPTION
## Summary

**Bug:** Afternoon cron `qu-afternoon` failed at 2026-04-09 12:45 PT with `Page.wait_for_selector: Timeout 15000ms exceeded` on `.ant-table`. Login succeeded but the data table never loaded.

**Root cause:** After a login redirect, `_cdp_ensure_auth()` (scraper.py:244) and `_scrape_qu100()` (scraper.py:283) both navigated back to the products page and then used `query_selector(SEARCH_BUTTON)` to find the Search button. `query_selector` returns immediately — but `domcontentloaded` fires before React/Ant Design has rendered the button. The selector returned `None`, the click was silently skipped, and the table never loaded.

Evidence from the failed cron logs:
```
12:45:18 qu_login_success url=https://www.quantunicorn.com/
12:45:18 session_saved
12:45:34 scraper_failed error='Page.wait_for_selector: Timeout 15000ms exceeded'
```
16s gap = navigation + 15s table timeout. No `cdp_clicking_search_button` log line between login and failure — confirming the Search click was silently skipped.

**Fix:** Replace `query_selector` with `wait_for_selector(..., timeout=15000)` in both post-login code paths. This waits up to 15s for React to render the button before clicking. Matches the pattern used elsewhere in the scraper.

As a side benefit, this turns a silent failure into a loud one: if the button never renders (e.g. still stuck on signin), we now get a clear `SEARCH_BUTTON not found` error instead of a confusing `.ant-table timeout`.

## Test Coverage

Scraper logic isn't unit-tested (it uses real Playwright + CDP against live site). The fix is a mechanical one-line API swap in two locations; verified by the full test suite still passing (321 passed, 1 skipped). Production verification on next cron run.

## Pre-Landing Review

Clean. Diff is ~4 lines across 2 sites, same pattern. No SQL, no LLM, no trust boundary concerns.

## Test plan

- [x] Full test suite passes (`uv run python -m pytest tests/`) — 321 passed, 1 skipped
- [ ] Next scheduled `qu-afternoon` cron run succeeds end-to-end (production verification)
- [ ] Or: manual verification with `uv run rainier scrape qu --session afternoon --cdp http://localhost:9222` after logging out to force the login path

🤖 Generated with [Claude Code](https://claude.com/claude-code)