### PR TITLE
Recover QU scraper from Chrome CDP version skew

### DIFF
--- a/scripts/ensure-chrome.sh
+++ b/scripts/ensure-chrome.sh
@@ -1,38 +1,77 @@
 #!/bin/bash
 # Ensure Chrome is running with remote debugging for CDP scraping.
-# Starts Chrome only if not already listening on port 9222.
-# Chrome stays running between scrapes to preserve the login session.
+#
+# Restarts Chrome if:
+#   - it is not currently listening on the debug port, OR
+#   - the running process's Chrome version differs from the on-disk binary
+#     (this happens when Chrome auto-updates in place while the process
+#     keeps running — the version skew breaks CDP context management
+#     on newer Playwright versions), OR
+#   - --force is passed (used by the scraper's CDP-connect retry path).
+#
+# Chrome otherwise stays running between scrapes to preserve the login session.
 
 CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 PORT=9222
 PROFILE="/tmp/chrome-debug-profile"
+FORCE=0
 
-# Check if Chrome is already listening on the debug port
-if curl -s "http://127.0.0.1:$PORT/json/version" > /dev/null 2>&1; then
-    echo "Chrome already running on port $PORT"
-    exit 0
+[ "$1" = "--force" ] && FORCE=1
+
+extract_version() {
+    echo "$1" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1
+}
+
+is_running() {
+    curl -s "http://127.0.0.1:$PORT/json/version" > /dev/null 2>&1
+}
+
+kill_chrome() {
+    pkill -f "remote-debugging-port=$PORT" 2>/dev/null
+    for i in $(seq 1 10); do
+        sleep 1
+        is_running || return 0
+    done
+    return 1
+}
+
+start_chrome() {
+    rm -f "$PROFILE/SingletonLock" 2>/dev/null
+    # Headed mode is required to pass Cloudflare bot challenges.
+    # On macOS the window opens but stays in the background.
+    "$CHROME" \
+        --remote-debugging-port=$PORT \
+        --user-data-dir="$PROFILE" \
+        --no-first-run \
+        >/dev/null 2>&1 &
+    for i in $(seq 1 15); do
+        is_running && return 0
+        sleep 1
+    done
+    return 1
+}
+
+if is_running; then
+    if [ "$FORCE" -eq 1 ]; then
+        echo "Force restart requested — stopping Chrome on port $PORT"
+        kill_chrome || { echo "ERROR: Chrome failed to stop"; exit 1; }
+    else
+        RUN_INFO=$(curl -s "http://127.0.0.1:$PORT/json/version" 2>/dev/null)
+        RUN_VER=$(extract_version "$(echo "$RUN_INFO" | grep Browser)")
+        BIN_VER=$(extract_version "$("$CHROME" --version 2>/dev/null)")
+        if [ -n "$RUN_VER" ] && [ -n "$BIN_VER" ] && [ "$RUN_VER" = "$BIN_VER" ]; then
+            echo "Chrome already running on port $PORT (version $RUN_VER)"
+            exit 0
+        fi
+        echo "Chrome version skew (running=$RUN_VER, binary=$BIN_VER) — restarting"
+        kill_chrome || { echo "ERROR: Chrome failed to stop"; exit 1; }
+    fi
 fi
 
-# Clean up stale state if Chrome crashed
-rm -f "$PROFILE/SingletonLock" 2>/dev/null
-
-# Start Chrome in background WITHOUT --headless.
-# Headed mode is required to pass Cloudflare bot challenges.
-# On macOS the window opens but stays in the background.
-"$CHROME" \
-    --remote-debugging-port=$PORT \
-    --user-data-dir="$PROFILE" \
-    --no-first-run \
-    >/dev/null 2>&1 &
-
-# Wait for Chrome to be ready (up to 15 seconds)
-for i in $(seq 1 15); do
-    if curl -s "http://127.0.0.1:$PORT/json/version" > /dev/null 2>&1; then
-        echo "Chrome started on port $PORT"
-        exit 0
-    fi
-    sleep 1
-done
+if start_chrome; then
+    echo "Chrome started on port $PORT"
+    exit 0
+fi
 
 echo "ERROR: Chrome failed to start on port $PORT"
 exit 1

--- a/src/rainier/scrapers/browser.py
+++ b/src/rainier/scrapers/browser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from contextlib import asynccontextmanager
@@ -14,6 +15,8 @@ from playwright.async_api import Browser, BrowserContext, Page, async_playwright
 from rainier.core.config import get_settings
 
 log = structlog.get_logger()
+
+ENSURE_CHROME_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "ensure-chrome.sh"
 
 
 class BrowserManager:
@@ -62,7 +65,14 @@ class BrowserManager:
         self._playwright = await async_playwright().start()
 
         if self._cdp_url:
-            self._browser = await self._playwright.chromium.connect_over_cdp(self._cdp_url)
+            try:
+                self._browser = await self._playwright.chromium.connect_over_cdp(self._cdp_url)
+            except Exception as e:
+                # Chrome can get into a bad CDP state after auto-updating in place
+                # or sitting idle for days. Force-restart it once and retry.
+                log.warning("cdp_connect_failed_restarting_chrome", error=str(e))
+                await self._force_restart_chrome()
+                self._browser = await self._playwright.chromium.connect_over_cdp(self._cdp_url)
             self._is_cdp = True
             log.info("browser_connected_cdp", url=self._cdp_url)
         else:
