### PR TITLE
feat(llm-thesis): PR3 — auto-research + ResearchInsight + accept/reject CLI

### DIFF
--- a/migrations/0003_llm_thesis_pr3.sql
+++ b/migrations/0003_llm_thesis_pr3.sql
@@ -1,0 +1,46 @@
+-- Migration 0003 — LLM Thesis PR3 schema additions
+--
+-- Adds:
+--   * research_insights table (design Section F item 22) — auto-research
+--     findings from the weekly job. Carries kind, severity, structured
+--     action JSONB (eng review D3), recurrence_count + partial unique index
+--     for UPSERT (eng review D6).
+--
+-- Apply with:
+--   psql "$DATABASE_URL" -f migrations/0003_llm_thesis_pr3.sql
+--
+-- Idempotent: re-applying is safe.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS research_insights (
+    id                 SERIAL PRIMARY KEY,
+    created_at         TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at         TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    kind               VARCHAR(40) NOT NULL,
+    severity           VARCHAR(10) NOT NULL,
+    subject            VARCHAR(100) NOT NULL,
+    evidence           JSONB,
+    action             JSONB,
+    rationale          TEXT,
+    recurrence_count   INTEGER NOT NULL DEFAULT 1,
+    status             VARCHAR(20) NOT NULL DEFAULT 'pending',
+    decided_at         TIMESTAMP WITH TIME ZONE,
+    decided_by         VARCHAR(200),
+    applied_change     JSONB
+);
+
+CREATE INDEX IF NOT EXISTS ix_research_insights_kind
+    ON research_insights (kind);
+CREATE INDEX IF NOT EXISTS ix_research_insights_subject
+    ON research_insights (subject);
+
+-- Partial unique index — at most ONE pending row per (kind, subject) so
+-- emit_insight() can UPSERT in a single statement and the recurrence_count
+-- counter increments deterministically. Rows that move to accepted/rejected/
+-- stale fall out of the constraint, allowing a fresh pending row later.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_research_insight_pending_kind_subject
+    ON research_insights (kind, subject)
+    WHERE status = 'pending';
+
+COMMIT;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
     "scikit-learn>=1.8.0",
     # Stats — Mann-Whitney U for per-signal contribution test in eval.py
     "scipy>=1.11",
+    # Round-trip YAML for the auto-research accept handler — preserves
+    # comments + key order when ACTION_EXECUTORS mutate config/settings.yaml.
+    "ruamel.yaml>=0.18",
 ]
 
 [project.scripts]

