### PR TITLE
fix: wait for antd spinner to clear before QU100 toggle clicks

### DIFF
--- a/src/rainier/scrapers/qu/scraper.py
+++ b/src/rainier/scrapers/qu/scraper.py
@@ -314,6 +314,11 @@ class QUScraper(BaseScraper):
                 except Exception:
                     pass
 
+                # The previous Search click leaves an antd loading spinner
+                # overlaying the toggle buttons. Clicking through it makes
+                # Playwright stall on actionability checks until 30s timeout.
+                await self._wait_for_no_spinner()
+
                 # Click toggle, then Search button (required per QU100 UI)
                 await page.click(button_sel)
                 search_btn = await page.query_selector(sel.SEARCH_BUTTON)
@@ -356,6 +361,19 @@ class QUScraper(BaseScraper):
                 error_msg = f"Failed to scrape {ranking_type}: {exc}"
                 self.log.warning("qu100_failed", ranking_type=ranking_type, error=str(exc))
                 result.errors.append(error_msg)
+
+    async def _wait_for_no_spinner(self, timeout_ms: int = 10000) -> None:
+        """Wait for any antd loading spinner to disappear.
+
+        Best-effort: a stuck spinner shouldn't kill the scrape — log and continue,
+        and let the actual click surface a clearer error if the page is truly broken.
+        """
+        try:
+            await self._page.wait_for_selector(
+                ".ant-spin-spinning", state="hidden", timeout=timeout_ms
+            )
+        except Exception as exc:
+            self.log.warning("spinner_wait_timeout", error=str(exc))
 
     async def _set_date(self, date_str: str) -> None:
         """Change the date picker to the given date and trigger search."""

--- a/tests/test_scrapers/test_cdp_auth.py
+++ b/tests/test_scrapers/test_cdp_auth.py
@@ -577,3 +577,87 @@ class TestScrapeQU100PostLogin:
         # Search button was found via wait_for_selector, not query_selector
         assert sel.SEARCH_BUTTON in wait_selectors
         search_btn.click.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_no_spinner() tests
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForNoSpinner:
+    """Tests for the antd loading-spinner wait that guards toggle clicks."""
+
+    @pytest.mark.asyncio
+    async def test_waits_for_spinner_hidden(self):
+        """Calls wait_for_selector with the antd spinner selector and state='hidden'."""
+        page, _ = _make_mock_page()
+        scraper = _make_scraper()
+        scraper._page = page
+
+        await scraper._wait_for_no_spinner(timeout_ms=5000)
+
+        page.wait_for_selector.assert_awaited_once_with(
+            ".ant-spin-spinning", state="hidden", timeout=5000
+        )
+
+    @pytest.mark.asyncio
+    async def test_swallows_timeout(self):
+        """A stuck spinner must not raise — we log and continue."""
+        page, _ = _make_mock_page()
+        page.wait_for_selector = AsyncMock(side_effect=TimeoutError("spinner stuck"))
+        scraper = _make_scraper()
+        scraper._page = page
+
+        # Must not raise — the actual click will surface a clearer error if needed
+        await scraper._wait_for_no_spinner(timeout_ms=100)
+
+    @pytest.mark.asyncio
+    async def test_invoked_before_toggle_click(self):
+        """_scrape_qu100 calls _wait_for_no_spinner before each toggle click."""
+        page, _ = _make_mock_page(url="https://www.quantunicorn.com/products#qu100")
+
+        # Order trace: every page.click and every _wait_for_no_spinner call
+        events: list[str] = []
+
+        async def trace_click(target):
+            events.append(f"click:{target}")
+
+        page.click = AsyncMock(side_effect=trace_click)
+        page.wait_for_selector = AsyncMock(return_value=AsyncMock())
+        page.query_selector = AsyncMock(return_value=None)
+        page.get_attribute = AsyncMock(return_value="2026-04-09")
+        page.evaluate = AsyncMock(return_value=[
+            {"rank": "1", "symbol": "NVDA", "daily_change": "▲5",
+             "sector": "Tech", "industry": "Semi", "long_short": "多"}
+        ])
+
+        scraper = _make_scraper()
+        scraper._page = page
+
+        async def trace_spinner_wait(timeout_ms=10000):
+            events.append("spinner_wait")
+
+        from datetime import datetime, timezone
+
+        from rainier.scrapers.base import ScrapeResult
+
+        result = ScrapeResult(scraper_name="qu", started_at=datetime.now(timezone.utc))
+
+        with (
+            patch("rainier.scrapers.qu.scraper.goto_with_retry", new_callable=AsyncMock),
+            patch("rainier.scrapers.qu.scraper.login", new_callable=AsyncMock),
+            patch.object(scraper, "_persist_qu100", return_value=1),
+            patch.object(scraper, "_wait_for_no_spinner", side_effect=trace_spinner_wait),
+        ):
+            await scraper._scrape_qu100("afternoon", datetime.now(timezone.utc), result)
+
+        # Both toggle clicks must be preceded by a spinner wait
+        toggle_clicks = [
+            (i, e) for i, e in enumerate(events)
+            if e in (f"click:{sel.TOP100_BUTTON}", f"click:{sel.BOTTOM100_BUTTON}")
+        ]
+        assert len(toggle_clicks) == 2, f"Expected 2 toggle clicks, got {events}"
+        for idx, _ in toggle_clicks:
+            assert events[idx - 1] == "spinner_wait", (
+                f"Expected spinner_wait before toggle click at index {idx}, got {events}"
+            )


### PR DESCRIPTION
## Summary
- The midday QU100 scrape failed with Playwright click timeouts on the top100/bottom100 toggle: locator resolved, element visible/enabled/stable, then stuck in `scrolling into view if needed` until the 30s deadline.
- Root cause: the Search click just before the loop kicks off the antd table-loading spinner. The spinner overlay sits over the toggle buttons, so Playwright's actionability check on the next click loops forever.
- Fix: best-effort `_wait_for_no_spinner` waits for `.ant-spin-spinning` to be hidden (timeout 10s), swallowing wait failures so a stuck spinner produces a clearer downstream error rather than silently blocking the click.

## Test plan
- [x] New `TestWaitForNoSpinner` covers selector+state args, timeout swallowing, and ordering before each toggle click
- [x] Full suite green (373 passed, 1 skipped, ignoring untracked WIP ML test files)
- [x] Lint baseline unchanged (7 pre-existing E501/I001 errors on main, unchanged here)
- [ ] Verify the next QU100 scrape (afternoon session, or manual `rainier scrape qu --session morning`) returns rows