### PR TITLE
feat(llm-thesis): PR5 — Discord embed redesign + chart PNG + dashboard link

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -172,6 +172,12 @@ llm_thesis:
     - afternoon
     - close
   fallback_to_anthropic_sdk: false
+  # PR5: when set, the Discord per-ticker embed gets a clickable link to the
+  # dashboard pre-filtered to this thesis. Leave as ``null`` to render no
+  # link (graceful degradation when the dashboard isn't running). Override
+  # for tunnelled / hosted setups, e.g. https://rainier.your-tunnel.example.
+  # dashboard_base_url: "http://localhost:8501"
+  dashboard_base_url: null
   signals:
     rank_trajectory:
       enabled: true

--- a/migrations/0004_llm_thesis_pr5.sql
+++ b/migrations/0004_llm_thesis_pr5.sql
@@ -1,0 +1,52 @@
+-- Migration 0004 — LLM Thesis PR5 schema additions
+--
+-- Extends `chart_images` to support inline PNG byte storage so the Discord
+-- renderer (and Streamlit dashboard) can serve the exact chart that was
+-- handed to the LLM without depending on the filesystem layout.
+--
+-- New columns are all nullable so legacy `file_path`-only rows from PR1 keep
+-- working unchanged; PR5 rows fill `image_bytes` + `sha256` and leave
+-- `file_path` empty.
+--
+-- Apply with:
+--   psql "$DATABASE_URL" -f migrations/0004_llm_thesis_pr5.sql
+--
+-- Idempotent: re-applying is safe.
+
+BEGIN;
+
+-- Original chart_images.file_path was NOT NULL. PR5 persists bytes inline,
+-- so file_path becomes optional. Drop the constraint if it exists.
+ALTER TABLE chart_images
+    ALTER COLUMN file_path DROP NOT NULL;
+
+ALTER TABLE chart_images
+    ADD COLUMN IF NOT EXISTS image_bytes BYTEA;
+
+ALTER TABLE chart_images
+    ADD COLUMN IF NOT EXISTS sha256 VARCHAR(64);
+
+ALTER TABLE chart_images
+    ADD COLUMN IF NOT EXISTS scan_date DATE;
+
+ALTER TABLE chart_images
+    ADD COLUMN IF NOT EXISTS width INTEGER;
+
+ALTER TABLE chart_images
+    ADD COLUMN IF NOT EXISTS height INTEGER;
+
+CREATE INDEX IF NOT EXISTS ix_chart_images_sha256
+    ON chart_images (sha256);
+
+CREATE INDEX IF NOT EXISTS ix_chart_images_scan_date
+    ON chart_images (scan_date);
+
+-- Partial unique index — at most one PR5 row per (symbol, scan_date, sha256)
+-- so the persist path is idempotent: re-running the same scan with identical
+-- chart bytes collapses to one row instead of inserting duplicates. Legacy
+-- rows (sha256 IS NULL) are excluded from the constraint.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_chart_image_symbol_scan_sha
+    ON chart_images (symbol, scan_date, sha256)
+    WHERE sha256 IS NOT NULL;
+
+COMMIT;

--- a/src/rainier/alerts/discord.py
+++ b/src/rainier/alerts/discord.py
@@ -478,10 +478,16 @@ def _why_bullets(thesis: dict) -> list[str]:
     Strategy: split paragraph_radar + paragraph_evidence on sentence
     boundaries, drop blanks, keep the first 4, cap each at 60 chars
     (word-boundary safe).
+
+    PR5 review iter-1: LLM-generated paragraphs flow into Discord text;
+    scrub ``@everyone`` / ``@here`` / backticks before emitting so an
+    adversarial completion can't trigger a mass-mention or break the
+    surrounding embed formatting (mirrors the same defense already in
+    place on the eval/research renderers).
     """
     chunks: list[str] = []
     for key in ("paragraph_radar", "paragraph_evidence"):
-        text = (thesis.get(key) or "").strip()
+        text = _scrub_discord_text((thesis.get(key) or "").strip())
         if not text:
             continue
         # Split on sentence-ish boundaries; we don't need linguistic
@@ -548,7 +554,8 @@ def _llm_noticed(thesis: dict) -> str | None:
     The schema's ``patterns_in_chart_not_in_indicators`` is either a list
     (max 5) of named patterns OR the literal string ``"none"``. We emit
     the field only when there's signal — joining the list into one short
-    sentence (or showing the first item if the list is long).
+    sentence (or showing the first item if the list is long). PR5 review
+    iter-1: scrubs LLM-controlled text via ``_scrub_discord_text``.
     """
     raw = thesis.get("patterns_in_chart_not_in_indicators")
     if raw == "none" or raw is None:
@@ -556,13 +563,14 @@ def _llm_noticed(thesis: dict) -> str | None:
     if isinstance(raw, list):
         if not raw:
             return None
-        items = [str(x).strip() for x in raw if str(x).strip()]
+        items = [_scrub_discord_text(str(x).strip()) for x in raw if str(x).strip()]
+        items = [i for i in items if i]
         if not items:
             return None
         text = "; ".join(items)
         return _truncate_at_word(text, 200)
     if isinstance(raw, str):
-        text = raw.strip()
+        text = _scrub_discord_text(raw.strip())
         if not text:
             return None
         return _truncate_at_word(text, 200)
@@ -570,13 +578,17 @@ def _llm_noticed(thesis: dict) -> str | None:
 
 
 def _risks_lines(thesis: dict) -> list[str]:
-    """Top-3 risks, each <80 chars, word-boundary safe."""
+    """Top-3 risks, each <80 chars, word-boundary safe.
+
+    PR5 review iter-1: scrubs LLM-controlled text so a malicious
+    ``risks=["@everyone bad risk"]`` can't trigger a mass mention.
+    """
     risks = thesis.get("risks") or []
     if not isinstance(risks, list):
         return []
     out: list[str] = []
     for r in risks[:3]:
-        text = str(r).strip()
+        text = _scrub_discord_text(str(r).strip())
         if not text:
             continue
         out.append(_truncate_at_word(text, 80))
@@ -584,11 +596,14 @@ def _risks_lines(thesis: dict) -> list[str]:
 
 
 def _watch_line(thesis: dict) -> str | None:
-    """Single most-actionable watch item, <120 chars, word-boundary safe."""
+    """Single most-actionable watch item, <120 chars, word-boundary safe.
+
+    PR5 review iter-1: scrubs LLM-controlled text.
+    """
     items = thesis.get("watch_items") or []
     if not isinstance(items, list) or not items:
         return None
-    first = str(items[0]).strip()
+    first = _scrub_discord_text(str(items[0]).strip())
     if not first:
         return None
     return _truncate_at_word(first, 120)

--- a/src/rainier/alerts/discord.py
+++ b/src/rainier/alerts/discord.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import date as date_cls
 from datetime import datetime
+from typing import Any
 
 import httpx
 