@@ -71,6 +81,23 @@ class BrowserManager:
             )
             self._is_cdp = False
             log.info("browser_started", headless=self._headless)
+
+    @staticmethod
+    async def _force_restart_chrome() -> None:
+        """Kill and relaunch the local debug Chrome via ensure-chrome.sh --force."""
+        if not ENSURE_CHROME_SCRIPT.exists():
+            raise RuntimeError(f"ensure-chrome.sh not found at {ENSURE_CHROME_SCRIPT}")
+        proc = await asyncio.create_subprocess_exec(
+            str(ENSURE_CHROME_SCRIPT),
+            "--force",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await proc.communicate()
+        output = stdout.decode(errors="replace").strip()
+        if proc.returncode != 0:
+            raise RuntimeError(f"Chrome force-restart failed: {output}")
+        log.info("chrome_force_restarted", output=output)
 
     async def stop(self) -> None:
         """Close/disconnect the browser and Playwright."""

--- a/tests/test_scrapers/test_browser.py
+++ b/tests/test_scrapers/test_browser.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import os
 import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from rainier.scrapers.browser import BrowserManager
 
@@ -45,3 +48,62 @@ class TestIsSessionValid:
         p = tmp_path / "session.json"
         p.write_text("{}")
         assert BrowserManager.is_session_valid(p, ttl_hours=0) is False
+
+
+def _mock_playwright(connect_side_effect):
+    """Build a patched async_playwright() whose chromium.connect_over_cdp uses the given side effect."""
+    mock_chromium = MagicMock()
+    mock_chromium.connect_over_cdp = AsyncMock(side_effect=connect_side_effect)
+    mock_pw = MagicMock()
+    mock_pw.chromium = mock_chromium
+    mock_pw_factory = MagicMock()
+    mock_pw_factory.start = AsyncMock(return_value=mock_pw)
+    return mock_pw_factory, mock_chromium
+
+
+class TestCDPConnectRetry:
+    """start() force-restarts Chrome and retries once if connect_over_cdp fails."""
+
+    async def test_retries_after_force_restart(self):
+        mock_browser = MagicMock()
+        factory, chromium = _mock_playwright(
+            [RuntimeError("Browser.setDownloadBehavior: not supported"), mock_browser]
+        )
+        with (
+            patch("rainier.scrapers.browser.async_playwright", return_value=factory),
+            patch.object(BrowserManager, "_force_restart_chrome", new=AsyncMock()) as restart,
+        ):
+            bm = BrowserManager(cdp_url="http://localhost:9222")
+            await bm.start()
+
+        assert bm._browser is mock_browser
+        assert bm._is_cdp is True
+        assert chromium.connect_over_cdp.await_count == 2
+        restart.assert_awaited_once()
+
+    async def test_second_failure_propagates(self):
+        factory, chromium = _mock_playwright(RuntimeError("still broken"))
+        with (
+            patch("rainier.scrapers.browser.async_playwright", return_value=factory),
+            patch.object(BrowserManager, "_force_restart_chrome", new=AsyncMock()) as restart,
+        ):
+            bm = BrowserManager(cdp_url="http://localhost:9222")
+            with pytest.raises(RuntimeError, match="still broken"):
+                await bm.start()
+
+        assert chromium.connect_over_cdp.await_count == 2
+        restart.assert_awaited_once()
+
+    async def test_happy_path_no_restart(self):
+        mock_browser = MagicMock()
+        factory, chromium = _mock_playwright([mock_browser])
+        with (
+            patch("rainier.scrapers.browser.async_playwright", return_value=factory),
+            patch.object(BrowserManager, "_force_restart_chrome", new=AsyncMock()) as restart,
+        ):
+            bm = BrowserManager(cdp_url="http://localhost:9222")
+            await bm.start()
+
+        assert bm._browser is mock_browser
+        assert chromium.connect_over_cdp.await_count == 1
+        restart.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Today's four QU100 scheduled scrapes (morning/midday/afternoon/close) all failed with `BrowserType.connect_over_cdp: Protocol error (Browser.setDownloadBehavior): Browser context management is not supported.`
- Root cause: Chrome had been running for 2+ days against `--user-data-dir=/tmp/chrome-debug-profile`. During that window Chrome auto-updated the binary on disk (147.0.7727.56 → .101) while the running process kept the old version loaded. Playwright 1.58's CDP connect issues a browser-level `Browser.setDownloadBehavior` call, and that rejects on the skewed process.
- Two defenses: the cron preflight detects the skew ahead of time, and the scraper's own CDP connect retries once after a forced restart.

## Changes
- `scripts/ensure-chrome.sh`: compare the running process's Chrome version (from `/json/version`) against the on-disk binary (from `--version`). Restart if they differ. Added `--force` for unconditional restart.
- `src/rainier/scrapers/browser.py`: wrap `connect_over_cdp` in try/except — on failure, call `ensure-chrome.sh --force` via `asyncio.create_subprocess_exec` and retry once. A second failure propagates.

## Test plan
- [x] `bash -n scripts/ensure-chrome.sh` — syntax clean
- [x] `scripts/ensure-chrome.sh` against matching-version Chrome: no-op
- [x] `python -m pytest tests/test_scrapers/` — 50/50 pass
- [x] Live end-to-end: ran `rainier scrape qu --session close --cdp http://127.0.0.1:9222` after manual Chrome restart — 200 records in 17s
- [ ] Next scheduled cron run (tomorrow 08:45 PT) exercises the preflight against the freshly-started Chrome