### PR TITLE
Add X/Twitter API v2 client with types (#52)

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -144,9 +144,6 @@ apis:
       - username: mingchikuo
         label: "Ming-Chi Kuo"
         vip: true
-      - username: elonmusk
-        label: "Elon Musk"
-        vip: true
       - username: unusual_whales
         label: "Unusual Whales"
         vip: false

--- a/src/rainier/apis/x/__init__.py
+++ b/src/rainier/apis/x/__init__.py
@@ -1,0 +1,6 @@
+"""X/Twitter API v2 client for trading intelligence."""
+
+from rainier.apis.x.client import XClient
+from rainier.apis.x.types import Tweet, TweetMetrics, XUser
+
+__all__ = ["XClient", "Tweet", "TweetMetrics", "XUser"]

--- a/src/rainier/apis/x/client.py
+++ b/src/rainier/apis/x/client.py
@@ -1,0 +1,144 @@
+"""X/Twitter API v2 client built on the generic ApiClient."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from rainier.apis.base import ApiClient
+from rainier.apis.x.types import Tweet, TweetMetrics, XUser
+
+
+class XClient(ApiClient):
+    """X/Twitter API v2 client.
+
+    Uses Bearer Token authentication (app-only).
+    Free tier allows ~1 request per 15 seconds.
+    """
+
+    TWEET_FIELDS = "created_at,public_metrics,entities,referenced_tweets"
+    USER_FIELDS = "id,name,username,public_metrics"
+
+    def __init__(self, bearer_token: str, rate_limit_delay: float = 16.0) -> None:
+        super().__init__(
+            base_url="https://api.twitter.com/2",
+            headers={"Authorization": f"Bearer {bearer_token}"},
+            rate_limit_delay=rate_limit_delay,
+        )
+
+    # -- Public API methods --------------------------------------------------
+
+    def get_tweet(self, tweet_id: str) -> Tweet:
+        """Fetch a single tweet by ID."""
+        data = self.get(
+            f"/tweets/{tweet_id}",
+            params={"tweet.fields": self.TWEET_FIELDS},
+        )
+        return self._parse_tweet(data["data"])
+
+    def get_user_by_username(self, username: str) -> XUser:
+        """Resolve a username to a user profile."""
+        data = self.get(
+            f"/users/by/username/{username}",
+            params={"user.fields": self.USER_FIELDS},
+        )
+        return self._parse_user(data["data"])
+
+    def get_user_tweets(
+        self,
+        user_id: str,
+        *,
+        max_results: int = 10,
+        since_id: str | None = None,
+    ) -> list[Tweet]:
+        """Fetch recent tweets from a user's timeline.
+
+        Args:
+            user_id: The user's numeric ID.
+            max_results: Number of tweets to return (5-100).
+            since_id: Only return tweets newer than this ID (for incremental polling).
+        """
+        params: dict[str, str | int] = {
+            "tweet.fields": self.TWEET_FIELDS,
+            "max_results": max(5, min(max_results, 100)),
+        }
+        if since_id:
+            params["since_id"] = since_id
+
+        data = self.get(f"/users/{user_id}/tweets", params=params)
+
+        # API returns {"meta": {"result_count": 0}} when no new tweets
+        tweets_data = data.get("data", [])
+        return [self._parse_tweet(t) for t in tweets_data]
+
+    def search_recent(self, query: str, max_results: int = 10) -> list[Tweet]:
+        """Search recent tweets (last 7 days).
+
+        Useful for cashtag searches like '$AAPL' or '$TSLA'.
+        """
+        params: dict[str, str | int] = {
+            "query": query,
+            "tweet.fields": self.TWEET_FIELDS,
+            "max_results": max(10, min(max_results, 100)),
+        }
+        data = self.get("/tweets/search/recent", params=params)
+        tweets_data = data.get("data", [])
+        return [self._parse_tweet(t) for t in tweets_data]
+
+    # -- Parsing helpers -----------------------------------------------------
+
+    @staticmethod
+    def _parse_tweet(data: dict) -> Tweet:
+        """Parse an X API v2 tweet object into our Tweet dataclass."""
+        # Public metrics
+        pm = data.get("public_metrics", {})
+        metrics = TweetMetrics(
+            retweet_count=pm.get("retweet_count", 0),
+            reply_count=pm.get("reply_count", 0),
+            like_count=pm.get("like_count", 0),
+            quote_count=pm.get("quote_count", 0),
+        )
+
+        # Extract $CASHTAG symbols from entities
+        entities = data.get("entities", {})
+        cashtags = entities.get("cashtags", [])
+        symbols = [ct["tag"].upper() for ct in cashtags]
+
+        # Extract URLs
+        url_entities = entities.get("urls", [])
+        urls = [u.get("expanded_url", u.get("url", "")) for u in url_entities]
+
+        # Referenced tweets (retweet / reply detection)
+        refs = data.get("referenced_tweets") or []
+        is_retweet = any(r.get("type") == "retweeted" for r in refs)
+        is_reply = any(r.get("type") == "replied_to" for r in refs)
+        ref_id = refs[0]["id"] if refs else None
+
+        # Parse created_at (ISO 8601)
+        created_at = datetime.fromisoformat(
+            data["created_at"].replace("Z", "+00:00")
+        )
+
+        return Tweet(
+            id=data["id"],
+            text=data["text"],
+            author_id=data.get("author_id", ""),
+            author_username=data.get("author_username", ""),
+            created_at=created_at,
+            metrics=metrics,
+            symbols_mentioned=symbols,
+            urls=urls,
+            is_retweet=is_retweet,
+            is_reply=is_reply,
+            referenced_tweet_id=ref_id,
+        )
+
+    @staticmethod
+    def _parse_user(data: dict) -> XUser:
+        """Parse an X API v2 user object into our XUser dataclass."""
+        pm = data.get("public_metrics", {})
+        return XUser(
+            id=data["id"],
+            username=data["username"],
+            name=data["name"],
+            followers_count=pm.get("followers_count", 0),
+        )

--- a/src/rainier/apis/x/types.py
+++ b/src/rainier/apis/x/types.py
@@ -1,0 +1,43 @@
+"""Data types for X/Twitter API v2 responses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass(frozen=True, slots=True)
+class TweetMetrics:
+    """Public engagement metrics for a tweet."""
+
+    retweet_count: int = 0
+    reply_count: int = 0
+    like_count: int = 0
+    quote_count: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class Tweet:
+    """A single tweet from the X API v2."""
+
+    id: str  # snowflake ID as string (exceeds 2^53)
+    text: str
+    author_id: str
+    author_username: str
+    created_at: datetime
+    metrics: TweetMetrics = field(default_factory=TweetMetrics)
+    symbols_mentioned: list[str] = field(default_factory=list)  # from $CASHTAG entities
+    urls: list[str] = field(default_factory=list)
+    is_retweet: bool = False
+    is_reply: bool = False
+    referenced_tweet_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class XUser:
+    """An X/Twitter user profile."""
+
+    id: str
+    username: str
+    name: str
+    followers_count: int = 0

--- a/tests/test_x_client.py
+++ b/tests/test_x_client.py
@@ -1,0 +1,342 @@
+"""Tests for X/Twitter API v2 client."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from rainier.apis.base import ApiError
+from rainier.apis.x.client import XClient
+
+# ---------------------------------------------------------------------------
+# Sample API responses (matching X API v2 format)
+# ---------------------------------------------------------------------------
+
+SAMPLE_TWEET_RESPONSE = {
+    "data": {
+        "id": "2043237287644070186",
+        "text": "$AAPL supply chain update: key supplier ramping production for new iPhone",
+        "author_id": "12345678",
+        "created_at": "2026-04-12T08:30:00.000Z",
+        "public_metrics": {
+            "retweet_count": 1500,
+            "reply_count": 200,
+            "like_count": 5000,
+            "quote_count": 300,
+        },
+        "entities": {
+            "cashtags": [{"start": 0, "end": 5, "tag": "AAPL"}],
+            "urls": [
+                {
+                    "url": "https://t.co/abc123",
+                    "expanded_url": "https://example.com/article",
+                }
+            ],
+        },
+        "referenced_tweets": None,
+    }
+}
+
+SAMPLE_RETWEET_RESPONSE = {
+    "data": {
+        "id": "9999999999",
+        "text": "RT @someone: Great analysis",
+        "author_id": "12345678",
+        "created_at": "2026-04-12T09:00:00.000Z",
+        "public_metrics": {
+            "retweet_count": 0,
+            "reply_count": 0,
+            "like_count": 0,
+            "quote_count": 0,
+        },
+        "entities": {},
+        "referenced_tweets": [{"type": "retweeted", "id": "8888888888"}],
+    }
+}
+
+SAMPLE_REPLY_RESPONSE = {
+    "data": {
+        "id": "7777777777",
+        "text": "@someone I agree with this take on $TSLA",
+        "author_id": "12345678",
+        "created_at": "2026-04-12T10:00:00.000Z",
+        "public_metrics": {
+            "retweet_count": 5,
+            "reply_count": 1,
+            "like_count": 20,
+            "quote_count": 0,
+        },
+        "entities": {
+            "cashtags": [{"start": 35, "end": 40, "tag": "TSLA"}],
+        },
+        "referenced_tweets": [{"type": "replied_to", "id": "6666666666"}],
+    }
+}
+
+SAMPLE_USER_RESPONSE = {
+    "data": {
+        "id": "12345678",
+        "username": "mingchikuo",
+        "name": "Ming-Chi Kuo",
+        "public_metrics": {
+            "followers_count": 500000,
+            "following_count": 100,
+            "tweet_count": 3000,
+            "listed_count": 5000,
+        },
+    }
+}
+
+SAMPLE_TIMELINE_RESPONSE = {
+    "data": [
+        SAMPLE_TWEET_RESPONSE["data"],
+        SAMPLE_RETWEET_RESPONSE["data"],
+    ],
+    "meta": {"result_count": 2, "newest_id": "2043237287644070186"},
+}
+
+SAMPLE_TIMELINE_EMPTY = {
+    "meta": {"result_count": 0},
+}
+
+SAMPLE_SEARCH_RESPONSE = {
+    "data": [SAMPLE_TWEET_RESPONSE["data"]],
+    "meta": {"result_count": 1},
+}
+
+SAMPLE_MULTI_CASHTAG = {
+    "data": {
+        "id": "5555555555",
+        "text": "Comparing $AAPL vs $MSFT vs $GOOGL earnings",
+        "author_id": "12345678",
+        "created_at": "2026-04-12T11:00:00.000Z",
+        "public_metrics": {
+            "retweet_count": 100,
+            "reply_count": 50,
+            "like_count": 800,
+            "quote_count": 25,
+        },
+        "entities": {
+            "cashtags": [
+                {"start": 10, "end": 15, "tag": "AAPL"},
+                {"start": 20, "end": 25, "tag": "MSFT"},
+                {"start": 30, "end": 36, "tag": "GOOGL"},
+            ],
+        },
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    """XClient with rate limiting disabled for fast tests."""
+    c = XClient(bearer_token="test_token", rate_limit_delay=0.0)
+    yield c
+    c.close()
+
+
+def _mock_response(status_code: int = 200, json_data: dict | None = None):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.text = str(json_data or {})
+    resp.headers = {}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Tests: Tweet parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseTweet:
+    def test_parse_basic_tweet(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_TWEET_RESPONSE),
+        ):
+            tweet = client.get_tweet("2043237287644070186")
+
+        assert tweet.id == "2043237287644070186"
+        assert "$AAPL" not in tweet.text or "AAPL" in tweet.text
+        assert tweet.author_id == "12345678"
+        assert tweet.created_at == datetime(2026, 4, 12, 8, 30, tzinfo=timezone.utc)
+        assert tweet.is_retweet is False
+        assert tweet.is_reply is False
+        assert tweet.referenced_tweet_id is None
+
+    def test_parse_cashtag_symbols(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_TWEET_RESPONSE),
+        ):
+            tweet = client.get_tweet("2043237287644070186")
+
+        assert tweet.symbols_mentioned == ["AAPL"]
+
+    def test_parse_multiple_cashtags(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_MULTI_CASHTAG),
+        ):
+            tweet = client.get_tweet("5555555555")
+
+        assert tweet.symbols_mentioned == ["AAPL", "MSFT", "GOOGL"]
+
+    def test_parse_metrics(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_TWEET_RESPONSE),
+        ):
+            tweet = client.get_tweet("2043237287644070186")
+
+        assert tweet.metrics.like_count == 5000
+        assert tweet.metrics.retweet_count == 1500
+        assert tweet.metrics.reply_count == 200
+        assert tweet.metrics.quote_count == 300
+
+    def test_parse_urls(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_TWEET_RESPONSE),
+        ):
+            tweet = client.get_tweet("2043237287644070186")
+
+        assert tweet.urls == ["https://example.com/article"]
+
+    def test_parse_retweet(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_RETWEET_RESPONSE),
+        ):
+            tweet = client.get_tweet("9999999999")
+
+        assert tweet.is_retweet is True
+        assert tweet.is_reply is False
+        assert tweet.referenced_tweet_id == "8888888888"
+
+    def test_parse_reply(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_REPLY_RESPONSE),
+        ):
+            tweet = client.get_tweet("7777777777")
+
+        assert tweet.is_reply is True
+        assert tweet.is_retweet is False
+        assert tweet.referenced_tweet_id == "6666666666"
+        assert tweet.symbols_mentioned == ["TSLA"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: User parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseUser:
+    def test_parse_user(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_USER_RESPONSE),
+        ):
+            user = client.get_user_by_username("mingchikuo")
+
+        assert user.id == "12345678"
+        assert user.username == "mingchikuo"
+        assert user.name == "Ming-Chi Kuo"
+        assert user.followers_count == 500000
+
+
+# ---------------------------------------------------------------------------
+# Tests: Timeline
+# ---------------------------------------------------------------------------
+
+
+class TestTimeline:
+    def test_get_user_tweets(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_TIMELINE_RESPONSE),
+        ):
+            tweets = client.get_user_tweets("12345678")
+
+        assert len(tweets) == 2
+        assert tweets[0].id == "2043237287644070186"
+        assert tweets[1].is_retweet is True
+
+    def test_empty_timeline(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_TIMELINE_EMPTY),
+        ):
+            tweets = client.get_user_tweets("12345678")
+
+        assert tweets == []
+
+    def test_since_id_passed(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_TIMELINE_EMPTY),
+        ) as mock_req:
+            client.get_user_tweets("12345678", since_id="999")
+
+        call_kwargs = mock_req.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        assert params["since_id"] == "999"
+
+    def test_max_results_clamped(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_TIMELINE_EMPTY),
+        ) as mock_req:
+            client.get_user_tweets("12345678", max_results=1)
+
+        call_kwargs = mock_req.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        assert params["max_results"] == 5  # clamped to minimum
+
+
+# ---------------------------------------------------------------------------
+# Tests: Search
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    def test_search_recent(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(200, SAMPLE_SEARCH_RESPONSE),
+        ):
+            tweets = client.search_recent("$AAPL")
+
+        assert len(tweets) == 1
+        assert tweets[0].symbols_mentioned == ["AAPL"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Auth + errors
+# ---------------------------------------------------------------------------
+
+
+class TestAuth:
+    def test_bearer_token_in_headers(self):
+        client = XClient(bearer_token="my_secret_token", rate_limit_delay=0.0)
+        assert client._client.headers["authorization"] == "Bearer my_secret_token"
+        client.close()
+
+    def test_401_raises_api_error(self, client):
+        with patch.object(
+            client._client, "request",
+            return_value=_mock_response(401, {"error": "Unauthorized"}),
+        ):
+            with pytest.raises(ApiError) as exc_info:
+                client.get_tweet("123")
+            assert exc_info.value.status_code == 401


### PR DESCRIPTION
## Summary
- `XClient(ApiClient)` in `apis/x/client.py` — wraps X API v2 endpoints: `get_tweet`, `get_user_by_username`, `get_user_tweets` (with `since_id` for incremental polling), `search_recent`
- `Tweet`, `TweetMetrics`, `XUser` dataclasses in `apis/x/types.py` — parses `$CASHTAG` entities into `symbols_mentioned` for trading signal extraction
- Handles `referenced_tweets` being `None` (X API quirk)
- Removes `elonmusk` from default tracked accounts

## Test plan
- [x] `uv run python -m pytest tests/test_x_client.py -v` — 15/15 passing
- [x] `uv run ruff check src/rainier/apis/x/ tests/test_x_client.py` — clean
- [x] Tests cover: tweet parsing, cashtag extraction, multi-cashtag, metrics, URLs, retweet/reply detection, user parsing, timeline, empty timeline, since_id, max_results clamping, search, auth headers, 401 errors