@@ -287,20 +289,515 @@ def _format_thesis_message(
     return _truncate(body, 1800)
 
 
+# ---------------------------------------------------------------------------
+# PR5 — Discord embed redesign + chart PNG attach + dashboard deep-link
+# ---------------------------------------------------------------------------
+#
+# The PR1/2 renderer emitted six wall-of-text paragraphs per ticker × 5 tickers
+# per scan. Live feedback after the first run was the same: too dense to scan,
+# decision-critical info (verdict, score, entry/SL/TP) buried in prose. PR5
+# replaces it with a Discord *embed* — color-coded bar by verdict, headline
+# `verdict · symbol · score`, chip line of decision-critical signals, monospace
+# trade-levels block, top risks, single most-actionable watch item, optional
+# short LLM-noticed observation, optional clickable link to the dashboard.
+#
+# Flow:
+#                                      ChartImage row (BYTEA)
+#                                              │
+#         ┌──────────┐    payload_json        ▼ files[0]   ┌─────────┐
+# thesis ▶│ format_  │──┐               ┌───────────────┐  │ Discord │
+#         │  thesis_ │  ├──multipart────▶ {embed, file} ├─▶│ webhook │
+# chart ─▶│  embed   │──┘               └───────────────┘  └─────────┘
+#         └──────────┘
+#
+# One ticker = one webhook POST = one Discord message with embed + attached
+# image. Webhooks don't support interactive components (buttons), so the
+# dashboard deep-link is rendered as a plain URL on the embed title.
+
+# Verdict → embed color bar. Matches the design review:
+#   setup_long  → green   (clear long setup)
+#   watch       → yellow  (on radar but not a buy)
+#   no_setup    → gray    (no edge here)
+_VERDICT_COLORS: dict[str, int] = {
+    "setup_long": 0x2ECC71,
+    "watch": 0xF1C40F,
+    "no_setup": 0x95A5A6,
+}
+
+# Discord embed-field limits we respect (webhook spec).
+_EMBED_TITLE_MAX = 256
+_EMBED_DESC_MAX = 4096
+_EMBED_FIELD_NAME_MAX = 256
+_EMBED_FIELD_VALUE_MAX = 1024
+_EMBED_FOOTER_MAX = 2048
+
+# Chip-line cap. Kept well under _EMBED_DESC_MAX so we never have to ellipsize
+# in the middle of a chip.
+_CHIP_LINE_MAX = 200
+
+
+def _truncate_at_word(text: str, max_chars: int) -> str:
+    """Word-boundary safe truncation. Appends ``…`` when shortened.
+
+    The PR1 renderer used naive ``text[:N-3] + '...'`` which produced
+    mid-word cuts like ``"breaking thru exte..."`` (live feedback iter-1).
+    PR5 backs up to the previous whitespace before the cap so the trailing
+    ellipsis lands at a real word break.
+
+    Returns the input unchanged when ``len(text) <= max_chars``. Returns an
+    empty string for ``max_chars <= 0`` (defensive — callers should never
+    pass a non-positive cap, but we don't want to raise from a renderer).
+    """
+    if max_chars <= 0:
+        return ""
+    if text is None:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    # Reserve one char for the ellipsis. We use the single-codepoint U+2026
+    # so length-checks are predictable.
+    cap = max_chars - 1
+    if cap <= 0:
+        return "…"
+    cut = text[:cap]
+    space = cut.rfind(" ")
+    if space > 0:
+        # Trim trailing whitespace so the ellipsis sits flush with the last word.
+        cut = cut[:space].rstrip()
+    return cut + "…"
+
+
+def _format_pct(value: float | None, *, with_sign: bool = True) -> str:
+    """Format a fractional value as a percentage string.
+
+    ``0.087`` -> ``"+8.7%"`` when ``with_sign`` else ``"8.7%"``.
+    Returns ``"-"`` for ``None``.
+    """
+    if value is None:
+        return "-"
+    if with_sign:
+        return f"{value * 100:+.1f}%"
+    return f"{value * 100:.1f}%"
+
+
+def _build_chip_line(
+    candidate: StockCandidate,
+    thesis: dict,
+    pattern_type: str | None,
+) -> str:
+    """Compose the embed description — a `·`-separated chip line.
+
+    Picks the most decision-critical 3–5 signals from the candidate +
+    thesis: pattern type + confidence, rank trajectory delta, sector
+    momentum delta, volume confirmation. Caps the total line at
+    ``_CHIP_LINE_MAX`` chars (200) so the user can read the whole line at
+    a glance — anything longer defeats the "scannable in 5s" goal.
+    """
+    chips: list[str] = []
+
+    # 1) Pattern type (e.g. w_bottom) + confidence when present.
+    if pattern_type:
+        label = pattern_type
+        conf = candidate.pattern_confidence
+        if conf is not None:
+            chips.append(f"{label} {conf:.2f}")
+        else:
+            chips.append(label)
+
+    # 2) Rank trajectory if the thesis carries it under signals payload.
+    rank_chip = _rank_chip(candidate, thesis)
+    if rank_chip:
+        chips.append(rank_chip)
+
+    # 3) Sector momentum delta when the signal payload carries it.
+    sector_chip = _sector_chip(thesis)
+    if sector_chip:
+        chips.append(sector_chip)
+
+    # 4) Volume confirmation flag.
+    if candidate.volume_confirmed:
+        chips.append("vol✓")
+
+    line = " · ".join(c for c in chips if c)
+    return _truncate_at_word(line, _CHIP_LINE_MAX)
+
+
+def _rank_chip(candidate: StockCandidate, thesis: dict) -> str | None:
+    """Build the rank-trajectory chip from the rank_trajectory signal payload.
+
+    Falls back to ``candidate.rank_change`` (single-day delta) when the
+    signal didn't run. Format: ``"rank #85→#14 in 4d ↗"`` or ``"rank +3"``.
+    """
+    signals = thesis.get("signals") if isinstance(thesis, dict) else None
+    if isinstance(signals, dict):
+        rt = signals.get("rank_trajectory")
+        if isinstance(rt, dict):
+            points = rt.get("points") or []
+            delta = rt.get("delta_10d")
+            trend = rt.get("trend")
+            if isinstance(points, list) and len(points) >= 2:
+                try:
+                    first = points[0]
+                    last = points[-1]
+                    # Each point may be (date, rank) or {"date":..,"rank":..}.
+                    first_rank = first[1] if isinstance(first, (list, tuple)) else first.get("rank")
+                    last_rank = last[1] if isinstance(last, (list, tuple)) else last.get("rank")
+                    arrow = (
+                        "↗" if trend == "rising"
+                        else ("↘" if trend == "falling" else "→")
+                    )
+                    days = len(points) - 1
+                    return f"rank #{int(first_rank)}→#{int(last_rank)} in {days}d {arrow}"
+                except (TypeError, ValueError, IndexError):
+                    pass
+            if isinstance(delta, (int, float)):
+                return f"rank delta {int(delta):+d}"
+    if candidate.rank_change:
+        return f"rank {candidate.rank_change:+d}"
+    return None
+
+
+def _sector_chip(thesis: dict) -> str | None:
+    """Sector momentum chip from the sector_momentum signal payload."""
+    signals = thesis.get("signals") if isinstance(thesis, dict) else None
+    if not isinstance(signals, dict):
+        return None
+    sm = signals.get("sector_momentum")
+    if not isinstance(sm, dict):
+        return None
+    delta = sm.get("delta")
+    if not isinstance(delta, (int, float)):
+        return None
+    arrow = "↗" if delta > 0 else ("↘" if delta < 0 else "→")
+    return f"sector {delta:+.2f} {arrow}"
+
+
+def _why_bullets(thesis: dict) -> list[str]:
+    """Top 3-4 short bullets pulled from the thesis prose.
+
+    Strategy: split paragraph_radar + paragraph_evidence on sentence
+    boundaries, drop blanks, keep the first 4, cap each at 60 chars
+    (word-boundary safe).
+    """
+    chunks: list[str] = []
+    for key in ("paragraph_radar", "paragraph_evidence"):
+        text = (thesis.get(key) or "").strip()
+        if not text:
+            continue
+        # Split on sentence-ish boundaries; we don't need linguistic
+        # accuracy, just visual chunks.
+        for piece in re.split(r"(?<=[.!?;])\s+", text):
+            piece = piece.strip().rstrip(".;")
+            if piece:
+                chunks.append(piece)
+    bullets = [_truncate_at_word(c, 60) for c in chunks[:4] if c]
+    return bullets
+
+
+def _levels_block(candidate: StockCandidate) -> str:
+    """Monospace block of Entry / Stop / Target / Now with %deltas + R/R.
+
+    Wrapped in triple backticks so Discord renders the field in a fixed
+    monospace font. Right-aligned dollar amounts so the eye scans the
+    decimal column.
+    """
+    lines: list[str] = []
+    entry = candidate.entry_price
+    stop = candidate.stop_loss
+    target = candidate.target_price
+    now = candidate.current_price
+    rr = candidate.rr_ratio
+
+    def _row(label: str, price: float | None, suffix: str = "") -> str:
+        if price is None:
+            return f"{label:<7} -"
+        body = f"${price:>10.2f}"
+        if suffix:
+            body = f"{body}  {suffix}"
+        return f"{label:<7} {body}"
+
+    lines.append(_row("Entry", entry))
+    if stop is not None and entry is not None:
+        pct = (stop - entry) / entry if entry else None
+        lines.append(_row("Stop", stop, f"({_format_pct(pct)})"))
+    else:
+        lines.append(_row("Stop", stop))
+    if target is not None and entry is not None:
+        pct = (target - entry) / entry if entry else None
+        suffix = f"({_format_pct(pct)}"
+        if rr is not None:
+            suffix += f", {rr:.1f}R"
+        suffix += ")"
+        lines.append(_row("Target", target, suffix))
+    else:
+        lines.append(_row("Target", target))
+    if now is not None:
+        if entry is not None:
+            pct = (now - entry) / entry if entry else None
+            lines.append(_row("Now", now, f"({_format_pct(pct)})"))
+        else:
+            lines.append(_row("Now", now))
+
+    body = "\n".join(lines)
+    return f"```\n{body}\n```"
+
+
+def _llm_noticed(thesis: dict) -> str | None:
+    """Compose the optional 'LLM noticed' field.
+
+    The schema's ``patterns_in_chart_not_in_indicators`` is either a list
+    (max 5) of named patterns OR the literal string ``"none"``. We emit
+    the field only when there's signal — joining the list into one short
+    sentence (or showing the first item if the list is long).
+    """
+    raw = thesis.get("patterns_in_chart_not_in_indicators")
+    if raw == "none" or raw is None:
+        return None
+    if isinstance(raw, list):
+        if not raw:
+            return None
+        items = [str(x).strip() for x in raw if str(x).strip()]
+        if not items:
+            return None
+        text = "; ".join(items)
+        return _truncate_at_word(text, 200)
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return None
+        return _truncate_at_word(text, 200)
+    return None
+
+
+def _risks_lines(thesis: dict) -> list[str]:
+    """Top-3 risks, each <80 chars, word-boundary safe."""
+    risks = thesis.get("risks") or []
+    if not isinstance(risks, list):
+        return []
+    out: list[str] = []
+    for r in risks[:3]:
+        text = str(r).strip()
+        if not text:
+            continue
+        out.append(_truncate_at_word(text, 80))
+    return out
+
+
+def _watch_line(thesis: dict) -> str | None:
+    """Single most-actionable watch item, <120 chars, word-boundary safe."""
+    items = thesis.get("watch_items") or []
+    if not isinstance(items, list) or not items:
+        return None
+    first = str(items[0]).strip()
+    if not first:
+        return None
+    return _truncate_at_word(first, 120)
+
+
+def format_thesis_embed(
+    thesis: dict,
+    candidate: StockCandidate,
+    *,
+    dashboard_base_url: str | None = None,
+    thesis_id: int | None = None,
+    chart_filename: str | None = None,
+) -> dict[str, Any]:
+    """Build the Discord embed dict for a single thesis.
+
+    The returned dict is ready to drop into the ``embeds`` list of a
+    Discord webhook payload. When ``chart_filename`` is set, the embed
+    references it via ``attachment://<filename>`` so the multipart
+    file part renders inline at the bottom of the embed.
+
+    When ``dashboard_base_url`` and ``thesis_id`` are both set the embed
+    title becomes a clickable link to ``<base>?thesis_id=<id>``. Either
+    being None (the default) renders no link.
+    """
+    verdict = str(thesis.get("verdict") or "?")
+    confidence = thesis.get("llm_confidence")
+    setup_q = thesis.get("setup_quality")
+
+    color = _VERDICT_COLORS.get(verdict, _VERDICT_COLORS["no_setup"])
+    title = f"{verdict} · {candidate.symbol}"
+    if confidence is not None:
+        title += f" · {confidence}/10"
+    title = _truncate_at_word(title, _EMBED_TITLE_MAX)
+
+    description = _build_chip_line(candidate, thesis, candidate.pattern_type)
+
+    embed: dict[str, Any] = {
+        "color": color,
+        "title": title,
+    }
+    if description:
+        embed["description"] = description
+
+    # Deep-link on the title.
+    if dashboard_base_url and thesis_id is not None:
+        sep = "&" if "?" in dashboard_base_url else "?"
+        embed["url"] = f"{dashboard_base_url}{sep}thesis_id={int(thesis_id)}"
+
+    # Inline image attachment by filename.
+    if chart_filename:
+        embed["image"] = {"url": f"attachment://{chart_filename}"}
+
+    fields: list[dict[str, Any]] = []
+
+    why_bullets = _why_bullets(thesis)
+    if why_bullets:
+        why_value = "\n".join(f"• {b}" for b in why_bullets)
+        fields.append({
+            "name": "WHY",
+            "value": _truncate_at_word(why_value, _EMBED_FIELD_VALUE_MAX),
+            "inline": False,
+        })
+
+    levels = _levels_block(candidate)
+    fields.append({
+        "name": "LEVELS",
+        "value": levels[:_EMBED_FIELD_VALUE_MAX],
+        "inline": False,
+    })
+
+    risks = _risks_lines(thesis)
+    if risks:
+        risks_value = "\n".join(f"• {r}" for r in risks)
+        fields.append({
+            "name": "RISKS",
+            "value": _truncate_at_word(risks_value, _EMBED_FIELD_VALUE_MAX),
+            "inline": False,
+        })
+
+    watch = _watch_line(thesis)
+    if watch:
+        fields.append({
+            "name": "WATCH",
+            "value": _truncate_at_word(watch, _EMBED_FIELD_VALUE_MAX),
+            "inline": False,
+        })
+
+    noticed = _llm_noticed(thesis)
+    if noticed:
+        fields.append({
+            "name": "LLM noticed",
+            "value": _truncate_at_word(noticed, _EMBED_FIELD_VALUE_MAX),
+            "inline": False,
+        })
+
+    embed["fields"] = fields
+
+    # Footer: setup_quality + signals_used (concise, small font in Discord).
+    signals_used = thesis.get("signals_used") or []
+    if isinstance(signals_used, list):
+        sigs = ", ".join(str(s) for s in signals_used[:6])
+    else:
+        sigs = ""
+    footer_parts: list[str] = []
+    if setup_q is not None:
+        footer_parts.append(f"setup_quality {setup_q}/10")
+    if sigs:
+        footer_parts.append(f"signals: {sigs}")
+    if footer_parts:
+        embed["footer"] = {
+            "text": _truncate_at_word(" · ".join(footer_parts), _EMBED_FOOTER_MAX)
+        }
+
+    return embed
+
+
+def _post_thesis_embed(
+    *,
+    webhook_url: str,
+    embed: dict[str, Any],
+    chart_bytes: bytes | None,
+    chart_filename: str,
+) -> None:
+    """POST one Discord webhook message: embed (+ optional file attachment).
+
+    When ``chart_bytes`` is set we POST as multipart/form-data per Discord's
+    webhook spec — the JSON envelope rides in ``payload_json`` and the file
+    rides in ``files[0]``. The embed's ``image.url`` references
+    ``attachment://<chart_filename>`` so Discord renders the file inline at
+    the bottom of the embed.
+
+    When ``chart_bytes`` is None we drop the embed's ``image`` field (if
+    set) and POST plain JSON.
+    """
+    payload_obj = {"embeds": [embed]}
+
+    if chart_bytes:
+        files = {
+            "files[0]": (chart_filename, chart_bytes, "image/png"),
+        }
+        data = {"payload_json": json.dumps(payload_obj)}
+        response = httpx.post(
+            webhook_url, files=files, data=data, timeout=10
+        )
+    else:
+        # Strip stale image reference if there's no actual file attached.
+        embed_no_image = dict(embed)
+        embed_no_image.pop("image", None)
+        payload_obj = {"embeds": [embed_no_image]}
+        response = httpx.post(webhook_url, json=payload_obj, timeout=10)
+    response.raise_for_status()
+
+
+def _load_chart_bytes_for_thesis(thesis: dict) -> bytes | None:
+    """Read the first ChartImage row referenced by the thesis (PR5).
+
+    PR5 promise: Discord pulls the EXACT bytes that went to the LLM from
+    the DB — never re-renders kaleido. Returns None when no chart is
+    associated; the caller posts the embed without an image attachment.
+    """
+    raw_id = thesis.get("_thesis_id")
+    if raw_id is None:
+        return None
+    try:
+        # Lazy import: keeps the alerts module from pulling SQLAlchemy
+        # in tests that only exercise pure formatting.
+        from rainier.dashboard.data import load_thesis_chart
+        return load_thesis_chart(int(raw_id))
+    except Exception:
+        log.exception("discord_load_chart_failed thesis_id=%s", raw_id)
+        return None
+
+
+def _resolve_thesis_id(thesis: dict) -> int | None:
+    """Pull the LLMAnalysisRecord id stamped on the thesis dict.
+
+    The scheduler/CLI persists the row id via ``out[symbol]["_thesis_id"]
+    = record_id`` so the renderer can build the dashboard deep-link.
+    Returns None when the field is missing (older callsites).
+    """
+    raw = thesis.get("_thesis_id") if isinstance(thesis, dict) else None
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str) and raw.isdigit():
+        return int(raw)
+    return None
+
+
 def send_stock_candidates(
     candidates: list[StockCandidate],
     config: DiscordConfig,
     theses: dict[str, dict] | None = None,
+    *,
+    dashboard_base_url: str | None = None,
 ) -> None:
     """Send QU100 stock candidate alerts to Discord.
 
     Args:
         candidates: Top N screened stock candidates, sorted by pattern match quality.
         config: Discord configuration with webhook URL and enabled flag.
-        theses: Optional `{symbol: thesis_dict}` map. When provided, the standard
-            top-20 summary is followed by a rich thesis message for each of the
-            top-5 candidates whose symbol is present in `theses`. Default `None`
-            preserves existing top-20-only behavior — the regression contract.
+        theses: Optional ``{symbol: thesis_dict}`` map. When provided, the standard
+            top-20 summary is followed by a Discord *embed* per top-5 ticker
+            with verdict color bar, chip line, monospace levels, attached
+            chart PNG, and (optionally) a clickable dashboard link. Default
+            ``None`` preserves existing top-20-only behavior — the regression
+            contract.
+        dashboard_base_url: Public URL of the Streamlit dashboard. When set
+            and the thesis dict carries ``_thesis_id``, the embed title
+            links to ``<base>?thesis_id=<id>``. None disables the link.
     """
     if not candidates:
         return
