### PR TITLE
feat(llm-thesis): PR4 — Streamlit dashboard (signals, performance, theses, insights)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ uv run rainier jobs sync
 uv run rainier jobs stop --name fetch-mes
 ```
 
+## LLM Thesis Dashboard
+
+Streamlit dashboard for the LLM thesis layer (signals config, per-signal
+contribution stats, recent theses with their forward returns, and the
+research-insight accept/reject UI).
+
+```bash
+uv sync --extra dashboard
+uv run streamlit run src/rainier/dashboard/app.py
+```
+
+Then open http://localhost:8501. Four tabs:
+
+- **Signals** — toggle signals on/off (writes to `config/settings.yaml`
+  via ruamel; comments preserved). Includes a "test signal" runner.
+- **Performance** — per-signal lift (Mann-Whitney U) and per-verdict
+  hit rate over a rolling window.
+- **Recent theses** — last 50 theses with `return_1d` / `return_5d` /
+  `return_10d` and the chart PNG that was sent to the LLM.
+- **Insights** — accept/reject pending `ResearchInsight` rows; accept
+  applies the structured action via `ACTION_EXECUTORS`.
+
 ## Project Structure
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ select = ["E", "F", "I", "N", "W"]
 ignore = ["E501", "E741", "N806"]
 
 [project.optional-dependencies]
-dashboard = ["streamlit>=1.30"]
+dashboard = ["streamlit>=1.30,<2"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",

--- a/src/rainier/dashboard/__init__.py
+++ b/src/rainier/dashboard/__init__.py
@@ -1,0 +1,22 @@
+"""Streamlit dashboard for the LLM thesis layer (PR4).
+
+Three pure-Python modules ship here:
+
+  * `data.py`    — read-only DB loaders + small dataclasses (NO Streamlit).
+  * `actions.py` — write helpers (toggle signal, accept/reject insight,
+                   test signal). Shared with the CLI accept/reject path.
+  * `app.py`     — Streamlit multi-tab entrypoint. Run via:
+                   `uv run streamlit run src/rainier/dashboard/app.py`.
+
+Only `app.py` imports Streamlit. `data.py` + `actions.py` stay testable
+without any Streamlit dependency, so unit tests can exercise the loaders
+directly. Per the design + eng review, Streamlit page rendering is
+covered by manual smoke only — we don't unit-test the UI layer.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "data",
+    "actions",
+]

--- a/src/rainier/dashboard/actions.py
+++ b/src/rainier/dashboard/actions.py
@@ -1,0 +1,304 @@
+"""Write helpers shared by the Streamlit dashboard and the CLI.
+
+These wrappers exist so the dashboard does not shell out to `rainier`
+(slow, brittle) — both UI surfaces hit the same Python paths.
+
+Every function returns a small dict the caller can render as a status
+line. Errors raise standard exceptions so the Streamlit page can show a
+red banner without being coupled to Click's exception types.
+
+  ┌──────────────┐         ┌──────────────────────────┐
+  │   app.py     │ ──────▶ │       actions.py         │
+  │ (Streamlit)  │         │  toggle / accept / reject │
+  └──────────────┘         └────────┬─────────────────┘
+                                    │
+                              ┌─────▼─────────────────────────┐
+                              │  llm_thesis.research          │
+                              │   (ACTION_EXECUTORS for accept │
+                              │    + ruamel.yaml round-trip)   │
+                              └────────────────────────────────┘
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date as date_cls
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from rainier.core.config import load_settings_fresh
+from rainier.core.database import get_session
+from rainier.core.models import ResearchInsight
+from rainier.core.types import StockCandidate
+from rainier.llm_thesis.research import apply_action
+from rainier.llm_thesis.signals import REGISTRY
+from rainier.llm_thesis.signals.base import SignalContext
+
+log = logging.getLogger(__name__)
+
+
+_DEFAULT_SETTINGS_PATH = "config/settings.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Internal: ruamel YAML helper (mirrors research._load_yaml_round_trip but
+# duplicated here so the dashboard's signal toggle uses the comment-
+# preserving loader, matching the auto-research accept handler. The CLI's
+# pre-PR3 toggle used PyYAML; we standardize on ruamel for PR4+.)
+# ---------------------------------------------------------------------------
+
+
+def _load_round_trip(path: Path):
+    """Round-trip YAML loader — preserves comments + key order on dump."""
+    from ruamel.yaml import YAML
+
+    yaml = YAML(typ="rt")
+    yaml.preserve_quotes = True
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    if path.exists():
+        with path.open("r") as f:
+            data = yaml.load(f) or {}
+    else:
+        data = {}
+    return yaml, data
+
+
+def _atomic_dump(yaml, data, path: Path) -> None:
+    """Atomic write via temp-file + os.replace. Keeps settings.yaml from
+    being half-written if the process crashes mid-dump.
+    """
+    import os
+    import tempfile
+
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".tmp_", dir=str(parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            yaml.dump(data, f)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# toggle_signal — Tab 1
+# ---------------------------------------------------------------------------
+
+
+def toggle_signal(
+    signal_name: str,
+    enabled: bool,
+    *,
+    settings_path: str | Path = _DEFAULT_SETTINGS_PATH,
+) -> dict[str, Any]:
+    """Flip `llm_thesis.signals.<name>.enabled` in settings.yaml.
+
+    Mirrors the CLI's `rainier thesis signals enable/disable`
+    semantics but uses ruamel.yaml so comments + key order survive
+    the round-trip (matching the auto-research executors).
+
+    Raises `ValueError` for unknown signals — the dashboard surfaces
+    this as an error toast.
+    """
+    if signal_name not in REGISTRY:
+        raise ValueError(
+            f"Unknown signal {signal_name!r}. Known: {sorted(REGISTRY)}"
+        )
+    path = Path(settings_path)
+    yaml, data = _load_round_trip(path)
+    section = data.setdefault("llm_thesis", {}).setdefault("signals", {})
+    entry = section.get(signal_name)
+    if entry is None:
+        section[signal_name] = {
+            "enabled": bool(enabled),
+            "params": {},
+            "weight": 1.0,
+        }
+    else:
+        entry["enabled"] = bool(enabled)
+    _atomic_dump(yaml, data, path)
+    log.info(
+        "dashboard_toggle_signal name=%s enabled=%s path=%s",
+        signal_name,
+        enabled,
+        path,
+    )
+    return {
+        "signal": signal_name,
+        "enabled": bool(enabled),
+        "settings_path": str(path),
+    }
+
+
+# ---------------------------------------------------------------------------
+# accept_insight / reject_insight — Tab 4
+# ---------------------------------------------------------------------------
+
+
+def accept_insight(
+    insight_id: int,
+    *,
+    settings_path: str | Path = _DEFAULT_SETTINGS_PATH,
+    decided_by: str = "dashboard",
+) -> dict[str, Any]:
+    """Apply the insight's structured action and mark it accepted.
+
+    Mirrors the CLI accept handler exactly (validate-then-apply order
+    so a YAML failure does not leak a half-accepted DB row). Raises
+    `LookupError` for unknown id, `ValueError` for non-pending status
+    or unknown action kind.
+    """
+    path = Path(settings_path)
+
+    with get_session() as session:
+        row = session.get(ResearchInsight, int(insight_id))
+        if row is None:
+            raise LookupError(f"No ResearchInsight with id={insight_id}")
+        if row.status != "pending":
+            raise ValueError(
+                f"Insight {insight_id} has status={row.status!r}, not pending."
+            )
+        action = row.action or {}
+        # apply_action validates the kind first (no side-effects) before
+        # touching the YAML. A ValueError here leaves both DB + YAML
+        # untouched.
+        diff = apply_action(action, path)
+        row.status = "accepted"
+        row.decided_at = datetime.now(timezone.utc)
+        row.decided_by = decided_by[:200]
+        row.applied_change = diff
+        session.flush()
+    log.info(
+        "dashboard_accept_insight id=%s kind=%s target=%s",
+        insight_id,
+        action.get("kind"),
+        action.get("target"),
+    )
+    return {
+        "insight_id": int(insight_id),
+        "status": "accepted",
+        "action_kind": action.get("kind"),
+        "applied_change": diff,
+    }
+
+
+def reject_insight(
+    insight_id: int,
+    reason: str,
+    *,
+    decided_by: str = "dashboard",
+) -> dict[str, Any]:
+    """Mark a pending insight as rejected.
+
+    The reason is stored in `decided_by` (200-char limit, matching the
+    CLI). settings.yaml is not touched.
+    """
+    if not reason or not reason.strip():
+        raise ValueError("Reject requires a non-empty reason.")
+    decided = f"{decided_by}: {reason.strip()}" if decided_by else reason.strip()
+
+    with get_session() as session:
+        row = session.get(ResearchInsight, int(insight_id))
+        if row is None:
+            raise LookupError(f"No ResearchInsight with id={insight_id}")
+        if row.status != "pending":
+            raise ValueError(
+                f"Insight {insight_id} has status={row.status!r}, not pending."
+            )
+        row.status = "rejected"
+        row.decided_at = datetime.now(timezone.utc)
+        row.decided_by = decided[:200]
+        session.flush()
+    log.info("dashboard_reject_insight id=%s reason=%s", insight_id, reason)
+    return {
+        "insight_id": int(insight_id),
+        "status": "rejected",
+        "reason": reason,
+    }
+
+
+# ---------------------------------------------------------------------------
+# test_signal — Tab 1 expander
+# ---------------------------------------------------------------------------
+
+
+def test_signal(
+    signal_name: str,
+    symbol: str,
+    *,
+    settings_path: str | Path = _DEFAULT_SETTINGS_PATH,
+) -> dict[str, Any]:
+    """Dry-run a single signal against the latest QU100 snapshot.
+
+    Mirrors `rainier thesis signals test NAME --symbol X`. Returns a dict
+    suitable for rendering as JSON in the Streamlit expander:
+
+      {"signal": ..., "symbol": ..., "value": <SignalValue>,
+       "render_for_prompt": <str>}
+
+    Heavy imports (the screener — pandas, yfinance) live inside this
+    function so the dashboard's import time stays reasonable when the
+    operator only browses Tab 4.
+    """
+    if signal_name not in REGISTRY:
+        raise ValueError(
+            f"Unknown signal {signal_name!r}. Known: {sorted(REGISTRY)}"
+        )
+
+    # Local import: screener is heavy and only needed when the operator
+    # actually runs the Test button.
+    from rainier.analysis.stock_screener import screen_stocks
+
+    settings = load_settings_fresh(str(settings_path))
+    candidates, ohlcv = screen_stocks(settings)
+    target: StockCandidate | None = next(
+        (c for c in candidates if c.symbol.upper() == symbol.upper()),
+        None,
+    )
+    if target is None:
+        # Build a stub candidate so the operator can still test the
+        # signal against a symbol the screener didn't pick up — same
+        # shape the CLI builds.
+        target = StockCandidate(
+            symbol=symbol.upper(),
+            rank=0,
+            rank_change=0,
+            long_short="Long in",
+            capital_flow_direction="N",
+            sector="Unknown",
+            signal_strength=0.0,
+        )
+
+    cfg = settings.llm_thesis.signals.get(signal_name)
+    params = dict(cfg.params) if cfg else {}
+    ctx = SignalContext(
+        symbol=target.symbol,
+        scan_date=date_cls.today(),
+        session_name="dashboard-test",
+        candidate=target,
+        ohlcv_df=ohlcv.get(target.symbol),
+        params=params,
+    )
+    sig = REGISTRY[signal_name]()
+    value = sig.compute(ctx)
+    rendered = sig.render_for_prompt(value) if value is not None else ""
+    return {
+        "signal": signal_name,
+        "symbol": target.symbol,
+        "value": value,
+        "render_for_prompt": rendered,
+    }
+
+
+__all__ = [
+    "accept_insight",
+    "reject_insight",
+    "test_signal",
+    "toggle_signal",
+]

--- a/src/rainier/dashboard/app.py
+++ b/src/rainier/dashboard/app.py
@@ -20,6 +20,7 @@ import pandas as pd
 import streamlit as st
 
 from rainier.dashboard import actions, data
+from rainier.llm_thesis.eval import VERDICTS
 from rainier.llm_thesis.signals import REGISTRY
 
 # ---------------------------------------------------------------------------
@@ -275,7 +276,9 @@ def _render_theses_tab() -> None:
     with col3:
         verdicts = st.multiselect(
             "Verdict",
-            options=["setup_long", "watch", "no_setup"],
+            # Single source of truth — eval.VERDICTS. Keeps the dashboard
+            # filter from going stale silently if a new verdict is added.
+            options=list(VERDICTS),
             default=[],
             key="theses_verdict",
         )

--- a/src/rainier/dashboard/app.py
+++ b/src/rainier/dashboard/app.py
@@ -1,0 +1,462 @@
+"""Streamlit dashboard entrypoint — `uv run streamlit run src/rainier/dashboard/app.py`.
+
+Four tabs, all data sourced from `dashboard.data` (read-only) and all
+writes routed through `dashboard.actions` so the CLI and the UI share
+the same code path. The UI layer is deliberately thin — page logic
+should not contain business rules. Add new logic to `data.py` /
+`actions.py` and unit-test it; render here.
+
+Smoke-tested manually only. Per the eng review (design doc Section G),
+Streamlit page rendering is excluded from unit tests; the data + action
+helpers are.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+
+import pandas as pd
+import streamlit as st
+
+from rainier.dashboard import actions, data
+from rainier.llm_thesis.signals import REGISTRY
+
+# ---------------------------------------------------------------------------
+# Page config
+# ---------------------------------------------------------------------------
+
+st.set_page_config(
+    page_title="Rainier LLM Thesis",
+    layout="wide",
+    initial_sidebar_state="collapsed",
+)
+
+
+# ---------------------------------------------------------------------------
+# Tab 1 — Signals (config + live status)
+# ---------------------------------------------------------------------------
+
+
+def _render_signals_tab() -> None:
+    st.header("Signals")
+    st.caption(
+        "Toggle signals on/off and inspect their last-7d hit count. "
+        "Edits write back to config/settings.yaml via ruamel "
+        "(comments preserved)."
+    )
+
+    signal_rows = data.load_signal_status()
+    if not signal_rows:
+        st.info("No signals registered.")
+        return
+
+    df = pd.DataFrame(
+        [
+            {
+                "name": r.name,
+                "enabled": r.enabled,
+                "version": r.version,
+                "weight": r.weight,
+                "cost_estimate_ms": r.cost_estimate_ms,
+                "last_7d_hit_count": r.last_7d_hit_count,
+            }
+            for r in signal_rows
+        ]
+    )
+
+    edited = st.data_editor(
+        df,
+        column_config={
+            "name": st.column_config.TextColumn("name", disabled=True),
+            "enabled": st.column_config.CheckboxColumn("enabled"),
+            "version": st.column_config.TextColumn("version", disabled=True),
+            "weight": st.column_config.NumberColumn(
+                "weight", disabled=True, format="%.2f"
+            ),
+            "cost_estimate_ms": st.column_config.NumberColumn(
+                "cost_estimate_ms", disabled=True
+            ),
+            "last_7d_hit_count": st.column_config.NumberColumn(
+                "last_7d_hits", disabled=True
+            ),
+        },
+        hide_index=True,
+        use_container_width=True,
+        num_rows="fixed",
+        key="signals_editor",
+    )
+
+    # Diff against the original frame; flip whatever changed.
+    changed = []
+    for original, new in zip(
+        df.itertuples(index=False), edited.itertuples(index=False)
+    ):
+        if bool(original.enabled) != bool(new.enabled):
+            changed.append((original.name, bool(new.enabled)))
+    if changed:
+        for name, enabled in changed:
+            try:
+                actions.toggle_signal(name, enabled)
+                st.toast(
+                    f"Set {name} enabled={enabled}", icon="OK"
+                )
+            except Exception as exc:  # noqa: BLE001
+                st.error(f"toggle_signal({name}) failed: {exc}")
+        st.rerun()
+
+    st.divider()
+    with st.expander("Test a signal"):
+        col1, col2 = st.columns(2)
+        with col1:
+            test_signal_name = st.selectbox(
+                "Signal",
+                options=sorted(REGISTRY.keys()),
+                key="test_signal_name",
+            )
+        with col2:
+            test_symbol = st.text_input(
+                "Symbol", value="NVDA", key="test_symbol"
+            )
+        if st.button("Run test", key="run_test_signal"):
+            try:
+                with st.spinner(f"Running {test_signal_name} on {test_symbol}..."):
+                    result = actions.test_signal(test_signal_name, test_symbol)
+                st.success(f"{result['signal']} on {result['symbol']}")
+                st.code(result.get("render_for_prompt") or "(no output)")
+                st.json(result.get("value") or {})
+            except Exception as exc:  # noqa: BLE001
+                st.error(f"test_signal failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tab 2 — Performance
+# ---------------------------------------------------------------------------
+
+
+_FALSIFICATION_LIFT_THRESHOLD = 0.001
+_FALSIFICATION_PVALUE_THRESHOLD = 0.20
+
+
+def _render_performance_tab() -> None:
+    st.header("Performance")
+    st.caption(
+        "Per-signal contribution (Mann-Whitney U used vs absent forward "
+        "returns) and per-verdict hit rate. Red rows indicate falsified "
+        "signals — flat lift AND no statistical signal over the window."
+    )
+
+    window = st.selectbox(
+        "Rolling window (days)",
+        options=[7, 14, 30, 60],
+        index=2,
+        key="perf_window",
+    )
+
+    contribs = data.load_signal_contribution(days=int(window))
+    if contribs:
+        contrib_df = pd.DataFrame(
+            [
+                {
+                    "name": c.name,
+                    "n_used": c.n_used,
+                    "n_absent": c.n_absent,
+                    "mean_used": c.mean_used,
+                    "mean_absent": c.mean_absent,
+                    "lift": c.lift,
+                    "p_value": c.p_value,
+                    "falsified": _is_falsified(c.lift, c.p_value),
+                }
+                for c in contribs
+            ]
+        )
+        st.subheader("Per-signal contribution")
+        # Highlight falsified rows with a red background; keep the rest
+        # default-themed.
+        st.dataframe(
+            contrib_df.style.apply(
+                lambda row: [
+                    "background-color: #ffe1e1"
+                    if bool(row.get("falsified"))
+                    else ""
+                ]
+                * len(row),
+                axis=1,
+            ),
+            hide_index=True,
+            use_container_width=True,
+        )
+
+        st.subheader("Lift over time")
+        # Each signal gets its own line — eng review wanted a rolling
+        # picture, not just a current snapshot.
+        lift_df = contrib_df.set_index("name")[["lift"]]
+        st.bar_chart(lift_df, use_container_width=True)
+    else:
+        st.info("No ThesisEvaluation rows in the selected window yet.")
+
+    # Per-signal scatterplot — value vs forward return.
+    st.subheader("Signal value vs forward return")
+    for name in sorted(REGISTRY.keys()):
+        with st.expander(f"{name} — scatter"):
+            df = data.load_signal_value_series(name, days=int(window))
+            if df.empty:
+                st.caption(
+                    f"No value/outcome pairs for `{name}` in the window."
+                )
+                continue
+            chart_df = df.rename(
+                columns={"signal_value": "x", "forward_return_5d": "y"}
+            )
+            st.scatter_chart(chart_df, x="x", y="y", use_container_width=True)
+            st.caption(f"n = {len(df)}")
+
+    # Per-verdict hit rate.
+    st.subheader("Verdict hit rate")
+    by_verdict = data.load_verdict_hit_rate(days=int(window))
+    rows: list[dict[str, Any]] = []
+    for verdict, hr_list in by_verdict.items():
+        for hr in hr_list:
+            rows.append(
+                {
+                    "verdict": verdict,
+                    "horizon": hr.horizon,
+                    "n": hr.n,
+                    "win_rate": hr.win_rate,
+                    "avg_return_pct": hr.avg_return_pct,
+                }
+            )
+    if rows:
+        st.dataframe(
+            pd.DataFrame(rows), hide_index=True, use_container_width=True
+        )
+    else:
+        st.info("No verdict outcomes available yet.")
+
+
+def _is_falsified(lift: float, p_value: float | None) -> bool:
+    """Red-flag rule (design Section G Tab 2): p>threshold AND lift<=threshold.
+
+    None p-value means too few samples — not falsified, just unproven.
+    """
+    if p_value is None:
+        return False
+    return (
+        p_value > _FALSIFICATION_PVALUE_THRESHOLD
+        and lift <= _FALSIFICATION_LIFT_THRESHOLD
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tab 3 — Recent theses
+# ---------------------------------------------------------------------------
+
+
+def _render_theses_tab() -> None:
+    st.header("Recent theses")
+    st.caption(
+        "Recent LLM-augmented picks with forward returns at 1d/5d/10d "
+        "(NULL until the daily eval job has run for that horizon)."
+    )
+
+    col1, col2, col3, col4 = st.columns([1, 1, 1, 2])
+    with col1:
+        since = st.date_input(
+            "Since",
+            value=date.today() - timedelta(days=30),
+            key="theses_since",
+        )
+    with col2:
+        until = st.date_input(
+            "Until",
+            value=date.today(),
+            key="theses_until",
+        )
+    with col3:
+        verdicts = st.multiselect(
+            "Verdict",
+            options=["setup_long", "watch", "no_setup"],
+            default=[],
+            key="theses_verdict",
+        )
+    with col4:
+        symbol = st.text_input("Symbol", value="", key="theses_symbol")
+
+    rows = data.load_recent_theses(
+        limit=50,
+        verdicts=verdicts or None,
+        symbol=symbol or None,
+        since=since,
+        until=until,
+    )
+    if not rows:
+        st.info("No theses match the filter.")
+        return
+
+    df = pd.DataFrame(
+        [
+            {
+                "thesis_id": r.thesis_id,
+                "scan_date": r.scan_date,
+                "session": r.session_name,
+                "symbol": r.symbol,
+                "verdict": r.verdict,
+                "confidence": r.llm_confidence,
+                "signals": ", ".join(r.signals_used) if r.signals_used else "",
+                "return_1d": r.return_1d,
+                "return_5d": r.return_5d,
+                "return_10d": r.return_10d,
+            }
+            for r in rows
+        ]
+    )
+    st.dataframe(df, hide_index=True, use_container_width=True)
+
+    selected_id = st.selectbox(
+        "Inspect thesis (id)",
+        options=[None, *df["thesis_id"].tolist()],
+        format_func=lambda x: "—" if x is None else str(x),
+        key="theses_inspect",
+    )
+    if selected_id is None:
+        return
+    selected = next((r for r in rows if r.thesis_id == selected_id), None)
+    if selected is None:
+        return
+    st.markdown(f"### {selected.symbol} — {selected.verdict}")
+    if selected.structured_output:
+        st.json(selected.structured_output)
+    chart_bytes = data.load_thesis_chart(selected.thesis_id)
+    if chart_bytes:
+        st.image(chart_bytes, caption=f"Chart for {selected.symbol}")
+    else:
+        st.caption("No chart on disk for this thesis.")
+
+
+# ---------------------------------------------------------------------------
+# Tab 4 — Insights
+# ---------------------------------------------------------------------------
+
+
+def _severity_color(severity: str) -> str:
+    # Matches the Discord ordering — readable on both light + dark themes.
+    return {
+        "critical": ":red[CRITICAL]",
+        "warn": ":orange[WARN]",
+        "info": ":blue[INFO]",
+    }.get(severity, severity)
+
+
+def _render_insights_tab() -> None:
+    st.header("Research insights")
+    st.caption(
+        "Pending insights (top) and audit trail (bottom). Accept applies "
+        "the structured action via ACTION_EXECUTORS; reject stores the "
+        "reason and leaves settings.yaml untouched."
+    )
+
+    pending = data.load_pending_insights()
+    st.subheader(f"Pending ({len(pending)})")
+    if not pending:
+        st.success("No pending insights.")
+    for r in pending:
+        with st.expander(
+            f"#{r.insight_id} — {r.kind} — {r.subject} "
+            f"({_severity_color(r.severity)})"
+        ):
+            st.write(r.rationale or "_(no rationale)_")
+            action = r.action or {}
+            st.markdown(
+                f"**Action:** `{action.get('kind', '?')}` "
+                f"-> `{action.get('target', '?')}`"
+            )
+            st.markdown(f"**Recurrence count:** {r.recurrence_count}")
+            with st.expander("Evidence (raw JSON)"):
+                st.json(r.evidence or {})
+
+            col1, col2, col3 = st.columns([1, 3, 1])
+            with col1:
+                if st.button("Accept", key=f"accept_{r.insight_id}"):
+                    try:
+                        result = actions.accept_insight(r.insight_id)
+                        st.toast(
+                            f"Accepted #{r.insight_id} -> {result['action_kind']}",
+                            icon="OK",
+                        )
+                        st.rerun()
+                    except Exception as exc:  # noqa: BLE001
+                        st.error(f"Accept failed: {exc}")
+            with col2:
+                reason = st.text_input(
+                    "Reject reason",
+                    key=f"reject_reason_{r.insight_id}",
+                    placeholder="Why are we dismissing this?",
+                )
+            with col3:
+                if st.button("Reject", key=f"reject_{r.insight_id}"):
+                    if not reason:
+                        st.warning("Provide a reason before rejecting.")
+                    else:
+                        try:
+                            actions.reject_insight(r.insight_id, reason)
+                            st.toast(
+                                f"Rejected #{r.insight_id}", icon="OK"
+                            )
+                            st.rerun()
+                        except Exception as exc:  # noqa: BLE001
+                            st.error(f"Reject failed: {exc}")
+
+    st.divider()
+    with st.expander("History (accepted / rejected / auto-applied)"):
+        statuses = st.multiselect(
+            "Status filter",
+            options=["accepted", "rejected", "auto_applied", "stale"],
+            default=["accepted", "rejected"],
+            key="hist_status",
+        )
+        history = data.load_insight_history(status=statuses or None)
+        if not history:
+            st.info("No history rows match the filter.")
+        else:
+            hist_df = pd.DataFrame(
+                [
+                    {
+                        "id": r.insight_id,
+                        "kind": r.kind,
+                        "subject": r.subject,
+                        "severity": r.severity,
+                        "status": r.status,
+                        "decided_at": r.decided_at,
+                        "decided_by": r.decided_by,
+                    }
+                    for r in history
+                ]
+            )
+            st.dataframe(
+                hist_df, hide_index=True, use_container_width=True
+            )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    st.title("Rainier — LLM thesis dashboard")
+    tab_signals, tab_perf, tab_theses, tab_insights = st.tabs(
+        ["Signals", "Performance", "Recent theses", "Insights"]
+    )
+    with tab_signals:
+        _render_signals_tab()
+    with tab_perf:
+        _render_performance_tab()
+    with tab_theses:
+        _render_theses_tab()
+    with tab_insights:
+        _render_insights_tab()
+
+
+# Streamlit imports the module and runs it top-to-top, so the entrypoint
+# call must be at module scope.
+main()

--- a/src/rainier/dashboard/data.py
+++ b/src/rainier/dashboard/data.py
@@ -1,0 +1,576 @@
+"""Read-only data loaders for the Streamlit dashboard.
+
+NO Streamlit imports. Every function is a plain DB query that returns
+typed dataclasses or pandas DataFrames so the loaders can be exercised
+in unit tests without spinning up a Streamlit runtime.
+
+Page layouts in `app.py` consume these helpers; the dashboard never
+talks to the database directly. Keeping the data layer pure means a
+loader bug fails a deterministic unit test instead of crashing the
+Streamlit page at runtime.
+
+  ┌──────────────┐         ┌──────────────┐
+  │   app.py     │ ──────▶ │   data.py    │ ──▶ ORM (read-only)
+  │ (Streamlit)  │         │ (pure funcs) │
+  └──────────────┘         └──────────────┘
+        │
+        └──▶ actions.py  (write helpers shared with the CLI)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from sqlalchemy import select
+
+from rainier.core.config import load_settings_fresh
+from rainier.core.database import get_session
+from rainier.core.models import (
+    ChartImage,
+    LLMAnalysisRecord,
+    ResearchInsight,
+    ScreenedStockRecord,
+    ThesisEvaluation,
+)
+from rainier.llm_thesis.eval import (
+    HitRate,
+    SignalContribution,
+    compute_signal_contribution,
+    compute_verdict_hit_rate,
+)
+from rainier.llm_thesis.signals import REGISTRY
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SignalRow:
+    """Tab 1 row — one per signal in the registry."""
+
+    name: str
+    enabled: bool
+    version: str
+    weight: float
+    cost_estimate_ms: int
+    last_7d_hit_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class ThesisRow:
+    """Tab 3 row — one per recent thesis."""
+
+    thesis_id: int
+    scan_date: date
+    session_name: str
+    symbol: str
+    verdict: str
+    llm_confidence: int | None
+    signals_used: list[str]
+    return_1d: float | None
+    return_5d: float | None
+    return_10d: float | None
+    chart_image_id: int | None
+    structured_output: dict[str, Any] | None = field(default=None, repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchInsightRow:
+    """Tab 4 row — one per ResearchInsight (pending or historical)."""
+
+    insight_id: int
+    created_at: datetime
+    updated_at: datetime
+    kind: str
+    severity: str
+    subject: str
+    rationale: str | None
+    evidence: dict[str, Any] | None
+    action: dict[str, Any] | None
+    recurrence_count: int
+    status: str
+    decided_at: datetime | None
+    decided_by: str | None
+    applied_change: dict[str, Any] | None
+
+
+# ---------------------------------------------------------------------------
+# Tab 1 — Signals
+# ---------------------------------------------------------------------------
+
+
+def _hit_count_window_days() -> int:
+    """How many days back to count `signals_used` hits for the Tab 1 status.
+
+    Centralized here so the test can override via monkeypatch and so any
+    future "last 14d" toggle has one place to change.
+    """
+    return 7
+
+
+def load_signal_status(*, settings_path: str | Path | None = None) -> list[SignalRow]:
+    """Tab 1: registry x settings.yaml x last-7d hit count.
+
+    For each signal in `REGISTRY`, look up the YAML toggle from a fresh
+    settings load, then query `LLMAnalysisRecord.signals_used` over the
+    rolling 7d window to count how often the signal contributed to a
+    thesis. Counts theses (not symbols) — one thesis per scan/symbol.
+    """
+    cfg_path = str(settings_path) if settings_path else "config/settings.yaml"
+    settings = load_settings_fresh(cfg_path)
+    cfg_map = settings.llm_thesis.signals
+
+    days = _hit_count_window_days()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    # Pull the entire signals_used array from records in the window once,
+    # then bucket in Python. Avoids one query per signal.
+    counts: dict[str, int] = {name: 0 for name in REGISTRY}
+    with get_session() as session:
+        rows = session.execute(
+            select(LLMAnalysisRecord.signals_used).where(
+                LLMAnalysisRecord.created_at >= cutoff,
+            )
+        ).all()
+    for (signals_used,) in rows:
+        if not signals_used:
+            continue
+        for name in signals_used:
+            if name in counts:
+                counts[name] += 1
+
+    out: list[SignalRow] = []
+    for name, sig_cls in REGISTRY.items():
+        instance = sig_cls()
+        cfg = cfg_map.get(name)
+        out.append(
+            SignalRow(
+                name=name,
+                enabled=bool(cfg.enabled) if cfg else True,
+                version=str(getattr(instance, "version", "?")),
+                weight=float(cfg.weight) if cfg else 1.0,
+                cost_estimate_ms=int(getattr(instance, "cost_estimate_ms", 0)),
+                last_7d_hit_count=counts.get(name, 0),
+            )
+        )
+    out.sort(key=lambda r: r.name)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tab 2 — Performance
+# ---------------------------------------------------------------------------
+
+
+def load_signal_contribution(
+    days: int = 30, horizon: str = "5d"
+) -> list[SignalContribution]:
+    """Wrapper around `eval.compute_signal_contribution` for Tab 2.
+
+    Kept as a thin wrapper so the dashboard page imports a single
+    `dashboard.data` namespace and can be mocked from tests without
+    reaching into `llm_thesis.eval`.
+    """
+    return compute_signal_contribution(days=days, horizon=horizon)
+
+
+def load_verdict_hit_rate(days: int = 30) -> dict[str, list[HitRate]]:
+    """Wrapper around `eval.compute_verdict_hit_rate` for Tab 2."""
+    return compute_verdict_hit_rate(days=days)
+
+
+# Per-signal value extractor map: signal_name -> (signals_used JSON dict) -> float | None.
+# When a new signal lands, add a row here so Tab 2's scatterplot can plot it.
+# Returning None drops the row from the scatter (the signal returned no
+# numeric quantity for that thesis).
+def _extract_rank_trajectory(value: dict[str, Any]) -> float | None:
+    delta = value.get("delta_10d")
+    return float(delta) if isinstance(delta, (int, float)) else None
+
+
+def _extract_capital_flow_streak(value: dict[str, Any]) -> float | None:
+    streak = value.get("streak_days")
+    direction = value.get("direction", "")
+    if not isinstance(streak, (int, float)):
+        return None
+    sign = -1 if direction == "-" else 1
+    return float(streak) * sign
+
+
+def _extract_sector_momentum(value: dict[str, Any]) -> float | None:
+    delta = value.get("delta")
+    return float(delta) if isinstance(delta, (int, float)) else None
+
+
+def _extract_fundamentals(value: dict[str, Any]) -> float | None:
+    # Forward P/E is the single most-actionable scalar; mirrors how the
+    # signal renders for the prompt (eg "Forward P/E: 23.4").
+    pe = value.get("pe_forward")
+    if not isinstance(pe, (int, float)):
+        return None
+    return float(pe)
+
+
+SIGNAL_VALUE_EXTRACTORS: dict[str, Any] = {
+    "rank_trajectory": _extract_rank_trajectory,
+    "capital_flow_streak": _extract_capital_flow_streak,
+    "sector_momentum": _extract_sector_momentum,
+    "fundamentals": _extract_fundamentals,
+}
+
+
+def load_signal_value_series(
+    signal_name: str, days: int = 30, horizon: str = "5d"
+) -> pd.DataFrame:
+    """Tab 2 scatter: signal numeric value vs forward return.
+
+    JOINs `LLMAnalysisRecord.structured_output` (where the per-signal
+    raw values live alongside the LLM output) with `ThesisEvaluation`
+    so we get one row per (thesis, horizon) with a paired x/y.
+
+    Returns an empty DataFrame with the expected columns when no rows
+    exist or the signal is unknown — keeps the Streamlit chart code
+    branchless.
+    """
+    cols = ["scan_date", "symbol", "signal_value", "forward_return_5d"]
+    extractor = SIGNAL_VALUE_EXTRACTORS.get(signal_name)
+    if extractor is None:
+        log.info("load_signal_value_series unknown_signal=%s", signal_name)
+        return pd.DataFrame(columns=cols)
+
+    cutoff = date.today() - timedelta(days=days)
+
+    with get_session() as session:
+        rows = session.execute(
+            select(
+                ThesisEvaluation.scan_date,
+                ThesisEvaluation.symbol,
+                ThesisEvaluation.return_pct,
+                LLMAnalysisRecord.structured_output,
+            )
+            .join(
+                LLMAnalysisRecord,
+                LLMAnalysisRecord.id == ThesisEvaluation.thesis_id,
+            )
+            .where(
+                ThesisEvaluation.horizon == horizon,
+                ThesisEvaluation.scan_date >= cutoff,
+            )
+            .order_by(ThesisEvaluation.scan_date.asc())
+        ).all()
+
+    records: list[dict[str, Any]] = []
+    for scan_dt, symbol, return_pct, structured in rows:
+        if not isinstance(structured, dict):
+            continue
+        # The signal raw values are nested under structured_output["signals"]
+        # when service.py persists them; degrade gracefully if absent.
+        signals_blob = structured.get("signals") or {}
+        if not isinstance(signals_blob, dict):
+            continue
+        raw = signals_blob.get(signal_name)
+        if not isinstance(raw, dict):
+            continue
+        try:
+            value = extractor(raw)
+        except Exception:
+            log.warning(
+                "signal_value_extract_failed signal=%s symbol=%s",
+                signal_name,
+                symbol,
+                exc_info=True,
+            )
+            continue
+        if value is None:
+            continue
+        records.append(
+            {
+                "scan_date": scan_dt,
+                "symbol": symbol,
+                "signal_value": value,
+                "forward_return_5d": float(return_pct),
+            }
+        )
+    return pd.DataFrame(records, columns=cols)
+
+
+# ---------------------------------------------------------------------------
+# Tab 3 — Recent theses
+# ---------------------------------------------------------------------------
+
+
+def _coerce_chart_image_id(value: Any) -> int | None:
+    """`LLMAnalysisRecord.chart_image_ids` is ARRAY(Integer); the dashboard
+    only renders the first chart. Return the first id or None.
+    """
+    if not value:
+        return None
+    if isinstance(value, list) and value:
+        first = value[0]
+        if isinstance(first, int):
+            return first
+        try:
+            return int(first)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def load_recent_theses(
+    limit: int = 50,
+    *,
+    verdicts: list[str] | None = None,
+    symbol: str | None = None,
+    since: date | None = None,
+    until: date | None = None,
+) -> list[ThesisRow]:
+    """Tab 3 list — recent theses with their forward returns.
+
+    JOINs `ScreenedStockRecord` -> `LLMAnalysisRecord` (LEFT) ->
+    `ThesisEvaluation` (LEFT, one row per horizon). Returns one
+    `ThesisRow` per screened+thesis pair with all three horizons
+    flattened into return_1d / return_5d / return_10d (None when the
+    eval row hasn't landed yet).
+
+    Filters are applied at the SQL level so the LIMIT is meaningful.
+    """
+    stmt = (
+        select(
+            ScreenedStockRecord.id.label("screened_id"),
+            ScreenedStockRecord.scan_date,
+            ScreenedStockRecord.session_name,
+            ScreenedStockRecord.symbol,
+            ScreenedStockRecord.thesis_id,
+            ScreenedStockRecord.llm_confidence,
+            LLMAnalysisRecord.recommendation,
+            LLMAnalysisRecord.signals_used,
+            LLMAnalysisRecord.chart_image_ids,
+            LLMAnalysisRecord.structured_output,
+        )
+        .join(
+            LLMAnalysisRecord,
+            LLMAnalysisRecord.id == ScreenedStockRecord.thesis_id,
+        )
+        .where(ScreenedStockRecord.thesis_id.isnot(None))
+    )
+    if verdicts:
+        stmt = stmt.where(LLMAnalysisRecord.recommendation.in_(verdicts))
+    if symbol:
+        stmt = stmt.where(ScreenedStockRecord.symbol == symbol.upper())
+    if since:
+        stmt = stmt.where(ScreenedStockRecord.scan_date >= since)
+    if until:
+        stmt = stmt.where(ScreenedStockRecord.scan_date <= until)
+
+    stmt = stmt.order_by(
+        ScreenedStockRecord.scan_date.desc(),
+        ScreenedStockRecord.id.desc(),
+    ).limit(int(limit))
+
+    with get_session() as session:
+        base_rows = session.execute(stmt).all()
+        thesis_ids = [r.thesis_id for r in base_rows if r.thesis_id is not None]
+
+        eval_map: dict[tuple[int, str], float] = {}
+        if thesis_ids:
+            eval_rows = session.execute(
+                select(
+                    ThesisEvaluation.thesis_id,
+                    ThesisEvaluation.horizon,
+                    ThesisEvaluation.return_pct,
+                ).where(ThesisEvaluation.thesis_id.in_(thesis_ids))
+            ).all()
+            for tid, horizon, ret in eval_rows:
+                eval_map[(int(tid), str(horizon))] = float(ret)
+
+    out: list[ThesisRow] = []
+    for r in base_rows:
+        tid = int(r.thesis_id)
+        out.append(
+            ThesisRow(
+                thesis_id=tid,
+                scan_date=r.scan_date,
+                session_name=r.session_name,
+                symbol=r.symbol,
+                verdict=str(r.recommendation or ""),
+                llm_confidence=(
+                    int(r.llm_confidence) if r.llm_confidence is not None else None
+                ),
+                signals_used=list(r.signals_used or []),
+                return_1d=eval_map.get((tid, "1d")),
+                return_5d=eval_map.get((tid, "5d")),
+                return_10d=eval_map.get((tid, "10d")),
+                chart_image_id=_coerce_chart_image_id(r.chart_image_ids),
+                structured_output=(
+                    dict(r.structured_output)
+                    if isinstance(r.structured_output, dict)
+                    else None
+                ),
+            )
+        )
+    return out
+
+
+def load_thesis_chart(thesis_id: int) -> bytes | None:
+    """Read the first chart PNG associated with a thesis.
+
+    `LLMAnalysisRecord.chart_image_ids` -> `ChartImage.file_path`.
+    Returns the file bytes, or None when the thesis has no chart, the
+    file is missing on disk, or anything errors. Never raises — Tab 3
+    just renders "no chart available" instead.
+    """
+    with get_session() as session:
+        analysis = session.get(LLMAnalysisRecord, int(thesis_id))
+        if analysis is None or not analysis.chart_image_ids:
+            return None
+        first_id = _coerce_chart_image_id(analysis.chart_image_ids)
+        if first_id is None:
+            return None
+        chart = session.get(ChartImage, int(first_id))
+        if chart is None or not chart.file_path:
+            return None
+        path = Path(chart.file_path)
+
+    try:
+        if not path.exists() or not path.is_file():
+            log.info("thesis_chart_missing path=%s", path)
+            return None
+        return path.read_bytes()
+    except OSError:
+        log.warning("thesis_chart_read_failed path=%s", path, exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tab 4 — Research insights
+# ---------------------------------------------------------------------------
+
+
+_SEVERITY_ORDER: dict[str, int] = {"critical": 0, "warn": 1, "info": 2}
+
+
+def _to_jsonable(value: Any) -> Any:
+    """Coerce a JSONB column value into a plain dict/list for the UI.
+
+    SQLAlchemy returns either dict/list (Postgres JSONB) or a JSON string
+    (SQLite via the test fakes); normalise so the dashboard always sees
+    Python primitives.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            return json.loads(bytes(value).decode("utf-8"))
+        except Exception:
+            return None
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
+    return value
+
+
+def _row_to_insight(row: ResearchInsight) -> ResearchInsightRow:
+    return ResearchInsightRow(
+        insight_id=int(row.id),
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        kind=row.kind,
+        severity=row.severity,
+        subject=row.subject,
+        rationale=row.rationale,
+        evidence=_to_jsonable(row.evidence),
+        action=_to_jsonable(row.action),
+        recurrence_count=int(row.recurrence_count or 0),
+        status=row.status,
+        decided_at=row.decided_at,
+        decided_by=row.decided_by,
+        applied_change=_to_jsonable(row.applied_change),
+    )
+
+
+def load_pending_insights() -> list[ResearchInsightRow]:
+    """Tab 4 'pending' panel.
+
+    Sorted by severity (critical -> warn -> info), then most-recently
+    updated first so a re-fired insight bubbles to the top of the queue.
+    """
+    with get_session() as session:
+        stmt = (
+            select(ResearchInsight)
+            .where(ResearchInsight.status == "pending")
+            .order_by(
+                ResearchInsight.updated_at.desc(),
+                ResearchInsight.id.desc(),
+            )
+        )
+        rows = session.execute(stmt).scalars().all()
+
+    out = [_row_to_insight(r) for r in rows]
+    out.sort(
+        key=lambda r: (
+            _SEVERITY_ORDER.get(r.severity, 99),
+            -int(r.updated_at.timestamp()) if r.updated_at else 0,
+            -r.insight_id,
+        )
+    )
+    return out
+
+
+def load_insight_history(
+    status: list[str] | None = None,
+) -> list[ResearchInsightRow]:
+    """Tab 4 'history' panel — accepted/rejected/auto_applied/stale.
+
+    Default filter excludes `pending` (those go in `load_pending_insights`)
+    and `stale` (ignored by the operator). Ordered by `decided_at`
+    descending so the most recent decision is on top.
+    """
+    if status is None:
+        status = ["accepted", "rejected", "auto_applied"]
+    if not status:
+        return []
+
+    with get_session() as session:
+        stmt = (
+            select(ResearchInsight)
+            .where(ResearchInsight.status.in_(list(status)))
+            .order_by(
+                ResearchInsight.decided_at.desc().nullslast(),
+                ResearchInsight.id.desc(),
+            )
+        )
+        rows = session.execute(stmt).scalars().all()
+    return [_row_to_insight(r) for r in rows]
+
+
+# Re-export for callers / tests
+__all__ = [
+    "HitRate",
+    "ResearchInsightRow",
+    "SignalContribution",
+    "SignalRow",
+    "ThesisRow",
+    "load_insight_history",
+    "load_pending_insights",
+    "load_recent_theses",
+    "load_signal_contribution",
+    "load_signal_status",
+    "load_signal_value_series",
+    "load_thesis_chart",
+    "load_verdict_hit_rate",
+    "SIGNAL_VALUE_EXTRACTORS",
+]

--- a/tests/test_dashboard/test_actions.py
+++ b/tests/test_dashboard/test_actions.py
@@ -1,0 +1,334 @@
+"""Unit tests for `dashboard.actions`.
+
+`toggle_signal` writes YAML; `accept_insight` / `reject_insight` mutate
+DB rows. We point the helpers at a temp YAML and a fake session so
+nothing escapes the test isolation.
+
+`test_signal` is exercised at the dispatch level — we mock the screener
++ registry so the test stays fast and doesn't fetch yfinance.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rainier.dashboard import actions as dactions
+
+# ---------------------------------------------------------------------------
+# Fake session — same shape as test_data.py but supports flush() + setattr
+# ---------------------------------------------------------------------------
+
+
+class _FakeRow:
+    """Mutable stand-in for a SQLAlchemy row — supports ORM attribute writes."""
+
+    def __init__(self, **kwargs: Any):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class _MutableSession:
+    def __init__(self, *, gets: dict[tuple[type, int], Any] | None = None):
+        self._gets = dict(gets or {})
+        self.flushed = 0
+
+    def get(self, model, ident):
+        return self._gets.get((model, int(ident)))
+
+    def flush(self):
+        self.flushed += 1
+
+
+@contextmanager
+def _session_cm(sess):
+    yield sess
+
+
+def _patch_session(sess):
+    return patch.object(
+        dactions, "get_session", return_value=_session_cm(sess)
+    )
+
+
+# ---------------------------------------------------------------------------
+# toggle_signal
+# ---------------------------------------------------------------------------
+
+
+def _write_yaml(path: Path, contents: str) -> None:
+    path.write_text(contents)
+
+
+def test_toggle_signal_disables_existing_entry(tmp_path):
+    yaml_path = tmp_path / "settings.yaml"
+    _write_yaml(
+        yaml_path,
+        """
+# Top comment preserved
+llm_thesis:
+  prompt_version: v1
+  signals:
+    rank_trajectory:
+      enabled: true
+      params: {days: 10}
+      weight: 1.0
+""".lstrip(),
+    )
+
+    out = dactions.toggle_signal(
+        "rank_trajectory", False, settings_path=yaml_path
+    )
+    assert out["enabled"] is False
+    body = yaml_path.read_text()
+    assert "enabled: false" in body
+    # Ruamel preserves comments + key order.
+    assert "Top comment preserved" in body
+    assert body.index("prompt_version") < body.index("signals")
+
+
+def test_toggle_signal_creates_missing_section(tmp_path):
+    yaml_path = tmp_path / "settings.yaml"
+    _write_yaml(yaml_path, "# nothing here\n")
+    dactions.toggle_signal("rank_trajectory", True, settings_path=yaml_path)
+    body = yaml_path.read_text()
+    assert "llm_thesis" in body
+    assert "rank_trajectory" in body
+    assert "enabled: true" in body
+
+
+def test_toggle_signal_rejects_unknown_name(tmp_path):
+    yaml_path = tmp_path / "settings.yaml"
+    _write_yaml(yaml_path, "{}\n")
+    with pytest.raises(ValueError, match="Unknown signal"):
+        dactions.toggle_signal("not_a_signal", True, settings_path=yaml_path)
+
+
+# ---------------------------------------------------------------------------
+# accept_insight
+# ---------------------------------------------------------------------------
+
+
+def test_accept_insight_dispatches_action_and_marks_row_accepted(tmp_path):
+    """Happy path mirrors the CLI flow: validate, apply YAML, mark row."""
+    from rainier.core.models import ResearchInsight
+
+    settings = tmp_path / "settings.yaml"
+    settings.write_text(
+        """
+llm_thesis:
+  signals:
+    rank_trajectory:
+      enabled: true
+      params: {days: 10}
+      weight: 1.0
+""".lstrip()
+    )
+
+    row = _FakeRow(
+        id=1,
+        status="pending",
+        action={"kind": "disable_signal", "target": "rank_trajectory", "params": {}},
+        decided_at=None,
+        decided_by=None,
+        applied_change=None,
+    )
+    sess = _MutableSession(gets={(ResearchInsight, 1): row})
+
+    diff_payload = {"signal": "rank_trajectory", "field": "enabled", "new_value": False}
+    with _patch_session(sess), patch.object(
+        dactions, "apply_action", return_value=diff_payload
+    ) as mock_apply:
+        out = dactions.accept_insight(1, settings_path=settings)
+
+    mock_apply.assert_called_once()
+    args, _kwargs = mock_apply.call_args
+    assert args[0]["kind"] == "disable_signal"
+    assert isinstance(args[1], Path)
+
+    assert out["status"] == "accepted"
+    assert out["action_kind"] == "disable_signal"
+    assert out["applied_change"] == diff_payload
+    assert row.status == "accepted"
+    assert isinstance(row.decided_at, datetime)
+    assert row.decided_by == "dashboard"
+    assert row.applied_change == diff_payload
+    assert sess.flushed == 1
+
+
+def test_accept_insight_lookup_error_for_missing_row(tmp_path):
+    from rainier.core.models import ResearchInsight  # noqa: F401
+
+    sess = _MutableSession(gets={})
+    with _patch_session(sess), pytest.raises(LookupError):
+        dactions.accept_insight(999, settings_path=tmp_path / "x.yaml")
+
+
+def test_accept_insight_rejects_non_pending_row(tmp_path):
+    from rainier.core.models import ResearchInsight
+
+    row = _FakeRow(id=2, status="accepted", action={"kind": "noop", "target": "x"})
+    sess = _MutableSession(gets={(ResearchInsight, 2): row})
+    with _patch_session(sess), pytest.raises(ValueError, match="not pending"):
+        dactions.accept_insight(2, settings_path=tmp_path / "x.yaml")
+
+
+def test_accept_insight_propagates_apply_action_error(tmp_path):
+    """A bad action.kind must surface BEFORE the row is marked accepted."""
+    from rainier.core.models import ResearchInsight
+
+    row = _FakeRow(
+        id=3,
+        status="pending",
+        action={"kind": "not_real", "target": "x", "params": {}},
+        decided_at=None,
+        decided_by=None,
+        applied_change=None,
+    )
+    sess = _MutableSession(gets={(ResearchInsight, 3): row})
+    with _patch_session(sess), patch.object(
+        dactions, "apply_action", side_effect=ValueError("Unknown action kind")
+    ):
+        with pytest.raises(ValueError, match="Unknown action kind"):
+            dactions.accept_insight(3, settings_path=tmp_path / "x.yaml")
+    # Status untouched.
+    assert row.status == "pending"
+
+
+# ---------------------------------------------------------------------------
+# reject_insight
+# ---------------------------------------------------------------------------
+
+
+def test_reject_insight_marks_row_with_reason():
+    from rainier.core.models import ResearchInsight
+
+    row = _FakeRow(
+        id=5,
+        status="pending",
+        decided_at=None,
+        decided_by=None,
+    )
+    sess = _MutableSession(gets={(ResearchInsight, 5): row})
+    with _patch_session(sess):
+        out = dactions.reject_insight(5, "noisy signal — wait for more data")
+
+    assert out["status"] == "rejected"
+    assert row.status == "rejected"
+    assert isinstance(row.decided_at, datetime)
+    assert "noisy signal" in (row.decided_by or "")
+
+
+def test_reject_insight_requires_reason():
+    with pytest.raises(ValueError, match="non-empty reason"):
+        dactions.reject_insight(1, "   ")
+
+
+def test_reject_insight_lookup_error_on_missing():
+    sess = _MutableSession(gets={})
+    with _patch_session(sess), pytest.raises(LookupError):
+        dactions.reject_insight(404, "stale")
+
+
+def test_reject_insight_rejects_non_pending():
+    from rainier.core.models import ResearchInsight
+
+    row = _FakeRow(id=6, status="rejected", decided_at=None, decided_by=None)
+    sess = _MutableSession(gets={(ResearchInsight, 6): row})
+    with _patch_session(sess), pytest.raises(ValueError, match="not pending"):
+        dactions.reject_insight(6, "double tap")
+
+
+# ---------------------------------------------------------------------------
+# test_signal — Tab 1 expander
+# ---------------------------------------------------------------------------
+
+
+def test_test_signal_runs_compute_and_returns_render(tmp_path):
+    """Mocks the screener + signal class so we don't fetch yfinance."""
+    from rainier.core.types import StockCandidate
+
+    candidate = StockCandidate(
+        symbol="NVDA",
+        rank=1,
+        rank_change=0,
+        long_short="Long in",
+        capital_flow_direction="N",
+        sector="Tech",
+        signal_strength=0.8,
+    )
+
+    fake_signal = MagicMock()
+    fake_signal.compute.return_value = {"streak_days": 4, "direction": "+"}
+    fake_signal.render_for_prompt.return_value = "4-day positive streak"
+    fake_cls = MagicMock(return_value=fake_signal)
+
+    fake_settings = MagicMock()
+    fake_signal_cfg = MagicMock()
+    fake_signal_cfg.params = {"days": 10}
+    fake_settings.llm_thesis.signals.get.return_value = fake_signal_cfg
+
+    yaml_path = tmp_path / "settings.yaml"
+    yaml_path.write_text("{}\n")
+
+    with patch.object(
+        dactions, "REGISTRY", {"capital_flow_streak": fake_cls}
+    ), patch.object(
+        dactions, "load_settings_fresh", return_value=fake_settings
+    ), patch(
+        "rainier.analysis.stock_screener.screen_stocks",
+        return_value=([candidate], {"NVDA": MagicMock()}),
+    ):
+        out = dactions.test_signal(
+            "capital_flow_streak", "NVDA", settings_path=yaml_path
+        )
+
+    assert out["signal"] == "capital_flow_streak"
+    assert out["symbol"] == "NVDA"
+    assert out["value"] == {"streak_days": 4, "direction": "+"}
+    assert out["render_for_prompt"] == "4-day positive streak"
+    fake_signal.compute.assert_called_once()
+
+
+def test_test_signal_rejects_unknown_name():
+    with pytest.raises(ValueError, match="Unknown signal"):
+        dactions.test_signal("not_a_signal", "NVDA")
+
+
+def test_test_signal_builds_stub_when_symbol_not_in_screener(tmp_path):
+    """Symbol not in screener output -> use a default-built StockCandidate."""
+    fake_signal = MagicMock()
+    fake_signal.compute.return_value = {"pe_forward": 18.5}
+    fake_signal.render_for_prompt.return_value = "Forward P/E: 18.5"
+    fake_cls = MagicMock(return_value=fake_signal)
+
+    fake_settings = MagicMock()
+    fake_settings.llm_thesis.signals.get.return_value = MagicMock(params={})
+
+    yaml_path = tmp_path / "settings.yaml"
+    yaml_path.write_text("{}\n")
+
+    with patch.object(
+        dactions, "REGISTRY", {"fundamentals": fake_cls}
+    ), patch.object(
+        dactions, "load_settings_fresh", return_value=fake_settings
+    ), patch(
+        "rainier.analysis.stock_screener.screen_stocks",
+        return_value=([], {}),  # screener returned no candidates
+    ):
+        out = dactions.test_signal(
+            "fundamentals", "ZZZZ", settings_path=yaml_path
+        )
+
+    assert out["symbol"] == "ZZZZ"
+    assert out["render_for_prompt"] == "Forward P/E: 18.5"
+    # Verify a stub candidate was passed (compute() called once).
+    fake_signal.compute.assert_called_once()
+    ctx_arg = fake_signal.compute.call_args.args[0]
+    assert ctx_arg.symbol == "ZZZZ"
+    assert ctx_arg.candidate.symbol == "ZZZZ"

--- a/tests/test_dashboard/test_data.py
+++ b/tests/test_dashboard/test_data.py
@@ -1,0 +1,552 @@
+"""Unit tests for `dashboard.data`.
+
+We mock `get_session` (and `compute_signal_contribution` /
+`compute_verdict_hit_rate` for the wrapper smoke tests) so the tests
+run against in-memory fakes — no Postgres ARRAY / JSONB needed. Same
+pattern as `tests/test_llm_thesis/test_eval.py`.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from rainier.dashboard import data as ddata
+from rainier.llm_thesis.eval import HitRate, SignalContribution
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal SQLAlchemy 2.x Session shim
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedSession:
+    """Returns scripted `execute().all()` and `execute().scalars().all()`
+    payloads in the order they're queued. `session.get(model, id)` reads
+    from a separate keyed dict.
+
+    Intentionally tiny — we don't need to support ORM mutation in these
+    read-only tests.
+    """
+
+    def __init__(
+        self,
+        *,
+        all_payloads: list[list[Any]] | None = None,
+        scalars_payloads: list[list[Any]] | None = None,
+        gets: dict[tuple[type, int], Any] | None = None,
+    ):
+        self._all = list(all_payloads or [])
+        self._scalars = list(scalars_payloads or [])
+        self._gets = dict(gets or {})
+        self.calls = 0
+
+    def execute(self, _stmt):  # noqa: ARG002
+        self.calls += 1
+        result = MagicMock()
+        next_all = self._all.pop(0) if self._all else []
+        result.all.return_value = next_all
+        scalars_obj = MagicMock()
+        next_scalars = self._scalars.pop(0) if self._scalars else []
+        scalars_obj.all.return_value = next_scalars
+        result.scalars.return_value = scalars_obj
+        return result
+
+    def get(self, model, ident):
+        return self._gets.get((model, int(ident)))
+
+
+@contextmanager
+def _session_cm(sess):
+    yield sess
+
+
+def _patch_session(sess):
+    """`with patch(...) as gs: gs.return_value = _session_cm(sess)`."""
+    return patch.object(
+        ddata,
+        "get_session",
+        return_value=_session_cm(sess),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stub Settings — load_signal_status reads the YAML toggle; we feed it a
+# minimal Settings instance instead.
+# ---------------------------------------------------------------------------
+
+
+class _StubSignalConfig:
+    def __init__(self, enabled: bool = True, weight: float = 1.0, params: dict | None = None):
+        self.enabled = enabled
+        self.weight = weight
+        self.params = params or {}
+
+
+class _StubLLMThesisConfig:
+    def __init__(self, signals: dict[str, _StubSignalConfig]):
+        self.signals = signals
+
+
+class _StubSettings:
+    def __init__(self, signals: dict[str, _StubSignalConfig]):
+        self.llm_thesis = _StubLLMThesisConfig(signals)
+
+
+# ---------------------------------------------------------------------------
+# load_signal_status
+# ---------------------------------------------------------------------------
+
+
+def test_load_signal_status_zero_theses_baseline():
+    """All signals appear with hit_count=0 when no theses are in the window."""
+    from rainier.llm_thesis.signals import REGISTRY
+
+    stub = _StubSettings(
+        signals={name: _StubSignalConfig(enabled=True) for name in REGISTRY}
+    )
+    sess = _ScriptedSession(all_payloads=[[]])  # empty signals_used result
+    with patch.object(ddata, "load_settings_fresh", return_value=stub), _patch_session(sess):
+        rows = ddata.load_signal_status()
+
+    assert len(rows) == len(REGISTRY)
+    assert {r.name for r in rows} == set(REGISTRY)
+    assert all(r.last_7d_hit_count == 0 for r in rows)
+    assert all(r.enabled for r in rows)
+
+
+def test_load_signal_status_counts_signals_used():
+    """Rows in the window with `signals_used` arrays bump per-name hits."""
+    from rainier.llm_thesis.signals import REGISTRY
+
+    # Pick the first two registry names; rest stay at 0.
+    names = list(REGISTRY.keys())
+    a, b = names[0], names[1]
+
+    stub = _StubSettings(
+        signals={
+            **{name: _StubSignalConfig(enabled=True) for name in REGISTRY},
+            a: _StubSignalConfig(enabled=False, weight=2.0),
+        }
+    )
+    payload = [
+        ([a, b],),  # thesis 1 used a, b
+        ([a],),  # thesis 2 used a
+        ([b],),  # thesis 3 used b
+        (None,),  # thesis 4 used no signals (still in window) — should not crash
+    ]
+    sess = _ScriptedSession(all_payloads=[payload])
+    with patch.object(ddata, "load_settings_fresh", return_value=stub), _patch_session(sess):
+        rows = ddata.load_signal_status()
+
+    by_name = {r.name: r for r in rows}
+    assert by_name[a].last_7d_hit_count == 2
+    assert by_name[b].last_7d_hit_count == 2
+    assert by_name[a].enabled is False  # honors stub
+    assert by_name[a].weight == 2.0
+
+
+# ---------------------------------------------------------------------------
+# load_signal_contribution / load_verdict_hit_rate — thin wrappers
+# ---------------------------------------------------------------------------
+
+
+def test_load_signal_contribution_wrapper_passes_args():
+    expected = [
+        SignalContribution(
+            name="rank_trajectory",
+            n_used=10,
+            n_absent=10,
+            mean_used=0.02,
+            mean_absent=0.0,
+            lift=0.02,
+            p_value=0.04,
+        )
+    ]
+    with patch.object(
+        ddata, "compute_signal_contribution", return_value=expected
+    ) as m:
+        out = ddata.load_signal_contribution(days=14, horizon="1d")
+    m.assert_called_once_with(days=14, horizon="1d")
+    assert out is expected
+
+
+def test_load_verdict_hit_rate_wrapper_passes_args():
+    expected = {
+        "setup_long": [
+            HitRate(
+                verdict="setup_long",
+                horizon="5d",
+                n=4,
+                win_rate=0.75,
+                avg_return_pct=0.012,
+            )
+        ]
+    }
+    with patch.object(
+        ddata, "compute_verdict_hit_rate", return_value=expected
+    ) as m:
+        out = ddata.load_verdict_hit_rate(days=7)
+    m.assert_called_once_with(days=7)
+    assert out is expected
+
+
+# ---------------------------------------------------------------------------
+# load_signal_value_series
+# ---------------------------------------------------------------------------
+
+
+def test_load_signal_value_series_unknown_signal_returns_empty_df():
+    df = ddata.load_signal_value_series("not_a_signal")
+    assert df.empty
+    assert list(df.columns) == [
+        "scan_date",
+        "symbol",
+        "signal_value",
+        "forward_return_5d",
+    ]
+
+
+def test_load_signal_value_series_extracts_rank_trajectory_delta_10d():
+    """rank_trajectory dispatcher must pull `delta_10d` from the JSON blob."""
+    today = date(2026, 5, 7)
+    rows = [
+        (
+            today - timedelta(days=2),
+            "NVDA",
+            0.015,
+            {"signals": {"rank_trajectory": {"delta_10d": 5}}},
+        ),
+        (
+            today - timedelta(days=1),
+            "TSLA",
+            -0.008,
+            {"signals": {"rank_trajectory": {"delta_10d": -3}}},
+        ),
+        # Row missing rank_trajectory — must be dropped silently.
+        (today, "AAPL", 0.001, {"signals": {"sector_momentum": {"delta": 0.1}}}),
+        # Row with non-numeric delta_10d — must be dropped.
+        (
+            today,
+            "MSFT",
+            0.001,
+            {"signals": {"rank_trajectory": {"delta_10d": "n/a"}}},
+        ),
+    ]
+    sess = _ScriptedSession(all_payloads=[rows])
+    with _patch_session(sess):
+        df = ddata.load_signal_value_series("rank_trajectory", days=30)
+
+    assert len(df) == 2
+    assert set(df.columns) == {
+        "scan_date",
+        "symbol",
+        "signal_value",
+        "forward_return_5d",
+    }
+    nvda = df[df["symbol"] == "NVDA"].iloc[0]
+    assert nvda["signal_value"] == 5.0
+    assert nvda["forward_return_5d"] == 0.015
+
+
+def test_load_signal_value_series_capital_flow_streak_signs_with_direction():
+    """capital_flow_streak extractor must invert sign on `direction='-'`."""
+    today = date(2026, 5, 7)
+    rows = [
+        (
+            today,
+            "AMZN",
+            0.02,
+            {
+                "signals": {
+                    "capital_flow_streak": {"streak_days": 4, "direction": "+"}
+                }
+            },
+        ),
+        (
+            today,
+            "META",
+            -0.01,
+            {
+                "signals": {
+                    "capital_flow_streak": {"streak_days": 3, "direction": "-"}
+                }
+            },
+        ),
+    ]
+    sess = _ScriptedSession(all_payloads=[rows])
+    with _patch_session(sess):
+        df = ddata.load_signal_value_series("capital_flow_streak", days=30)
+
+    by_symbol = {r["symbol"]: r["signal_value"] for _i, r in df.iterrows()}
+    assert by_symbol["AMZN"] == 4.0
+    assert by_symbol["META"] == -3.0
+
+
+# ---------------------------------------------------------------------------
+# load_recent_theses
+# ---------------------------------------------------------------------------
+
+
+def _thesis_row(
+    *,
+    screened_id: int,
+    scan_d: date,
+    symbol: str,
+    thesis_id: int,
+    confidence: int = 7,
+    verdict: str = "setup_long",
+    signals: list[str] | None = None,
+    chart_ids: list[int] | None = None,
+    structured: dict | None = None,
+    session: str = "afternoon",
+):
+    """Mirror the SELECT row shape `load_recent_theses` expects."""
+    obj = MagicMock()
+    obj.screened_id = screened_id
+    obj.scan_date = scan_d
+    obj.session_name = session
+    obj.symbol = symbol
+    obj.thesis_id = thesis_id
+    obj.llm_confidence = confidence
+    obj.recommendation = verdict
+    obj.signals_used = signals or ["rank_trajectory"]
+    obj.chart_image_ids = chart_ids
+    obj.structured_output = structured
+    return obj
+
+
+def test_load_recent_theses_join_and_horizon_flatten():
+    """Forward returns at 1d/5d/10d must appear on the right thesis rows;
+    missing horizons stay None."""
+    today = date(2026, 5, 7)
+    base = [
+        _thesis_row(
+            screened_id=1,
+            scan_d=today,
+            symbol="NVDA",
+            thesis_id=10,
+            chart_ids=[200],
+        ),
+        _thesis_row(
+            screened_id=2,
+            scan_d=today,
+            symbol="TSLA",
+            thesis_id=11,
+        ),
+    ]
+    # Two horizons for thesis 10, none for thesis 11.
+    eval_rows = [
+        (10, "1d", 0.01),
+        (10, "5d", 0.025),
+        # 10d for thesis 10 is missing on purpose — expect None.
+    ]
+    sess = _ScriptedSession(all_payloads=[base, eval_rows])
+    with _patch_session(sess):
+        rows = ddata.load_recent_theses(limit=10)
+
+    assert len(rows) == 2
+    by_sym = {r.symbol: r for r in rows}
+    assert by_sym["NVDA"].return_1d == 0.01
+    assert by_sym["NVDA"].return_5d == 0.025
+    assert by_sym["NVDA"].return_10d is None
+    assert by_sym["NVDA"].chart_image_id == 200
+    # No eval rows queried for TSLA.
+    assert by_sym["TSLA"].return_1d is None
+    assert by_sym["TSLA"].return_5d is None
+    assert by_sym["TSLA"].return_10d is None
+
+
+def test_load_recent_theses_skips_eval_query_when_no_thesis_ids():
+    """If no theses are returned, the eval query must NOT run."""
+    sess = _ScriptedSession(all_payloads=[[]])  # only the base SELECT runs
+    with _patch_session(sess):
+        rows = ddata.load_recent_theses(limit=5)
+    assert rows == []
+    assert sess.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# load_thesis_chart
+# ---------------------------------------------------------------------------
+
+
+def test_load_thesis_chart_returns_none_for_unknown_id():
+    sess = _ScriptedSession(gets={})  # session.get(...) returns None
+    with _patch_session(sess):
+        out = ddata.load_thesis_chart(999)
+    assert out is None
+
+
+def test_load_thesis_chart_returns_bytes_when_file_exists(tmp_path):
+    """Happy path: thesis -> ChartImage(file_path) -> bytes."""
+    from rainier.core.models import ChartImage, LLMAnalysisRecord
+
+    png_path = tmp_path / "nvda.png"
+    png_bytes = b"\x89PNG\r\n\x1a\nfake"
+    png_path.write_bytes(png_bytes)
+
+    analysis = MagicMock(spec=LLMAnalysisRecord)
+    analysis.chart_image_ids = [42]
+    chart = MagicMock(spec=ChartImage)
+    chart.file_path = str(png_path)
+
+    sess = _ScriptedSession(
+        gets={
+            (LLMAnalysisRecord, 100): analysis,
+            (ChartImage, 42): chart,
+        }
+    )
+    with _patch_session(sess):
+        out = ddata.load_thesis_chart(100)
+    assert out == png_bytes
+
+
+def test_load_thesis_chart_returns_none_when_file_missing(tmp_path):
+    """Path on the row points at a non-existent file."""
+    from rainier.core.models import ChartImage, LLMAnalysisRecord
+
+    analysis = MagicMock(spec=LLMAnalysisRecord)
+    analysis.chart_image_ids = [42]
+    chart = MagicMock(spec=ChartImage)
+    chart.file_path = str(tmp_path / "missing.png")
+
+    sess = _ScriptedSession(
+        gets={
+            (LLMAnalysisRecord, 100): analysis,
+            (ChartImage, 42): chart,
+        }
+    )
+    with _patch_session(sess):
+        out = ddata.load_thesis_chart(100)
+    assert out is None
+
+
+def test_load_thesis_chart_returns_none_when_thesis_has_no_chart_ids():
+    from rainier.core.models import LLMAnalysisRecord
+
+    analysis = MagicMock(spec=LLMAnalysisRecord)
+    analysis.chart_image_ids = []
+    sess = _ScriptedSession(gets={(LLMAnalysisRecord, 5): analysis})
+    with _patch_session(sess):
+        out = ddata.load_thesis_chart(5)
+    assert out is None
+
+
+# ---------------------------------------------------------------------------
+# load_pending_insights
+# ---------------------------------------------------------------------------
+
+
+def _insight_row(
+    *,
+    rid: int,
+    kind: str = "signal_underperform",
+    severity: str = "warn",
+    subject: str = "rank_trajectory",
+    rationale: str = "rationale",
+    evidence: dict | None = None,
+    action: dict | None = None,
+    recurrence: int = 1,
+    status: str = "pending",
+    updated: datetime | None = None,
+    decided_at: datetime | None = None,
+    decided_by: str | None = None,
+    applied_change: dict | None = None,
+):
+    obj = MagicMock()
+    obj.id = rid
+    obj.kind = kind
+    obj.severity = severity
+    obj.subject = subject
+    obj.rationale = rationale
+    obj.evidence = evidence or {}
+    obj.action = action or {"kind": "noop", "target": subject, "params": {}}
+    obj.recurrence_count = recurrence
+    obj.status = status
+    obj.created_at = (updated or datetime.now(timezone.utc)) - timedelta(hours=1)
+    obj.updated_at = updated or datetime.now(timezone.utc)
+    obj.decided_at = decided_at
+    obj.decided_by = decided_by
+    obj.applied_change = applied_change
+    return obj
+
+
+def test_load_pending_insights_orders_by_severity_then_recency():
+    now = datetime.now(timezone.utc)
+    rows = [
+        _insight_row(
+            rid=1, severity="info", subject="A", updated=now - timedelta(minutes=5)
+        ),
+        _insight_row(rid=2, severity="critical", subject="B", updated=now - timedelta(hours=3)),
+        _insight_row(rid=3, severity="warn", subject="C", updated=now),
+        _insight_row(rid=4, severity="critical", subject="D", updated=now - timedelta(hours=1)),
+    ]
+    sess = _ScriptedSession(scalars_payloads=[rows])
+    with _patch_session(sess):
+        out = ddata.load_pending_insights()
+
+    # critical first (D before B because D is more recent), then warn, info.
+    assert [r.insight_id for r in out] == [4, 2, 3, 1]
+    assert all(r.status == "pending" for r in out)
+
+
+def test_load_insight_history_filter_passthrough():
+    accepted = _insight_row(
+        rid=10,
+        severity="info",
+        status="accepted",
+        decided_at=datetime.now(timezone.utc),
+        decided_by="user",
+    )
+    sess = _ScriptedSession(scalars_payloads=[[accepted]])
+    with _patch_session(sess):
+        out = ddata.load_insight_history(status=["accepted"])
+    assert len(out) == 1
+    assert out[0].insight_id == 10
+    assert out[0].status == "accepted"
+
+
+def test_load_insight_history_default_excludes_pending_and_stale():
+    """Default filter is the audit-trail set: accepted + rejected + auto_applied."""
+    sess = _ScriptedSession(scalars_payloads=[[]])
+    with _patch_session(sess):
+        ddata.load_insight_history()
+    # We can't easily inspect the WHERE clause, but the empty status case
+    # is defensive: an empty list short-circuits to [].
+    assert ddata.load_insight_history(status=[]) == []
+
+
+def test_load_insight_history_jsonable_string_evidence():
+    """`evidence` may come back as a JSON string from SQLite — coerce to dict."""
+    accepted = _insight_row(
+        rid=11,
+        status="accepted",
+        decided_at=datetime.now(timezone.utc),
+        evidence='{"lift": 0.005, "n": 12}',  # string, not dict
+    )
+    accepted.action = '{"kind": "raise_signal_weight", "target": "x", "params": {}}'
+    sess = _ScriptedSession(scalars_payloads=[[accepted]])
+    with _patch_session(sess):
+        out = ddata.load_insight_history(status=["accepted"])
+    assert out[0].evidence == {"lift": 0.005, "n": 12}
+    assert out[0].action == {
+        "kind": "raise_signal_weight",
+        "target": "x",
+        "params": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the SIGNAL_VALUE_EXTRACTORS map covers the registry
+# ---------------------------------------------------------------------------
+
+
+def test_signal_value_extractors_cover_registry():
+    from rainier.llm_thesis.signals import REGISTRY
+
+    missing = set(REGISTRY) - set(ddata.SIGNAL_VALUE_EXTRACTORS)
+    assert not missing, (
+        f"Add SIGNAL_VALUE_EXTRACTORS entries for new signals: {missing}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2230,7 +2230,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.11" },
     { name = "shap", specifier = ">=0.51.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
-    { name = "streamlit", marker = "extra == 'dashboard'", specifier = ">=1.30" },
+    { name = "streamlit", marker = "extra == 'dashboard'", specifier = ">=1.30,<2" },
     { name = "structlog", specifier = ">=24.0" },
     { name = "xgboost", specifier = ">=3.2.0" },
     { name = "yfinance", specifier = ">=1.2.0" },


### PR DESCRIPTION
## Summary
- Streamlit dashboard at `src/rainier/dashboard/` with 4 tabs: Signals (config + toggle), Performance (per-signal contribution + verdict hit rates), Recent theses (browse with chart PNGs), Insights (accept/reject UI).
- Data-loading functions in `dashboard/data.py` are pure + unit-tested (32 tests). Streamlit pages are smoke-tested manually only (per design doc + eng review).
- Action wrappers in `dashboard/actions.py` share code with the CLI accept/reject/toggle flows so both UIs hit the same Python paths.
- ruamel.yaml round-trip preserves comments + key order on signal toggle (matches the auto-research executors from PR3).

## Scope (PR4 of 4 — final PR)
Per `docs/llm_thesis_design.md` Section G item 23. Stacked on PR #66 (feat/llm-thesis-pr3).

## How to launch
```bash
uv sync --extra dashboard
uv run streamlit run src/rainier/dashboard/app.py
```
Visit http://localhost:8501.

## Reviews
- Codex review: SKIPPED (rate-limited at 2026-05-08T05:46Z; verified twice, reset ~2026-05-08 01:05 PT)
- /review skill: PASS — 1 iteration with one auto-fix (single-source verdict list via `eval.VERDICTS`); second pass clean

## Test plan
- [x] `uv run pytest tests/test_dashboard/ -v` — 32 dashboard tests pass
- [x] `uv run pytest tests/ --ignore=tests/test_ml_emitter.py --ignore=tests/test_ml_compare.py` — 624 pass, 3 skipped (unrelated ml files are untracked, out of scope)
- [x] `uv run ruff check src/rainier/dashboard/ tests/test_dashboard/` — clean
- [x] Streamlit launch smoke — `streamlit run src/rainier/dashboard/app.py` boots cleanly
- [ ] Manual: open dashboard, click each tab, verify no Python errors
- [ ] Tab 1: signal table shows 4 signals with correct enabled state from settings.yaml; toggle a signal off, verify YAML changed + comments preserved (ruamel round-trip)
- [ ] Tab 4: pending insights list with accept button works; accept applies YAML change; status moves to accepted in DB

## Out of scope
- Auto-apply insights without user approval (deferred to v2 per design)
- Multi-model A/B (schema is plumbed, deferred to v2)