--- a/src/rainier/alerts/discord.py
+++ b/src/rainier/alerts/discord.py
@@ -464,6 +464,111 @@ def send_eval_report(
         log.exception("discord_eval_send_failed")
 
 
+# ---------------------------------------------------------------------------
+# Weekly research report (PR3) — auto-research insight summary
+# ---------------------------------------------------------------------------
+
+
+_INSIGHT_SEVERITY_TAGS: dict[str, str] = {
+    "info": "[info]",
+    "warn": "[WARN]",
+    "critical": "[CRIT]",
+}
+
+
+def _format_research_message(
+    *,
+    eval_date: date_cls,
+    insights: list,           # [ResearchInsight]
+    severity_filter: tuple[str, ...] = ("warn", "critical"),
+) -> str:
+    """Render the weekly research report. <=1800 chars per message.
+
+    Lists pending `warn`/`critical` insights with the structured action and
+    rationale. `info` severities are excluded by default (they're suggestions,
+    not alerts) but can be opted in via the filter.
+
+    Each line includes the insight id so the operator can quickly run
+    `rainier thesis research insights accept ID` from the CLI.
+    """
+    lines: list[str] = []
+    lines.append(f"**Research report — {eval_date.isoformat()}**")
+    if not insights:
+        lines.append("No new pending warn/critical insights this week.")
+        body = "\n".join(lines)
+        return _truncate(body, 1800)
+
+    bucket: list = [
+        ins for ins in insights
+        if getattr(ins, "severity", None) in severity_filter
+        and getattr(ins, "status", "pending") == "pending"
+    ]
+    if not bucket:
+        lines.append(
+            "No new pending warn/critical insights this week."
+        )
+        body = "\n".join(lines)
+        return _truncate(body, 1800)
+
+    # Sort: critical first, then warn; within each, by recurrence_count desc
+    # so the loudest signals show first.
+    severity_order = {"critical": 0, "warn": 1, "info": 2}
+    bucket.sort(
+        key=lambda i: (
+            severity_order.get(i.severity, 99),
+            -(getattr(i, "recurrence_count", 1) or 1),
+        )
+    )
+
+    lines.append(f"{len(bucket)} pending insight(s) this week:")
+    for ins in bucket:
+        tag = _INSIGHT_SEVERITY_TAGS.get(ins.severity, ins.severity)
+        kind = ins.kind
+        subj = (ins.subject or "")[:30]
+        recur = getattr(ins, "recurrence_count", 1) or 1
+        action_kind = "noop"
+        if isinstance(ins.action, dict):
+            action_kind = str(ins.action.get("kind", "?"))
+        rationale = (ins.rationale or "").strip().replace("\n", " ")
+        if len(rationale) > 200:
+            rationale = rationale[:197] + "..."
+        recur_part = f" (x{recur})" if recur > 1 else ""
+        lines.append(
+            f"  {tag} #{ins.id} {kind} <{subj}>{recur_part} -> action={action_kind}"
+        )
+        lines.append(f"      {rationale}")
+
+    lines.append("")
+    lines.append("Review with `rainier thesis research insights list`")
+    body = "\n".join(lines)
+    return _truncate(body, 1800)
+
+
+def send_research_report(
+    *,
+    eval_date: date_cls,
+    insights: list,
+    config: DiscordConfig,
+) -> None:
+    """Post the weekly research report to Discord (stock channel, then webhook)."""
+    if not config.enabled:
+        log.debug("discord_alerts_disabled")
+        return
+    webhook_url = _resolve_webhook_url(config)
+    if not webhook_url:
+        log.warning("discord_no_webhook_url_research")
+        return
+
+    message = _format_research_message(
+        eval_date=eval_date, insights=insights,
+    )
+    try:
+        response = httpx.post(webhook_url, json={"content": message}, timeout=10)
+        response.raise_for_status()
+    except Exception:
+        log.exception("discord_research_send_failed")
+
+
 def format_stock_candidates_json(candidates: list[StockCandidate]) -> str:
     """Format candidates as JSON string for dry-run / debugging."""
     if not candidates:

--- a/src/rainier/alerts/discord.py
+++ b/src/rainier/alerts/discord.py
@@ -476,6 +476,28 @@ _INSIGHT_SEVERITY_TAGS: dict[str, str] = {
 }
 
 
+def _scrub_discord_text(text: str) -> str:
+    """Strip Discord-meaningful characters from LLM/user text rendered into
+    a webhook message.
+
+    `subject` (e.g. `new_pattern_discovered`) and `rationale` text can include
+    LLM-generated strings — an adversarial LLM could embed `@everyone`,
+    backticks, or markdown that breaks the surrounding code block.
+
+    We replace `@` with a fullwidth variant (still readable, no mention),
+    drop backticks, and collapse newlines to spaces. Cheap, no escape
+    arms-race.
+    """
+    if not text:
+        return ""
+    return (
+        text.replace("@", "＠")  # FULLWIDTH COMMERCIAL AT
+        .replace("`", "'")
+        .replace("\r", " ")
+        .replace("\n", " ")
+    )
+
+
 def _format_research_message(
     *,
     eval_date: date_cls,
@@ -524,12 +546,15 @@ def _format_research_message(
     for ins in bucket:
         tag = _INSIGHT_SEVERITY_TAGS.get(ins.severity, ins.severity)
         kind = ins.kind
-        subj = (ins.subject or "")[:30]
+        # Review iter-1 [P2]: scrub LLM-generated text (subject + rationale)
+        # before piping to Discord so an adversarial pattern name like
+        # "@everyone bad pattern" can't trigger a server-wide mention.
+        subj = _scrub_discord_text((ins.subject or "")[:30])
         recur = getattr(ins, "recurrence_count", 1) or 1
         action_kind = "noop"
         if isinstance(ins.action, dict):
             action_kind = str(ins.action.get("kind", "?"))
-        rationale = (ins.rationale or "").strip().replace("\n", " ")
+        rationale = _scrub_discord_text((ins.rationale or "").strip())
         if len(rationale) > 200:
             rationale = rationale[:197] + "..."
         recur_part = f" (x{recur})" if recur > 1 else ""

--- a/src/rainier/alerts/discord.py
+++ b/src/rainier/alerts/discord.py
@@ -353,25 +353,46 @@ def _format_eval_message(
     signal_contribs: list,         # [SignalContribution]
     p_threshold: float = 0.05,
 ) -> str:
-    """Render the Discord eval-report body. <=1800 chars per message."""
+    """Render the Discord eval-report body. <=1800 chars per message.
+
+    PR3 carry-over [P2]: when ``yesterday_rows`` mixes ``afternoon`` and
+    ``close`` sessions, render a separate header per session so the operator
+    can distinguish "afternoon scan picks" from "close scan picks". The old
+    renderer used the first row's session as a single global heading and
+    interleaved both sets of picks underneath, hiding which scan produced
+    each pick.
+    """
     lines: list[str] = []
     lines.append(f"**Eval report — {eval_date.isoformat()}**")
     if yesterday_rows:
-        scan_date = yesterday_rows[0].get("scan_date") or "(prior scan)"
-        session = yesterday_rows[0].get("session_name") or "afternoon"
-        lines.append(
-            f"Yesterday's {session} scan ({scan_date}):"
-        )
+        # Group rows by session_name preserving session insertion order. Use a
+        # plain list-of-(key, list) so the rendering stays deterministic and
+        # we don't need an OrderedDict import. Rows of unknown session collapse
+        # under the "(unknown)" bucket.
+        by_session: list[tuple[str, list[dict]]] = []
+        index: dict[str, int] = {}
         for row in yesterday_rows:
-            mark = "[HIT]" if row.get("hit") else "[miss]"
-            verdict = row.get("verdict") or "?"
-            confidence = row.get("llm_confidence")
-            sym = row.get("symbol") or "?"
-            ret = float(row.get("return_pct") or 0.0)
-            conf_part = f"({confidence}/10)" if confidence is not None else ""
-            lines.append(
-                f"  {mark} {sym:<6} {verdict:<10} {conf_part:<7} -> {ret:+.2%}"
-            )
+            sess = row.get("session_name") or "(unknown)"
+            idx = index.get(sess)
+            if idx is None:
+                index[sess] = len(by_session)
+                by_session.append((sess, [row]))
+            else:
+                by_session[idx][1].append(row)
+
+        for sess, rows in by_session:
+            scan_date = rows[0].get("scan_date") or "(prior scan)"
+            lines.append(f"Yesterday's {sess} scan ({scan_date}):")
+            for row in rows:
+                mark = "[HIT]" if row.get("hit") else "[miss]"
+                verdict = row.get("verdict") or "?"
+                confidence = row.get("llm_confidence")
+                sym = row.get("symbol") or "?"
+                ret = float(row.get("return_pct") or 0.0)
+                conf_part = f"({confidence}/10)" if confidence is not None else ""
+                lines.append(
+                    f"  {mark} {sym:<6} {verdict:<10} {conf_part:<7} -> {ret:+.2%}"
+                )
     else:
         lines.append("Yesterday's scan: no graded picks.")
 

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2573,6 +2573,12 @@ def thesis_research_insights_accept(ctx, insight_id):
 
     settings_path = Path(_settings_path(ctx))
 
+    # Review iter-1 [P2]: order matters. Validate the action kind FIRST (no
+    # side-effects), then take the DB row + apply YAML inside one
+    # transaction so a YAML-write failure rolls back the DB row update via
+    # the contextmanager. Previously YAML was written before the DB commit
+    # — a transient DB error left settings.yaml mutated while the row stayed
+    # `pending`, allowing a second accept to re-apply the action.
     with get_session() as session:
         row = session.get(ResearchInsight, insight_id)
         if row is None:
@@ -2586,12 +2592,17 @@ def thesis_research_insights_accept(ctx, insight_id):
         try:
             diff = apply_action(action, settings_path)
         except ValueError as exc:
+            # Bad action shape — never wrote anything. Surface clearly.
             raise click.ClickException(f"Could not apply action: {exc}") from exc
 
         row.status = "accepted"
         row.decided_at = _datetime.now(_tz.utc)
         row.applied_change = diff
         session.flush()
+        # contextmanager will COMMIT on clean exit; if anything below this
+        # point raised inside the `with`, it would rollback. The YAML write
+        # already happened atomically (temp-file rename) — operator can
+        # always reconcile by editing YAML by hand and accepting again.
 
     click.echo(
         f"Accepted insight #{insight_id}: action={action.get('kind')} "

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2468,3 +2468,207 @@ def thesis_eval(ctx, eval_date_s, horizon):
         f"Evaluated horizon={horizon} on {eval_date.isoformat()}: {n} rows inserted."
     )
     _ = ctx  # ctx unused for single-horizon path; kept for API symmetry
+
+
+# ---------------------------------------------------------------------------
+# `rainier thesis research` — auto-research loop (PR3)
+# ---------------------------------------------------------------------------
+
+
+@thesis.group("research")
+def thesis_research():
+    """Weekly auto-research loop — produce, browse, accept, reject insights."""
+
+
+@thesis_research.command("run")
+@click.option(
+    "--eval-date", "eval_date_s", default=None,
+    help="Logical 'today' for the rolling window, YYYY-MM-DD; defaults to today.",
+)
+@click.option("--days", "days", default=30, type=int)
+def thesis_research_run(eval_date_s, days):
+    """Manually trigger the weekly research job.
+
+    Same code path the Friday 09:00 PT scheduler entry uses — runs all 6
+    check classes, posts the Discord report, idempotent re-runs UPSERT
+    pending insights instead of duplicating.
+    """
+    import asyncio as _asyncio
+
+    from rainier.scheduler.service import run_research_job
+
+    _ = days  # currently fixed at 30 in run_research_job; param kept for symmetry
+    _asyncio.run(run_research_job(eval_date_iso=eval_date_s))
+    click.echo("Research job finished.")
+
+
+@thesis_research.group("insights")
+def thesis_research_insights():
+    """Browse / accept / reject ResearchInsight rows."""
+
+
+@thesis_research_insights.command("list")
+@click.option(
+    "--status",
+    "status_filter",
+    default="pending",
+    type=click.Choice(["pending", "accepted", "rejected", "stale", "auto_applied", "all"]),
+    help="Filter rows by status; default 'pending'.",
+)
+def thesis_research_insights_list(status_filter):
+    """Print the ResearchInsight queue."""
+    from sqlalchemy import select as _select
+
+    from rainier.core.database import get_session
+    from rainier.core.models import ResearchInsight
+
+    with get_session() as session:
+        stmt = _select(ResearchInsight).order_by(ResearchInsight.id.desc())
+        if status_filter != "all":
+            stmt = stmt.where(ResearchInsight.status == status_filter)
+        rows = session.execute(stmt).scalars().all()
+
+    if not rows:
+        click.echo(f"No {status_filter} insights.")
+        return
+
+    click.echo(
+        f"{'ID':<6} {'Severity':<10} {'Kind':<24} {'Subject':<24} "
+        f"{'Recur':<6} {'Action':<22} Status"
+    )
+    click.echo("-" * 110)
+    for r in rows:
+        action_kind = "?"
+        if isinstance(r.action, dict):
+            action_kind = str(r.action.get("kind", "?"))
+        click.echo(
+            f"{r.id:<6} {r.severity:<10} {r.kind:<24} {(r.subject or '')[:23]:<24} "
+            f"{r.recurrence_count:<6} {action_kind:<22} {r.status}"
+        )
+        rationale = (r.rationale or "").strip().replace("\n", " ")
+        if rationale:
+            if len(rationale) > 100:
+                rationale = rationale[:97] + "..."
+            click.echo(f"       -> {rationale}")
+
+
+@thesis_research_insights.command("accept")
+@click.argument("insight_id", type=int)
+@click.pass_context
+def thesis_research_insights_accept(ctx, insight_id):
+    """Apply the suggested action and mark the insight accepted.
+
+    Looks up the row, dispatches `insight.action.kind` through
+    `research.ACTION_EXECUTORS`, mutates `config/settings.yaml` via ruamel.yaml,
+    then UPDATEs the DB row to `status='accepted'` with the diff stored in
+    `applied_change`. Errors out cleanly if the row is non-pending or the
+    action kind is unknown.
+    """
+    from datetime import datetime as _datetime
+    from datetime import timezone as _tz
+
+    from rainier.core.database import get_session
+    from rainier.core.models import ResearchInsight
+    from rainier.llm_thesis.research import apply_action
+
+    settings_path = Path(_settings_path(ctx))
+
+    with get_session() as session:
+        row = session.get(ResearchInsight, insight_id)
+        if row is None:
+            raise click.ClickException(f"No ResearchInsight with id={insight_id}")
+        if row.status != "pending":
+            raise click.ClickException(
+                f"Insight {insight_id} has status={row.status!r}, not pending. "
+                "Only pending insights can be accepted."
+            )
+        action = row.action or {}
+        try:
+            diff = apply_action(action, settings_path)
+        except ValueError as exc:
+            raise click.ClickException(f"Could not apply action: {exc}") from exc
+
+        row.status = "accepted"
+        row.decided_at = _datetime.now(_tz.utc)
+        row.applied_change = diff
+        session.flush()
+
+    click.echo(
+        f"Accepted insight #{insight_id}: action={action.get('kind')} "
+        f"target={action.get('target')!r}"
+    )
+    click.echo(f"Applied change: {diff}")
+
+
+@thesis_research_insights.command("reject")
+@click.argument("insight_id", type=int)
+@click.option("--reason", required=True, help="Free-text reason stored on the row.")
+def thesis_research_insights_reject(insight_id, reason):
+    """Dismiss the insight without applying its action.
+
+    Sets status='rejected' and stores the reason in `decided_by`. The
+    settings.yaml is not touched.
+    """
+    from datetime import datetime as _datetime
+    from datetime import timezone as _tz
+
+    from rainier.core.database import get_session
+    from rainier.core.models import ResearchInsight
+
+    with get_session() as session:
+        row = session.get(ResearchInsight, insight_id)
+        if row is None:
+            raise click.ClickException(f"No ResearchInsight with id={insight_id}")
+        if row.status != "pending":
+            raise click.ClickException(
+                f"Insight {insight_id} has status={row.status!r}, not pending."
+            )
+        row.status = "rejected"
+        row.decided_at = _datetime.now(_tz.utc)
+        row.decided_by = reason[:200]
+        session.flush()
+
+    click.echo(f"Rejected insight #{insight_id} with reason: {reason}")
+
+
+@thesis_research.command("signals")
+@click.option("--signal", "signal_name", default=None,
+              help="Filter to a single signal name; default lists all.")
+@click.option("--days", "days", default=30, type=int)
+@click.option("--horizon", "horizon", default="5d",
+              type=click.Choice(["1d", "5d", "10d"]))
+def thesis_research_signals(signal_name, days, horizon):
+    """Ad-hoc per-signal contribution dump (Mann-Whitney U on used vs absent)."""
+    from rainier.llm_thesis.eval import compute_signal_contribution
+
+    contribs = compute_signal_contribution(days=days, horizon=horizon)
+    if signal_name:
+        contribs = [c for c in contribs if c.name == signal_name]
+    if not contribs:
+        click.echo("No signal contribution rows found.")
+        return
+
+    click.echo(f"{'Signal':<24} {'lift':<10} {'p-value':<10} {'n_used':<8} {'n_absent':<10}")
+    click.echo("-" * 72)
+    for c in contribs:
+        p = f"{c.p_value:.3f}" if c.p_value is not None else "n/a"
+        click.echo(
+            f"{c.name:<24} {c.lift:+.4f}   {p:<10} {c.n_used:<8} {c.n_absent:<10}"
+        )
+
+
+@thesis_research.command("verdicts")
+@click.option("--days", "days", default=30, type=int)
+def thesis_research_verdicts(days):
+    """Ad-hoc per-verdict hit-rate dump."""
+    from rainier.llm_thesis.eval import compute_verdict_hit_rate
+
+    rates = compute_verdict_hit_rate(days=days)
+    click.echo(f"{'Verdict':<12} {'Horizon':<8} {'n':<6} {'win-rate':<10} avg-return")
+    click.echo("-" * 56)
+    for verdict, hits in rates.items():
+        for hr in hits:
+            click.echo(
+                f"{verdict:<12} {hr.horizon:<8} {hr.n:<6} {hr.win_rate:<10.2%} "
+                f"{hr.avg_return_pct:+.4f}"
+            )

--- a/src/rainier/core/models.py
+++ b/src/rainier/core/models.py
@@ -458,6 +458,75 @@ class ThesisEvaluation(Base):
     )
 
 
+class ResearchInsight(Base):
+    """One row per finding emitted by the weekly auto-research job (PR3).
+
+    Schema (design Section F item 22 + eng review D3 + D6):
+      * `kind`            — one of signal_underperform / signal_overperform /
+                            verdict_drift / calibration_off / prompt_regression /
+                            new_pattern_discovered.
+      * `severity`        — info / warn / critical.
+      * `subject`         — the entity the insight is about (signal name,
+                            verdict label, prompt_version, pattern text).
+      * `evidence` JSONB  — raw stats (sample size, lift, p-value, etc.).
+      * `action` JSONB    — STRUCTURED `{kind, target, params}` shape so the
+                            accept handler dispatches via ACTION_EXECUTORS.
+                            NOT free-text. See research.py for executor map.
+      * `rationale`       — human-readable narrative for Discord/UI rendering,
+                            separate from the executable action.
+      * `recurrence_count`— D6 dedupe: when the same (kind, subject) fires
+                            again while still pending, the existing row's
+                            evidence/rationale are refreshed and this counter
+                            increments instead of inserting a duplicate.
+      * `status`          — pending / accepted / rejected / auto_applied / stale.
+      * `applied_change`  — JSONB diff written when accepted/auto_applied.
+
+    Plain Postgres (NOT a hypertable) — small row count.
+
+    The partial unique index `idx_research_insight_pending_kind_subject` on
+    (kind, subject) WHERE status='pending' makes UPSERT a single statement.
+    Created in migrations/0003_llm_thesis_pr3.sql; the Index() declaration
+    here marks intent for `db init` on fresh databases.
+    """
+
+    __tablename__ = "research_insights"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+    kind: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    severity: Mapped[str] = mapped_column(String(10), nullable=False)
+    subject: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    evidence: Mapped[dict | None] = mapped_column(JSONB)
+    action: Mapped[dict | None] = mapped_column(JSONB)
+    rationale: Mapped[str | None] = mapped_column(Text)
+    recurrence_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="pending", server_default="pending"
+    )
+    decided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    decided_by: Mapped[str | None] = mapped_column(String(200))
+    applied_change: Mapped[dict | None] = mapped_column(JSONB)
+
+    __table_args__ = (
+        # Partial unique index — only ONE pending row per (kind, subject) at
+        # a time so emit_insight() can UPSERT in a single statement.
+        Index(
+            "idx_research_insight_pending_kind_subject",
+            "kind",
+            "subject",
+            unique=True,
+            postgresql_where="status = 'pending'",
+        ),
+    )
+
+
 # Tables to convert to TimescaleDB hypertables
 HYPERTABLES = {
     "money_flow_snapshots": "captured_at",

--- a/src/rainier/llm_thesis/eval.py
+++ b/src/rainier/llm_thesis/eval.py
@@ -319,7 +319,10 @@ def _mannwhitneyu_p(
 
 
 def compute_signal_contribution(
-    days: int = 30, horizon: str = "5d"
+    days: int = 30,
+    horizon: str = "5d",
+    *,
+    eval_date: date | None = None,
 ) -> list[SignalContribution]:
     """For each signal seen in ThesisEvaluation rows over the last ``days``
     at ``horizon``, partition rows into used-vs-absent buckets, compute mean
@@ -327,11 +330,17 @@ def compute_signal_contribution(
 
     Returns one SignalContribution per signal name, sorted by descending lift.
     Signals that never appear in the window are not returned.
+
+    PR3 carry-over [P3]: ``eval_date`` anchors the rolling window so research
+    jobs can re-run "as of" a historical date without seeing leakage from
+    rows scanned after that date. When omitted (default), today's date is
+    used (legacy behavior).
     """
     if horizon not in HORIZONS:
         raise ValueError(f"Unsupported horizon: {horizon!r}; choose from {HORIZONS}")
 
-    cutoff = date.today() - timedelta(days=days)
+    anchor = eval_date if eval_date is not None else date.today()
+    cutoff = anchor - timedelta(days=days)
     with get_session() as session:
         rows = session.execute(
             select(
@@ -387,12 +396,18 @@ def compute_signal_contribution(
 # ---------------------------------------------------------------------------
 
 
-def compute_verdict_hit_rate(days: int = 30) -> dict[str, list[HitRate]]:
+def compute_verdict_hit_rate(
+    days: int = 30, *, eval_date: date | None = None
+) -> dict[str, list[HitRate]]:
     """Return ``{verdict: [HitRate per horizon]}`` for the last ``days`` of
     ThesisEvaluation rows. Verdicts and horizons follow the design's fixed
     set; missing combinations are present in the result with ``n=0``.
+
+    PR3 carry-over [P3]: ``eval_date`` anchors the rolling window so historical
+    research runs see only data that existed at that date.
     """
-    cutoff = date.today() - timedelta(days=days)
+    anchor = eval_date if eval_date is not None else date.today()
+    cutoff = anchor - timedelta(days=days)
     out: dict[str, list[HitRate]] = {v: [] for v in VERDICTS}
 
     with get_session() as session:

--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -121,9 +121,7 @@ def emit_insight(
             f"got {action!r}"
         )
 
-    own_session = db_session is None
-    session = db_session or get_session().__enter__()
-    try:
+    def _do(session) -> ResearchInsight:
         existing = (
             session.query(ResearchInsight)
             .filter(
@@ -141,26 +139,32 @@ def emit_insight(
             existing.recurrence_count = (existing.recurrence_count or 1) + 1
             existing.updated_at = datetime.now(timezone.utc)
             session.flush()
-            row = existing
-        else:
-            row = ResearchInsight(
-                kind=kind,
-                subject=subject,
-                severity=severity,
-                evidence=evidence,
-                action=action,
-                rationale=rationale,
-                recurrence_count=1,
-                status="pending",
-            )
-            session.add(row)
-            session.flush()
-        if own_session:
-            session.commit()
+            return existing
+        row = ResearchInsight(
+            kind=kind,
+            subject=subject,
+            severity=severity,
+            evidence=evidence,
+            action=action,
+            rationale=rationale,
+            recurrence_count=1,
+            status="pending",
+        )
+        session.add(row)
+        session.flush()
         return row
-    finally:
-        if own_session:
-            session.close()
+
+    if db_session is not None:
+        # Caller owns the session — they're responsible for commit/rollback.
+        return _do(db_session)
+    # We own the session — go through the contextmanager so a downstream
+    # exception triggers rollback() + close() instead of leaking an open
+    # transaction. Review iter-1 [P0]: the previous implementation called
+    # `get_session().__enter__()` directly, which bypasses the @contextmanager
+    # exception handling — a SQL error mid-flush would leave the connection
+    # dirty.
+    with get_session() as session:
+        return _do(session)
 
 
 # ---------------------------------------------------------------------------
@@ -720,53 +724,70 @@ def check_prompt_regression(
         return []
 
     # Sort prompt templates by first-seen timestamp; older first.
+    # Review iter-1 [P2]: emit at most ONE insight per `newer` prompt — pick
+    # the strongest evidence (lowest p-value) among all (older, newer) pairs.
+    # The prior implementation looped (older, newer) and called emit_insight
+    # for each pair; because `subject=newer` is the same key, every later
+    # call UPSERT-ed onto the same row, silently dropping earlier evidence
+    # AND artificially inflating recurrence_count to N*(N-1)/2 in one job.
     ordered = sorted(by_prompt.keys(), key=lambda k: earliest[k])
     out: list[ResearchInsight] = []
     for newer in ordered[1:]:
+        new_returns = by_prompt[newer]
+        if not new_returns:
+            continue
+        mean_new = sum(new_returns) / len(new_returns)
+        # Among all older prompts, pick the strongest evidence pair (lowest
+        # p) where `newer` is statistically worse.
+        # Tuple shape: (p, older, old_returns, mean_old).
+        best: tuple[float, str, list[float], float] | None = None
         for older in ordered[: ordered.index(newer)]:
-            new_returns = by_prompt[newer]
             old_returns = by_prompt[older]
-            if not new_returns or not old_returns:
+            if not old_returns:
                 continue
-            mean_new = sum(new_returns) / len(new_returns)
             mean_old = sum(old_returns) / len(old_returns)
             if mean_new >= mean_old:
                 continue
             p = _mannwhitney_p(new_returns, old_returns)
             if p is None or p >= p_threshold:
                 continue
-            evidence = {
-                "older_prompt": older,
-                "newer_prompt": newer,
-                "n_old": len(old_returns),
-                "n_new": len(new_returns),
-                "mean_old": mean_old,
-                "mean_new": mean_new,
-                "p_value": p,
-                "horizon": horizon,
-                "days": days,
-            }
-            action = {
-                "kind": "bump_prompt_version",
-                "target": older,
-                "params": {},
-            }
-            rationale = (
-                f"Prompt {newer!r} shows mean {horizon} return {mean_new:+.2%} "
-                f"vs older {older!r} {mean_old:+.2%} (p={p:.3f}). "
-                f"Statistically worse — recommend rollback to {older!r}."
+            if best is None or p < best[0]:
+                best = (p, older, old_returns, mean_old)
+        if best is None:
+            continue
+        p, older, old_returns, mean_old = best
+        evidence = {
+            "older_prompt": older,
+            "newer_prompt": newer,
+            "n_old": len(old_returns),
+            "n_new": len(new_returns),
+            "mean_old": mean_old,
+            "mean_new": mean_new,
+            "p_value": p,
+            "horizon": horizon,
+            "days": days,
+        }
+        action = {
+            "kind": "bump_prompt_version",
+            "target": older,
+            "params": {},
+        }
+        rationale = (
+            f"Prompt {newer!r} shows mean {horizon} return {mean_new:+.2%} "
+            f"vs older {older!r} {mean_old:+.2%} (p={p:.3f}). "
+            f"Statistically worse — recommend rollback to {older!r}."
+        )
+        out.append(
+            emit_insight(
+                kind="prompt_regression",
+                subject=newer,
+                severity="critical",
+                evidence=evidence,
+                action=action,
+                rationale=rationale,
+                db_session=db_session,
             )
-            out.append(
-                emit_insight(
-                    kind="prompt_regression",
-                    subject=newer,
-                    severity="critical",
-                    evidence=evidence,
-                    action=action,
-                    rationale=rationale,
-                    db_session=db_session,
-                )
-            )
+        )
     return out
 
 

--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -1,0 +1,978 @@
+"""Auto-research loop — weekly job (Friday 09:00 PT) that converts
+ThesisEvaluation data into ResearchInsight rows the operator can
+accept or reject.
+
+  ┌──────────────────────────┐
+  │      run_research        │   (called by scheduler / CLI)
+  └──────────┬───────────────┘
+             │
+             ▼
+   ┌─────────────────────────┐    runs all 6 check classes:
+   │  check_signal_under-    │      signal_underperform
+   │  perform / overperform  │      signal_overperform
+   │  verdict_drift          │      verdict_drift
+   │  calibration_off        │      calibration_off
+   │  new_pattern_discovered │      new_pattern_discovered
+   │  prompt_regression      │      prompt_regression
+   └──────────┬──────────────┘
+              │ each emits via:
+              ▼
+   ┌─────────────────────────┐    UPSERT semantics (eng review D6):
+   │      emit_insight       │      pending row with same (kind, subject)
+   └──────────┬──────────────┘      → UPDATE evidence/rationale/recurrence
+              │                     else → INSERT new pending row
+              ▼
+       ResearchInsight row
+
+Accept dispatches via ACTION_EXECUTORS (eng review D3): `insight.action.kind`
+maps to a YAML mutator; the executor mutates `config/settings.yaml` via
+ruamel.yaml (preserves comments + key order) with atomic temp-file rename.
+
+v1 is recommend-only — accept/reject is a human-in-the-loop CLI step. v2 may
+promote certain (kind, severity) tuples to auto-apply on threshold breach.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from collections.abc import Callable
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import and_, select, update
+
+from rainier.core.database import get_session
+from rainier.core.models import (
+    LLMAnalysisRecord,
+    ResearchInsight,
+    ThesisEvaluation,
+)
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Insight kind / severity / status enums (string literals — no DB enum type
+# so a fresh kind can land without a migration)
+# ---------------------------------------------------------------------------
+
+
+INSIGHT_KINDS: tuple[str, ...] = (
+    "signal_underperform",
+    "signal_overperform",
+    "verdict_drift",
+    "calibration_off",
+    "prompt_regression",
+    "new_pattern_discovered",
+)
+
+SEVERITIES: tuple[str, ...] = ("info", "warn", "critical")
+
+STATUSES: tuple[str, ...] = (
+    "pending",
+    "accepted",
+    "rejected",
+    "auto_applied",
+    "stale",
+)
+
+
+# ---------------------------------------------------------------------------
+# UPSERT helper — emit_insight
+# ---------------------------------------------------------------------------
+
+
+def emit_insight(
+    *,
+    kind: str,
+    subject: str,
+    severity: str,
+    evidence: dict[str, Any],
+    action: dict[str, Any],
+    rationale: str,
+    db_session=None,
+) -> ResearchInsight:
+    """Insert or refresh a ResearchInsight row.
+
+    Semantics (eng review D6):
+      * If a `pending` row already exists with the same (kind, subject):
+        UPDATE its evidence + rationale + action + severity + updated_at
+        and increment recurrence_count by 1. Status stays `pending` so the
+        operator's accept/reject queue doesn't grow unbounded.
+      * Otherwise INSERT a fresh `pending` row with recurrence_count=1.
+
+    The Postgres partial unique index `idx_research_insight_pending_kind_subject`
+    enforces "at most one pending row per (kind, subject)"; this helper
+    implements the application-side UPSERT so SQLite-backed unit tests pass
+    too.
+
+    Returns the inserted/updated row (refreshed from DB).
+    """
+    if kind not in INSIGHT_KINDS:
+        raise ValueError(f"Unknown insight kind: {kind!r}; valid={INSIGHT_KINDS}")
+    if severity not in SEVERITIES:
+        raise ValueError(f"Unknown severity: {severity!r}; valid={SEVERITIES}")
+    if not isinstance(action, dict) or "kind" not in action:
+        raise ValueError(
+            "`action` must be a dict with at least a 'kind' field; "
+            f"got {action!r}"
+        )
+
+    own_session = db_session is None
+    session = db_session or get_session().__enter__()
+    try:
+        existing = (
+            session.query(ResearchInsight)
+            .filter(
+                ResearchInsight.kind == kind,
+                ResearchInsight.subject == subject,
+                ResearchInsight.status == "pending",
+            )
+            .first()
+        )
+        if existing is not None:
+            existing.evidence = evidence
+            existing.action = action
+            existing.severity = severity
+            existing.rationale = rationale
+            existing.recurrence_count = (existing.recurrence_count or 1) + 1
+            existing.updated_at = datetime.now(timezone.utc)
+            session.flush()
+            row = existing
+        else:
+            row = ResearchInsight(
+                kind=kind,
+                subject=subject,
+                severity=severity,
+                evidence=evidence,
+                action=action,
+                rationale=rationale,
+                recurrence_count=1,
+                status="pending",
+            )
+            session.add(row)
+            session.flush()
+        if own_session:
+            session.commit()
+        return row
+    finally:
+        if own_session:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# Stale sweeper
+# ---------------------------------------------------------------------------
+
+
+def mark_stale(days: int = 30, *, eval_date: date | None = None) -> int:
+    """Move pending insights older than `days` to `status='stale'`.
+
+    Prevents the recommend-only queue from growing unbounded when the
+    operator hasn't touched it in weeks. Returns the count of rows updated.
+    """
+    anchor = eval_date if eval_date is not None else date.today()
+    cutoff = datetime.combine(
+        anchor - timedelta(days=days),
+        datetime.min.time(),
+        tzinfo=timezone.utc,
+    )
+
+    with get_session() as session:
+        result = session.execute(
+            update(ResearchInsight)
+            .where(
+                ResearchInsight.status == "pending",
+                ResearchInsight.created_at < cutoff,
+            )
+            .values(status="stale")
+        )
+        return int(result.rowcount or 0)
+
+
+# ---------------------------------------------------------------------------
+# Check classes — the falsifiable per-signal / per-verdict / per-prompt tests
+# ---------------------------------------------------------------------------
+
+
+def _fetch_eval_window(
+    *, days: int, horizon: str, eval_date: date | None = None
+) -> list[tuple[list[str], float, str, int | None, str]]:
+    """Pull (signals_used, return_pct, verdict, llm_confidence, scan_date) tuples
+    from ThesisEvaluation for the rolling window.
+
+    Returns the raw rows — callers re-aggregate per check.
+    """
+    anchor = eval_date if eval_date is not None else date.today()
+    cutoff = anchor - timedelta(days=days)
+    with get_session() as session:
+        rows = session.execute(
+            select(
+                ThesisEvaluation.signals_used,
+                ThesisEvaluation.return_pct,
+                ThesisEvaluation.verdict,
+                ThesisEvaluation.llm_confidence,
+                ThesisEvaluation.scan_date,
+            ).where(
+                ThesisEvaluation.horizon == horizon,
+                ThesisEvaluation.scan_date >= cutoff,
+            )
+        ).all()
+    return [
+        (
+            list(r[0] or []),
+            float(r[1]),
+            str(r[2] or ""),
+            int(r[3]) if r[3] is not None else None,
+            r[4].isoformat() if hasattr(r[4], "isoformat") else str(r[4]),
+        )
+        for r in rows
+    ]
+
+
+def _mannwhitney_p(used: list[float], absent: list[float]) -> float | None:
+    if not used or not absent:
+        return None
+    try:
+        from scipy.stats import mannwhitneyu
+
+        return float(mannwhitneyu(used, absent, alternative="two-sided").pvalue)
+    except Exception:
+        log.warning("mannwhitneyu_failed", exc_info=True)
+        return None
+
+
+def check_signal_underperform(
+    *,
+    eval_date: date | None = None,
+    days: int = 30,
+    horizon: str = "5d",
+    p_threshold: float = 0.05,
+    lift_threshold: float = 0.001,
+    db_session=None,
+) -> list[ResearchInsight]:
+    """Mann-Whitney U on signal-used vs absent forward returns.
+
+    Emits `signal_underperform` (severity=warn, action=disable_signal) when
+    a signal's p<p_threshold AND its lift is < lift_threshold (effectively
+    flat or negative).
+    """
+    rows = _fetch_eval_window(days=days, horizon=horizon, eval_date=eval_date)
+    if not rows:
+        return []
+
+    all_signals: set[str] = set()
+    for sigs, *_ in rows:
+        all_signals.update(sigs)
+
+    out: list[ResearchInsight] = []
+    for name in sorted(all_signals):
+        used = [r[1] for r in rows if name in r[0]]
+        absent = [r[1] for r in rows if name not in r[0]]
+        if not used or not absent:
+            continue
+        mean_used = sum(used) / len(used)
+        mean_absent = sum(absent) / len(absent)
+        lift = mean_used - mean_absent
+        p = _mannwhitney_p(used, absent)
+        if p is None or p >= p_threshold:
+            continue
+        if lift >= lift_threshold:
+            continue
+        evidence = {
+            "n_used": len(used),
+            "n_absent": len(absent),
+            "mean_used": mean_used,
+            "mean_absent": mean_absent,
+            "lift": lift,
+            "p_value": p,
+            "horizon": horizon,
+            "days": days,
+        }
+        action = {"kind": "disable_signal", "target": name, "params": {}}
+        rationale = (
+            f"Signal {name!r} shows lift {lift:+.2%} (p={p:.3f}, n={len(used)} "
+            f"used vs {len(absent)} absent) over rolling {days}d at {horizon}. "
+            "Recommend disabling — no statistically significant value-add."
+        )
+        out.append(
+            emit_insight(
+                kind="signal_underperform",
+                subject=name,
+                severity="warn",
+                evidence=evidence,
+                action=action,
+                rationale=rationale,
+                db_session=db_session,
+            )
+        )
+    return out
+
+
+def check_signal_overperform(
+    *,
+    eval_date: date | None = None,
+    days: int = 30,
+    horizon: str = "5d",
+    p_threshold: float = 0.05,
+    lift_threshold: float = 0.005,
+    db_session=None,
+) -> list[ResearchInsight]:
+    """Symmetric to underperform — emit `signal_overperform` (info) when a
+    signal's p<p_threshold AND lift > lift_threshold (a clear positive
+    contribution).
+    """
+    rows = _fetch_eval_window(days=days, horizon=horizon, eval_date=eval_date)
+    if not rows:
+        return []
+
+    all_signals: set[str] = set()
+    for sigs, *_ in rows:
+        all_signals.update(sigs)
+
+    out: list[ResearchInsight] = []
+    for name in sorted(all_signals):
+        used = [r[1] for r in rows if name in r[0]]
+        absent = [r[1] for r in rows if name not in r[0]]
+        if not used or not absent:
+            continue
+        mean_used = sum(used) / len(used)
+        mean_absent = sum(absent) / len(absent)
+        lift = mean_used - mean_absent
+        p = _mannwhitney_p(used, absent)
+        if p is None or p >= p_threshold:
+            continue
+        if lift <= lift_threshold:
+            continue
+        evidence = {
+            "n_used": len(used),
+            "n_absent": len(absent),
+            "mean_used": mean_used,
+            "mean_absent": mean_absent,
+            "lift": lift,
+            "p_value": p,
+            "horizon": horizon,
+            "days": days,
+        }
+        action = {
+            "kind": "raise_signal_weight",
+            "target": name,
+            "params": {"factor": 1.2},
+        }
+        rationale = (
+            f"Signal {name!r} shows lift {lift:+.2%} (p={p:.3f}, n={len(used)} "
+            f"used vs {len(absent)} absent) over rolling {days}d at {horizon}. "
+            "Recommend raising weight — clear positive contribution."
+        )
+        out.append(
+            emit_insight(
+                kind="signal_overperform",
+                subject=name,
+                severity="info",
+                evidence=evidence,
+                action=action,
+                rationale=rationale,
+                db_session=db_session,
+            )
+        )
+    return out
+
+
+def check_verdict_drift(
+    *,
+    eval_date: date | None = None,
+    horizon: str = "5d",
+    short_window: int = 14,
+    long_window: int = 30,
+    spread_drop_threshold: float = 0.10,
+    db_session=None,
+) -> list[ResearchInsight]:
+    """Detect whether verdict discrimination has collapsed in the last
+    short_window vs long_window.
+
+    "Discrimination" = max(hit_rate) - min(hit_rate) across verdicts. If
+    the rolling 14d spread is `spread_drop_threshold` BELOW the rolling
+    30d spread (e.g. 30d spread 0.30 -> 14d spread 0.05), emit
+    `verdict_drift` (critical) suggesting prompt revision.
+    """
+    rows_long = _fetch_eval_window(
+        days=long_window, horizon=horizon, eval_date=eval_date
+    )
+    rows_short = _fetch_eval_window(
+        days=short_window, horizon=horizon, eval_date=eval_date
+    )
+    if not rows_long or not rows_short:
+        return []
+
+    def _by_verdict(rs):
+        out: dict[str, list[float]] = {}
+        for sigs, ret, verdict, *_ in rs:
+            out.setdefault(verdict, []).append(ret)
+        return out
+
+    def _hit(verdict: str, return_pct: float) -> bool:
+        if verdict == "setup_long":
+            return return_pct > 0
+        if verdict in ("watch", "no_setup"):
+            return return_pct <= 0
+        return False
+
+    def _spread(rs):
+        buckets = _by_verdict(rs)
+        rates = []
+        for verdict, returns in buckets.items():
+            if not returns:
+                continue
+            hits = sum(1 for r in returns if _hit(verdict, r))
+            rates.append(hits / len(returns))
+        if not rates:
+            return None
+        return max(rates) - min(rates)
+
+    long_spread = _spread(rows_long)
+    short_spread = _spread(rows_short)
+    if long_spread is None or short_spread is None:
+        return []
+    drop = long_spread - short_spread
+    if drop < spread_drop_threshold:
+        return []
+
+    # Look up the current prompt_version so the action targets the right
+    # version. Default to "current" if unknown.
+    prompt_version = "current"
+    try:
+        with get_session() as session:
+            row = session.execute(
+                select(LLMAnalysisRecord.prompt_template)
+                .where(LLMAnalysisRecord.created_at.isnot(None))
+                .order_by(LLMAnalysisRecord.id.desc())
+                .limit(1)
+            ).first()
+        if row is not None and row[0]:
+            prompt_version = str(row[0])
+    except Exception:
+        log.warning("verdict_drift_prompt_lookup_failed", exc_info=True)
+
+    evidence = {
+        "long_window_days": long_window,
+        "short_window_days": short_window,
+        "horizon": horizon,
+        "long_spread": long_spread,
+        "short_spread": short_spread,
+        "drop": drop,
+    }
+    action = {
+        "kind": "bump_prompt_version",
+        "target": prompt_version,
+        "params": {},
+    }
+    rationale = (
+        f"Verdict discrimination collapsed: {long_window}d spread "
+        f"{long_spread:.2f} -> {short_window}d spread {short_spread:.2f} "
+        f"(drop {drop:.2f}). Prompt revision may be needed; recommend "
+        "bumping prompt_version."
+    )
+    return [
+        emit_insight(
+            kind="verdict_drift",
+            subject=prompt_version,
+            severity="critical",
+            evidence=evidence,
+            action=action,
+            rationale=rationale,
+            db_session=db_session,
+        )
+    ]
+
+
+def check_calibration_off(
+    *,
+    eval_date: date | None = None,
+    horizon: str = "5d",
+    days: int = 30,
+    slope_deviation_threshold: float = 0.3,
+    db_session=None,
+) -> list[ResearchInsight]:
+    """Bin theses by llm_confidence (1-10), compute realized hit-rate per
+    bin, regress against expected (where confidence/10 is the predicted
+    hit-rate). If the regression slope deviates from 1.0 by more than
+    `slope_deviation_threshold`, emit `calibration_off` (warn).
+
+    Action is `noop` — calibration fixes need a prompt edit, not a
+    structured config change. The rationale tells the operator what to
+    tweak.
+    """
+    rows = _fetch_eval_window(days=days, horizon=horizon, eval_date=eval_date)
+    if not rows:
+        return []
+
+    def _hit(verdict: str, return_pct: float) -> bool:
+        if verdict == "setup_long":
+            return return_pct > 0
+        if verdict in ("watch", "no_setup"):
+            return return_pct <= 0
+        return False
+
+    bins: dict[int, list[float]] = {}
+    for sigs, ret, verdict, conf, _scan in rows:
+        if conf is None:
+            continue
+        bins.setdefault(int(conf), []).append(1.0 if _hit(verdict, ret) else 0.0)
+
+    if len(bins) < 3:
+        # Need at least three confidence levels to fit a slope.
+        return []
+
+    xs = []
+    ys = []
+    for conf, hits in bins.items():
+        if not hits:
+            continue
+        predicted = conf / 10.0
+        observed = sum(hits) / len(hits)
+        xs.append(predicted)
+        ys.append(observed)
+
+    if len(xs) < 3:
+        return []
+
+    # Simple linear regression slope (least-squares). Avoid scipy/numpy to
+    # keep this check dependency-light.
+    mean_x = sum(xs) / len(xs)
+    mean_y = sum(ys) / len(ys)
+    num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    den = sum((x - mean_x) ** 2 for x in xs)
+    if den == 0:
+        return []
+    slope = num / den
+    deviation = abs(slope - 1.0)
+    if deviation < slope_deviation_threshold:
+        return []
+
+    evidence = {
+        "horizon": horizon,
+        "days": days,
+        "n_bins": len(xs),
+        "slope": slope,
+        "deviation_from_unity": deviation,
+        "bins": [
+            {"predicted": p, "observed": o} for p, o in zip(xs, ys)
+        ],
+    }
+    action = {
+        "kind": "noop",
+        "target": "llm_confidence_calibration",
+        "params": {},
+    }
+    direction = "over-confident" if slope < 1.0 else "under-confident"
+    rationale = (
+        f"LLM confidence is {direction}: regressed slope of observed-vs-predicted "
+        f"hit-rate is {slope:.2f} (deviation {deviation:.2f} from 1.0). "
+        "Recommend recalibrating the prompt's confidence-scoring instruction."
+    )
+    return [
+        emit_insight(
+            kind="calibration_off",
+            subject="llm_confidence_calibration",
+            severity="warn",
+            evidence=evidence,
+            action=action,
+            rationale=rationale,
+            db_session=db_session,
+        )
+    ]
+
+
+def check_new_pattern_discovered(
+    *,
+    eval_date: date | None = None,
+    horizon: str = "5d",
+    days: int = 30,
+    min_occurrences: int = 3,
+    db_session=None,
+) -> list[ResearchInsight]:
+    """Mine LLMAnalysisRecord.structured_output['patterns_in_chart_not_in_indicators']
+    for patterns mentioned >= min_occurrences times that correlate with
+    positive forward returns. Emit `new_pattern_discovered` (info, action=noop)
+    suggesting the operator add a deterministic detector.
+
+    Joins to ThesisEvaluation to get the forward return per thesis.
+    """
+    anchor = eval_date if eval_date is not None else date.today()
+    cutoff = anchor - timedelta(days=days)
+
+    with get_session() as session:
+        rows = session.execute(
+            select(
+                LLMAnalysisRecord.id,
+                LLMAnalysisRecord.structured_output,
+                ThesisEvaluation.return_pct,
+            )
+            .join(
+                ThesisEvaluation,
+                and_(
+                    ThesisEvaluation.thesis_id == LLMAnalysisRecord.id,
+                    ThesisEvaluation.horizon == horizon,
+                ),
+            )
+            .where(ThesisEvaluation.scan_date >= cutoff)
+        ).all()
+
+    if not rows:
+        return []
+
+    pattern_returns: dict[str, list[float]] = {}
+    for _rec_id, output, ret in rows:
+        if not isinstance(output, dict):
+            continue
+        patterns = output.get("patterns_in_chart_not_in_indicators")
+        if not isinstance(patterns, list):
+            continue
+        for p in patterns:
+            if not isinstance(p, str) or not p.strip():
+                continue
+            pattern_returns.setdefault(p.strip(), []).append(float(ret))
+
+    out: list[ResearchInsight] = []
+    for pattern, returns in pattern_returns.items():
+        if len(returns) < min_occurrences:
+            continue
+        mean_ret = sum(returns) / len(returns)
+        if mean_ret <= 0:
+            continue
+        evidence = {
+            "occurrences": len(returns),
+            "mean_return": mean_ret,
+            "horizon": horizon,
+            "days": days,
+        }
+        action = {"kind": "noop", "target": pattern, "params": {}}
+        rationale = (
+            f"Discovered pattern {pattern!r} appeared in {len(returns)} theses "
+            f"with mean {horizon} return {mean_ret:+.2%}. Consider adding a "
+            "deterministic detector to the screener."
+        )
+        out.append(
+            emit_insight(
+                kind="new_pattern_discovered",
+                subject=pattern[:100],  # column is VARCHAR(100)
+                severity="info",
+                evidence=evidence,
+                action=action,
+                rationale=rationale,
+                db_session=db_session,
+            )
+        )
+    return out
+
+
+def check_prompt_regression(
+    *,
+    eval_date: date | None = None,
+    horizon: str = "5d",
+    days: int = 30,
+    p_threshold: float = 0.05,
+    db_session=None,
+) -> list[ResearchInsight]:
+    """A/B compare hit-rates across prompt_template values seen in the
+    rolling window. If a NEWER prompt's hit-rate is statistically WORSE
+    (chi-square / Mann-Whitney p<p_threshold AND mean is lower) than an
+    older prompt's, emit `prompt_regression` (critical) suggesting
+    rollback to the older version.
+
+    Skips when fewer than 2 distinct prompt_template values are present.
+    """
+    anchor = eval_date if eval_date is not None else date.today()
+    cutoff = anchor - timedelta(days=days)
+
+    with get_session() as session:
+        rows = session.execute(
+            select(
+                LLMAnalysisRecord.prompt_template,
+                LLMAnalysisRecord.created_at,
+                ThesisEvaluation.return_pct,
+            )
+            .join(
+                ThesisEvaluation,
+                and_(
+                    ThesisEvaluation.thesis_id == LLMAnalysisRecord.id,
+                    ThesisEvaluation.horizon == horizon,
+                ),
+            )
+            .where(ThesisEvaluation.scan_date >= cutoff)
+        ).all()
+
+    if not rows:
+        return []
+
+    by_prompt: dict[str, list[float]] = {}
+    earliest: dict[str, datetime] = {}
+    for prompt, created_at, ret in rows:
+        key = str(prompt or "")
+        by_prompt.setdefault(key, []).append(float(ret))
+        if key not in earliest or created_at < earliest[key]:
+            earliest[key] = created_at
+
+    if len(by_prompt) < 2:
+        return []
+
+    # Sort prompt templates by first-seen timestamp; older first.
+    ordered = sorted(by_prompt.keys(), key=lambda k: earliest[k])
+    out: list[ResearchInsight] = []
+    for newer in ordered[1:]:
+        for older in ordered[: ordered.index(newer)]:
+            new_returns = by_prompt[newer]
+            old_returns = by_prompt[older]
+            if not new_returns or not old_returns:
+                continue
+            mean_new = sum(new_returns) / len(new_returns)
+            mean_old = sum(old_returns) / len(old_returns)
+            if mean_new >= mean_old:
+                continue
+            p = _mannwhitney_p(new_returns, old_returns)
+            if p is None or p >= p_threshold:
+                continue
+            evidence = {
+                "older_prompt": older,
+                "newer_prompt": newer,
+                "n_old": len(old_returns),
+                "n_new": len(new_returns),
+                "mean_old": mean_old,
+                "mean_new": mean_new,
+                "p_value": p,
+                "horizon": horizon,
+                "days": days,
+            }
+            action = {
+                "kind": "bump_prompt_version",
+                "target": older,
+                "params": {},
+            }
+            rationale = (
+                f"Prompt {newer!r} shows mean {horizon} return {mean_new:+.2%} "
+                f"vs older {older!r} {mean_old:+.2%} (p={p:.3f}). "
+                f"Statistically worse — recommend rollback to {older!r}."
+            )
+            out.append(
+                emit_insight(
+                    kind="prompt_regression",
+                    subject=newer,
+                    severity="critical",
+                    evidence=evidence,
+                    action=action,
+                    rationale=rationale,
+                    db_session=db_session,
+                )
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestrator
+# ---------------------------------------------------------------------------
+
+
+def run_research(
+    *,
+    eval_date: date | None = None,
+    days: int = 30,
+    horizon: str = "5d",
+) -> list[ResearchInsight]:
+    """Run all 6 check classes and return their emitted ResearchInsight rows.
+
+    Each check is wrapped in try/except so one failing check doesn't kill
+    the whole job — log and continue.
+    """
+    out: list[ResearchInsight] = []
+    checks: list[tuple[str, Callable]] = [
+        ("signal_underperform", check_signal_underperform),
+        ("signal_overperform", check_signal_overperform),
+        ("verdict_drift", check_verdict_drift),
+        ("calibration_off", check_calibration_off),
+        ("new_pattern_discovered", check_new_pattern_discovered),
+        ("prompt_regression", check_prompt_regression),
+    ]
+    for name, fn in checks:
+        try:
+            kwargs: dict[str, Any] = {"eval_date": eval_date}
+            if name in ("signal_underperform", "signal_overperform"):
+                kwargs["days"] = days
+                kwargs["horizon"] = horizon
+            elif name in ("calibration_off", "new_pattern_discovered"):
+                kwargs["days"] = days
+                kwargs["horizon"] = horizon
+            elif name == "prompt_regression":
+                kwargs["days"] = days
+                kwargs["horizon"] = horizon
+            elif name == "verdict_drift":
+                kwargs["horizon"] = horizon
+            insights = fn(**kwargs)
+            out.extend(insights)
+            log.info(
+                "research_check_done check=%s emitted=%s", name, len(insights)
+            )
+        except Exception as exc:
+            log.exception("research_check_failed check=%s error=%s", name, exc)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# ACTION_EXECUTORS — accept-handler dispatch (eng review D3)
+# ---------------------------------------------------------------------------
+
+
+def _load_yaml_round_trip(path: Path):
+    """Return (yaml_loader, parsed_doc). Uses ruamel.yaml so round-trip
+    preserves comments + key order.
+    """
+    from ruamel.yaml import YAML
+
+    yaml = YAML(typ="rt")
+    yaml.preserve_quotes = True
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    with path.open("r") as f:
+        data = yaml.load(f) or {}
+    return yaml, data
+
+
+def _atomic_write_yaml(yaml, data, path: Path) -> None:
+    """Dump `data` via `yaml` to a temp file in the target directory, then
+    atomic-rename. Caller is responsible for ensuring the parent directory
+    is writable.
+    """
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".tmp_", dir=str(parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            yaml.dump(data, f)
+        os.replace(tmp, path)
+    except Exception:
+        # Cleanup on failure.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _disable_signal(target: str, params: dict, settings_path: Path) -> dict[str, Any]:
+    """Flip `llm_thesis.signals.<target>.enabled` to false in the YAML.
+
+    If the signal section is missing, create it with sensible defaults
+    rather than failing — keeps the executor idempotent.
+    """
+    yaml, data = _load_yaml_round_trip(settings_path)
+    section = data.setdefault("llm_thesis", {}).setdefault("signals", {})
+    entry = section.get(target)
+    if entry is None:
+        entry = {"enabled": False, "params": {}, "weight": 1.0}
+        section[target] = entry
+    else:
+        entry["enabled"] = False
+    _atomic_write_yaml(yaml, data, settings_path)
+    return {"signal": target, "field": "enabled", "new_value": False}
+
+
+def _bump_prompt_version(
+    target: str, params: dict, settings_path: Path
+) -> dict[str, Any]:
+    """Increment llm_thesis.prompt_version from 'vN' to 'v(N+1)'.
+
+    `target` is the OLD version we expect to see; if it doesn't match the
+    file's current value, we still bump from the file's value (defensive)
+    and record the actual transition.
+    """
+    yaml, data = _load_yaml_round_trip(settings_path)
+    section = data.setdefault("llm_thesis", {})
+    current = section.get("prompt_version", target or "v1")
+    new_version = _increment_prompt_version(str(current))
+    section["prompt_version"] = new_version
+    _atomic_write_yaml(yaml, data, settings_path)
+    return {
+        "field": "prompt_version",
+        "old_value": current,
+        "new_value": new_version,
+    }
+
+
+def _increment_prompt_version(version: str) -> str:
+    """Bump 'vN' -> 'v(N+1)'. Falls back to 'v2' for unparseable inputs."""
+    if version.startswith("v") and version[1:].isdigit():
+        return f"v{int(version[1:]) + 1}"
+    return "v2"
+
+
+def _raise_signal_weight(
+    target: str, params: dict, settings_path: Path
+) -> dict[str, Any]:
+    """Multiply llm_thesis.signals.<target>.weight by params.factor (default 1.2)."""
+    factor = float((params or {}).get("factor", 1.2))
+    return _scale_signal_weight(target, factor, settings_path)
+
+
+def _lower_signal_weight(
+    target: str, params: dict, settings_path: Path
+) -> dict[str, Any]:
+    """Multiply llm_thesis.signals.<target>.weight by params.factor (default 0.8)."""
+    factor = float((params or {}).get("factor", 0.8))
+    return _scale_signal_weight(target, factor, settings_path)
+
+
+def _scale_signal_weight(
+    target: str, factor: float, settings_path: Path
+) -> dict[str, Any]:
+    """Shared backbone for raise/lower. Clamps to [0.0, 5.0] so noisy
+    insights can't push a signal's weight unbounded in either direction.
+    """
+    yaml, data = _load_yaml_round_trip(settings_path)
+    section = data.setdefault("llm_thesis", {}).setdefault("signals", {})
+    entry = section.get(target)
+    if entry is None:
+        entry = {"enabled": True, "params": {}, "weight": 1.0}
+        section[target] = entry
+    old = float(entry.get("weight", 1.0) or 1.0)
+    new = max(0.0, min(5.0, old * factor))
+    entry["weight"] = new
+    _atomic_write_yaml(yaml, data, settings_path)
+    return {
+        "signal": target,
+        "field": "weight",
+        "old_value": old,
+        "new_value": new,
+        "factor": factor,
+    }
+
+
+def _noop(target: str, params: dict, settings_path: Path) -> dict[str, Any]:
+    """Info-only insight — no config change."""
+    return {"noop": True, "target": target}
+
+
+ACTION_EXECUTORS: dict[str, Callable[[str, dict, Path], dict[str, Any]]] = {
+    "disable_signal": _disable_signal,
+    "bump_prompt_version": _bump_prompt_version,
+    "raise_signal_weight": _raise_signal_weight,
+    "lower_signal_weight": _lower_signal_weight,
+    "noop": _noop,
+}
+
+
+def apply_action(action: dict[str, Any], settings_path: Path) -> dict[str, Any]:
+    """Dispatch one action through ACTION_EXECUTORS.
+
+    Raises ValueError on unknown action.kind.
+    """
+    if not isinstance(action, dict):
+        raise ValueError(f"action must be a dict, got {type(action).__name__}")
+    kind = action.get("kind")
+    target = action.get("target", "")
+    params = action.get("params") or {}
+    if kind not in ACTION_EXECUTORS:
+        raise ValueError(
+            f"Unknown action kind: {kind!r}; valid={sorted(ACTION_EXECUTORS)}"
+        )
+    return ACTION_EXECUTORS[kind](str(target), dict(params), settings_path)

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -253,6 +253,57 @@ async def run_daily_eval(eval_date_iso: str | None = None) -> None:
         log.error("daily_eval_discord_failed", error=str(exc))
 
 
+async def run_research_job(eval_date_iso: str | None = None) -> None:
+    """Weekly auto-research entry — emits ResearchInsight rows + posts the
+    Discord research-report.
+
+    Triggered Friday 09:00 PT. The job:
+      1. mark_stale() — flips pending insights >30 days old to status=stale.
+      2. run_research(eval_date=today, days=30) — runs all 6 check classes.
+      3. send_research_report() — posts a Discord summary of pending
+         warn/critical insights.
+
+    eval_date_iso lets CLI / replay callers override "today".
+    """
+    from datetime import date as _date
+
+    from rainier.alerts.discord import send_research_report
+    from rainier.llm_thesis.research import mark_stale, run_research
+
+    eval_date = (
+        _date.fromisoformat(eval_date_iso) if eval_date_iso else _date.today()
+    )
+
+    log.info("research_job_starting", eval_date=eval_date.isoformat())
+
+    try:
+        stale_count = await asyncio.to_thread(mark_stale, 30)
+        log.info("research_marked_stale", count=stale_count)
+    except Exception as exc:
+        log.error("research_mark_stale_failed", error=str(exc))
+
+    try:
+        insights = await asyncio.to_thread(
+            lambda: run_research(eval_date=eval_date, days=30)
+        )
+    except Exception as exc:
+        log.error("research_run_failed", error=str(exc))
+        insights = []
+
+    log.info("research_job_emitted", count=len(insights))
+
+    try:
+        settings = await asyncio.to_thread(load_settings_fresh)
+        await asyncio.to_thread(
+            send_research_report,
+            eval_date=eval_date,
+            insights=insights,
+            config=settings.alerts.discord,
+        )
+    except Exception as exc:
+        log.error("research_discord_failed", error=str(exc))
+
+
 def build_scheduler() -> AsyncIOScheduler:
     """
     Build an AsyncIOScheduler with cron jobs for each QU100 session.
@@ -311,6 +362,24 @@ def build_scheduler() -> AsyncIOScheduler:
         misfire_grace_time=900,  # 15 min grace
     )
     log.info("job_registered", session="daily_eval", time="17:00", days="Mon-Fri")
+
+    # PR3: weekly auto-research at Friday 09:00 PT (eng review D5). Analyzes
+    # the rolling 30d window and emits ResearchInsight rows. The schedule is
+    # Friday so the eval data has had a full work-week to accumulate.
+    research_trigger = CronTrigger(
+        day_of_week="fri",
+        hour=9,
+        minute=0,
+        timezone=tz,
+    )
+    scheduler.add_job(
+        run_research_job,
+        trigger=research_trigger,
+        id="weekly_research",
+        name="Weekly auto-research + Discord report",
+        misfire_grace_time=1800,  # 30 min grace — research is non-urgent
+    )
+    log.info("job_registered", session="weekly_research", time="09:00", days="Fri")
 
     return scheduler
 

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -166,13 +166,19 @@ async def run_daily_eval(eval_date_iso: str | None = None) -> None:
 
     settings = await asyncio.to_thread(load_settings_fresh)
 
-    # Pull "yesterday's afternoon scan" rows for the report block. We use the
+    # Pull "yesterday's scan" rows for the report block. We use the
     # 1d horizon since that captures the freshest readout the operator cares
     # about each morning.
+    #
+    # PR3 carry-over [P2]: roll back via TRADING days, not calendar days. On
+    # a Monday eval, calendar-rollback lands on Sunday and quietly returns
+    # zero theses; the operator never sees Friday's afternoon/close picks
+    # graded. `_trading_days_back` from llm_thesis.eval already handles the
+    # weekend skip — reuse it here.
     def _fetch_yesterday():
-        from datetime import timedelta as _td
+        from rainier.llm_thesis.eval import _trading_days_back
 
-        prior = eval_date - _td(days=1)
+        prior = _trading_days_back(eval_date, 1)
         with get_session() as session:
             rows = (
                 session.query(
@@ -216,13 +222,20 @@ async def run_daily_eval(eval_date_iso: str | None = None) -> None:
         yesterday_rows = []
 
     try:
-        base_rates = await asyncio.to_thread(compute_verdict_hit_rate, 30)
+        # PR3 carry-over [P3]: pass eval_date so the rolling window anchors on
+        # the run's logical "today" rather than `date.today()` at function-call
+        # time (matters for historical replay / manual eval).
+        base_rates = await asyncio.to_thread(
+            lambda: compute_verdict_hit_rate(30, eval_date=eval_date)
+        )
     except Exception as exc:
         log.error("daily_eval_base_rates_failed", error=str(exc))
         base_rates = {}
 
     try:
-        contribs = await asyncio.to_thread(compute_signal_contribution, 30, "5d")
+        contribs = await asyncio.to_thread(
+            lambda: compute_signal_contribution(30, "5d", eval_date=eval_date)
+        )
     except Exception as exc:
         log.error("daily_eval_contribs_failed", error=str(exc))
         contribs = []

--- a/tests/test_alerts/test_discord_research.py
+++ b/tests/test_alerts/test_discord_research.py
@@ -149,6 +149,42 @@ def test_send_research_report_skips_when_no_webhook():
     mock_post.assert_not_called()
 
 
+def test_format_research_message_scrubs_at_mentions_in_subject():
+    """[P2 from review] Adversarial LLM-generated `subject` text containing
+    `@everyone` or `@here` must NOT pass through to Discord — the rendered
+    message must replace `@` with a non-mention variant.
+    """
+    insights = [
+        _ins(
+            id=1, severity="warn",
+            subject="@everyone bad",
+            rationale="@here please review",
+        ),
+    ]
+    msg = _format_research_message(
+        eval_date=date(2026, 5, 7), insights=insights
+    )
+    assert "@everyone" not in msg
+    assert "@here" not in msg
+    # The fullwidth-at variant survives so the operator can still read it.
+    assert "＠" in msg
+
+
+def test_format_research_message_scrubs_backticks():
+    """Backticks in rationale could break the surrounding code-block block
+    formatting; they must be replaced (or stripped)."""
+    insights = [
+        _ins(
+            id=1, severity="warn",
+            rationale="bad `code injection` attempt",
+        ),
+    ]
+    msg = _format_research_message(
+        eval_date=date(2026, 5, 7), insights=insights
+    )
+    assert "`code" not in msg
+
+
 def test_send_research_report_posts_when_enabled():
     cfg = DiscordConfig(enabled=True, webhook_url="https://example/test")
     with patch("rainier.alerts.discord.httpx.post") as mock_post:

--- a/tests/test_alerts/test_discord_research.py
+++ b/tests/test_alerts/test_discord_research.py
@@ -1,0 +1,163 @@
+"""Tests for the Discord research-report renderer (PR3)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from unittest.mock import patch
+
+from rainier.alerts.discord import _format_research_message, send_research_report
+from rainier.core.config import DiscordConfig
+from rainier.core.models import ResearchInsight
+
+
+def _ins(
+    *,
+    id: int,
+    kind: str = "signal_underperform",
+    subject: str = "rank_trajectory",
+    severity: str = "warn",
+    rationale: str = "Default rationale.",
+    recurrence: int = 1,
+    action: dict | None = None,
+    status: str = "pending",
+) -> ResearchInsight:
+    return ResearchInsight(
+        id=id,
+        kind=kind,
+        subject=subject,
+        severity=severity,
+        evidence={"sample": 1},
+        action=action or {"kind": "disable_signal", "target": subject, "params": {}},
+        rationale=rationale,
+        recurrence_count=recurrence,
+        status=status,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+def test_format_research_message_renders_pending_only():
+    """Accepted/rejected/stale rows must NOT appear — only pending."""
+    insights = [
+        _ins(id=1, severity="warn", status="pending"),
+        _ins(id=2, severity="warn", status="accepted"),
+        _ins(id=3, severity="critical", status="rejected"),
+        _ins(id=4, severity="critical", status="pending"),
+    ]
+    msg = _format_research_message(
+        eval_date=date(2026, 5, 7), insights=insights
+    )
+    assert "#1" in msg
+    assert "#4" in msg
+    assert "#2" not in msg
+    assert "#3" not in msg
+
+
+def test_format_research_message_filters_info_by_default():
+    """info-severity insights are suggestions; the report shows warn+critical
+    only by default."""
+    insights = [
+        _ins(id=1, severity="info", status="pending"),
+        _ins(id=2, severity="warn", status="pending"),
+    ]
+    msg = _format_research_message(
+        eval_date=date(2026, 5, 7), insights=insights
+    )
+    assert "#2" in msg
+    assert "#1" not in msg
+
+
+def test_format_research_message_orders_critical_first():
+    insights = [
+        _ins(id=1, severity="warn", status="pending"),
+        _ins(id=2, severity="critical", status="pending"),
+        _ins(id=3, severity="warn", status="pending"),
+    ]
+    msg = _format_research_message(
+        eval_date=date(2026, 5, 7), insights=insights
+    )
+    crit_idx = msg.index("#2")
+    warn1_idx = msg.index("#1")
+    warn3_idx = msg.index("#3")
+    assert crit_idx < warn1_idx
+    assert crit_idx < warn3_idx
+
+
+def test_format_research_message_no_pending_insights():
+    msg = _format_research_message(
+        eval_date=date(2026, 5, 7), insights=[]
+    )
+    assert "No new pending" in msg
+
+
+def test_format_research_message_under_1800_chars():
+    insights = [
+        _ins(
+            id=i, severity="warn",
+            rationale="rationale " * 30,  # long rationale
+        )
+        for i in range(20)
+    ]
+    msg = _format_research_message(
+        eval_date=date(2026, 5, 7), insights=insights
+    )
+    assert len(msg) <= 1800
+
+
+def test_format_research_message_recurrence_label():
+    insights = [
+        _ins(id=1, severity="warn", recurrence=3),
+        _ins(id=2, severity="warn", recurrence=1),
+    ]
+    msg = _format_research_message(
+        eval_date=date(2026, 5, 7), insights=insights
+    )
+    assert "(x3)" in msg
+    # Recurrence=1 doesn't get a label (would be noisy).
+    one_line = next(line for line in msg.splitlines() if "#2" in line)
+    assert "(x1)" not in one_line
+
+
+def test_format_research_message_includes_action_kind():
+    insights = [
+        _ins(
+            id=1, severity="critical", kind="verdict_drift",
+            action={"kind": "bump_prompt_version", "target": "v1", "params": {}},
+        ),
+    ]
+    msg = _format_research_message(
+        eval_date=date(2026, 5, 7), insights=insights
+    )
+    assert "bump_prompt_version" in msg
+
+
+def test_send_research_report_skips_when_disabled():
+    cfg = DiscordConfig(enabled=False, webhook_url="https://x")
+    with patch("rainier.alerts.discord.httpx.post") as mock_post:
+        send_research_report(
+            eval_date=date(2026, 5, 7), insights=[], config=cfg,
+        )
+    mock_post.assert_not_called()
+
+
+def test_send_research_report_skips_when_no_webhook():
+    cfg = DiscordConfig(enabled=True, webhook_url="")
+    with patch("rainier.alerts.discord.httpx.post") as mock_post:
+        send_research_report(
+            eval_date=date(2026, 5, 7), insights=[], config=cfg,
+        )
+    mock_post.assert_not_called()
+
+
+def test_send_research_report_posts_when_enabled():
+    cfg = DiscordConfig(enabled=True, webhook_url="https://example/test")
+    with patch("rainier.alerts.discord.httpx.post") as mock_post:
+        mock_post.return_value.raise_for_status = lambda: None
+        send_research_report(
+            eval_date=date(2026, 5, 7),
+            insights=[_ins(id=1, severity="warn", status="pending")],
+            config=cfg,
+        )
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert kwargs.get("json", {}).get("content")

--- a/tests/test_llm_thesis/test_cli_thesis_research.py
+++ b/tests/test_llm_thesis/test_cli_thesis_research.py
@@ -1,0 +1,401 @@
+"""Tests for `rainier thesis research` CLI subcommands — list, accept,
+reject, run, signals, verdicts.
+
+Covers the human-in-the-loop accept/reject flow including the YAML-mutation
+side effect (handled via a tmp_path settings file).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from rainier.cli import cli
+from rainier.core.models import ResearchInsight
+
+# ---------------------------------------------------------------------------
+# Fake session helpers
+# ---------------------------------------------------------------------------
+
+
+def _ins(
+    *,
+    id: int,
+    kind: str = "signal_underperform",
+    subject: str = "rank_trajectory",
+    severity: str = "warn",
+    rationale: str = "Default rationale.",
+    recurrence: int = 1,
+    action: dict | None = None,
+    status: str = "pending",
+) -> ResearchInsight:
+    return ResearchInsight(
+        id=id,
+        kind=kind,
+        subject=subject,
+        severity=severity,
+        evidence={"sample": 1},
+        action=action or {"kind": "disable_signal", "target": subject, "params": {}},
+        rationale=rationale,
+        recurrence_count=recurrence,
+        status=status,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+SAMPLE_YAML = """\
+# top comment
+app:
+  name: rainier
+  data_dir: ./data
+
+llm_thesis:
+  enabled: true
+  prompt_version: "v1"
+  signals:
+    rank_trajectory:
+      enabled: true
+      params: {days: 10}
+      weight: 1.0
+    fundamentals:
+      enabled: true
+      params: {}
+      weight: 1.0
+"""
+
+
+@pytest.fixture
+def settings_path(tmp_path: Path) -> Path:
+    p = tmp_path / "settings.yaml"
+    p.write_text(SAMPLE_YAML)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# `rainier thesis research insights list`
+# ---------------------------------------------------------------------------
+
+
+def test_insights_list_filters_by_status(settings_path: Path):
+    rows = [
+        _ins(id=1, severity="warn", status="pending"),
+        _ins(id=2, severity="critical", status="accepted"),
+    ]
+    sess = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = sess
+    cm.__exit__.return_value = False
+    sess.execute.return_value.scalars.return_value.all.return_value = [rows[0]]
+
+    runner = CliRunner()
+    with patch("rainier.core.database.get_session", return_value=cm):
+        result = runner.invoke(
+            cli,
+            [
+                "--config", str(settings_path),
+                "thesis", "research", "insights", "list",
+                "--status", "pending",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "ID" in result.output
+    assert "rank_trajectory" in result.output
+    assert "warn" in result.output
+
+
+def test_insights_list_no_rows(settings_path: Path):
+    sess = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = sess
+    cm.__exit__.return_value = False
+    sess.execute.return_value.scalars.return_value.all.return_value = []
+    runner = CliRunner()
+    with patch("rainier.core.database.get_session", return_value=cm):
+        result = runner.invoke(
+            cli,
+            [
+                "--config", str(settings_path),
+                "thesis", "research", "insights", "list",
+                "--status", "pending",
+            ],
+        )
+    assert result.exit_code == 0
+    assert "No pending insights" in result.output
+
+
+# ---------------------------------------------------------------------------
+# `rainier thesis research insights accept`
+# ---------------------------------------------------------------------------
+
+
+def test_insights_accept_applies_yaml_change_and_marks_accepted(
+    settings_path: Path,
+):
+    """End-to-end: accept a disable_signal insight → YAML flipped + DB row
+    moves to status=accepted with applied_change populated.
+    """
+    row = _ins(
+        id=42, severity="warn", subject="rank_trajectory",
+        action={"kind": "disable_signal", "target": "rank_trajectory", "params": {}},
+        status="pending",
+    )
+    captured: dict = {}
+
+    sess = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = sess
+    cm.__exit__.return_value = False
+    sess.get.return_value = row
+
+    def _flush():
+        captured["status"] = row.status
+        captured["applied_change"] = row.applied_change
+        captured["decided_at"] = row.decided_at
+
+    sess.flush.side_effect = _flush
+
+    runner = CliRunner()
+    with patch("rainier.core.database.get_session", return_value=cm):
+        result = runner.invoke(
+            cli,
+            [
+                "--config", str(settings_path),
+                "thesis", "research", "insights", "accept", "42",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "Accepted insight #42" in result.output
+    # YAML mutated.
+    text = settings_path.read_text()
+    rt_section = text.split("rank_trajectory:")[1].split("fundamentals:")[0]
+    assert "enabled: false" in rt_section
+    # DB updates flushed.
+    assert captured["status"] == "accepted"
+    assert captured["applied_change"]["new_value"] is False
+    assert captured["decided_at"] is not None
+
+
+def test_insights_accept_rejects_non_pending(settings_path: Path):
+    """An already-accepted/rejected/stale row must error out clearly."""
+    row = _ins(id=42, severity="warn", status="accepted")
+    sess = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = sess
+    cm.__exit__.return_value = False
+    sess.get.return_value = row
+
+    runner = CliRunner()
+    with patch("rainier.core.database.get_session", return_value=cm):
+        result = runner.invoke(
+            cli,
+            [
+                "--config", str(settings_path),
+                "thesis", "research", "insights", "accept", "42",
+            ],
+        )
+    assert result.exit_code != 0
+    assert "not pending" in result.output
+
+
+def test_insights_accept_missing_row(settings_path: Path):
+    sess = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = sess
+    cm.__exit__.return_value = False
+    sess.get.return_value = None
+
+    runner = CliRunner()
+    with patch("rainier.core.database.get_session", return_value=cm):
+        result = runner.invoke(
+            cli,
+            [
+                "--config", str(settings_path),
+                "thesis", "research", "insights", "accept", "999",
+            ],
+        )
+    assert result.exit_code != 0
+    assert "No ResearchInsight with id=999" in result.output
+
+
+def test_insights_accept_unknown_action_kind(settings_path: Path):
+    """If an old insight has an action.kind no longer in ACTION_EXECUTORS,
+    surface a clear error rather than partial side effect.
+    """
+    row = _ins(
+        id=42,
+        severity="warn",
+        action={"kind": "delete_universe", "target": "x", "params": {}},
+        status="pending",
+    )
+    sess = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = sess
+    cm.__exit__.return_value = False
+    sess.get.return_value = row
+    original = settings_path.read_text()
+    runner = CliRunner()
+    with patch("rainier.core.database.get_session", return_value=cm):
+        result = runner.invoke(
+            cli,
+            [
+                "--config", str(settings_path),
+                "thesis", "research", "insights", "accept", "42",
+            ],
+        )
+    assert result.exit_code != 0
+    assert "Could not apply action" in result.output
+    # YAML untouched.
+    assert settings_path.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# `rainier thesis research insights reject`
+# ---------------------------------------------------------------------------
+
+
+def test_insights_reject_marks_rejected_with_reason(settings_path: Path):
+    row = _ins(id=42, severity="warn", status="pending")
+    captured: dict = {}
+
+    sess = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = sess
+    cm.__exit__.return_value = False
+    sess.get.return_value = row
+
+    def _flush():
+        captured["status"] = row.status
+        captured["decided_by"] = row.decided_by
+
+    sess.flush.side_effect = _flush
+
+    original = settings_path.read_text()
+    runner = CliRunner()
+    with patch("rainier.core.database.get_session", return_value=cm):
+        result = runner.invoke(
+            cli,
+            [
+                "--config", str(settings_path),
+                "thesis", "research", "insights", "reject", "42",
+                "--reason", "noise",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "Rejected insight #42" in result.output
+    assert captured["status"] == "rejected"
+    assert captured["decided_by"] == "noise"
+    # YAML untouched on rejection.
+    assert settings_path.read_text() == original
+
+
+def test_insights_reject_requires_reason(settings_path: Path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--config", str(settings_path),
+            "thesis", "research", "insights", "reject", "42",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "reason" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# `rainier thesis research run`
+# ---------------------------------------------------------------------------
+
+
+def test_research_run_invokes_scheduler_entry(settings_path: Path):
+    runner = CliRunner()
+    captured: dict = {}
+
+    async def _fake_run(eval_date_iso=None):
+        captured["eval_date_iso"] = eval_date_iso
+
+    with patch(
+        "rainier.scheduler.service.run_research_job",
+        side_effect=_fake_run,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "--config", str(settings_path),
+                "thesis", "research", "run",
+                "--eval-date", "2026-05-08",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert captured["eval_date_iso"] == "2026-05-08"
+
+
+# ---------------------------------------------------------------------------
+# `rainier thesis research signals` and `verdicts`
+# ---------------------------------------------------------------------------
+
+
+def test_research_signals_prints_contributions(settings_path: Path):
+    from rainier.llm_thesis.eval import SignalContribution
+
+    contribs = [
+        SignalContribution(
+            "rank_trajectory", n_used=20, n_absent=18,
+            mean_used=0.012, mean_absent=0.004, lift=0.008, p_value=0.03,
+        ),
+    ]
+    runner = CliRunner()
+    with patch(
+        "rainier.llm_thesis.eval.compute_signal_contribution",
+        return_value=contribs,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "--config", str(settings_path),
+                "thesis", "research", "signals", "--days", "30",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "rank_trajectory" in result.output
+    assert "0.030" in result.output  # p-value
+
+
+def test_research_verdicts_prints_hit_rates(settings_path: Path):
+    from rainier.llm_thesis.eval import HitRate
+
+    rates = {
+        "setup_long": [
+            HitRate("setup_long", "1d", 4, 0.75, 0.01),
+            HitRate("setup_long", "5d", 4, 0.75, 0.02),
+            HitRate("setup_long", "10d", 4, 0.75, 0.03),
+        ],
+        "watch": [
+            HitRate("watch", "1d", 0, 0.0, 0.0),
+            HitRate("watch", "5d", 0, 0.0, 0.0),
+            HitRate("watch", "10d", 0, 0.0, 0.0),
+        ],
+        "no_setup": [
+            HitRate("no_setup", "1d", 0, 0.0, 0.0),
+            HitRate("no_setup", "5d", 0, 0.0, 0.0),
+            HitRate("no_setup", "10d", 0, 0.0, 0.0),
+        ],
+    }
+    runner = CliRunner()
+    with patch(
+        "rainier.llm_thesis.eval.compute_verdict_hit_rate", return_value=rates,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "--config", str(settings_path),
+                "thesis", "research", "verdicts", "--days", "30",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "setup_long" in result.output
+    assert "75.00%" in result.output or "75%" in result.output

--- a/tests/test_llm_thesis/test_pr2_carryovers.py
+++ b/tests/test_llm_thesis/test_pr2_carryovers.py
@@ -1,0 +1,346 @@
+"""Regression tests for the three PR2 carry-over P2/P3 review findings
+fixed in PR3:
+
+1. [P2] `_fetch_yesterday` in `scheduler.service.run_daily_eval` rolls back
+   via TRADING days (skip Sat/Sun) instead of calendar days. On Monday the
+   prior trading day is Friday, not Sunday.
+2. [P2] The Discord eval renderer (`alerts.discord._format_eval_message`)
+   splits afternoon and close session blocks into separate sections so the
+   operator can attribute picks to the right scan.
+3. [P3] `eval.compute_signal_contribution` accepts an ``eval_date`` keyword
+   so the rolling-window cutoff anchors on the caller's logical "today"
+   (matters for historical replay / weekly research). Same for
+   `compute_verdict_hit_rate`.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rainier.alerts.discord import _format_eval_message
+from rainier.llm_thesis.eval import (
+    HitRate,
+    compute_signal_contribution,
+    compute_verdict_hit_rate,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — _fetch_yesterday uses trading-day rollback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_daily_eval_yesterday_uses_trading_day_rollback():
+    """On Monday eval, _fetch_yesterday must query the prior FRIDAY, not Sunday.
+
+    We patch the LLMThesisConfig + SQLAlchemy session and capture which
+    `scan_date` is filtered on. The prior implementation used a calendar
+    `timedelta(days=1)`; the fix uses `_trading_days_back(eval_date, 1)`.
+    """
+    from rainier.core.config import (
+        AlertsConfig,
+        AppConfig,
+        DiscordConfig,
+        LLMThesisConfig,
+        ScrapingConfig,
+        ScrapingSchedule,
+        Settings,
+    )
+
+    settings = Settings(
+        database_url="postgresql://test:test@localhost/test",
+        app=AppConfig(timezone="America/Los_Angeles"),
+        scraping=ScrapingConfig(
+            schedule=ScrapingSchedule(
+                morning="08:35", midday="10:35",
+                afternoon="12:35", close="14:35",
+            )
+        ),
+        alerts=AlertsConfig(discord=DiscordConfig(enabled=False, webhook_url="")),
+        llm_thesis=LLMThesisConfig(),
+    )
+
+    captured_filter_args: list = []
+
+    cm = MagicMock()
+    chain = (
+        cm.__enter__.return_value.query.return_value
+        .join.return_value
+    )
+
+    def _filter(*args, **_kwargs):
+        # Capture the filter arguments so we can introspect what scan_date
+        # was used. SQLAlchemy BinaryExpression `.right.value` is the value.
+        captured_filter_args.append(args)
+        next_chain = MagicMock()
+        next_chain.order_by.return_value.all.return_value = []
+        return next_chain
+
+    chain.filter.side_effect = _filter
+    cm.__exit__.return_value = False
+
+    with (
+        patch(
+            "rainier.scheduler.service.load_settings_fresh",
+            return_value=settings,
+        ),
+        patch(
+            "rainier.llm_thesis.eval.evaluate_horizon", return_value=0
+        ),
+        patch(
+            "rainier.llm_thesis.eval.compute_signal_contribution", return_value=[]
+        ),
+        patch(
+            "rainier.llm_thesis.eval.compute_verdict_hit_rate", return_value={}
+        ),
+        patch(
+            "rainier.alerts.discord.send_eval_report"
+        ),
+        patch("rainier.core.database.get_session", return_value=cm),
+    ):
+        from rainier.scheduler.service import run_daily_eval
+        # Monday 2026-05-04. Prior trading day is Friday 2026-05-01.
+        await run_daily_eval(eval_date_iso="2026-05-04")
+
+    # Pull the scan_date value out of the captured filter args. The call
+    # filters on `ThesisEvaluation.scan_date == prior` so the prior date is
+    # one of the comparison expressions.
+    expected_friday = date(2026, 5, 1)
+    sundays = date(2026, 5, 3)
+
+    found_dates: set = set()
+    for args in captured_filter_args:
+        for expr in args:
+            # Compare against the .right.value attribute of a comparator;
+            # tolerate non-comparator arguments by ignoring AttributeError.
+            try:
+                v = expr.right.value
+            except AttributeError:
+                continue
+            if isinstance(v, date):
+                found_dates.add(v)
+
+    assert expected_friday in found_dates, (
+        f"trading-day rollback should query {expected_friday}; "
+        f"saw filters on {found_dates}"
+    )
+    assert sundays not in found_dates, (
+        f"calendar-day rollback regression: must NOT query {sundays}; "
+        f"saw filters on {found_dates}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — Discord eval renderer splits sessions
+# ---------------------------------------------------------------------------
+
+
+def _hit_rates_empty():
+    return {
+        v: [
+            HitRate(v, "1d", 0, 0.0, 0.0),
+            HitRate(v, "5d", 0, 0.0, 0.0),
+            HitRate(v, "10d", 0, 0.0, 0.0),
+        ]
+        for v in ("setup_long", "watch", "no_setup")
+    }
+
+
+def test_format_eval_message_splits_afternoon_and_close_sections():
+    """When yesterday_rows mixes 'afternoon' and 'close', render two
+    distinct headers — not one merged block.
+    """
+    rows = [
+        {
+            "scan_date": date(2026, 5, 6),
+            "session_name": "afternoon",
+            "symbol": "NVDA",
+            "verdict": "setup_long",
+            "llm_confidence": 8,
+            "return_pct": 0.02,
+            "hit": True,
+        },
+        {
+            "scan_date": date(2026, 5, 6),
+            "session_name": "close",
+            "symbol": "TSLA",
+            "verdict": "watch",
+            "llm_confidence": 5,
+            "return_pct": -0.01,
+            "hit": False,
+        },
+        {
+            "scan_date": date(2026, 5, 6),
+            "session_name": "afternoon",
+            "symbol": "AAPL",
+            "verdict": "no_setup",
+            "llm_confidence": 3,
+            "return_pct": 0.001,
+            "hit": True,
+        },
+    ]
+    msg = _format_eval_message(
+        eval_date=date(2026, 5, 7),
+        yesterday_rows=rows,
+        base_rates=_hit_rates_empty(),
+        signal_contribs=[],
+    )
+
+    assert "Yesterday's afternoon scan" in msg
+    assert "Yesterday's close scan" in msg
+    # Both NVDA (afternoon) and TSLA (close) appear with their own picks.
+    assert "NVDA" in msg
+    assert "TSLA" in msg
+    assert "AAPL" in msg
+
+    afternoon_idx = msg.index("Yesterday's afternoon scan")
+    close_idx = msg.index("Yesterday's close scan")
+    nvda_idx = msg.index("NVDA")
+    aapl_idx = msg.index("AAPL")
+    tsla_idx = msg.index("TSLA")
+    # NVDA + AAPL group under afternoon (before close header); TSLA under close.
+    assert afternoon_idx < nvda_idx < close_idx
+    assert afternoon_idx < aapl_idx < close_idx
+    assert close_idx < tsla_idx
+
+
+def test_format_eval_message_single_session_unchanged():
+    """Single-session rendering should still produce one header (back-compat)."""
+    rows = [
+        {
+            "scan_date": date(2026, 5, 6),
+            "session_name": "afternoon",
+            "symbol": "NVDA",
+            "verdict": "setup_long",
+            "llm_confidence": 8,
+            "return_pct": 0.02,
+            "hit": True,
+        }
+    ]
+    msg = _format_eval_message(
+        eval_date=date(2026, 5, 7),
+        yesterday_rows=rows,
+        base_rates=_hit_rates_empty(),
+        signal_contribs=[],
+    )
+    assert msg.count("Yesterday's afternoon scan") == 1
+    assert "Yesterday's close scan" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — compute_signal_contribution honors eval_date
+# ---------------------------------------------------------------------------
+
+
+def test_compute_signal_contribution_eval_date_anchors_window():
+    """Passing eval_date=2026-04-30, days=30 must filter on
+    scan_date >= (2026-04-30 - 30 days) regardless of date.today().
+    """
+    captured_cutoffs: list[date] = []
+
+    sess = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = sess
+    cm.__exit__.return_value = False
+
+    def _execute(stmt):
+        # Walk through the WHERE clauses to extract the date cutoff.
+        # `.whereclause` is a BooleanClauseList for and_(...).
+        try:
+            clauses = stmt.whereclause.clauses  # type: ignore[attr-defined]
+        except AttributeError:
+            clauses = []
+        for clause in clauses:
+            try:
+                v = clause.right.value
+            except AttributeError:
+                continue
+            if isinstance(v, date):
+                captured_cutoffs.append(v)
+        result = MagicMock()
+        result.all.return_value = []
+        return result
+
+    sess.execute.side_effect = _execute
+
+    with patch("rainier.llm_thesis.eval.get_session", return_value=cm):
+        compute_signal_contribution(
+            days=30, horizon="5d", eval_date=date(2026, 4, 30),
+        )
+
+    # The cutoff stored on the WHERE clause must equal eval_date - 30 days.
+    expected_cutoff = date(2026, 4, 30) - __import__("datetime").timedelta(days=30)
+    assert expected_cutoff in captured_cutoffs
+
+
+def test_compute_signal_contribution_default_uses_today():
+    """Without eval_date, default behavior anchors on date.today() — the
+    backwards-compatible legacy path.
+    """
+    captured: list[date] = []
+
+    sess = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = sess
+    cm.__exit__.return_value = False
+
+    def _execute(stmt):
+        try:
+            for clause in stmt.whereclause.clauses:  # type: ignore[attr-defined]
+                try:
+                    v = clause.right.value
+                except AttributeError:
+                    continue
+                if isinstance(v, date):
+                    captured.append(v)
+        except AttributeError:
+            pass
+        result = MagicMock()
+        result.all.return_value = []
+        return result
+
+    sess.execute.side_effect = _execute
+
+    with patch("rainier.llm_thesis.eval.get_session", return_value=cm):
+        compute_signal_contribution(days=30, horizon="5d")
+
+    today = date.today()
+    expected_cutoff = today - __import__("datetime").timedelta(days=30)
+    assert expected_cutoff in captured
+
+
+def test_compute_verdict_hit_rate_eval_date_anchors_window():
+    """Same eval_date contract for the verdict aggregator."""
+    captured: list[date] = []
+
+    sess = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = sess
+    cm.__exit__.return_value = False
+
+    def _execute(stmt):
+        try:
+            clause = stmt.whereclause
+            try:
+                v = clause.right.value
+            except AttributeError:
+                v = None
+            if isinstance(v, date):
+                captured.append(v)
+        except AttributeError:
+            pass
+        result = MagicMock()
+        result.all.return_value = []
+        return result
+
+    sess.execute.side_effect = _execute
+
+    with patch("rainier.llm_thesis.eval.get_session", return_value=cm):
+        compute_verdict_hit_rate(days=30, eval_date=date(2026, 4, 30))
+
+    expected_cutoff = date(2026, 4, 30) - __import__("datetime").timedelta(days=30)
+    assert expected_cutoff in captured

--- a/tests/test_llm_thesis/test_pr2_carryovers.py
+++ b/tests/test_llm_thesis/test_pr2_carryovers.py
@@ -27,7 +27,6 @@ from rainier.llm_thesis.eval import (
     compute_verdict_hit_rate,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fix 1 — _fetch_yesterday uses trading-day rollback
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_thesis/test_research.py
+++ b/tests/test_llm_thesis/test_research.py
@@ -807,3 +807,118 @@ def test_run_research_isolates_failures():
 def test_apply_action_is_callable():
     """Sanity: the dispatcher is exported from research.py."""
     assert callable(apply_action)
+
+
+# ---------------------------------------------------------------------------
+# /review iter-1 fixes
+# ---------------------------------------------------------------------------
+
+
+def test_emit_insight_owns_session_via_contextmanager():
+    """[P0 from review] When the caller does NOT pass `db_session`, the helper
+    must drive the session through `get_session()`'s contextmanager so a
+    SQL-level exception triggers rollback() + close() instead of leaking an
+    open transaction. Previously the code called `get_session().__enter__()`
+    directly, which bypassed the @contextmanager exception handling.
+    """
+    cm_calls: dict[str, int] = {"enter": 0, "exit": 0, "rollback": 0, "commit": 0}
+
+    class _SpySession:
+        def __init__(self):
+            self.committed = False
+            self.rolled_back = False
+
+        def query(self, *_a, **_kw):
+            return _Query([])
+
+        def add(self, _r):
+            pass
+
+        def flush(self):
+            return None
+
+        def commit(self):
+            cm_calls["commit"] += 1
+            self.committed = True
+
+        def rollback(self):
+            cm_calls["rollback"] += 1
+            self.rolled_back = True
+
+        def close(self):
+            pass
+
+    spy = _SpySession()
+
+    class _CM:
+        def __enter__(self):
+            cm_calls["enter"] += 1
+            return spy
+
+        def __exit__(self, exc_type, exc, tb):
+            cm_calls["exit"] += 1
+            if exc_type is not None:
+                spy.rollback()
+            else:
+                spy.commit()
+            return False
+
+    with patch("rainier.llm_thesis.research.get_session", return_value=_CM()):
+        emit_insight(
+            kind="signal_underperform",
+            subject="rank_trajectory",
+            severity="warn",
+            evidence={},
+            action={"kind": "disable_signal", "target": "x", "params": {}},
+            rationale="r",
+        )
+
+    # The helper must have entered AND exited the contextmanager exactly once.
+    assert cm_calls["enter"] == 1
+    assert cm_calls["exit"] == 1
+    assert cm_calls["commit"] == 1
+    assert cm_calls["rollback"] == 0
+
+
+def test_check_prompt_regression_emits_at_most_one_per_newer_prompt():
+    """[P2 from review] When three prompts exist (v1 older, v2 mid, v3
+    newest) and v3 is statistically worse than BOTH v1 and v2, the previous
+    implementation called emit_insight twice (once per pair), each UPSERT-ing
+    the same `subject=v3` row. That silently dropped earlier evidence and
+    inflated recurrence_count. The fix picks the strongest pair (lowest p)
+    and calls emit_insight exactly once per `newer`.
+    """
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+
+    v1_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    v2_at = datetime(2026, 4, 15, tzinfo=timezone.utc)
+    v3_at = datetime(2026, 4, 25, tzinfo=timezone.utc)
+
+    # v1 returns +0.05; v2 returns +0.04 (slightly worse); v3 returns -0.03
+    # (much worse). v3 is significantly worse than BOTH older prompts.
+    fake_rows = (
+        [("v1", v1_at, 0.05)] * 12
+        + [("v2", v2_at, 0.04)] * 12
+        + [("v3", v3_at, -0.03)] * 12
+    )
+
+    cm = MagicMock()
+    cm.__enter__.return_value.execute.return_value.all.return_value = fake_rows
+    cm.__exit__.return_value = False
+
+    with patch(
+        "rainier.llm_thesis.research.get_session", return_value=cm
+    ):
+        out = check_prompt_regression(
+            eval_date=today, days=30, db_session=sess
+        )
+
+    # v2 is barely worse than v1 (likely no significant p), v3 is much worse
+    # than both. So we expect at most one emission for v3 — never one for v2
+    # AND v3 from the same `newer=v3` group.
+    v3_emissions = [r for r in out if r.subject == "v3"]
+    assert len(v3_emissions) == 1, (
+        "v3 must produce a single insight (best-pair semantics), "
+        "not one per older predecessor"
+    )

--- a/tests/test_llm_thesis/test_research.py
+++ b/tests/test_llm_thesis/test_research.py
@@ -1,0 +1,809 @@
+"""Tests for the auto-research module — emit_insight UPSERT, mark_stale,
+and each of the 6 check classes against synthetic data.
+
+The eval/research code touches Postgres-only ARRAY + JSONB columns, so we
+mock `get_session` boundaries with in-test fakes (same pattern as
+test_eval.py). Postgres integration tests live in `tests/integration/` and
+run on demand against a real DB.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rainier.core.models import ResearchInsight
+from rainier.llm_thesis.research import (
+    INSIGHT_KINDS,
+    SEVERITIES,
+    apply_action,
+    check_calibration_off,
+    check_new_pattern_discovered,
+    check_prompt_regression,
+    check_signal_overperform,
+    check_signal_underperform,
+    check_verdict_drift,
+    emit_insight,
+    mark_stale,
+    run_research,
+)
+
+# ---------------------------------------------------------------------------
+# In-memory ResearchInsight session — supports emit_insight() UPSERT
+# ---------------------------------------------------------------------------
+
+
+class _MemSession:
+    """A tiny in-memory store for ResearchInsight rows used by emit_insight().
+
+    Implements just enough of the SQLAlchemy 2.x session interface to satisfy
+    the production code: query().filter(...).first(), add(), flush(), and
+    execute(update(...)) — the last for mark_stale().
+    """
+
+    def __init__(self):
+        self.rows: list[ResearchInsight] = []
+        self._next_id = 1
+        self.committed = False
+
+    # ----- query path used by emit_insight to look up an existing pending row
+    def query(self, model):  # noqa: ARG002
+        return _Query(self.rows)
+
+    def add(self, row: ResearchInsight) -> None:
+        if row.id is None:
+            row.id = self._next_id
+            self._next_id += 1
+        if row.created_at is None:
+            row.created_at = datetime.now(timezone.utc)
+        if row.updated_at is None:
+            row.updated_at = datetime.now(timezone.utc)
+        if row.recurrence_count is None:
+            row.recurrence_count = 1
+        if row.status is None:
+            row.status = "pending"
+        self.rows.append(row)
+
+    def flush(self) -> None:
+        return None
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def close(self) -> None:
+        return None
+
+    # ----- update path used by mark_stale
+    def execute(self, stmt):
+        # mark_stale uses sqlalchemy.update(...).where(...).values(...).
+        # We only support that one shape.
+        try:
+            params = stmt.compile().params
+        except Exception:
+            params = {}
+        result = MagicMock()
+        # Determine which rows match: status='pending' and created_at < cutoff.
+        cutoff = None
+        new_status = None
+        # Best-effort introspection.
+        try:
+            new_status = stmt._values["status"].value
+        except Exception:
+            new_status = "stale"
+        try:
+            for clause in stmt._where_criteria:
+                v = clause.right.value
+                if isinstance(v, datetime):
+                    cutoff = v
+        except Exception:
+            pass
+
+        rowcount = 0
+        if cutoff is not None:
+            for r in self.rows:
+                if r.status == "pending" and r.created_at < cutoff:
+                    r.status = new_status or "stale"
+                    rowcount += 1
+        result.rowcount = rowcount
+        _ = params  # unused, kept for symmetry
+        return result
+
+    # ----- context manager
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = rows
+        self._filters: list = []
+
+    def filter(self, *args):
+        self._filters.extend(args)
+        return self
+
+    def first(self):
+        candidates = list(self._rows)
+        for f in self._filters:
+            try:
+                col_name = f.left.key
+                expected = f.right.value
+            except AttributeError:
+                continue
+            candidates = [r for r in candidates if getattr(r, col_name, None) == expected]
+        return candidates[0] if candidates else None
+
+    def all(self):
+        return list(self._rows)
+
+
+# ---------------------------------------------------------------------------
+# emit_insight — UPSERT semantics
+# ---------------------------------------------------------------------------
+
+
+def test_emit_insight_inserts_first_row():
+    sess = _MemSession()
+    row = emit_insight(
+        kind="signal_underperform",
+        subject="rank_trajectory",
+        severity="warn",
+        evidence={"lift": -0.001, "p_value": 0.02},
+        action={"kind": "disable_signal", "target": "rank_trajectory", "params": {}},
+        rationale="No lift",
+        db_session=sess,
+    )
+    assert row.recurrence_count == 1
+    assert row.status == "pending"
+    assert row.kind == "signal_underperform"
+    assert row.subject == "rank_trajectory"
+    assert len(sess.rows) == 1
+
+
+def test_emit_insight_upsert_increments_recurrence():
+    sess = _MemSession()
+    emit_insight(
+        kind="signal_underperform",
+        subject="rank_trajectory",
+        severity="warn",
+        evidence={"lift": -0.001},
+        action={"kind": "disable_signal", "target": "rank_trajectory", "params": {}},
+        rationale="No lift v1",
+        db_session=sess,
+    )
+    second = emit_insight(
+        kind="signal_underperform",
+        subject="rank_trajectory",
+        severity="warn",
+        evidence={"lift": -0.002},  # refreshed evidence
+        action={"kind": "disable_signal", "target": "rank_trajectory", "params": {}},
+        rationale="No lift v2",
+        db_session=sess,
+    )
+    # Same row, recurrence bumped to 2, evidence + rationale refreshed.
+    assert len(sess.rows) == 1
+    assert second.recurrence_count == 2
+    assert second.evidence == {"lift": -0.002}
+    assert second.rationale == "No lift v2"
+
+
+def test_emit_insight_after_decided_creates_new_pending_row():
+    """When a previous insight is decided (accepted/rejected/stale), the
+    next emit for the same (kind, subject) must INSERT a fresh pending
+    row — not refresh the decided one.
+    """
+    sess = _MemSession()
+    first = emit_insight(
+        kind="signal_overperform",
+        subject="sector_momentum",
+        severity="info",
+        evidence={"lift": 0.006},
+        action={"kind": "raise_signal_weight", "target": "sector_momentum", "params": {}},
+        rationale="lift",
+        db_session=sess,
+    )
+    # Operator marks the row accepted offline.
+    first.status = "accepted"
+    first.decided_at = datetime.now(timezone.utc)
+
+    # Re-emit the same insight: the helper must NOT bump recurrence on the
+    # accepted row; it should INSERT a fresh pending row.
+    second = emit_insight(
+        kind="signal_overperform",
+        subject="sector_momentum",
+        severity="info",
+        evidence={"lift": 0.007},
+        action={"kind": "raise_signal_weight", "target": "sector_momentum", "params": {}},
+        rationale="lift again",
+        db_session=sess,
+    )
+    assert len(sess.rows) == 2
+    assert second.id != first.id
+    assert second.status == "pending"
+    assert second.recurrence_count == 1
+
+
+def test_emit_insight_rejects_unknown_kind():
+    sess = _MemSession()
+    with pytest.raises(ValueError, match="Unknown insight kind"):
+        emit_insight(
+            kind="not_a_real_kind",
+            subject="x",
+            severity="warn",
+            evidence={},
+            action={"kind": "noop", "target": "x", "params": {}},
+            rationale="r",
+            db_session=sess,
+        )
+
+
+def test_emit_insight_rejects_unknown_severity():
+    sess = _MemSession()
+    with pytest.raises(ValueError, match="Unknown severity"):
+        emit_insight(
+            kind="signal_underperform",
+            subject="x",
+            severity="catastrophic",
+            evidence={},
+            action={"kind": "noop", "target": "x", "params": {}},
+            rationale="r",
+            db_session=sess,
+        )
+
+
+def test_emit_insight_rejects_action_without_kind():
+    sess = _MemSession()
+    with pytest.raises(ValueError, match="must be a dict with at least"):
+        emit_insight(
+            kind="signal_underperform",
+            subject="x",
+            severity="warn",
+            evidence={},
+            action={"target": "x"},  # no 'kind'
+            rationale="r",
+            db_session=sess,
+        )
+
+
+def test_insight_kinds_and_severities_are_complete():
+    """Sanity check the public enums match the design's fixed set."""
+    assert set(INSIGHT_KINDS) == {
+        "signal_underperform",
+        "signal_overperform",
+        "verdict_drift",
+        "calibration_off",
+        "prompt_regression",
+        "new_pattern_discovered",
+    }
+    assert set(SEVERITIES) == {"info", "warn", "critical"}
+
+
+# ---------------------------------------------------------------------------
+# mark_stale
+# ---------------------------------------------------------------------------
+
+
+def test_mark_stale_flips_old_pending_rows():
+    sess = _MemSession()
+    now = datetime.now(timezone.utc)
+    # Old pending row (40 days back).
+    old = ResearchInsight(
+        id=1, kind="signal_underperform", subject="old", severity="warn",
+        evidence={}, action={"kind": "disable_signal", "target": "old", "params": {}},
+        rationale="r", recurrence_count=1, status="pending",
+        created_at=now - timedelta(days=40),
+        updated_at=now - timedelta(days=40),
+    )
+    sess.rows.append(old)
+    # Fresh pending row (5 days back).
+    fresh = ResearchInsight(
+        id=2, kind="signal_underperform", subject="fresh", severity="warn",
+        evidence={}, action={"kind": "disable_signal", "target": "fresh", "params": {}},
+        rationale="r", recurrence_count=1, status="pending",
+        created_at=now - timedelta(days=5),
+        updated_at=now - timedelta(days=5),
+    )
+    sess.rows.append(fresh)
+    # Already-accepted old row — must not be touched.
+    accepted = ResearchInsight(
+        id=3, kind="signal_underperform", subject="acc", severity="warn",
+        evidence={}, action={"kind": "disable_signal", "target": "acc", "params": {}},
+        rationale="r", recurrence_count=1, status="accepted",
+        created_at=now - timedelta(days=40),
+        updated_at=now - timedelta(days=40),
+    )
+    sess.rows.append(accepted)
+
+    with patch(
+        "rainier.llm_thesis.research.get_session",
+        return_value=sess,
+    ):
+        n = mark_stale(days=30)
+
+    assert n == 1
+    statuses = {r.id: r.status for r in sess.rows}
+    assert statuses[1] == "stale"
+    assert statuses[2] == "pending"
+    assert statuses[3] == "accepted"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic eval-row helpers — drive the check_* functions
+# ---------------------------------------------------------------------------
+
+
+def _scan_iso(d: date) -> str:
+    return d.isoformat()
+
+
+def _eval_rows(
+    *,
+    rows: list[tuple[list[str], float, str, int | None, date]],
+):
+    """Match the shape `_fetch_eval_window` returns from the SQL boundary."""
+    return [(sigs, ret, verdict, conf, _scan_iso(scan)) for sigs, ret, verdict, conf, scan in rows]
+
+
+# ---------------------------------------------------------------------------
+# check_signal_underperform
+# ---------------------------------------------------------------------------
+
+
+def test_check_signal_underperform_emits_when_signal_flat():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+    # signal "flat" used: returns ~0; absent: returns ~0.05. Lift very negative
+    # and signal is statistically distinct from absent set.
+    rows = []
+    for _ in range(10):
+        rows.append((["flat", "other"], 0.0, "setup_long", 7, today))
+    for _ in range(10):
+        rows.append((["other"], 0.05, "setup_long", 7, today))
+    fetched = _eval_rows(rows=rows)
+
+    with patch(
+        "rainier.llm_thesis.research._fetch_eval_window", return_value=fetched
+    ):
+        out = check_signal_underperform(
+            eval_date=today, days=30, db_session=sess
+        )
+
+    names = {r.subject for r in out}
+    assert "flat" in names
+    flat = next(r for r in out if r.subject == "flat")
+    assert flat.severity == "warn"
+    assert flat.action["kind"] == "disable_signal"
+    assert flat.action["target"] == "flat"
+    assert flat.evidence["lift"] < 0
+
+
+def test_check_signal_underperform_no_emit_when_signal_lifts():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+    rows = []
+    for _ in range(10):
+        rows.append((["winner"], 0.05, "setup_long", 7, today))
+    for _ in range(10):
+        rows.append(([], 0.0, "setup_long", 7, today))
+    fetched = _eval_rows(rows=rows)
+
+    with patch(
+        "rainier.llm_thesis.research._fetch_eval_window", return_value=fetched
+    ):
+        out = check_signal_underperform(
+            eval_date=today, days=30, db_session=sess
+        )
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# check_signal_overperform
+# ---------------------------------------------------------------------------
+
+
+def test_check_signal_overperform_emits_when_signal_lifts_strongly():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+    rows = []
+    for _ in range(15):
+        rows.append((["star"], 0.04, "setup_long", 7, today))
+    for _ in range(15):
+        rows.append(([], 0.0, "setup_long", 7, today))
+    fetched = _eval_rows(rows=rows)
+
+    with patch(
+        "rainier.llm_thesis.research._fetch_eval_window", return_value=fetched
+    ):
+        out = check_signal_overperform(
+            eval_date=today, days=30, db_session=sess
+        )
+
+    names = {r.subject for r in out}
+    assert "star" in names
+    star = next(r for r in out if r.subject == "star")
+    assert star.severity == "info"
+    assert star.action["kind"] == "raise_signal_weight"
+    assert star.action["params"].get("factor") == 1.2
+
+
+# ---------------------------------------------------------------------------
+# check_verdict_drift
+# ---------------------------------------------------------------------------
+
+
+def test_check_verdict_drift_emits_when_spread_collapses():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+
+    # Long-window: setup_long is 80% hit (positive returns), no_setup is 20% hit
+    # (mostly positive returns -> losing the no_setup bet). Spread = 0.6.
+    long_rows = []
+    for _ in range(20):
+        long_rows.append(([], 0.02, "setup_long", 7, today - timedelta(days=20)))
+    for _ in range(5):
+        long_rows.append(([], -0.01, "setup_long", 7, today - timedelta(days=21)))
+    for _ in range(20):
+        long_rows.append(([], 0.02, "no_setup", 3, today - timedelta(days=22)))
+    for _ in range(5):
+        long_rows.append(([], -0.01, "no_setup", 3, today - timedelta(days=23)))
+    # Short-window subset (last 14 days): each verdict ~50% hit. Spread ~0.
+    short_rows = []
+    for _ in range(5):
+        short_rows.append(([], 0.01, "setup_long", 7, today - timedelta(days=2)))
+    for _ in range(5):
+        short_rows.append(([], -0.01, "setup_long", 7, today - timedelta(days=3)))
+    for _ in range(5):
+        short_rows.append(([], -0.01, "no_setup", 3, today - timedelta(days=4)))
+    for _ in range(5):
+        short_rows.append(([], 0.01, "no_setup", 3, today - timedelta(days=5)))
+
+    def _fetch(*, days: int, horizon: str, eval_date):
+        return _eval_rows(
+            rows=long_rows if days >= 30 else short_rows
+        )
+
+    with patch(
+        "rainier.llm_thesis.research._fetch_eval_window", side_effect=_fetch
+    ), patch("rainier.llm_thesis.research.get_session") as gs:
+        # The verdict_drift check looks up the latest prompt_template via
+        # get_session — return a no-op chain so the lookup yields None.
+        cm = MagicMock()
+        cm.__enter__.return_value.execute.return_value.first.return_value = None
+        cm.__exit__.return_value = False
+        gs.return_value = cm
+
+        out = check_verdict_drift(eval_date=today, db_session=sess)
+
+    assert len(out) == 1
+    assert out[0].kind == "verdict_drift"
+    assert out[0].severity == "critical"
+    assert out[0].action["kind"] == "bump_prompt_version"
+    assert out[0].evidence["drop"] >= 0.10
+
+
+def test_check_verdict_drift_no_emit_when_stable():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+    rows = []
+    for _ in range(20):
+        rows.append(([], 0.02, "setup_long", 7, today))
+    for _ in range(20):
+        rows.append(([], 0.02, "no_setup", 3, today))
+
+    def _fetch(*, days, horizon, eval_date):
+        return _eval_rows(rows=rows)
+
+    with patch(
+        "rainier.llm_thesis.research._fetch_eval_window", side_effect=_fetch
+    ), patch("rainier.llm_thesis.research.get_session") as gs:
+        cm = MagicMock()
+        cm.__enter__.return_value.execute.return_value.first.return_value = None
+        cm.__exit__.return_value = False
+        gs.return_value = cm
+
+        out = check_verdict_drift(eval_date=today, db_session=sess)
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# check_calibration_off
+# ---------------------------------------------------------------------------
+
+
+def test_check_calibration_off_emits_on_overconfidence():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+    # confidence 9 -> hit rate ~0.1 (massively over-confident); confidence 7 ->
+    # hit rate ~0.2; confidence 5 -> hit rate ~0.5. Slope way below 1.0.
+    rows = []
+    rows.extend([([], 0.0, "setup_long", 9, today)] * 9)  # 9 misses
+    rows.extend([([], 0.05, "setup_long", 9, today)])     # 1 hit
+    rows.extend([([], 0.0, "setup_long", 7, today)] * 8)  # 8 misses
+    rows.extend([([], 0.05, "setup_long", 7, today)] * 2) # 2 hits
+    rows.extend([([], 0.0, "setup_long", 5, today)] * 5)
+    rows.extend([([], 0.05, "setup_long", 5, today)] * 5)
+    fetched = _eval_rows(rows=rows)
+
+    with patch(
+        "rainier.llm_thesis.research._fetch_eval_window", return_value=fetched
+    ):
+        out = check_calibration_off(eval_date=today, db_session=sess)
+
+    assert len(out) == 1
+    insight = out[0]
+    assert insight.kind == "calibration_off"
+    assert insight.severity == "warn"
+    assert insight.action["kind"] == "noop"
+    assert insight.evidence["deviation_from_unity"] > 0.3
+
+
+def test_check_calibration_off_no_emit_when_calibrated():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+    rows = []
+    # confidence 9 -> 9/10 hits, confidence 5 -> 5/10 hits, confidence 3 -> 3/10
+    rows.extend([([], 0.05, "setup_long", 9, today)] * 9)
+    rows.extend([([], 0.0, "setup_long", 9, today)])
+    rows.extend([([], 0.05, "setup_long", 5, today)] * 5)
+    rows.extend([([], 0.0, "setup_long", 5, today)] * 5)
+    rows.extend([([], 0.05, "setup_long", 3, today)] * 3)
+    rows.extend([([], 0.0, "setup_long", 3, today)] * 7)
+    fetched = _eval_rows(rows=rows)
+
+    with patch(
+        "rainier.llm_thesis.research._fetch_eval_window", return_value=fetched
+    ):
+        out = check_calibration_off(eval_date=today, db_session=sess)
+    assert out == []
+
+
+def test_check_calibration_off_skips_when_too_few_bins():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+    rows = [([], 0.0, "setup_long", 5, today)] * 10
+    fetched = _eval_rows(rows=rows)
+    with patch(
+        "rainier.llm_thesis.research._fetch_eval_window", return_value=fetched
+    ):
+        out = check_calibration_off(eval_date=today, db_session=sess)
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# check_new_pattern_discovered
+# ---------------------------------------------------------------------------
+
+
+def test_check_new_pattern_discovered_emits_for_recurring_winner():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+    # 4 rows mention "ascending_triangle" + 1 mentions "noisy_pattern".
+    # All ascending_triangle rows have positive returns; noisy_pattern is below
+    # the min_occurrences threshold.
+    fake_rows = [
+        (1, {"patterns_in_chart_not_in_indicators": ["ascending_triangle"]}, 0.04),
+        (2, {"patterns_in_chart_not_in_indicators": ["ascending_triangle", "noisy_pattern"]}, 0.03),
+        (3, {"patterns_in_chart_not_in_indicators": ["ascending_triangle"]}, 0.02),
+        (4, {"patterns_in_chart_not_in_indicators": ["ascending_triangle"]}, 0.05),
+        (5, {"patterns_in_chart_not_in_indicators": []}, 0.0),
+    ]
+    cm = MagicMock()
+    cm.__enter__.return_value.execute.return_value.all.return_value = fake_rows
+    cm.__exit__.return_value = False
+
+    with patch(
+        "rainier.llm_thesis.research.get_session", return_value=cm
+    ):
+        out = check_new_pattern_discovered(
+            eval_date=today, days=30, db_session=sess
+        )
+
+    subjects = {r.subject for r in out}
+    assert "ascending_triangle" in subjects
+    assert "noisy_pattern" not in subjects
+    insight = next(r for r in out if r.subject == "ascending_triangle")
+    assert insight.action["kind"] == "noop"
+    assert insight.evidence["occurrences"] == 4
+
+
+def test_check_new_pattern_discovered_skips_negative_mean():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+    fake_rows = [
+        (1, {"patterns_in_chart_not_in_indicators": ["loser"]}, -0.04),
+        (2, {"patterns_in_chart_not_in_indicators": ["loser"]}, -0.03),
+        (3, {"patterns_in_chart_not_in_indicators": ["loser"]}, -0.02),
+    ]
+    cm = MagicMock()
+    cm.__enter__.return_value.execute.return_value.all.return_value = fake_rows
+    cm.__exit__.return_value = False
+
+    with patch(
+        "rainier.llm_thesis.research.get_session", return_value=cm
+    ):
+        out = check_new_pattern_discovered(
+            eval_date=today, days=30, db_session=sess
+        )
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# check_prompt_regression
+# ---------------------------------------------------------------------------
+
+
+def test_check_prompt_regression_emits_when_new_prompt_worse():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+    older_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    newer_at = datetime(2026, 4, 25, tzinfo=timezone.utc)
+    # v1 -> consistent +5% returns; v2 -> consistent -3% returns.
+    fake_rows = [("v1", older_at, 0.05)] * 12 + [("v2", newer_at, -0.03)] * 12
+
+    cm = MagicMock()
+    cm.__enter__.return_value.execute.return_value.all.return_value = fake_rows
+    cm.__exit__.return_value = False
+
+    with patch(
+        "rainier.llm_thesis.research.get_session", return_value=cm
+    ):
+        out = check_prompt_regression(
+            eval_date=today, days=30, db_session=sess
+        )
+
+    assert len(out) == 1
+    insight = out[0]
+    assert insight.kind == "prompt_regression"
+    assert insight.severity == "critical"
+    assert insight.action["kind"] == "bump_prompt_version"
+    assert insight.action["target"] == "v1"  # rollback to older
+    assert insight.subject == "v2"
+
+
+def test_check_prompt_regression_no_emit_when_stable():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+    older_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    newer_at = datetime(2026, 4, 25, tzinfo=timezone.utc)
+    fake_rows = [("v1", older_at, 0.02)] * 10 + [("v2", newer_at, 0.025)] * 10
+    cm = MagicMock()
+    cm.__enter__.return_value.execute.return_value.all.return_value = fake_rows
+    cm.__exit__.return_value = False
+    with patch(
+        "rainier.llm_thesis.research.get_session", return_value=cm
+    ):
+        out = check_prompt_regression(
+            eval_date=today, days=30, db_session=sess
+        )
+    assert out == []
+
+
+def test_check_prompt_regression_no_emit_when_single_prompt():
+    sess = _MemSession()
+    today = date(2026, 5, 7)
+    older_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    fake_rows = [("v1", older_at, 0.02)] * 10
+    cm = MagicMock()
+    cm.__enter__.return_value.execute.return_value.all.return_value = fake_rows
+    cm.__exit__.return_value = False
+    with patch(
+        "rainier.llm_thesis.research.get_session", return_value=cm
+    ):
+        out = check_prompt_regression(
+            eval_date=today, days=30, db_session=sess
+        )
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# run_research orchestrator — calls all 6 checks, isolates failures
+# ---------------------------------------------------------------------------
+
+
+def test_run_research_runs_all_checks_and_collects_emissions():
+    """Each individual check is patched to emit a single insight; the
+    orchestrator should collect 6 total."""
+    sentinel_rows: list[Any] = []
+
+    def _fake(name):
+        def fn(**_kwargs):
+            row = ResearchInsight(
+                id=len(sentinel_rows) + 1,
+                kind=name,
+                subject="x",
+                severity="warn",
+                evidence={},
+                action={"kind": "noop", "target": "x", "params": {}},
+                rationale="r",
+                recurrence_count=1,
+                status="pending",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+            sentinel_rows.append(row)
+            return [row]
+        return fn
+
+    with (
+        patch(
+            "rainier.llm_thesis.research.check_signal_underperform",
+            side_effect=_fake("signal_underperform"),
+        ),
+        patch(
+            "rainier.llm_thesis.research.check_signal_overperform",
+            side_effect=_fake("signal_overperform"),
+        ),
+        patch(
+            "rainier.llm_thesis.research.check_verdict_drift",
+            side_effect=_fake("verdict_drift"),
+        ),
+        patch(
+            "rainier.llm_thesis.research.check_calibration_off",
+            side_effect=_fake("calibration_off"),
+        ),
+        patch(
+            "rainier.llm_thesis.research.check_new_pattern_discovered",
+            side_effect=_fake("new_pattern_discovered"),
+        ),
+        patch(
+            "rainier.llm_thesis.research.check_prompt_regression",
+            side_effect=_fake("prompt_regression"),
+        ),
+    ):
+        out = run_research(eval_date=date(2026, 5, 7))
+
+    assert len(out) == 6
+    assert {r.kind for r in out} == set(INSIGHT_KINDS)
+
+
+def test_run_research_isolates_failures():
+    """One check raising must not crash the orchestrator."""
+    def _ok(**_kwargs):
+        return []
+
+    def _boom(**_kwargs):
+        raise RuntimeError("intentional")
+
+    with (
+        patch(
+            "rainier.llm_thesis.research.check_signal_underperform",
+            side_effect=_boom,
+        ),
+        patch(
+            "rainier.llm_thesis.research.check_signal_overperform",
+            side_effect=_ok,
+        ),
+        patch(
+            "rainier.llm_thesis.research.check_verdict_drift", side_effect=_ok
+        ),
+        patch(
+            "rainier.llm_thesis.research.check_calibration_off", side_effect=_ok
+        ),
+        patch(
+            "rainier.llm_thesis.research.check_new_pattern_discovered",
+            side_effect=_ok,
+        ),
+        patch(
+            "rainier.llm_thesis.research.check_prompt_regression", side_effect=_ok
+        ),
+    ):
+        out = run_research(eval_date=date(2026, 5, 7))
+    # No crash; the failing check just contributed nothing.
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# apply_action smoke tests live in test_yaml_mutation.py — re-import here
+# only to confirm the symbol is wired in.
+# ---------------------------------------------------------------------------
+
+
+def test_apply_action_is_callable():
+    """Sanity: the dispatcher is exported from research.py."""
+    assert callable(apply_action)

--- a/tests/test_llm_thesis/test_yaml_mutation.py
+++ b/tests/test_llm_thesis/test_yaml_mutation.py
@@ -1,0 +1,256 @@
+"""Round-trip YAML preservation tests — ensures the ACTION_EXECUTOR helpers
+mutate `config/settings.yaml` without nuking comments, key order, or
+unrelated sections.
+
+ruamel.yaml is the only YAML lib that round-trips comments + indent
+preferences. PyYAML drops both. The tests here use a fixture YAML with
+comments + multiple sections to verify only the targeted line changes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rainier.llm_thesis.research import (
+    _bump_prompt_version,
+    _disable_signal,
+    _increment_prompt_version,
+    _lower_signal_weight,
+    _raise_signal_weight,
+    apply_action,
+)
+
+SAMPLE_YAML = """\
+# Top-level settings comment.
+app:
+  name: rainier
+  # data_dir is overridable via .env
+  data_dir: ./data
+  log_level: INFO
+
+# --- LLM thesis layer (PR1) ---
+#
+# Per-scan settings reload (eng review D2).
+llm_thesis:
+  enabled: true
+  model: "claude-sonnet-4-6"
+  max_usd_per_scan: 1.0
+  prompt_version: "v1"
+  enabled_sessions:
+    - afternoon
+    - close
+  signals:
+    rank_trajectory:
+      enabled: true        # leading signal
+      params:
+        days: 10
+      weight: 1.0
+    fundamentals:
+      enabled: true
+      params: {}
+      weight: 1.0
+
+# Trailing comment that must survive.
+"""
+
+
+@pytest.fixture
+def settings_path(tmp_path: Path) -> Path:
+    p = tmp_path / "settings.yaml"
+    p.write_text(SAMPLE_YAML)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# disable_signal — flips enabled, preserves comments/order
+# ---------------------------------------------------------------------------
+
+
+def test_disable_signal_flips_enabled(settings_path: Path):
+    diff = _disable_signal("rank_trajectory", {}, settings_path)
+    assert diff == {
+        "signal": "rank_trajectory",
+        "field": "enabled",
+        "new_value": False,
+    }
+    text = settings_path.read_text()
+    # The targeted line moved from `enabled: true` to `enabled: false`.
+    assert "rank_trajectory:" in text
+    rt_section = text.split("rank_trajectory:")[1].split("fundamentals:")[0]
+    assert "enabled: false" in rt_section
+    # The other signal untouched.
+    fund_section = text.split("fundamentals:")[1]
+    assert "enabled: true" in fund_section
+
+
+def test_disable_signal_preserves_comments(settings_path: Path):
+    _disable_signal("rank_trajectory", {}, settings_path)
+    text = settings_path.read_text()
+    # Top-level + section comments + inline + trailing comments all survive.
+    assert "# Top-level settings comment." in text
+    assert "# --- LLM thesis layer (PR1) ---" in text
+    assert "# Per-scan settings reload (eng review D2)." in text
+    assert "leading signal" in text  # inline comment on rank_trajectory.enabled
+    assert "# Trailing comment that must survive." in text
+
+
+def test_disable_signal_preserves_key_order(settings_path: Path):
+    _disable_signal("rank_trajectory", {}, settings_path)
+    text = settings_path.read_text()
+    # Order: app -> llm_thesis. Within llm_thesis: enabled, model,
+    # max_usd_per_scan, prompt_version, enabled_sessions, signals.
+    app_idx = text.index("app:")
+    thesis_idx = text.index("llm_thesis:")
+    assert app_idx < thesis_idx
+    enabled_idx = text.index("enabled: true", thesis_idx)
+    model_idx = text.index('model: "claude-sonnet-4-6"', thesis_idx)
+    max_idx = text.index("max_usd_per_scan:", thesis_idx)
+    prompt_idx = text.index("prompt_version:", thesis_idx)
+    sessions_idx = text.index("enabled_sessions:", thesis_idx)
+    signals_idx = text.index("signals:", thesis_idx)
+    assert enabled_idx < model_idx < max_idx < prompt_idx < sessions_idx < signals_idx
+
+
+def test_disable_signal_creates_missing_entry(settings_path: Path):
+    """When the target signal is not in YAML yet, create a sensible default
+    rather than raise. Keeps the executor idempotent.
+    """
+    _disable_signal("brand_new_signal", {}, settings_path)
+    text = settings_path.read_text()
+    assert "brand_new_signal:" in text
+    new_section = text.split("brand_new_signal:")[1]
+    assert "enabled: false" in new_section
+
+
+def test_disable_signal_only_targeted_line_changes(settings_path: Path):
+    original = settings_path.read_text()
+    _disable_signal("rank_trajectory", {}, settings_path)
+    after = settings_path.read_text()
+    # Compute line-level diff: the only change should be the rank_trajectory
+    # `enabled` line; every other line in the file must be unchanged.
+    orig_lines = original.splitlines()
+    new_lines = after.splitlines()
+    diffs = [
+        (i, o, n)
+        for i, (o, n) in enumerate(zip(orig_lines, new_lines))
+        if o != n
+    ]
+    assert len(diffs) == 1, f"expected 1 line change, got {diffs}"
+    _, old, new = diffs[0]
+    assert "rank_trajectory" not in old  # the change is on the enabled line
+    assert "enabled: true" in old
+    assert "enabled: false" in new
+
+
+# ---------------------------------------------------------------------------
+# bump_prompt_version
+# ---------------------------------------------------------------------------
+
+
+def test_bump_prompt_version_increments(settings_path: Path):
+    diff = _bump_prompt_version("v1", {}, settings_path)
+    assert diff["new_value"] == "v2"
+    assert diff["old_value"] == "v1"
+    text = settings_path.read_text()
+    assert 'prompt_version: "v2"' in text or "prompt_version: v2" in text
+
+
+def test_increment_prompt_version_handles_double_digits():
+    assert _increment_prompt_version("v9") == "v10"
+    assert _increment_prompt_version("v99") == "v100"
+
+
+def test_increment_prompt_version_falls_back():
+    assert _increment_prompt_version("custom") == "v2"
+    assert _increment_prompt_version("") == "v2"
+
+
+# ---------------------------------------------------------------------------
+# raise / lower signal weight
+# ---------------------------------------------------------------------------
+
+
+def test_raise_signal_weight_default_factor(settings_path: Path):
+    diff = _raise_signal_weight("rank_trajectory", {}, settings_path)
+    assert abs(diff["new_value"] - 1.2) < 1e-9
+    assert diff["old_value"] == 1.0
+    assert diff["factor"] == 1.2
+
+
+def test_raise_signal_weight_custom_factor(settings_path: Path):
+    diff = _raise_signal_weight(
+        "rank_trajectory", {"factor": 1.5}, settings_path
+    )
+    assert abs(diff["new_value"] - 1.5) < 1e-9
+
+
+def test_lower_signal_weight_default_factor(settings_path: Path):
+    diff = _lower_signal_weight("rank_trajectory", {}, settings_path)
+    assert abs(diff["new_value"] - 0.8) < 1e-9
+
+
+def test_signal_weight_clamps_at_zero(settings_path: Path):
+    """Negative factor results in clamped 0.0 (no negative weights)."""
+    diff = _raise_signal_weight(
+        "rank_trajectory", {"factor": -1.0}, settings_path
+    )
+    assert diff["new_value"] == 0.0
+
+
+def test_signal_weight_clamps_at_five(settings_path: Path):
+    """A runaway factor caps at 5.0 to prevent dominance."""
+    diff = _raise_signal_weight(
+        "rank_trajectory", {"factor": 100.0}, settings_path
+    )
+    assert diff["new_value"] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# apply_action — dispatcher
+# ---------------------------------------------------------------------------
+
+
+def test_apply_action_disable_signal_dispatches(settings_path: Path):
+    diff = apply_action(
+        {"kind": "disable_signal", "target": "fundamentals", "params": {}},
+        settings_path,
+    )
+    assert diff["signal"] == "fundamentals"
+    assert diff["new_value"] is False
+
+
+def test_apply_action_noop_returns_marker(settings_path: Path):
+    diff = apply_action(
+        {"kind": "noop", "target": "anything", "params": {}}, settings_path
+    )
+    assert diff["noop"] is True
+    # File contents unchanged (binary equality).
+    assert settings_path.read_text() == SAMPLE_YAML
+
+
+def test_apply_action_unknown_kind_raises(settings_path: Path):
+    with pytest.raises(ValueError, match="Unknown action kind"):
+        apply_action(
+            {"kind": "explode_universe", "target": "x", "params": {}},
+            settings_path,
+        )
+
+
+def test_apply_action_non_dict_raises(settings_path: Path):
+    with pytest.raises(ValueError, match="must be a dict"):
+        apply_action("not_a_dict", settings_path)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Atomic write — temp file is gone after success
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_no_temp_files_left(settings_path: Path):
+    _disable_signal("rank_trajectory", {}, settings_path)
+    siblings = list(settings_path.parent.iterdir())
+    # Only the target file should remain — no .tmp_ leftovers.
+    tmp_files = [f for f in siblings if f.name.startswith(".tmp_")]
+    assert tmp_files == []

--- a/tests/test_models/test_research_insight.py
+++ b/tests/test_models/test_research_insight.py
@@ -1,0 +1,81 @@
+"""Schema tests for ResearchInsight (PR3) — columns, defaults, partial
+unique index, and SQLite parity for fixture-driven tests.
+
+The partial unique index uses Postgres-only WHERE syntax, so the round-trip
+INSERT/UPDATE semantics test runs against an in-memory SQLite engine where
+we replicate the constraint logic at the application level (one pending row
+per (kind, subject)).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import inspect
+
+from rainier.core.models import ResearchInsight
+
+# ---------------------------------------------------------------------------
+# Schema shape
+# ---------------------------------------------------------------------------
+
+
+def test_table_name():
+    assert ResearchInsight.__tablename__ == "research_insights"
+
+
+def test_columns_present():
+    cols = {c.name for c in inspect(ResearchInsight).columns}
+    expected = {
+        "id", "created_at", "updated_at", "kind", "severity", "subject",
+        "evidence", "action", "rationale", "recurrence_count", "status",
+        "decided_at", "decided_by", "applied_change",
+    }
+    missing = expected - cols
+    assert not missing, f"missing columns: {missing}"
+
+
+def test_kind_indexed():
+    indexes = list(ResearchInsight.__table__.indexes)
+    assert any(
+        any(c.name == "kind" for c in idx.columns) for idx in indexes
+    )
+
+
+def test_subject_indexed():
+    indexes = list(ResearchInsight.__table__.indexes)
+    assert any(
+        any(c.name == "subject" for c in idx.columns) for idx in indexes
+    )
+
+
+def test_pending_partial_unique_index_declared():
+    indexes = {idx.name: idx for idx in ResearchInsight.__table__.indexes}
+    target = indexes.get("idx_research_insight_pending_kind_subject")
+    assert target is not None, (
+        "partial unique index `idx_research_insight_pending_kind_subject` "
+        "must be declared on ResearchInsight so emit_insight() UPSERTs "
+        "atomically"
+    )
+    col_names = {c.name for c in target.columns}
+    assert col_names == {"kind", "subject"}
+    assert target.unique is True
+    # Postgres-side WHERE is hung off the dialect_options, not the index
+    # object. Check that the postgresql_where clause is present so the SQL
+    # generator emits the partial-index clause.
+    pg_opts = target.dialect_options.get("postgresql", {})
+    assert pg_opts.get("where") is not None
+
+
+def test_recurrence_count_defaults_to_one():
+    col = ResearchInsight.__table__.c.recurrence_count
+    # Server default is "1" so existing pending rows post-migration have
+    # the right starting value. Python-side default is 1 too.
+    assert col.default is not None and col.default.arg == 1
+    assert col.server_default is not None
+    assert str(col.server_default.arg) == "1"
+
+
+def test_status_defaults_to_pending():
+    col = ResearchInsight.__table__.c.status
+    assert col.default is not None and col.default.arg == "pending"
+    assert col.server_default is not None
+    assert str(col.server_default.arg) == "pending"

--- a/tests/test_scheduler/test_research_job.py
+++ b/tests/test_scheduler/test_research_job.py
@@ -1,0 +1,188 @@
+"""Tests for `run_research_job` and the Friday 09:00 PT cron registration (PR3)."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+from rainier.core.config import (
+    AlertsConfig,
+    AppConfig,
+    DiscordConfig,
+    LLMThesisConfig,
+    ScrapingConfig,
+    ScrapingSchedule,
+    Settings,
+)
+
+
+def _settings():
+    return Settings(
+        database_url="postgresql://test:test@localhost/test",
+        app=AppConfig(timezone="America/Los_Angeles"),
+        scraping=ScrapingConfig(
+            schedule=ScrapingSchedule(
+                morning="08:35", midday="10:35",
+                afternoon="12:35", close="14:35",
+            )
+        ),
+        alerts=AlertsConfig(
+            discord=DiscordConfig(enabled=True, webhook_url="https://example/test")
+        ),
+        llm_thesis=LLMThesisConfig(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_research_job orchestration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_research_job_calls_mark_stale_then_run_research():
+    """The job must run mark_stale FIRST (so old insights flip to stale
+    before the new run_research adds fresh ones).
+    """
+    call_order: list[str] = []
+
+    def _mark_stale(days):
+        call_order.append("mark_stale")
+        assert days == 30
+        return 0
+
+    def _run_research(*, eval_date, days):  # noqa: ARG001
+        call_order.append("run_research")
+        return []
+
+    with (
+        patch(
+            "rainier.scheduler.service.load_settings_fresh",
+            return_value=_settings(),
+        ),
+        patch(
+            "rainier.llm_thesis.research.mark_stale", side_effect=_mark_stale,
+        ),
+        patch(
+            "rainier.llm_thesis.research.run_research", side_effect=_run_research,
+        ),
+        patch(
+            "rainier.alerts.discord.send_research_report"
+        ) as mock_discord,
+    ):
+        from rainier.scheduler.service import run_research_job
+        await run_research_job(eval_date_iso="2026-05-08")
+
+    assert call_order == ["mark_stale", "run_research"]
+    mock_discord.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_research_job_continues_when_mark_stale_fails():
+    """A mark_stale exception must not skip the run_research + Discord post."""
+    def _mark_stale(_days):
+        raise RuntimeError("boom")
+
+    def _run_research(*, eval_date, days):
+        _ = eval_date, days
+        return []
+
+    with (
+        patch(
+            "rainier.scheduler.service.load_settings_fresh",
+            return_value=_settings(),
+        ),
+        patch(
+            "rainier.llm_thesis.research.mark_stale", side_effect=_mark_stale,
+        ),
+        patch(
+            "rainier.llm_thesis.research.run_research", side_effect=_run_research,
+        ),
+        patch(
+            "rainier.alerts.discord.send_research_report"
+        ) as mock_discord,
+    ):
+        from rainier.scheduler.service import run_research_job
+        await run_research_job(eval_date_iso="2026-05-08")
+
+    mock_discord.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_research_job_continues_when_run_research_fails():
+    """A run_research exception must still post the (empty) Discord report
+    so the operator sees a heartbeat that the job ran."""
+    def _run_research(*, eval_date, days):
+        _ = eval_date, days
+        raise RuntimeError("checks all failed")
+
+    with (
+        patch(
+            "rainier.scheduler.service.load_settings_fresh",
+            return_value=_settings(),
+        ),
+        patch(
+            "rainier.llm_thesis.research.mark_stale", return_value=0,
+        ),
+        patch(
+            "rainier.llm_thesis.research.run_research", side_effect=_run_research,
+        ),
+        patch(
+            "rainier.alerts.discord.send_research_report"
+        ) as mock_discord,
+    ):
+        from rainier.scheduler.service import run_research_job
+        await run_research_job(eval_date_iso="2026-05-08")
+
+    mock_discord.assert_called_once()
+    args, kwargs = mock_discord.call_args
+    # When checks fail wholesale the insights list is empty.
+    assert kwargs["insights"] == []
+
+
+@pytest.mark.asyncio
+async def test_run_research_job_defaults_to_today():
+    captured = {}
+
+    def _run_research(*, eval_date, days):  # noqa: ARG001
+        captured["eval_date"] = eval_date
+        return []
+
+    with (
+        patch(
+            "rainier.scheduler.service.load_settings_fresh",
+            return_value=_settings(),
+        ),
+        patch(
+            "rainier.llm_thesis.research.mark_stale", return_value=0,
+        ),
+        patch(
+            "rainier.llm_thesis.research.run_research", side_effect=_run_research,
+        ),
+        patch("rainier.alerts.discord.send_research_report"),
+    ):
+        from rainier.scheduler.service import run_research_job
+        await run_research_job()
+
+    assert captured["eval_date"] == date.today()
+
+
+# ---------------------------------------------------------------------------
+# Cron registration — Friday 09:00 PT
+# ---------------------------------------------------------------------------
+
+
+def test_build_scheduler_registers_weekly_research_friday_0900():
+    with patch("rainier.scheduler.service.get_settings", return_value=_settings()):
+        from rainier.scheduler.service import build_scheduler
+        sched = build_scheduler()
+
+    job = sched.get_job("weekly_research")
+    assert job is not None
+    trigger = job.trigger
+    # The CronTrigger stores fields keyed by name on `.fields`.
+    field_lookup = {f.name: str(f) for f in trigger.fields}
+    assert field_lookup["day_of_week"] == "fri"
+    assert field_lookup["hour"] == "9"
+    assert field_lookup["minute"] == "0"

--- a/tests/test_scheduler/test_scheduler.py
+++ b/tests/test_scheduler/test_scheduler.py
@@ -30,15 +30,15 @@ def _make_settings(**overrides) -> Settings:
 class TestBuildScheduler:
     """Test that build_scheduler creates the correct jobs."""
 
-    def test_creates_five_jobs(self):
-        """4 QU scrape jobs + 1 daily eval job (PR2)."""
+    def test_creates_six_jobs(self):
+        """4 QU scrape jobs + 1 daily eval job (PR2) + 1 weekly research (PR3)."""
         settings = _make_settings()
         with patch("rainier.scheduler.service.get_settings", return_value=settings):
             from rainier.scheduler.service import build_scheduler
             scheduler = build_scheduler()
 
         jobs = scheduler.get_jobs()
-        assert len(jobs) == 5
+        assert len(jobs) == 6
 
     def test_job_ids(self):
         settings = _make_settings()
@@ -53,6 +53,7 @@ class TestBuildScheduler:
             "qu_scrape_afternoon",
             "qu_scrape_close",
             "daily_eval",
+            "weekly_research",
         }
 
     def test_job_names(self):
@@ -66,6 +67,7 @@ class TestBuildScheduler:
         assert "QU100 scrape (close)" in names
 
     def test_cron_triggers_weekdays_only(self):
+        """All scrape + daily_eval jobs run mon-fri; weekly_research runs Friday only."""
         settings = _make_settings()
         with patch("rainier.scheduler.service.get_settings", return_value=settings):
             from rainier.scheduler.service import build_scheduler
@@ -73,9 +75,11 @@ class TestBuildScheduler:
 
         for job in scheduler.get_jobs():
             trigger = job.trigger
-            # CronTrigger fields: day_of_week should be mon-fri
-            dow_field = trigger.fields[4]  # day_of_week is index 4
-            assert str(dow_field) == "mon-fri"
+            dow_field = trigger.fields[4]
+            if job.id == "weekly_research":
+                assert str(dow_field) == "fri"
+            else:
+                assert str(dow_field) == "mon-fri"
 
     def test_morning_job_time(self):
         settings = _make_settings()
@@ -134,7 +138,7 @@ class TestBuildScheduler:
         assert str(scheduler.timezone) == "US/Eastern"
 
     def test_misfire_grace_time(self):
-        """QU scrape jobs use 5-min grace; daily eval uses 15-min grace."""
+        """QU scrape jobs use 5-min grace; daily_eval 15-min; weekly_research 30-min."""
         settings = _make_settings()
         with patch("rainier.scheduler.service.get_settings", return_value=settings):
             from rainier.scheduler.service import build_scheduler
@@ -143,6 +147,8 @@ class TestBuildScheduler:
         for job in scheduler.get_jobs():
             if job.id == "daily_eval":
                 assert job.misfire_grace_time == 900
+            elif job.id == "weekly_research":
+                assert job.misfire_grace_time == 1800
             else:
                 assert job.misfire_grace_time == 300
 

--- a/uv.lock
+++ b/uv.lock
@@ -2177,6 +2177,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "ruamel-yaml" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "shap" },
@@ -2223,6 +2224,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruamel-yaml", specifier = ">=0.18" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3" },
     { name = "scikit-learn", specifier = ">=1.8.0" },
     { name = "scipy", specifier = ">=1.11" },
@@ -2457,6 +2459,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
     { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
     { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Auto-research weekly job (Friday 09:00 PT) emits ResearchInsight rows from ThesisEvaluation data.
- 6 insight kinds: signal under/overperform, verdict drift, calibration off, new pattern discovered, prompt regression.
- ACTION_EXECUTORS dispatch table maps insight.action.kind to YAML mutators (ruamel.yaml preserves comments/order).
- CLI accept/reject flow: human-in-the-loop config changes via `rainier thesis research insights accept ID`.
- 3 P2/P3 carry-overs from PR2 review fixed (trading-day rollback, mixed-session rendering, eval_date param).

## Scope (PR3 of 4)
Per `docs/llm_thesis_design.md` Section F. Stacked on PR #65 (feat/llm-thesis-pr2).

## Reviews
- Codex review: PASS after 2 iterations (iter-2 confirmed clean)
- /review skill: PASS after 1 invocation (4 findings AUTO-FIXED)

## Test plan
- [x] `uv run pytest tests/ -v` — 592 passed, 3 skipped (PR3 surface clean).
- [x] `uv run ruff check` on PR3-touched files — clean (pre-existing cli.py errors are not introduced by this PR).
- [ ] Manual: `uv run rainier thesis research run` produces ResearchInsight rows visible via `insights list`.
- [ ] Recurrence: run twice 7 days apart on same data, same (kind, subject) UPSERTs (recurrence_count=2, no duplicate row).
- [ ] Accept flow: `insights accept ID` for `disable_signal` mutates settings.yaml AND preserves all comments/key order. DB row → status=accepted.
- [ ] Reject flow: `insights reject ID --reason "noise"` → status=rejected, settings.yaml unchanged.
- [ ] Stale: pending rows >30 days old auto-flip to stale on next research run.

## Out of scope
- PR4: Streamlit dashboard.