@@ -325,17 +822,28 @@ def send_stock_candidates(
     if not theses:
         return
 
-    # Per-ticker rich thesis messages — top 5 only, in candidate order.
+    # Per-ticker rich thesis embeds — top 5 only, in candidate order.
     for candidate in candidates[:5]:
         thesis = theses.get(candidate.symbol)
         if not thesis:
             continue
         try:
-            content = _format_thesis_message(candidate, thesis)
-            response = httpx.post(
-                webhook_url, json={"content": content}, timeout=10
+            thesis_id = _resolve_thesis_id(thesis)
+            chart_bytes = _load_chart_bytes_for_thesis(thesis)
+            chart_filename = f"chart_{candidate.symbol}.png"
+            embed = format_thesis_embed(
+                thesis,
+                candidate,
+                dashboard_base_url=dashboard_base_url,
+                thesis_id=thesis_id,
+                chart_filename=chart_filename if chart_bytes else None,
             )
-            response.raise_for_status()
+            _post_thesis_embed(
+                webhook_url=webhook_url,
+                embed=embed,
+                chart_bytes=chart_bytes,
+                chart_filename=chart_filename,
+            )
         except Exception:
             log.exception("discord_thesis_send_failed symbol=%s", candidate.symbol)
 

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2194,7 +2194,14 @@ def thesis_daily(ctx, session_name, top_n, discord, dry_run, max_usd):
         click.echo(f"\n({len(theses)} theses generated, Discord skipped)")
         return
 
-    send_stock_candidates(candidates, settings.alerts.discord, theses=theses or None)
+    send_stock_candidates(
+        candidates,
+        settings.alerts.discord,
+        theses=theses or None,
+        # PR5: pipe the dashboard base URL through so embed titles get a
+        # clickable deep-link. None disables the link.
+        dashboard_base_url=settings.llm_thesis.dashboard_base_url,
+    )
     click.echo(f"Sent {len(theses)} theses + summary to Discord.")
 
 

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -290,7 +290,14 @@ def _default_thesis_signals() -> dict[str, ThesisSignalConfig]:
 
 
 class LLMThesisConfig(BaseModel):
-    """LLM thesis layer config (eng review D2: reload fresh each scan)."""
+    """LLM thesis layer config (eng review D2: reload fresh each scan).
+
+    PR5 adds ``dashboard_base_url`` — the public URL of the Streamlit
+    dashboard. When set, the Discord embed renderer attaches a clickable
+    "open in dashboard" link on each thesis. Default ``None`` keeps the
+    embed link-less so a tunnelled / hosted dashboard can be wired in
+    without touching code.
+    """
 
     enabled: bool = True
     model: str = "claude-sonnet-4-6"
@@ -303,6 +310,7 @@ class LLMThesisConfig(BaseModel):
     signals: dict[str, ThesisSignalConfig] = Field(
         default_factory=_default_thesis_signals
     )
+    dashboard_base_url: str | None = None
 
 
 class NotifyConfig(BaseModel):

--- a/src/rainier/core/models.py
+++ b/src/rainier/core/models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    LargeBinary,
     PrimaryKeyConstraint,
     String,
     Text,
@@ -223,6 +224,20 @@ class StockPrice(Base):
 
 
 class ChartImage(Base):
+    """Persisted chart PNG per (symbol, scan_date).
+
+    Originally PR1's ChartImage used a `file_path` to point at chart files on disk.
+    PR5 introduces inline byte storage so the Discord renderer (and dashboard)
+    can serve the exact PNG that went to the LLM without depending on the
+    filesystem layout. New columns are nullable for backward compatibility:
+    legacy rows keep using ``file_path``; new rows fill ``image_bytes`` +
+    ``sha256`` and leave ``file_path`` empty.
+
+    The partial unique index on ``(symbol, scan_date, sha256)`` (declared in
+    migrations/0004_llm_thesis_pr5.sql) makes the persist path idempotent —
+    two re-runs that produce identical PNG bytes collapse to one row.
+    """
+
     __tablename__ = "chart_images"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -233,13 +248,35 @@ class ChartImage(Base):
         DateTime(timezone=True), server_default=func.now()
     )
     timeframe_days: Mapped[int] = mapped_column(Integer, default=120)
-    file_path: Mapped[str] = mapped_column(String(500), nullable=False)
+    # Nullable now: PR5 rows persist bytes inline and leave file_path empty.
+    file_path: Mapped[str | None] = mapped_column(String(500))
     file_size_bytes: Mapped[int | None] = mapped_column(Integer)
+    # PR5: store the PNG bytes that went to the LLM so Discord/dashboard can
+    # serve the exact image without re-rendering or hitting the filesystem.
+    image_bytes: Mapped[bytes | None] = mapped_column(LargeBinary)
+    sha256: Mapped[str | None] = mapped_column(String(64), index=True)
+    scan_date: Mapped[date | None] = mapped_column(Date, index=True)
+    width: Mapped[int | None] = mapped_column(Integer)
+    height: Mapped[int | None] = mapped_column(Integer)
 
     stock: Mapped[Stock] = relationship(
         back_populates="chart_images",
         foreign_keys=[symbol],
         primaryjoin="ChartImage.symbol == Stock.symbol",
+    )
+
+    __table_args__ = (
+        # Partial unique index — only one PR5 row per (symbol, scan_date,
+        # sha256) at a time. Legacy rows (sha256 IS NULL) are excluded so the
+        # constraint never fires on PR1-vintage data.
+        Index(
+            "idx_chart_image_symbol_scan_sha",
+            "symbol",
+            "scan_date",
+            "sha256",
+            unique=True,
+            postgresql_where="sha256 IS NOT NULL",
+        ),
     )
 
 

--- a/src/rainier/dashboard/app.py
+++ b/src/rainier/dashboard/app.py
@@ -253,6 +253,24 @@ def _is_falsified(lift: float, p_value: float | None) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _read_query_thesis_id() -> int | None:
+    """Pull ?thesis_id=N from the URL for the Discord deep-link (PR5).
+
+    When a Discord embed's "open in dashboard" link fires, Streamlit lands
+    on this page with the query param set. We pre-select the matching row
+    and auto-expand its detail panel so the user lands directly on the
+    thesis they clicked. Returns None when the param is missing or
+    malformed (the tab degrades to its default view).
+    """
+    raw = st.query_params.get("thesis_id")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
 def _render_theses_tab() -> None:
     st.header("Recent theses")
     st.caption(
@@ -260,11 +278,20 @@ def _render_theses_tab() -> None:
         "(NULL until the daily eval job has run for that horizon)."
     )
 
+    deep_link_id = _read_query_thesis_id()
+    # PR5: a deep-link from Discord widens the date window so the
+    # referenced thesis is always in the view, no matter how stale.
+    default_since = (
+        date.today() - timedelta(days=365)
+        if deep_link_id is not None
+        else date.today() - timedelta(days=30)
+    )
+
     col1, col2, col3, col4 = st.columns([1, 1, 1, 2])
     with col1:
         since = st.date_input(
             "Since",
-            value=date.today() - timedelta(days=30),
+            value=default_since,
             key="theses_since",
         )
     with col2:
@@ -315,9 +342,16 @@ def _render_theses_tab() -> None:
     )
     st.dataframe(df, hide_index=True, use_container_width=True)
 
