### PR TITLE
Add generic ApiClient base class (#50)

### DIFF
--- a/docs/x_api_client_plan.md
+++ b/docs/x_api_client_plan.md
@@ -1,0 +1,261 @@
+# Generic API Client Layer + X/Twitter Integration
+
+## Context
+
+We need a reusable API client infrastructure for Rainier. X/Twitter is the first integration, but the same pattern will serve Polygon, future broker APIs, news APIs, etc. The design prioritizes:
+- **One generic base client** with auth, rate limiting, retry — reused across all API integrations
+- **Centralized config** — all API credentials and settings in one `apis` section of settings.yaml
+- **Quick setup** — get a working X client fast, built on the reusable base
+
+## Module Structure
+
+```
+src/rainier/apis/
+├── __init__.py          # Public exports
+├── base.py              # ApiClient base class (httpx, auth, rate limit, retry)
+├── x/
+│   ├── __init__.py
+│   ├── client.py        # XClient(ApiClient) — X API v2 endpoints
+│   ├── types.py         # Tweet, TweetMetrics, XUser dataclasses
+│   ├── store.py         # DB upsert (Tweet → TweetRecord)
+│   ├── alerts.py        # Discord embeds for VIP tweets
+│   └── poller.py        # Poll tracked accounts → store → alert
+└── (future: polygon/, newsapi/, etc.)
+```
+
+## Implementation Steps
+
+### Step 1: Generic ApiClient Base (`apis/base.py`)
+
+Reusable base that any API client inherits from:
+
+```python
+class ApiClient:
+    """Generic HTTP API client with auth, rate limiting, and retries."""
+
+    def __init__(
+        self,
+        base_url: str,
+        headers: dict[str, str] | None = None,
+        rate_limit_delay: float = 0.0,    # min seconds between requests
+        timeout: float = 30.0,
+        max_retries: int = 3,
+    ):
+        self._client = httpx.Client(
+            base_url=base_url,
+            headers=headers or {},
+            timeout=timeout,
+        )
+        self._rate_limit_delay = rate_limit_delay
+        self._max_retries = max_retries
+        self._last_request_time: float = 0.0
+        self._log = structlog.get_logger(client=self.__class__.__name__)
+
+    def get(self, path: str, params: dict | None = None) -> dict: ...
+    def post(self, path: str, json: dict | None = None) -> dict: ...
+    def close(self) -> None: ...
+    def __enter__(self) -> Self: ...
+    def __exit__(self, *args) -> None: ...
+
+    # Internal
+    def _request(self, method: str, path: str, **kwargs) -> dict:
+        """Send request with throttle + retry + error handling."""
+        # 1. Proactive rate limit (sleep if needed)
+        # 2. Send request
+        # 3. Handle 429 (read Retry-After / x-rate-limit-reset header)
+        # 4. Retry on 5xx with exponential backoff
+        # 5. Return parsed JSON
+```
+
+This gives every future API client: rate limiting, retries, structured logging, context manager.
+
+### Step 2: Centralized Config (`core/config.py`)
+
+Merge all API configs under one `apis` section:
+
+```python
+class XTrackedAccount(BaseModel):
+    username: str
+    label: str = ""
+    vip: bool = False                    # triggers Discord alert
+
+class XApiConfig(BaseModel):
+    enabled: bool = False
+    poll_interval_minutes: int = 15
+    max_results_per_user: int = 10
+    rate_limit_delay: float = 16.0       # X free tier: ~1 req/15s
+    tracked_accounts: list[XTrackedAccount] = []
+
+class ApisConfig(BaseModel):
+    """All external API configurations in one place."""
+    x: XApiConfig = XApiConfig()
+    # Future: polygon, newsapi, alpaca, etc.
+```
+
+Add to Settings:
+```python
+x_api_bearer_token: str = ""     # secret from .env
+apis: ApisConfig = ApisConfig()  # app config from YAML
+```
+
+In `settings.yaml`:
+```yaml
+apis:
+  x:
+    enabled: true
+    poll_interval_minutes: 15
+    tracked_accounts:
+      - username: mingchikuo
+        label: "Ming-Chi Kuo"
+        vip: true
+      - username: elonmusk
+        label: "Elon Musk"
+        vip: true
+```
+
+In `.env`:
+```
+X_API_BEARER_TOKEN=your_bearer_token
+```
+
+### Step 3: X Types (`apis/x/types.py`)
+
+```python
+@dataclass(frozen=True, slots=True)
+class TweetMetrics:
+    retweet_count: int = 0
+    reply_count: int = 0
+    like_count: int = 0
+    quote_count: int = 0
+
+@dataclass(frozen=True, slots=True)
+class Tweet:
+    id: str                        # snowflake ID as string (>2^53)
+    text: str
+    author_id: str
+    author_username: str
+    created_at: datetime
+    metrics: TweetMetrics
+    symbols_mentioned: list[str]   # from $CASHTAG entities
+    urls: list[str]
+    is_retweet: bool
+    is_reply: bool
+    referenced_tweet_id: str | None = None
+
+@dataclass(frozen=True, slots=True)
+class XUser:
+    id: str
+    username: str
+    name: str
+    followers_count: int = 0
+```
+
+### Step 4: XClient (`apis/x/client.py`)
+
+```python
+class XClient(ApiClient):
+    """X/Twitter API v2 client."""
+
+    TWEET_FIELDS = "created_at,public_metrics,entities,referenced_tweets"
+    USER_FIELDS = "id,name,username,public_metrics"
+
+    def __init__(self, bearer_token: str, rate_limit_delay: float = 16.0):
+        super().__init__(
+            base_url="https://api.twitter.com/2",
+            headers={"Authorization": f"Bearer {bearer_token}"},
+            rate_limit_delay=rate_limit_delay,
+        )
+
+    def get_tweet(self, tweet_id: str) -> Tweet: ...
+    def get_user_by_username(self, username: str) -> XUser: ...
+    def get_user_tweets(self, user_id: str, *, max_results: int = 10, since_id: str | None = None) -> list[Tweet]: ...
+    def search_recent(self, query: str, max_results: int = 10) -> list[Tweet]: ...
+```
+
+### Step 5: DB Model (add to `core/models.py`)
+
+```python
+class TweetRecord(Base):
+    __tablename__ = "tweets"
+    __table_args__ = (
+        PrimaryKeyConstraint("id", "created_at"),
+        Index("ix_tweets_author", "author_username"),
+        Index("ix_tweets_symbols", "symbols_mentioned", postgresql_using="gin"),
+    )
+    id: Mapped[str] = mapped_column(String(30))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    author_id: Mapped[str] = mapped_column(String(30))
+    author_username: Mapped[str] = mapped_column(String(50))
+    text: Mapped[str] = mapped_column(Text)
+    symbols_mentioned: Mapped[list[str] | None] = mapped_column(ARRAY(String(10)))
+    retweet_count: Mapped[int] = mapped_column(Integer, default=0)
+    like_count: Mapped[int] = mapped_column(Integer, default=0)
+    reply_count: Mapped[int] = mapped_column(Integer, default=0)
+    quote_count: Mapped[int] = mapped_column(Integer, default=0)
+    is_retweet: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_reply: Mapped[bool] = mapped_column(Boolean, default=False)
+    urls: Mapped[list[str] | None] = mapped_column(ARRAY(Text))
+    raw_data: Mapped[dict | None] = mapped_column(JSONB)
+    sentiment: Mapped[float | None] = mapped_column(Float)
+    trading_relevance: Mapped[float | None] = mapped_column(Float)
+```
+
+Add `"tweets": "created_at"` to HYPERTABLES.
+
+### Step 6: Store + Alerts + Poller (`apis/x/store.py`, `alerts.py`, `poller.py`)
+
+- **store.py**: Upsert Tweet → TweetRecord, dedup by tweet ID
+- **alerts.py**: `send_vip_tweet_alert(tweet, label, config)` — Discord embed with tweet text, symbols, engagement, link
+- **poller.py**: `poll_tracked_accounts(settings)` — for each account: get since_id from DB → fetch new → store → alert VIPs
+
+### Step 7: CLI Commands (`cli.py`)
+
+```
+rainier x fetch <tweet_id>          # fetch + display single tweet
+rainier x poll                      # one-shot poll all tracked accounts
+rainier x poll --dry-run            # fetch without storing/alerting
+rainier x track                     # show tracked accounts + last tweet time
+```
+
+### Step 8: Scheduler (`scheduler/service.py`)
+
+Add X poll job in `build_scheduler()`:
+```python
+if settings.apis.x.enabled and settings.x_api_bearer_token:
+    scheduler.add_job(run_x_poll, CronTrigger(
+        day_of_week="mon-fri", hour="6-17",
+        minute=f"*/{settings.apis.x.poll_interval_minutes}",
+    ), id="x_api_poll")
+```
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/rainier/core/config.py` | Add `ApisConfig`, `XApiConfig`, `XTrackedAccount`; add `apis` to Settings + `load_settings()` |
+| `src/rainier/core/models.py` | Add `TweetRecord` + HYPERTABLES entry |
+| `src/rainier/cli.py` | Add `x` command group |
+| `src/rainier/scheduler/service.py` | Add `run_x_poll()` job |
+| `config/settings.yaml` | Add `apis.x` section |
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `src/rainier/apis/__init__.py` | Exports ApiClient |
+| `src/rainier/apis/base.py` | Generic ApiClient (httpx, rate limit, retry) |
+| `src/rainier/apis/x/__init__.py` | Exports XClient, Tweet |
+| `src/rainier/apis/x/types.py` | Tweet, TweetMetrics, XUser dataclasses |
+| `src/rainier/apis/x/client.py` | XClient(ApiClient) — X API v2 |
+| `src/rainier/apis/x/store.py` | DB upsert logic |
+| `src/rainier/apis/x/alerts.py` | Discord VIP tweet alerts |
+| `src/rainier/apis/x/poller.py` | Poll orchestration |
+| `tests/test_x_client.py` | Unit tests (mocked httpx) |
+
+## Verification
+
+1. `uv run pytest tests/test_x_client.py -v` — mock API responses, test parsing
+2. `uv run rainier x fetch 2043237287644070186` — fetch Ming-Chi Kuo's tweet (needs bearer token in .env)
+3. `uv run rainier x poll --dry-run` — test polling without persistence
+4. `uv run rainier x poll` — full poll with DB + Discord
+5. `uv run ruff check src/rainier/apis/`

--- a/src/rainier/apis/__init__.py
+++ b/src/rainier/apis/__init__.py
@@ -1,0 +1,5 @@
+"""Reusable API client infrastructure for external data sources."""
+
+from rainier.apis.base import ApiClient, ApiError
+
+__all__ = ["ApiClient", "ApiError"]

--- a/src/rainier/apis/base.py
+++ b/src/rainier/apis/base.py
@@ -1,0 +1,145 @@
+"""Generic HTTP API client with auth, rate limiting, and retries."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Self
+
+import httpx
+import structlog
+
+log = structlog.get_logger()
+
+
+class ApiError(Exception):
+    """Raised when an API request fails after retries."""
+
+    def __init__(self, status_code: int, message: str, url: str = "") -> None:
+        self.status_code = status_code
+        self.url = url
+        super().__init__(f"HTTP {status_code}: {message} ({url})")
+
+
+class ApiClient:
+    """Generic HTTP API client with auth, rate limiting, and retries.
+
+    Subclasses set base_url/headers and add domain-specific methods.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        headers: dict[str, str] | None = None,
+        rate_limit_delay: float = 0.0,
+        timeout: float = 30.0,
+        max_retries: int = 3,
+    ) -> None:
+        self._client = httpx.Client(
+            base_url=base_url,
+            headers=headers or {},
+            timeout=timeout,
+        )
+        self._rate_limit_delay = rate_limit_delay
+        self._max_retries = max_retries
+        self._last_request_time: float = 0.0
+        self._log = log.bind(client=self.__class__.__name__)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    # -- Public convenience methods ------------------------------------------
+
+    def get(self, path: str, params: dict[str, Any] | None = None) -> dict:
+        """GET request, returns parsed JSON."""
+        return self._request("GET", path, params=params)
+
+    def post(self, path: str, json: dict[str, Any] | None = None) -> dict:
+        """POST request, returns parsed JSON."""
+        return self._request("POST", path, json=json)
+
+    # -- Internal ------------------------------------------------------------
+
+    def _throttle(self) -> None:
+        """Enforce minimum delay between requests."""
+        if self._rate_limit_delay <= 0:
+            return
+        elapsed = time.monotonic() - self._last_request_time
+        if elapsed < self._rate_limit_delay:
+            sleep_for = self._rate_limit_delay - elapsed
+            self._log.debug("rate_limit_throttle", sleep_seconds=round(sleep_for, 2))
+            time.sleep(sleep_for)
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> dict:
+        """Send request with throttle, retry on 5xx, and 429 handling."""
+        last_exc: Exception | None = None
+
+        for attempt in range(1, self._max_retries + 1):
+            self._throttle()
+            self._last_request_time = time.monotonic()
+
+            try:
+                resp = self._client.request(method, path, **kwargs)
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                self._log.warning(
+                    "request_error", attempt=attempt, path=path, error=str(exc),
+                )
+                time.sleep(2 ** attempt)
+                continue
+
+            # Rate limited — honour Retry-After or x-rate-limit-reset
+            if resp.status_code == 429:
+                retry_after = self._parse_retry_after(resp)
+                self._log.warning(
+                    "rate_limited", attempt=attempt, path=path, retry_after=retry_after,
+                )
+                time.sleep(retry_after)
+                continue
+
+            # Server error — retry with backoff
+            if resp.status_code >= 500:
+                self._log.warning(
+                    "server_error", attempt=attempt, path=path, status=resp.status_code,
+                )
+                last_exc = ApiError(resp.status_code, resp.text, path)
+                time.sleep(2 ** attempt)
+                continue
+
+            # Client error — don't retry
+            if resp.status_code >= 400:
+                raise ApiError(resp.status_code, resp.text, path)
+
+            return resp.json()
+
+        # Exhausted retries
+        if last_exc:
+            raise last_exc
+        raise ApiError(0, "max retries exhausted", path)
+
+    @staticmethod
+    def _parse_retry_after(resp: httpx.Response) -> float:
+        """Extract wait time from rate-limit headers."""
+        # Standard Retry-After header (seconds)
+        retry_after = resp.headers.get("retry-after")
+        if retry_after:
+            try:
+                return float(retry_after)
+            except ValueError:
+                pass
+
+        # X/Twitter: x-rate-limit-reset (unix timestamp)
+        reset_ts = resp.headers.get("x-rate-limit-reset")
+        if reset_ts:
+            try:
+                wait = float(reset_ts) - time.time()
+                return max(wait, 1.0)
+            except ValueError:
+                pass
+
+        return 60.0  # conservative default

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,202 @@
+"""Tests for the generic ApiClient base class."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from rainier.apis.base import ApiClient, ApiError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_response():
+    """Factory for mock httpx.Response objects."""
+    def _make(status_code: int = 200, json_data: dict | None = None, headers: dict | None = None):
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = status_code
+        resp.json.return_value = json_data or {}
+        resp.text = str(json_data or {})
+        resp.headers = headers or {}
+        return resp
+    return _make
+
+
+@pytest.fixture
+def client():
+    """ApiClient with rate limiting disabled for fast tests."""
+    c = ApiClient(
+        base_url="https://api.example.com",
+        headers={"Authorization": "Bearer test"},
+        rate_limit_delay=0.0,
+        max_retries=3,
+    )
+    yield c
+    c.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestApiClientInit:
+    def test_context_manager(self):
+        with ApiClient(base_url="https://example.com") as client:
+            assert client is not None
+
+    def test_default_params(self):
+        client = ApiClient(base_url="https://example.com")
+        assert client._rate_limit_delay == 0.0
+        assert client._max_retries == 3
+        client.close()
+
+
+class TestSuccessfulRequests:
+    def test_get_returns_json(self, client, mock_response):
+        expected = {"data": {"id": "123", "text": "hello"}}
+        with patch.object(client._client, "request", return_value=mock_response(200, expected)):
+            result = client.get("/tweets/123")
+        assert result == expected
+
+    def test_post_returns_json(self, client, mock_response):
+        expected = {"ok": True}
+        with patch.object(client._client, "request", return_value=mock_response(200, expected)):
+            result = client.post("/endpoint", json={"key": "value"})
+        assert result == expected
+
+    def test_get_with_params(self, client, mock_response):
+        expected = {"data": []}
+        resp = mock_response(200, expected)
+        with patch.object(client._client, "request", return_value=resp) as mock_req:
+            client.get("/search", params={"q": "test"})
+            mock_req.assert_called_once_with("GET", "/search", params={"q": "test"})
+
+
+class TestClientErrors:
+    def test_4xx_raises_api_error(self, client, mock_response):
+        with patch.object(
+            client._client, "request",
+            return_value=mock_response(401, {"error": "unauthorized"}),
+        ):
+            with pytest.raises(ApiError) as exc_info:
+                client.get("/protected")
+            assert exc_info.value.status_code == 401
+
+    def test_404_raises_api_error(self, client, mock_response):
+        with patch.object(
+            client._client, "request",
+            return_value=mock_response(404, {"error": "not found"}),
+        ):
+            with pytest.raises(ApiError) as exc_info:
+                client.get("/missing")
+            assert exc_info.value.status_code == 404
+
+    def test_4xx_no_retry(self, client, mock_response):
+        """Client errors should fail immediately, not retry."""
+        with patch.object(
+            client._client, "request",
+            return_value=mock_response(403, {"error": "forbidden"}),
+        ) as mock_req:
+            with pytest.raises(ApiError):
+                client.get("/forbidden")
+            assert mock_req.call_count == 1
+
+
+class TestRetries:
+    @patch("rainier.apis.base.time.sleep")
+    def test_5xx_retries_then_raises(self, mock_sleep, client, mock_response):
+        with patch.object(
+            client._client, "request",
+            return_value=mock_response(500, {"error": "server error"}),
+        ) as mock_req:
+            with pytest.raises(ApiError) as exc_info:
+                client.get("/flaky")
+            assert exc_info.value.status_code == 500
+            assert mock_req.call_count == 3
+
+    @patch("rainier.apis.base.time.sleep")
+    def test_5xx_recovers_on_second_attempt(self, mock_sleep, client, mock_response):
+        fail = mock_response(503, {"error": "unavailable"})
+        success = mock_response(200, {"data": "ok"})
+        with patch.object(client._client, "request", side_effect=[fail, success]) as mock_req:
+            result = client.get("/flaky")
+        assert result == {"data": "ok"}
+        assert mock_req.call_count == 2
+
+    @patch("rainier.apis.base.time.sleep")
+    def test_connection_error_retries(self, mock_sleep, client):
+        with patch.object(
+            client._client, "request",
+            side_effect=httpx.ConnectError("connection refused"),
+        ) as mock_req:
+            with pytest.raises(httpx.ConnectError):
+                client.get("/down")
+            assert mock_req.call_count == 3
+
+
+class TestRateLimiting:
+    @patch("rainier.apis.base.time.sleep")
+    def test_429_retries_with_retry_after(self, mock_sleep, client, mock_response):
+        rate_limited = mock_response(429, {}, headers={"retry-after": "5"})
+        success = mock_response(200, {"data": "ok"})
+        with patch.object(client._client, "request", side_effect=[rate_limited, success]):
+            result = client.get("/rate-limited")
+        assert result == {"data": "ok"}
+        # Should have slept for 5 seconds (from Retry-After header)
+        mock_sleep.assert_any_call(5.0)
+
+    @patch("rainier.apis.base.time.sleep")
+    def test_429_default_wait_when_no_header(self, mock_sleep, client, mock_response):
+        rate_limited = mock_response(429, {}, headers={})
+        success = mock_response(200, {"data": "ok"})
+        with patch.object(client._client, "request", side_effect=[rate_limited, success]):
+            result = client.get("/rate-limited")
+        assert result == {"data": "ok"}
+        mock_sleep.assert_any_call(60.0)
+
+    @patch("rainier.apis.base.time.sleep")
+    def test_throttle_enforces_delay(self, mock_sleep, mock_response):
+        """Client with rate_limit_delay should sleep between requests."""
+        client = ApiClient(
+            base_url="https://example.com",
+            rate_limit_delay=16.0,
+        )
+        # Make first request (no throttle — _last_request_time is 0 in the past)
+        success = mock_response(200, {"ok": True})
+        with patch.object(client._client, "request", return_value=success):
+            client.get("/first")
+            # Second request immediately after — should trigger throttle
+            client.get("/second")
+
+        # At least one sleep call should have been made for throttling
+        assert mock_sleep.call_count >= 1
+        # The sleep duration should be close to rate_limit_delay
+        sleep_args = [call.args[0] for call in mock_sleep.call_args_list]
+        assert any(s > 10.0 for s in sleep_args), f"Expected throttle sleep >10s, got {sleep_args}"
+        client.close()
+
+
+class TestParseRetryAfter:
+    def test_retry_after_header(self):
+        resp = MagicMock()
+        resp.headers = {"retry-after": "30"}
+        assert ApiClient._parse_retry_after(resp) == 30.0
+
+    def test_x_rate_limit_reset_header(self):
+        import time as _time
+        future_ts = str(_time.time() + 120)
+        resp = MagicMock()
+        resp.headers = {"x-rate-limit-reset": future_ts}
+        wait = ApiClient._parse_retry_after(resp)
+        assert 118.0 <= wait <= 122.0  # ~120 seconds
+
+    def test_no_headers_returns_default(self):
+        resp = MagicMock()
+        resp.headers = {}
+        assert ApiClient._parse_retry_after(resp) == 60.0


### PR DESCRIPTION
## Summary
- Generic `ApiClient` base class in `src/rainier/apis/base.py` — reusable for all external API integrations
- Features: httpx wrapper, configurable auth headers, proactive rate limiting, retry on 5xx with exponential backoff, 429 handling (Retry-After + x-rate-limit-reset)
- 17 unit tests covering success, 4xx errors, retries, rate limiting, and throttle behavior
- Plan doc at `docs/x_api_client_plan.md` for the full X/Twitter integration (#49)

## Test plan
- [x] `uv run python -m pytest tests/test_api_client.py -v` — 17/17 passing
- [x] `uv run ruff check src/rainier/apis/ tests/test_api_client.py` — clean