+    # PR5: when the deep-link query param is set AND that id is in the
+    # filtered rows, auto-select it. Otherwise default to no selection.
+    options_list: list[int | None] = [None, *df["thesis_id"].tolist()]
+    default_idx = 0
+    if deep_link_id is not None and deep_link_id in df["thesis_id"].tolist():
+        default_idx = options_list.index(deep_link_id)
     selected_id = st.selectbox(
         "Inspect thesis (id)",
-        options=[None, *df["thesis_id"].tolist()],
+        options=options_list,
+        index=default_idx,
         format_func=lambda x: "—" if x is None else str(x),
         key="theses_inspect",
     )

--- a/src/rainier/dashboard/data.py
+++ b/src/rainier/dashboard/data.py
@@ -424,7 +424,11 @@ def load_recent_theses(
 def load_thesis_chart(thesis_id: int) -> bytes | None:
     """Read the first chart PNG associated with a thesis.
 
-    `LLMAnalysisRecord.chart_image_ids` -> `ChartImage.file_path`.
+    PR5: prefer the inline ``image_bytes`` column (filled by
+    ``llm_thesis.chart_persistence.persist_chart_image``) so Discord +
+    dashboard never depend on the filesystem. Legacy rows that only have
+    ``file_path`` set still resolve via the on-disk read path.
+
     Returns the file bytes, or None when the thesis has no chart, the
     file is missing on disk, or anything errors. Never raises — Tab 3
     just renders "no chart available" instead.
@@ -437,7 +441,12 @@ def load_thesis_chart(thesis_id: int) -> bytes | None:
         if first_id is None:
             return None
         chart = session.get(ChartImage, int(first_id))
-        if chart is None or not chart.file_path:
+        if chart is None:
+            return None
+        # PR5 path: bytes inline.
+        if chart.image_bytes:
+            return bytes(chart.image_bytes)
+        if not chart.file_path:
             return None
         path = Path(chart.file_path)
 

--- a/src/rainier/llm_thesis/chart_persistence.py
+++ b/src/rainier/llm_thesis/chart_persistence.py
@@ -98,8 +98,34 @@ def persist_chart_image(
                 return int(refetch[0]) if refetch else None
             return int(row[0])
         except Exception:
+            # PR5 review iter-1: race-loser path. The probe missed the row
+            # (no concurrent insert visible yet), our INSERT lost the unique
+            # constraint, so the row DOES exist now under the other call's
+            # transaction. Re-probe in a fresh session so we surface the id
+            # instead of silently returning None and missing the chart
+            # attachment downstream.
+            log.warning(
+                "persist_chart_image_conflict_refetch symbol=%s scan_date=%s sha=%s",
+                symbol,
+                scan_date,
+                sha256[:8] if sha256 else None,
+            )
+
+    # Fresh session to refetch — the original session was rolled back by the
+    # context-manager exit when the INSERT raised.
+    with get_session() as session:
+        try:
+            row = session.execute(
+                select(ChartImage.id).where(
+                    ChartImage.symbol == symbol,
+                    ChartImage.scan_date == scan_date,
+                    ChartImage.sha256 == sha256,
+                )
+            ).first()
+            return int(row[0]) if row else None
+        except Exception:
             log.exception(
-                "persist_chart_image_failed symbol=%s scan_date=%s sha=%s",
+                "persist_chart_image_refetch_failed symbol=%s scan_date=%s sha=%s",
                 symbol,
                 scan_date,
                 sha256[:8] if sha256 else None,

--- a/src/rainier/llm_thesis/chart_persistence.py
+++ b/src/rainier/llm_thesis/chart_persistence.py
@@ -1,0 +1,128 @@
+"""Persistence helpers for ``ChartImage`` rows (PR5).
+
+Why a dedicated module? PR1's ``ChartImage`` was filesystem-backed and only
+referenced by analytics dashboards. PR5 needs the chart bytes that went to
+the LLM to be readable later by the Discord renderer (multipart attachment)
+and the Streamlit dashboard (deep-link). Persisting bytes inline (BYTEA on
+Postgres) plus the sha256 digest gives us a deterministic idempotency key.
+
+  ┌──────────────────┐    persist_chart_image
+  │ render_chart_png │  ─►  ChartImage(symbol, scan_date, image_bytes,
+  │  (kaleido / PNG) │      sha256, width, height)
+  └──────────────────┘  ─►  partial-unique on (symbol, scan_date, sha256)
+
+The ``persist_chart_image`` helper is idempotent: a re-run with identical
+PNG bytes returns the existing row's id instead of inserting a duplicate.
+This keeps Tier-2 cache misses from spamming chart_images with the same
+bytes when the user manually re-fires a scan.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date as date_cls
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from rainier.core.database import get_session
+from rainier.core.models import ChartImage
+
+log = logging.getLogger(__name__)
+
+
+def persist_chart_image(
+    *,
+    symbol: str,
+    scan_date: date_cls,
+    image_bytes: bytes,
+    sha256: str,
+    width: int = 1280,
+    height: int = 800,
+) -> int | None:
+    """Insert (or reuse) a ChartImage row for this (symbol, scan_date, sha256).
+
+    Returns the row id, or ``None`` on persistence failure. The SELECT before
+    INSERT is a deliberate two-step on the partial unique index: Postgres'
+    ``ON CONFLICT`` on a partial index requires matching the partial WHERE
+    in the conflict target, and SQLAlchemy's ``index_where`` bookkeeping
+    differs across versions. The select probe is a single index seek and
+    keeps the persist path version-portable.
+    """
+    if not image_bytes or not sha256:
+        log.warning(
+            "persist_chart_image_invalid_args symbol=%s sha=%s len=%s",
+            symbol,
+            sha256[:8] if sha256 else None,
+            len(image_bytes) if image_bytes else 0,
+        )
+        return None
+
+    with get_session() as session:
+        existing = session.execute(
+            select(ChartImage.id).where(
+                ChartImage.symbol == symbol,
+                ChartImage.scan_date == scan_date,
+                ChartImage.sha256 == sha256,
+            )
+        ).first()
+        if existing is not None:
+            return int(existing[0])
+
+        try:
+            stmt = (
+                pg_insert(ChartImage)
+                .values(
+                    symbol=symbol,
+                    scan_date=scan_date,
+                    image_bytes=image_bytes,
+                    sha256=sha256,
+                    file_size_bytes=len(image_bytes),
+                    width=int(width),
+                    height=int(height),
+                    timeframe_days=120,
+                )
+                .returning(ChartImage.id)
+            )
+            row = session.execute(stmt).first()
+            if row is None:
+                # ON CONFLICT handled at the DB level — reread by the unique key.
+                refetch = session.execute(
+                    select(ChartImage.id).where(
+                        ChartImage.symbol == symbol,
+                        ChartImage.scan_date == scan_date,
+                        ChartImage.sha256 == sha256,
+                    )
+                ).first()
+                return int(refetch[0]) if refetch else None
+            return int(row[0])
+        except Exception:
+            log.exception(
+                "persist_chart_image_failed symbol=%s scan_date=%s sha=%s",
+                symbol,
+                scan_date,
+                sha256[:8] if sha256 else None,
+            )
+            return None
+
+
+def attach_chart_id_to_thesis(*, thesis_id: int, chart_id: int) -> bool:
+    """Append ``chart_id`` to LLMAnalysisRecord.chart_image_ids if not present.
+
+    Returns True iff the array was mutated. Idempotent — a chart id that's
+    already in the array is left alone (no duplicate ids).
+    """
+    from rainier.core.models import LLMAnalysisRecord
+
+    with get_session() as session:
+        record = session.get(LLMAnalysisRecord, int(thesis_id))
+        if record is None:
+            log.warning("attach_chart_thesis_missing thesis_id=%s", thesis_id)
+            return False
+        existing: list[Any] = list(record.chart_image_ids or [])
+        if int(chart_id) in [int(x) for x in existing]:
+            return False
+        existing.append(int(chart_id))
+        record.chart_image_ids = existing
+    return True

--- a/src/rainier/llm_thesis/service.py
+++ b/src/rainier/llm_thesis/service.py
@@ -573,6 +573,7 @@ async def _compute_theses_async(
     settings: Settings,
 ) -> dict[str, dict[str, Any]]:
     from .chart_export import render_chart_png
+    from .chart_persistence import attach_chart_id_to_thesis, persist_chart_image
 
     thesis_cfg = settings.llm_thesis
     max_usd = float(thesis_cfg.max_usd_per_scan)
@@ -582,6 +583,10 @@ async def _compute_theses_async(
     # Pre-rank by composite_score so we can compute would_be_combined_rank
     # within just the LLM-augmented set (top N — typically 5).
     ranked: list[tuple[StockCandidate, dict[str, Any]]] = []
+    # PR5: track the persisted chart_id per symbol so the post-thesis hook
+    # can attach it to LLMAnalysisRecord.chart_image_ids. This stays bounded
+    # to top-N candidates, so dict size is trivial.
+    chart_ids_by_symbol: dict[str, int] = {}
 
     for candidate in candidates:
         if cost_used >= max_usd:
@@ -604,15 +609,30 @@ async def _compute_theses_async(
         pattern = _candidate_to_pattern_signal(candidate)
 
         async def _async_provider(c=candidate, s=symbol, _df=df, _pattern=pattern):
+            image_bytes: bytes | None = None
+            digest: str | None = None
             try:
-                image_bytes, _digest = (
-                    render_chart_png(s, _df, pattern=_pattern)
-                    if _df is not None
-                    else (None, None)
-                )
+                if _df is not None:
+                    image_bytes, digest = render_chart_png(s, _df, pattern=_pattern)
             except Exception:
                 log.exception("chart_export_failed symbol=%s", s)
                 image_bytes = None
+                digest = None
+            # PR5: persist the chart bytes alongside their sha256 digest so
+            # the Discord renderer + dashboard can serve the exact PNG that
+            # went to the LLM. Idempotent on (symbol, scan_date, sha256).
+            if image_bytes is not None and digest is not None:
+                try:
+                    chart_id = persist_chart_image(
+                        symbol=s,
+                        scan_date=scan_date,
+                        image_bytes=image_bytes,
+                        sha256=digest,
+                    )
+                    if chart_id is not None:
+                        chart_ids_by_symbol[s] = chart_id
+                except Exception:
+                    log.exception("persist_chart_image_failed symbol=%s", s)
             pack, renders = await assemble_evidence(
                 c, _df, scan_date, session_name, thesis_cfg
             )
@@ -645,8 +665,36 @@ async def _compute_theses_async(
             continue
 
         thesis_dict = thesis.model_dump()
+        # PR5: stamp the LLMAnalysisRecord id on the thesis dict so the
+        # Discord renderer can build a dashboard deep-link without making
+        # an extra DB lookup. Underscore-prefixed key — not part of the
+        # Pydantic schema, just transport metadata for downstream
+        # rendering. The leading underscore matches the existing
+        # `_session_name` precedent in service._persist_thesis.
+        if record_id is not None:
+            thesis_dict["_thesis_id"] = int(record_id)
         out[symbol] = thesis_dict
         ranked.append((candidate, thesis_dict))
+
+        # PR5: attach the persisted chart_id (if any) to the thesis record so
+        # the Discord renderer + dashboard can read the exact bytes back. We
+        # do this AFTER the thesis succeeds — a cache hit returns no chart
+        # bytes (we never invoked the provider) and that's fine: an earlier
+        # scan's row already carries chart_image_ids. This is also why the
+        # mutation is idempotent at the data layer (skip if already present).
+        chart_id = chart_ids_by_symbol.get(symbol)
+        if chart_id is not None and record_id is not None:
+            try:
+                attach_chart_id_to_thesis(
+                    thesis_id=record_id, chart_id=chart_id
+                )
+            except Exception:
+                log.exception(
+                    "attach_chart_id_failed symbol=%s thesis_id=%s chart_id=%s",
+                    symbol,
+                    record_id,
+                    chart_id,
+                )
 
         # Persist LLM-side fields onto ScreenedStockRecord.
         composite = float(candidate.signal_strength or 0.0)

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -15,6 +15,28 @@ from rainier.core.config import get_settings, load_settings_fresh
 log = structlog.get_logger()
 
 
+def _send_stock_candidates_with_dashboard_url(
+    candidates,
+    discord_config,
+    theses,
+    dashboard_base_url,
+):
+    """Sync helper so ``asyncio.to_thread`` can carry the dashboard URL kwarg.
+
+    ``send_stock_candidates`` accepts ``dashboard_base_url`` only as a keyword
+    argument; ``asyncio.to_thread`` forwards positional + keyword args but is
+    cleaner with a small wrapper that names them.
+    """
+    from rainier.alerts.discord import send_stock_candidates as _send
+
+    _send(
+        candidates,
+        discord_config,
+        theses=theses,
+        dashboard_base_url=dashboard_base_url,
+    )
+
+
 async def run_qu_scrape(session_name: str) -> None:
     """Run a single QU100 scrape for the given session. Called by APScheduler.
 
@@ -55,7 +77,9 @@ async def run_qu_scrape(session_name: str) -> None:
         settings = await asyncio.to_thread(load_settings_fresh)
 
         # 2. Screener — refactored to return (candidates, ohlcv_dict).
-        from rainier.alerts.discord import send_stock_candidates
+        # send_stock_candidates is invoked indirectly via
+        # _send_stock_candidates_with_dashboard_url so we don't need it
+        # imported in this scope.
         from rainier.analysis.stock_screener import screen_stocks
 
         all_candidates, ohlcv_by_symbol = await asyncio.to_thread(
@@ -109,11 +133,15 @@ async def run_qu_scrape(session_name: str) -> None:
                 theses = {}
 
         # 5. Discord — empty theses dict means existing top-20-only behavior.
+        # PR5: pass the dashboard base URL through so per-ticker embeds carry
+        # a clickable deep-link to the Streamlit dashboard. None disables the
+        # link (graceful degradation when the dashboard isn't running).
         await asyncio.to_thread(
-            send_stock_candidates,
+            _send_stock_candidates_with_dashboard_url,
             candidates,
             settings.alerts.discord,
-            theses=theses or None,
+            theses or None,
+            settings.llm_thesis.dashboard_base_url,
         )
 
     except Exception as exc:

--- a/tests/test_alerts/test_discord_attachment.py
+++ b/tests/test_alerts/test_discord_attachment.py
@@ -1,0 +1,190 @@
+"""Tests for the PR5 Discord webhook multipart attachment path.
+
+These cover:
+  * ``send_stock_candidates(theses=...)`` POSTs multipart/form-data when
+    chart bytes load successfully — verifies ``payload_json`` + ``files[0]``
+    structure.
+  * Chart bytes are loaded from ``ChartImage`` (via
+    ``dashboard.data.load_thesis_chart``), NOT re-rendered by kaleido.
+  * Missing chart bytes (eg. cache hit returning None) → embed posts
+    without the ``image`` field; no crash.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from rainier.alerts.discord import send_stock_candidates
+from rainier.core.config import DiscordConfig
+from rainier.core.types import StockCandidate
+
+
+def _candidate(symbol: str = "NVDA") -> StockCandidate:
+    return StockCandidate(
+        symbol=symbol,
+        rank=5,
+        rank_change=2,
+        long_short="Long in",
+        capital_flow_direction="+",
+        sector="Technology",
+        signal_strength=0.8,
+        money_flow_score=0.6,
+        pattern_type="w_bottom",
+        pattern_direction="bullish",
+        pattern_status="confirmed",
+        pattern_confidence=0.9,
+        entry_price=100.0,
+        stop_loss=95.0,
+        target_price=120.0,
+        rr_ratio=4.0,
+        volume_confirmed=True,
+        current_price=105.0,
+    )
+
+
+def _thesis(**overrides) -> dict:
+    base = dict(
+        verdict="setup_long",
+        setup_quality=7,
+        llm_confidence=8,
+        paragraph_radar="Strong setup.",
+        paragraph_evidence="Volume + sector.",
+        paragraph_invalidation="Reject below 95.",
+        risks=["earnings"],
+        watch_items=["pullback to 100"],
+        evidence_used=["pattern"],
+        signals_used=["rank_trajectory"],
+        patterns_in_chart_not_in_indicators="none",
+        _thesis_id=42,
+    )
+    base.update(overrides)
+    return base
+
+
+class TestMultipartAttachment:
+
+    def test_thesis_with_chart_bytes_posts_multipart(self):
+        config = DiscordConfig(enabled=True, webhook_url="https://x/hook")
+        png_bytes = b"\x89PNG\r\n\x1a\nFAKE"
+        with patch(
+            "rainier.alerts.discord.httpx.post"
+        ) as mock_post, patch(
+            "rainier.alerts.discord._load_chart_bytes_for_thesis",
+            return_value=png_bytes,
+        ):
+            mock_post.return_value = MagicMock(status_code=204)
+            send_stock_candidates(
+                [_candidate("NVDA")],
+                config,
+                theses={"NVDA": _thesis()},
+            )
+
+        # Top-20 summary call (json=) + thesis call (multipart with files=).
+        calls = mock_post.call_args_list
+        # Find the multipart call.
+        multipart_calls = [c for c in calls if "files" in c.kwargs]
+        assert len(multipart_calls) == 1
+        call = multipart_calls[0]
+        files = call.kwargs["files"]
+        assert "files[0]" in files
+        filename, body, mime = files["files[0]"]
+        assert filename == "chart_NVDA.png"
+        assert body == png_bytes
+        assert mime == "image/png"
+        # payload_json present in the data field.
+        assert "data" in call.kwargs
+        assert "payload_json" in call.kwargs["data"]
+
+    def test_chart_bytes_loaded_from_db_not_rerendered(self):
+        """The Discord renderer never calls kaleido directly — bytes must
+        come from the ChartImage row via ``load_thesis_chart``."""
+        config = DiscordConfig(enabled=True, webhook_url="https://x/hook")
+        with patch(
+            "rainier.alerts.discord.httpx.post"
+        ) as mock_post, patch(
+            "rainier.dashboard.data.load_thesis_chart"
+        ) as mock_load, patch(
+            "rainier.llm_thesis.chart_export.render_chart_png"
+        ) as mock_render:
+            mock_post.return_value = MagicMock(status_code=204)
+            mock_load.return_value = b"FROM-DB"
+            send_stock_candidates(
+                [_candidate("NVDA")],
+                config,
+                theses={"NVDA": _thesis()},
+            )
+
+        mock_load.assert_called_once_with(42)
+        mock_render.assert_not_called()
+
+    def test_missing_chart_bytes_posts_without_image(self):
+        """Cache-hit path returns None bytes — embed posts without image,
+        no crash, no multipart."""
+        config = DiscordConfig(enabled=True, webhook_url="https://x/hook")
+        with patch(
+            "rainier.alerts.discord.httpx.post"
+        ) as mock_post, patch(
+            "rainier.alerts.discord._load_chart_bytes_for_thesis",
+            return_value=None,
+        ):
+            mock_post.return_value = MagicMock(status_code=204)
+            send_stock_candidates(
+                [_candidate("NVDA")],
+                config,
+                theses={"NVDA": _thesis()},
+            )
+
+        # Find the thesis call — it shouldn't be multipart.
+        calls = mock_post.call_args_list
+        # The summary embed call uses json=. The thesis call should also
+        # use json= (no files) when bytes are missing.
+        multipart_calls = [c for c in calls if "files" in c.kwargs]
+        assert multipart_calls == []
+        # And the thesis embed dict in the json payload should not have
+        # an image field.
+        json_calls = [c for c in calls if "json" in c.kwargs]
+        # Find the thesis call (it has a single embed without table-style
+        # description).
+        thesis_calls = [
+            c
+            for c in json_calls
+            if isinstance(c.kwargs["json"], dict)
+            and isinstance(c.kwargs["json"].get("embeds"), list)
+            and len(c.kwargs["json"]["embeds"]) == 1
+            and c.kwargs["json"]["embeds"][0].get("title", "").startswith(
+                "setup_long"
+            )
+        ]
+        assert len(thesis_calls) == 1
+        embed = thesis_calls[0].kwargs["json"]["embeds"][0]
+        assert "image" not in embed
+
+    def test_dashboard_base_url_is_passed_through(self):
+        config = DiscordConfig(enabled=True, webhook_url="https://x/hook")
+        with patch(
+            "rainier.alerts.discord.httpx.post"
+        ) as mock_post, patch(
+            "rainier.alerts.discord._load_chart_bytes_for_thesis",
+            return_value=None,
+        ):
+            mock_post.return_value = MagicMock(status_code=204)
+            send_stock_candidates(
+                [_candidate("NVDA")],
+                config,
+                theses={"NVDA": _thesis(_thesis_id=999)},
+                dashboard_base_url="http://dashboard.local",
+            )
+        # Find the thesis call.
+        json_calls = [
+            c for c in mock_post.call_args_list if "json" in c.kwargs
+        ]
+        thesis_calls = [
+            c
+            for c in json_calls
+            if isinstance(c.kwargs["json"], dict)
+            and len(c.kwargs["json"].get("embeds") or []) == 1
+            and c.kwargs["json"]["embeds"][0].get("title", "").startswith("setup_long")
+        ]
+        assert len(thesis_calls) == 1
+        embed = thesis_calls[0].kwargs["json"]["embeds"][0]
+        assert embed["url"] == "http://dashboard.local?thesis_id=999"

--- a/tests/test_alerts/test_discord_embed.py
+++ b/tests/test_alerts/test_discord_embed.py
@@ -1,0 +1,414 @@
+"""Tests for the PR5 Discord embed renderer.
+
+These cover the pure-function ``format_thesis_embed`` and its helpers — no
+HTTP, no DB. Multipart attachment + DB chart-load happens in
+``test_discord_attachment.py``.
+"""
+
+from __future__ import annotations
+
+from rainier.alerts.discord import (
+    _VERDICT_COLORS,
+    _build_chip_line,
+    _levels_block,
+    _llm_noticed,
+    _risks_lines,
+    _truncate_at_word,
+    _watch_line,
+    format_thesis_embed,
+)
+from rainier.core.types import StockCandidate
+
+
+def _candidate(**overrides) -> StockCandidate:
+    base = dict(
+        symbol="CRWD",
+        rank=14,
+        rank_change=2,
+        long_short="Long in",
+        capital_flow_direction="+",
+        sector="Technology",
+        signal_strength=0.82,
+        money_flow_score=0.7,
+        pattern_type="w_bottom",
+        pattern_direction="bullish",
+        pattern_status="confirmed",
+        pattern_confidence=0.95,
+        entry_price=486.55,
+        stop_loss=476.82,
+        target_price=528.79,
+        rr_ratio=4.3,
+        volume_confirmed=True,
+        current_price=505.72,
+        distance_to_entry_pct=3.94,
+    )
+    base.update(overrides)
+    return StockCandidate(**base)
+
+
+def _thesis(**overrides) -> dict:
+    base = dict(
+        verdict="watch",
+        setup_quality=6,
+        llm_confidence=6,
+        paragraph_radar=(
+            "Rank improved sharply over four sessions. Volume confirms breakout."
+        ),
+        paragraph_evidence=(
+            "Sector recovering from -0.17 to -0.06. Late entry — already +3.94%."
+        ),
+        paragraph_invalidation="Reject below 480 on volume.",
+        risks=[
+            "late entry, R/R degraded",
+            "earnings 26d out",
+            "cap flow neutral",
+            "extra risk that should be cut",
+        ],
+        watch_items=["pullback 486-490 on low volume"],
+        evidence_used=["pattern", "rank", "volume"],
+        signals_used=["rank_trajectory", "sector_momentum"],
+        patterns_in_chart_not_in_indicators=[
+            "strong neckline breakout with extended upper wick",
+        ],
+        signals={
+            "rank_trajectory": {
+                "points": [["2026-05-04", 85], ["2026-05-08", 14]],
+                "delta_10d": -71,
+                "trend": "rising",
+            },
+            "sector_momentum": {
+                "delta": 0.11,
+                "sentiment_today": -0.06,
+                "sentiment_5d_ago": -0.17,
+            },
+        },
+    )
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _truncate_at_word
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateAtWord:
+
+    def test_returns_input_when_under_cap(self):
+        assert _truncate_at_word("hello world", 50) == "hello world"
+
+    def test_appends_ellipsis_when_truncated(self):
+        out = _truncate_at_word("hello world this is a long sentence", 16)
+        assert out.endswith("…")
+        assert len(out) <= 16
+
+    def test_never_breaks_mid_word(self):
+        # The naive cut would put us mid-word; the function must back up.
+        text = "breaking thru extended upper wick area"
+        out = _truncate_at_word(text, 20)
+        # No word should be cut in half — the body before the ellipsis ends
+        # at a real word boundary.
+        assert out.endswith("…")
+        body = out[:-1]
+        assert not body.endswith("ext")  # would-be naive cut
+        # Last char before ellipsis should be alphanumeric or end of word.
+        assert body.rstrip()[-1].isalpha()
+
+    def test_zero_or_negative_cap_returns_empty(self):
+        assert _truncate_at_word("anything", 0) == ""
+        assert _truncate_at_word("anything", -5) == ""
+
+    def test_empty_input_returns_empty(self):
+        assert _truncate_at_word("", 10) == ""
+        assert _truncate_at_word(None, 10) == ""  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# format_thesis_embed — title + colors
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedTitleAndColor:
+
+    def test_setup_long_is_green(self):
+        embed = format_thesis_embed(
+            _thesis(verdict="setup_long", llm_confidence=8), _candidate()
+        )
+        assert embed["color"] == _VERDICT_COLORS["setup_long"] == 0x2ECC71
+
+    def test_watch_is_yellow(self):
+        embed = format_thesis_embed(_thesis(verdict="watch"), _candidate())
+        assert embed["color"] == _VERDICT_COLORS["watch"] == 0xF1C40F
+
+    def test_no_setup_is_gray(self):
+        embed = format_thesis_embed(
+            _thesis(verdict="no_setup", llm_confidence=2), _candidate()
+        )
+        assert embed["color"] == _VERDICT_COLORS["no_setup"] == 0x95A5A6
+
+    def test_unknown_verdict_falls_back_to_no_setup_color(self):
+        embed = format_thesis_embed(_thesis(verdict="???"), _candidate())
+        assert embed["color"] == _VERDICT_COLORS["no_setup"]
+
+    def test_title_format_is_verdict_symbol_score(self):
+        embed = format_thesis_embed(
+            _thesis(verdict="watch", llm_confidence=6),
+            _candidate(symbol="CRWD"),
+        )
+        assert embed["title"] == "watch · CRWD · 6/10"
+
+
+# ---------------------------------------------------------------------------
+# Chip line
+# ---------------------------------------------------------------------------
+
+
+class TestChipLine:
+
+    def test_chip_line_under_200_chars(self):
+        line = _build_chip_line(_candidate(), _thesis(), "w_bottom")
+        assert len(line) <= 200
+
+    def test_chip_line_includes_pattern(self):
+        line = _build_chip_line(_candidate(), _thesis(), "w_bottom")
+        assert "w_bottom" in line
+
+    def test_chip_line_includes_volume_check_when_confirmed(self):
+        line = _build_chip_line(
+            _candidate(volume_confirmed=True), _thesis(), "w_bottom"
+        )
+        assert "vol" in line
+
+    def test_chip_line_omits_volume_when_not_confirmed(self):
+        line = _build_chip_line(
+            _candidate(volume_confirmed=False), _thesis(), "w_bottom"
+        )
+        assert "vol" not in line
+
+    def test_chip_line_renders_rank_trajectory(self):
+        line = _build_chip_line(_candidate(), _thesis(), "w_bottom")
+        assert "rank #85" in line
+        assert "#14" in line
+
+    def test_chip_line_falls_back_to_rank_change_when_no_signal(self):
+        line = _build_chip_line(
+            _candidate(rank_change=3),
+            {"signals": {}},
+            "w_bottom",
+        )
+        # No signal payload → uses rank_change
+        assert "rank +3" in line
+
+
+# ---------------------------------------------------------------------------
+# LEVELS field
+# ---------------------------------------------------------------------------
+
+
+class TestLevelsField:
+
+    def test_levels_block_has_all_four_lines(self):
+        block = _levels_block(_candidate())
+        assert "Entry" in block
+        assert "Stop" in block
+        assert "Target" in block
+        assert "Now" in block
+
+    def test_levels_block_is_monospace(self):
+        block = _levels_block(_candidate())
+        assert block.startswith("```")
+        assert block.endswith("```")
+
+    def test_levels_renders_stop_pct(self):
+        # entry=486.55, stop=476.82 -> ~-2.0%
+        block = _levels_block(_candidate())
+        assert "-2.0%" in block
+
+    def test_levels_renders_target_pct_and_rr(self):
+        # entry=486.55, target=528.79 -> ~+8.7%, R/R=4.3
+        block = _levels_block(_candidate())
+        assert "+8.7%" in block
+        assert "4.3R" in block
+
+    def test_levels_renders_now_pct(self):
+        # entry=486.55, now=505.72 -> ~+3.94%
+        block = _levels_block(_candidate())
+        assert "+3.9%" in block or "+4.0%" in block  # rounding tolerance
+
+    def test_levels_handles_missing_fields(self):
+        c = _candidate(stop_loss=None, target_price=None, current_price=None)
+        block = _levels_block(c)
+        # Should still render Entry; missing rows show "-".
+        assert "Entry" in block
+
+
+# ---------------------------------------------------------------------------
+# RISKS field
+# ---------------------------------------------------------------------------
+
+
+class TestRisksField:
+
+    def test_risks_truncates_to_three(self):
+        risks = _risks_lines(
+            _thesis(risks=["a", "b", "c", "d", "e"])
+        )
+        assert len(risks) == 3
+
+    def test_risks_under_80_chars_each(self):
+        long = "x " * 200
+        risks = _risks_lines(_thesis(risks=[long, long, long]))
+        for r in risks:
+            assert len(r) <= 80
+
+    def test_risks_is_word_boundary_safe(self):
+        long = "earnings risk extended position with major catalyst nearby"
+        risks = _risks_lines(_thesis(risks=[long]))
+        # Either the original (if under cap) or word-bounded with ellipsis.
+        assert risks[0] == long or risks[0].endswith("…")
+
+    def test_risks_skips_empty_strings(self):
+        risks = _risks_lines(_thesis(risks=["", "  ", "real risk"]))
+        assert risks == ["real risk"]
+
+
+# ---------------------------------------------------------------------------
+# WATCH field
+# ---------------------------------------------------------------------------
+
+
+class TestWatchField:
+
+    def test_watch_renders_first_item_only(self):
+        out = _watch_line(_thesis(watch_items=["item one", "item two", "item three"]))
+        assert out == "item one"
+
+    def test_watch_truncates_at_120_word_boundary(self):
+        long = "watch for pullback to entry zone with low volume " * 5
+        out = _watch_line(_thesis(watch_items=[long]))
+        assert out is not None
+        assert len(out) <= 120
+        if len(long) > 120:
+            assert out.endswith("…")
+
+    def test_watch_returns_none_when_empty(self):
+        assert _watch_line(_thesis(watch_items=[])) is None
+        assert _watch_line(_thesis(watch_items=["", "  "])) is None
+
+
+# ---------------------------------------------------------------------------
+# LLM noticed field
+# ---------------------------------------------------------------------------
+
+
+class TestLLMNoticedField:
+
+    def test_llm_noticed_omitted_when_none_string(self):
+        out = _llm_noticed(_thesis(patterns_in_chart_not_in_indicators="none"))
+        assert out is None
+
+    def test_llm_noticed_omitted_when_empty_list_yields_falsy_field(self):
+        # The Pydantic schema rejects empty lists, but the renderer
+        # defends in case a degraded payload sneaks through.
+        out = _llm_noticed({"patterns_in_chart_not_in_indicators": []})
+        assert out is None
+
+    def test_llm_noticed_renders_short_observation(self):
+        out = _llm_noticed(
+            _thesis(patterns_in_chart_not_in_indicators=["narrowing volume profile"])
+        )
+        assert out == "narrowing volume profile"
+
+    def test_llm_noticed_truncates_at_200_word_boundary(self):
+        long = "very long observation about an unusual chart pattern " * 10
+        out = _llm_noticed(_thesis(patterns_in_chart_not_in_indicators=[long]))
+        assert out is not None
+        assert len(out) <= 200
+        assert out.endswith("…")
+        # Ellipsis must follow a complete word (no mid-word cut).
+        body = out[:-1].rstrip()
+        assert body[-1].isalpha()
+
+    def test_llm_noticed_field_omitted_in_embed_when_none(self):
+        embed = format_thesis_embed(
+            _thesis(patterns_in_chart_not_in_indicators="none"), _candidate(),
+        )
+        names = [f["name"] for f in embed["fields"]]
+        assert "LLM noticed" not in names
+
+    def test_llm_noticed_field_present_in_embed_when_set(self):
+        embed = format_thesis_embed(
+            _thesis(patterns_in_chart_not_in_indicators=["strong neckline"]),
+            _candidate(),
+        )
+        names = [f["name"] for f in embed["fields"]]
+        assert "LLM noticed" in names
+
+
+# ---------------------------------------------------------------------------
+# Dashboard deep-link
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardLink:
+
+    def test_no_url_when_dashboard_base_url_is_none(self):
+        embed = format_thesis_embed(_thesis(), _candidate(), dashboard_base_url=None)
+        assert "url" not in embed
+
+    def test_no_url_when_thesis_id_is_none(self):
+        embed = format_thesis_embed(
+            _thesis(),
+            _candidate(),
+            dashboard_base_url="http://localhost:8501",
+            thesis_id=None,
+        )
+        assert "url" not in embed
+
+    def test_url_built_when_both_set(self):
+        embed = format_thesis_embed(
+            _thesis(),
+            _candidate(),
+            dashboard_base_url="http://x",
+            thesis_id=42,
+        )
+        assert embed["url"] == "http://x?thesis_id=42"
+
+    def test_url_appends_with_amp_when_existing_query(self):
+        embed = format_thesis_embed(
+            _thesis(),
+            _candidate(),
+            dashboard_base_url="http://x?tab=3",
+            thesis_id=42,
+        )
+        assert embed["url"] == "http://x?tab=3&thesis_id=42"
+
+
+# ---------------------------------------------------------------------------
+# Footer + image
+# ---------------------------------------------------------------------------
+
+
+class TestFooterAndImage:
+
+    def test_footer_renders_setup_quality_and_signals(self):
+        embed = format_thesis_embed(
+            _thesis(setup_quality=8, signals_used=["rank_trajectory", "sector_momentum"]),
+            _candidate(),
+        )
+        footer = embed.get("footer", {}).get("text", "")
+        assert "setup_quality 8/10" in footer
+        assert "rank_trajectory" in footer
+
+    def test_image_attachment_url_reflects_filename(self):
+        embed = format_thesis_embed(
+            _thesis(), _candidate(symbol="CRWD"),
+            chart_filename="chart_CRWD.png",
+        )
+        assert embed["image"]["url"] == "attachment://chart_CRWD.png"
+
+    def test_image_omitted_when_no_chart_filename(self):
+        embed = format_thesis_embed(
+            _thesis(), _candidate(symbol="CRWD"), chart_filename=None,
+        )
+        assert "image" not in embed

--- a/tests/test_alerts/test_discord_embed.py
+++ b/tests/test_alerts/test_discord_embed.py
@@ -389,6 +389,48 @@ class TestDashboardLink:
 # ---------------------------------------------------------------------------
 
 
+class TestLLMTextScrubbing:
+    """PR5 review iter-1 regression — LLM-generated text fields must NOT
+    leak ``@everyone`` / ``@here`` / backticks into Discord because an
+    adversarial completion could trigger a server-wide mention or break
+    the surrounding embed formatting. Mirrors the existing scrub on the
+    eval/research renderers (PR3 review iter-1 [P2]).
+    """
+
+    def test_risks_scrub_at_everyone(self):
+        risks = _risks_lines(_thesis(risks=["@everyone bad risk"]))
+        assert risks
+        assert "@everyone" not in risks[0]
+        # FULLWIDTH @ sign replacement — visible to the user, not a mention.
+        assert "＠" in risks[0]
+
+    def test_watch_scrub_at_here(self):
+        out = _watch_line(_thesis(watch_items=["@here pullback to 100"]))
+        assert out is not None
+        assert "@here" not in out
+        assert "＠" in out
+
+    def test_llm_noticed_scrub_backticks(self):
+        out = _llm_noticed(
+            _thesis(
+                patterns_in_chart_not_in_indicators=["pattern with ``code`` block"]
+            )
+        )
+        assert out is not None
+        # Backticks would break the surrounding embed code-block formatting.
+        assert "`" not in out
+
+    def test_why_bullets_scrub_paragraph_radar(self):
+        from rainier.alerts.discord import _why_bullets
+        bullets = _why_bullets(
+            _thesis(
+                paragraph_radar="@everyone strong setup. Volume confirms."
+            )
+        )
+        for b in bullets:
+            assert "@everyone" not in b
+
+
 class TestFooterAndImage:
 
     def test_footer_renders_setup_quality_and_signals(self):

--- a/tests/test_dashboard/test_data.py
+++ b/tests/test_dashboard/test_data.py
@@ -380,7 +380,7 @@ def test_load_thesis_chart_returns_none_for_unknown_id():
 
 
 def test_load_thesis_chart_returns_bytes_when_file_exists(tmp_path):
-    """Happy path: thesis -> ChartImage(file_path) -> bytes."""
+    """Legacy path: thesis -> ChartImage(file_path) -> bytes."""
     from rainier.core.models import ChartImage, LLMAnalysisRecord
 
     png_path = tmp_path / "nvda.png"
@@ -391,6 +391,9 @@ def test_load_thesis_chart_returns_bytes_when_file_exists(tmp_path):
     analysis.chart_image_ids = [42]
     chart = MagicMock(spec=ChartImage)
     chart.file_path = str(png_path)
+    # PR5: legacy rows have image_bytes=None and the loader falls back to
+    # the on-disk file_path read path.
+    chart.image_bytes = None
 
     sess = _ScriptedSession(
         gets={
@@ -411,6 +414,7 @@ def test_load_thesis_chart_returns_none_when_file_missing(tmp_path):
     analysis.chart_image_ids = [42]
     chart = MagicMock(spec=ChartImage)
     chart.file_path = str(tmp_path / "missing.png")
+    chart.image_bytes = None
 
     sess = _ScriptedSession(
         gets={
@@ -421,6 +425,29 @@ def test_load_thesis_chart_returns_none_when_file_missing(tmp_path):
     with _patch_session(sess):
         out = ddata.load_thesis_chart(100)
     assert out is None
+
+
+def test_load_thesis_chart_prefers_inline_image_bytes_over_file_path(tmp_path):
+    """PR5: when ``image_bytes`` is set, return them directly without
+    touching the filesystem (the file_path may be empty/legacy)."""
+    from rainier.core.models import ChartImage, LLMAnalysisRecord
+
+    inline_bytes = b"\x89PNG\r\n\x1a\nINLINE-PR5"
+    analysis = MagicMock(spec=LLMAnalysisRecord)
+    analysis.chart_image_ids = [42]
+    chart = MagicMock(spec=ChartImage)
+    chart.file_path = None
+    chart.image_bytes = inline_bytes
+
+    sess = _ScriptedSession(
+        gets={
+            (LLMAnalysisRecord, 100): analysis,
+            (ChartImage, 42): chart,
+        }
+    )
+    with _patch_session(sess):
+        out = ddata.load_thesis_chart(100)
+    assert out == inline_bytes
 
 
 def test_load_thesis_chart_returns_none_when_thesis_has_no_chart_ids():

--- a/tests/test_dashboard/test_query_params.py
+++ b/tests/test_dashboard/test_query_params.py
@@ -1,0 +1,101 @@
+"""Tests for the PR5 dashboard deep-link query-param handling.
+
+Per the design doc Section G, Streamlit page rendering is excluded from
+unit tests — we test the data-loading helpers used by the deep-link path.
+That keeps the test stable across Streamlit version churn.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from rainier.dashboard import data as ddata
+
+
+@contextmanager
+def _patch_session(session_obj):
+    @contextmanager
+    def _ctx():
+        yield session_obj
+
+    with patch("rainier.dashboard.data.get_session", _ctx):
+        yield
+
+
+class _ScriptedSession:
+    def __init__(self, *, all_payloads=None, gets=None):
+        self._all = list(all_payloads or [])
+        self._gets = dict(gets or {})
+
+    def execute(self, _stmt):  # noqa: ARG002
+        result = MagicMock()
+        result.all.return_value = self._all.pop(0) if self._all else []
+        return result
+
+    def get(self, model, key):
+        return self._gets.get((model, int(key)))
+
+
+# ---------------------------------------------------------------------------
+# load_recent_theses with thesis_id deep-link scenario
+# ---------------------------------------------------------------------------
+
+
+class TestDeepLinkLoad:
+    """The Streamlit page passes a wide ``since`` window when the
+    ``thesis_id`` query param is present so the referenced row can't be
+    filtered out by a recent date window. We unit-test the loader's
+    ability to surface a specific thesis given that wide window.
+    """
+
+    def _row(self, thesis_id: int, scan_date: date, symbol: str = "NVDA"):
+        row = MagicMock()
+        row.screened_id = thesis_id * 10
+        row.scan_date = scan_date
+        row.session_name = "afternoon"
+        row.symbol = symbol
+        row.thesis_id = thesis_id
+        row.llm_confidence = 7
+        row.recommendation = "setup_long"
+        row.signals_used = ["rank_trajectory"]
+        row.chart_image_ids = [thesis_id]
+        row.structured_output = {"verdict": "setup_long"}
+        return row
+
+    def test_load_recent_theses_returns_row_for_deep_link_thesis_id(self):
+        # Wide window — covers the requested thesis from a year ago.
+        sess = _ScriptedSession(
+            all_payloads=[
+                [self._row(thesis_id=42, scan_date=date(2025, 8, 1))],
+                [],  # eval_rows query
+            ]
+        )
+        with _patch_session(sess):
+            rows = ddata.load_recent_theses(
+                limit=50,
+                since=date(2024, 1, 1),  # wide window simulates deep-link expansion
+                until=date.today(),
+            )
+        assert len(rows) == 1
+        assert rows[0].thesis_id == 42
+
+    def test_load_thesis_chart_resolves_inline_bytes_for_deep_link(self):
+        from rainier.core.models import ChartImage, LLMAnalysisRecord
+
+        analysis = MagicMock(spec=LLMAnalysisRecord)
+        analysis.chart_image_ids = [99]
+        chart = MagicMock(spec=ChartImage)
+        chart.image_bytes = b"PNG-BYTES-FROM-DB"
+        chart.file_path = None
+
+        sess = _ScriptedSession(
+            gets={
+                (LLMAnalysisRecord, 42): analysis,
+                (ChartImage, 99): chart,
+            }
+        )
+        with _patch_session(sess):
+            out = ddata.load_thesis_chart(42)
+        assert out == b"PNG-BYTES-FROM-DB"

--- a/tests/test_llm_thesis/test_chart_persistence.py
+++ b/tests/test_llm_thesis/test_chart_persistence.py
@@ -1,0 +1,153 @@
+"""Tests for ``llm_thesis.chart_persistence`` (PR5).
+
+Covers idempotent persist + attach helpers. The DB session is mocked so
+these tests don't require Postgres.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import date as date_cls
+from unittest.mock import MagicMock, patch
+
+from rainier.llm_thesis.chart_persistence import (
+    attach_chart_id_to_thesis,
+    persist_chart_image,
+)
+
+
+@contextmanager
+def _patch_session(session_obj):
+    @contextmanager
+    def _ctx():
+        yield session_obj
+
+    with patch(
+        "rainier.llm_thesis.chart_persistence.get_session", _ctx
+    ):
+        yield
+
+
+class _ScriptedSession:
+    """Minimal SQLAlchemy 2.x Session shim — scripted execute() responses
+    + session.get() reads from a keyed dict.
+    """
+
+    def __init__(self, *, execute_scripts=None, gets=None):
+        self._execute_scripts = list(execute_scripts or [])
+        self._gets = dict(gets or {})
+
+    def execute(self, _stmt):  # noqa: ARG002
+        result = MagicMock()
+        if self._execute_scripts:
+            first_value = self._execute_scripts.pop(0)
+            result.first.return_value = first_value
+        else:
+            result.first.return_value = None
+        return result
+
+    def get(self, model, key):
+        return self._gets.get((model, int(key)))
+
+    # Context-manager protocol support not needed because the helper uses
+    # ``get_session()`` directly.
+
+
+class TestPersistChartImage:
+
+    def test_returns_existing_id_when_sha_already_persisted(self):
+        # First execute() = SELECT probe returns existing row id.
+        sess = _ScriptedSession(execute_scripts=[(7,)])
+        with _patch_session(sess):
+            out = persist_chart_image(
+                symbol="NVDA",
+                scan_date=date_cls(2026, 5, 8),
+                image_bytes=b"FAKE",
+                sha256="a" * 64,
+            )
+        assert out == 7
+
+    def test_inserts_new_row_when_no_existing(self):
+        # First execute = SELECT (None), second execute = INSERT returning id.
+        sess = _ScriptedSession(execute_scripts=[None, (123,)])
+        with _patch_session(sess):
+            out = persist_chart_image(
+                symbol="NVDA",
+                scan_date=date_cls(2026, 5, 8),
+                image_bytes=b"FAKE",
+                sha256="b" * 64,
+            )
+        assert out == 123
+
+    def test_idempotent_on_same_sha256(self):
+        """Two calls with identical bytes return the same id."""
+        sess1 = _ScriptedSession(execute_scripts=[None, (50,)])
+        sess2 = _ScriptedSession(execute_scripts=[(50,)])  # second call hits SELECT
+        with _patch_session(sess1):
+            first = persist_chart_image(
+                symbol="NVDA",
+                scan_date=date_cls(2026, 5, 8),
+                image_bytes=b"X",
+                sha256="c" * 64,
+            )
+        with _patch_session(sess2):
+            second = persist_chart_image(
+                symbol="NVDA",
+                scan_date=date_cls(2026, 5, 8),
+                image_bytes=b"X",
+                sha256="c" * 64,
+            )
+        assert first == second == 50
+
+    def test_returns_none_on_invalid_args(self):
+        out = persist_chart_image(
+            symbol="NVDA",
+            scan_date=date_cls(2026, 5, 8),
+            image_bytes=b"",
+            sha256="",
+        )
+        assert out is None
+
+
+class TestAttachChartIdToThesis:
+
+    def test_appends_when_not_present(self):
+        from rainier.core.models import LLMAnalysisRecord
+
+        record = MagicMock(spec=LLMAnalysisRecord)
+        record.chart_image_ids = [1, 2]
+
+        sess = _ScriptedSession(gets={(LLMAnalysisRecord, 100): record})
+        with _patch_session(sess):
+            mutated = attach_chart_id_to_thesis(thesis_id=100, chart_id=3)
+        assert mutated is True
+        assert record.chart_image_ids == [1, 2, 3]
+
+    def test_skips_when_already_present(self):
+        from rainier.core.models import LLMAnalysisRecord
+
+        record = MagicMock(spec=LLMAnalysisRecord)
+        record.chart_image_ids = [1, 2, 3]
+
+        sess = _ScriptedSession(gets={(LLMAnalysisRecord, 100): record})
+        with _patch_session(sess):
+            mutated = attach_chart_id_to_thesis(thesis_id=100, chart_id=3)
+        assert mutated is False
+
+    def test_starts_fresh_when_array_is_none(self):
+        from rainier.core.models import LLMAnalysisRecord
+
+        record = MagicMock(spec=LLMAnalysisRecord)
+        record.chart_image_ids = None
+
+        sess = _ScriptedSession(gets={(LLMAnalysisRecord, 100): record})
+        with _patch_session(sess):
+            mutated = attach_chart_id_to_thesis(thesis_id=100, chart_id=42)
+        assert mutated is True
+        assert record.chart_image_ids == [42]
+
+    def test_returns_false_when_thesis_missing(self):
+        sess = _ScriptedSession(gets={})
+        with _patch_session(sess):
+            mutated = attach_chart_id_to_thesis(thesis_id=999, chart_id=1)
+        assert mutated is False


### PR DESCRIPTION
## Summary
- Discord per-ticker thesis renderer rewritten as a Discord embed: color-coded bar (green/yellow/gray), headline (verdict · symbol · score), chip line of decision-critical signals, monospace trade-levels block, top-3 risks, single most-actionable watch item, short LLM-noticed observation. ~70% less prose vs. prior text format.
- Chart PNGs (already rendered for the LLM) now persisted via the existing ChartImage table (extended with `image_bytes` / `sha256` / `scan_date` / `width` / `height`) and attached inline to the Discord message via webhook multipart upload. User sees the actual chart in Discord, not just text.
- Dashboard deep-link: embed title links to the Streamlit dashboard's recent-theses tab pre-filtered by thesis_id (configurable base URL via `dashboard_base_url` setting; defaults to `null` for graceful degradation).
- Word-boundary-safe truncation everywhere (no more mid-word "exte…" cuts).
- LLM-controlled text scrubbed via `_scrub_discord_text` before emit so an adversarial completion can't trigger `@everyone` mass mentions.

## Why
First live run on 2026-05-08 produced 5 wall-of-text Discord messages. Decision-critical info buried in prose. User feedback: "too dense text, hard to follow." This PR makes the Discord output scannable in <5s per ticker.

## Scope (PR5)
Per the PR4 design-review iteration. Stacked on PR #67 (feat/llm-thesis-pr4).

Files added:
- `migrations/0004_llm_thesis_pr5.sql` — extends `chart_images` with bytes + sha256 + scan_date columns and a partial unique index for idempotency.
- `src/rainier/llm_thesis/chart_persistence.py` — `persist_chart_image` (idempotent on sha256, race-loser refetch) + `attach_chart_id_to_thesis`.
- `tests/test_alerts/test_discord_embed.py` — 46 unit tests for the embed renderer + helpers.
- `tests/test_alerts/test_discord_attachment.py` — 4 tests for the multipart webhook upload + DB chart-load (no kaleido re-render).
- `tests/test_dashboard/test_query_params.py` — 2 tests for the deep-link data-loader path.
- `tests/test_llm_thesis/test_chart_persistence.py` — 8 tests for persist + attach.

Files modified:
- `src/rainier/alerts/discord.py` — adds `format_thesis_embed`, multipart sender, `_truncate_at_word`, scrubs LLM text via `_scrub_discord_text`. PR1 `theses=None` regression contract preserved.
- `src/rainier/core/models.py` — `ChartImage` extended (legacy `file_path` made optional + new bytes/sha256/scan_date/width/height columns with partial unique index).
- `src/rainier/core/config.py` — `LLMThesisConfig.dashboard_base_url`.
- `config/settings.yaml` — commented-out `dashboard_base_url` example.
- `src/rainier/llm_thesis/service.py` — persist chart bytes + attach to LLMAnalysisRecord; stamp `_thesis_id` on the thesis dict for downstream dashboard deep-link.
- `src/rainier/dashboard/data.py` — `load_thesis_chart` prefers inline bytes, falls back to `file_path`.
- `src/rainier/dashboard/app.py` — read `?thesis_id=N` query param, pre-select that row + widen window so the link can't 404.
- `src/rainier/scheduler/service.py` — wrap `send_stock_candidates` to forward `dashboard_base_url`.
- `src/rainier/cli.py` — `rainier thesis daily --discord` forwards the same setting.
- `tests/test_dashboard/test_data.py` — adds inline-bytes regression test alongside legacy `file_path` tests.

## Reviews
- **Codex review:** SKIPPED — rate-limited at 2026-05-08 (usage quota hit; retry was blocked until 1:05 AM PT). /review skill is the load-bearing reviewer per global CLAUDE.md.
- **/review skill (iter-1):** found two findings, both fixed:
  * [P1] LLM-controlled text fields (`paragraph_radar`, `risks`, `watch_items`, `patterns_in_chart_not_in_indicators`) emitted to Discord without scrubbing — added `_scrub_discord_text` defense and regression tests.
  * [P2] `persist_chart_image` race-loser returned `None` instead of the freshly-inserted row id when the unique constraint fired — added refetch-in-fresh-session path so the chart attachment never gets dropped.
- **/review skill (iter-2):** clean.

## Test plan
- [x] `uv run pytest tests/ -v` — 685 passed, 3 skipped.
- [x] `uv run ruff check` clean on all PR5-touched files.
- [ ] Manual: re-run `uv run rainier thesis daily --session afternoon --top-n 5 --max-usd 1.0 --discord`. Verify Discord shows 5 embeds with color bars, chart PNGs attached inline, scannable layout, dashboard link clickable.
- [ ] Verify cache hit: re-running the CLI does NOT re-render kaleido (chart bytes loaded from ChartImage). Cost stays \$0.
- [ ] Click "Open in dashboard" on a Discord embed: opens Streamlit at the right thesis with chart inline.
- [ ] Word-boundary truncation: long LLM observations don't break mid-word.

## Out of scope
- Discord interactive buttons (would require a bot, not a webhook).
- Auto-apply insights without user approval (still v2).
- Multi-model A/B (still v2).