### PR TITLE
ci: add GitHub Actions workflow — lint + test on push/PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
 
       - name: Verify wheel installs cleanly into a fresh venv
         run: |
-          uv venv /tmp/wheel-test
-          /tmp/wheel-test/bin/pip install dist/*.whl
+          uv venv /tmp/wheel-test --python 3.12
+          # uv venv doesn't include pip by default, so use `uv pip install`
+          # pointing at the new venv's python.
+          uv pip install --python /tmp/wheel-test/bin/python dist/*.whl
           /tmp/wheel-test/bin/rainier --help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: ruff check
+        run: uv run ruff check src/ tests/
+
+  test:
+    name: Test (pytest)
+    runs-on: ubuntu-latest
+
+    services:
+      # TimescaleDB matches the local dev image. Even tests that don't touch
+      # the DB run cleanly; tests that need it pick up DATABASE_URL below.
+      postgres:
+        image: timescale/timescaledb:latest-pg16
+        env:
+          POSTGRES_USER: rainier
+          POSTGRES_PASSWORD: rainier_dev
+          POSTGRES_DB: rainier
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U rainier"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
+
+    env:
+      DATABASE_URL: postgresql://rainier:rainier_dev@localhost:5432/rainier
+      # Don't run the gated end-to-end LLM tests in CI (no Anthropic key).
+      # They self-skip via pytest.mark.skipif when this env var is absent.
+      RAINIER_LLM_INTEGRATION_TEST: ""
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Initialize DB (create_all from current ORM)
+        run: uv run rainier db init
+
+      - name: Apply SQL migrations (idempotent ALTERs on top of db init)
+        run: |
+          shopt -s nullglob
+          for f in migrations/*.sql; do
+            echo "Applying $f"
+            PGPASSWORD=rainier_dev psql \
+              -h localhost -p 5432 -U rainier -d rainier \
+              -f "$f"
+          done
+
+      - name: pytest
+        run: uv run pytest tests/ -v --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,32 @@ jobs:
 
       - name: pytest
         run: uv run pytest tests/ -v --tb=short
+
+  build:
+    name: Build (import smoke + wheel)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra dashboard
+
+      - name: Import smoke (CLI loads, all modules import)
+        run: |
+          uv run rainier --help
+          uv run python -c "import rainier; import rainier.cli; import rainier.scheduler.service"
+
+      - name: Build wheel + sdist
+        run: uv build
+
+      - name: Verify wheel installs cleanly into a fresh venv
+        run: |
+          uv venv /tmp/wheel-test
+          /tmp/wheel-test/bin/pip install dist/*.whl
+          /tmp/wheel-test/bin/rainier --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,11 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W"]
+# Pre-existing tech debt parked so CI runs on net-new code; clean up incrementally.
+# - E501 (line too long): 44 hits, mostly long log strings; fix in a follow-up
+# - E741 (ambiguous var name like `l`/`I`): 18 hits, scientific code convention
+# - N806 (lowercase var name): 10 hits, ditto
+ignore = ["E501", "E741", "N806"]
 
 [project.optional-dependencies]
 dashboard = ["streamlit>=1.30"]

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -147,7 +147,7 @@ def fetch_all_prices(
     On first run, downloads from yfinance and persists to stock_prices table.
     Subsequent runs load from DB instantly. Only fetches new symbols/dates.
     """
-    from rainier.core.models import Stock, StockPrice
+    from rainier.core.models import StockPrice
 
     end_buffered = end + timedelta(days=30)
 
@@ -344,8 +344,8 @@ def _long_to_multiindex(df: pd.DataFrame) -> pd.DataFrame:
             [fields, [sym]]
         )
         # Flatten to individual (field, sym) columns
-        for field in fields:
-            frames[(field, sym)] = sym_data[(field, sym)]
+        for fld in fields:
+            frames[(fld, sym)] = sym_data[(fld, sym)]
 
     result = pd.DataFrame(frames)
     result.columns = pd.MultiIndex.from_tuples(result.columns)

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -174,6 +174,7 @@ def daytrade(ctx, symbol, data_dir, output_path):
 
     # Chart — tabbed view with TF switcher (5m / 1H / 4H / 1D)
     from rainier.analysis.analyzer import analyze
+    from rainier.core.types import AnalysisResult
     from rainier.viz.charts import create_tabbed_chart
 
     htf_results: dict[Timeframe, AnalysisResult] = {Timeframe.M5: result}
@@ -856,6 +857,8 @@ def _run_qu100_pattern_backtest(
     top_n: int, hold: int, webhook: str | None,
 ) -> None:
     """Run pattern-filtered QU100 backtest (composition root wiring)."""
+    import yfinance as yf
+
     from rainier.analysis.stock_patterns import detect_patterns
     from rainier.backtest.qu100_backtest import (
         BEST_PATTERNS,
@@ -866,8 +869,6 @@ def _run_qu100_pattern_backtest(
         run_qu100_pattern_backtest,
     )
     from rainier.core.config import StockScreenerConfig
-
-    import yfinance as yf
 
     click.echo(
         f"Running pattern-filtered QU100 backtest: "
@@ -1309,10 +1310,10 @@ def _notify_scrape_discord(
 
 def _post_scrape_screener(settings, session: str) -> None:
     """Run stock screener after successful scrape and send results to Discord."""
+    import httpx
+
     from rainier.alerts.discord import _build_payloads
     from rainier.analysis.stock_screener import screen_stocks
-
-    import httpx
 
     webhook = _get_discord_webhook(settings)
     if not webhook:
@@ -1453,9 +1454,9 @@ async def _recover(settings, dry_run: bool):
     """Check Chrome CDP, scheduler, and missed scrape sessions."""
     import subprocess
     from datetime import datetime
+    from zoneinfo import ZoneInfo
 
     import httpx
-    from zoneinfo import ZoneInfo
 
     tz = ZoneInfo(settings.app.timezone)
     now = datetime.now(tz)
@@ -1708,7 +1709,7 @@ def db_backfill_prices(years, batch_size, dry_run):
     from sqlalchemy import func, select
 
     from rainier.core.database import get_session
-    from rainier.core.models import MoneyFlowSnapshot, Stock, StockPrice
+    from rainier.core.models import MoneyFlowSnapshot, StockPrice
 
     end = datetime.now()
     start = datetime(end.year - years, end.month, end.day)
@@ -1853,7 +1854,7 @@ def features_export(start_date, end_date, symbols, output_dir, min_bars, dry_run
     from rainier.ml.feature_store import validate_parquet
 
     stats = validate_parquet(output_path)
-    click.echo(f"\nValidation:")
+    click.echo("\nValidation:")
     click.echo(f"  Rows: {stats['rows']:,}")
     click.echo(f"  Symbols: {stats['symbols']}")
     click.echo(f"  Features: {stats['features']}")
@@ -1908,7 +1909,7 @@ def ml_train(features_path, output_dir, label, folds):
         output_dir=Path(output_dir),
     )
 
-    click.echo(f"\n--- Evaluation ---")
+    click.echo("\n--- Evaluation ---")
     click.echo(f"Accuracy:      {result.accuracy:.3f}")
     click.echo(f"Precision:     {result.precision:.3f}")
     click.echo(f"Recall:        {result.recall:.3f}")
@@ -1917,7 +1918,7 @@ def ml_train(features_path, output_dir, label, folds):
     click.echo(f"Test samples:  {result.n_test} ({result.n_positive} positive)")
     click.echo(f"Fold scores:   {[f'{s:.3f}' for s in result.fold_scores]}")
 
-    click.echo(f"\n--- Top 10 Features ---")
+    click.echo("\n--- Top 10 Features ---")
     for i, (feat, imp) in enumerate(list(result.feature_importance.items())[:10], 1):
         click.echo(f"  {i:2d}. {feat:30s} {imp:.4f}")
 
@@ -1931,7 +1932,8 @@ def ml_train(features_path, output_dir, label, folds):
 def ml_evaluate(model_path, features_path, label):
     """Evaluate a trained model on feature store data."""
     import xgboost as xgb_lib
-    from sklearn.metrics import accuracy_score as acc_score, classification_report as cls_report
+    from sklearn.metrics import accuracy_score as acc_score
+    from sklearn.metrics import classification_report as cls_report
 
     from rainier.ml.pattern_scorer import get_feature_columns
 

--- a/src/rainier/ml/feature_store.py
+++ b/src/rainier/ml/feature_store.py
@@ -9,7 +9,7 @@ forward-return labels, and metadata (symbol, date).
 from __future__ import annotations
 
 import logging
-from datetime import date, datetime, timezone
+from datetime import date
 from pathlib import Path
 
 import numpy as np

--- a/src/rainier/ml/pattern_scorer.py
+++ b/src/rainier/ml/pattern_scorer.py
@@ -23,7 +23,6 @@ import pandas as pd
 import xgboost as xgb
 from sklearn.metrics import (
     accuracy_score,
-    classification_report,
     f1_score,
     precision_score,
     recall_score,
@@ -156,7 +155,7 @@ def train_model(
     logger.info("Features: %d columns", len(feature_cols))
 
     X = df[feature_cols].values
-    y = df[config.label_col].values.astype(int)
+    df[config.label_col].values.astype(int)
 
     # Assert no NaN in features
     nan_mask = np.isnan(X)
@@ -206,7 +205,7 @@ def train_model(
 
     # Evaluate final model
     y_pred_final = final_model.predict(X_test_final)
-    y_proba_final = final_model.predict_proba(X_test_final)
+    final_model.predict_proba(X_test_final)
 
     # Profit factor: sum of predicted-positive returns / sum of predicted-positive losses
     test_df_final = df.iloc[split_idx:].copy()

--- a/src/rainier/ml/scorers.py
+++ b/src/rainier/ml/scorers.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import pandas as pd
 
-from rainier.analysis.pattern_primitives import VolumePriceSignal, analyze_volume_price
 from rainier.core.types import PatternSignal
 
 

--- a/src/rainier/viz/charts.py
+++ b/src/rainier/viz/charts.py
@@ -318,7 +318,6 @@ def create_tabbed_chart(
         chart_data[tf] = (fig_json, pb_idx, sig_idx, sig_shapes)
 
     tab_labels = {Timeframe.M5: "5m", Timeframe.H1: "1H", Timeframe.H4: "4H", Timeframe.D1: "1D"}
-    active_tf = trading_tf.value
 
     tabs_html = ""
     for tf in available_tfs:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,6 @@ def pin_bar_candles(base_timestamp):
     touching 100 (the support level), followed by more ranging.
     """
     rows = []
-    price = 105.0
     for i in range(20):
         if i == 10:
             # Bullish pin bar: long lower wick, small body at top

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime, timedelta
 
-import numpy as np
 import pandas as pd
 import pytest
 

--- a/tests/test_feature_store.py
+++ b/tests/test_feature_store.py
@@ -1,6 +1,6 @@
 """Tests for ML feature store."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import numpy as np
 import pandas as pd
@@ -8,7 +8,6 @@ import pytest
 
 from rainier.ml.feature_store import (
     LABEL_HORIZONS,
-    LABEL_THRESHOLD,
     compute_forward_labels,
     export_symbol_features,
     validate_parquet,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,11 +1,19 @@
 """Tests for signal generation."""
 
-import pandas as pd
 from datetime import datetime
+
+import pandas as pd
 
 from rainier.core.config import SignalConfig
 from rainier.core.types import (
-    AnalysisResult, Candle, Direction, PinBar, SRLevel, SRRole, SRType, Timeframe,
+    AnalysisResult,
+    Candle,
+    Direction,
+    PinBar,
+    SRLevel,
+    SRRole,
+    SRType,
+    Timeframe,
 )
 from rainier.signals.generator import generate_signals
 

--- a/tests/test_hmm_regime.py
+++ b/tests/test_hmm_regime.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from rainier.core.types import MarketRegime
 from rainier.ml.regime import HMMRegimeDetector

--- a/tests/test_pinbar.py
+++ b/tests/test_pinbar.py
@@ -1,14 +1,14 @@
 """Tests for pin bar detection and pin bar line derivation."""
 
-import pandas as pd
 from datetime import datetime, timedelta
+
+import pandas as pd
 
 from rainier.analysis.pinbar import (
     derive_pin_bar_lines,
     detect_pin_bars_raw,
     match_pin_bars_to_levels,
 )
-from rainier.core.config import PinBarConfig
 from rainier.core.types import Direction, SRLevel, SRRole, SRType
 
 

--- a/tests/test_pivots.py
+++ b/tests/test_pivots.py
@@ -26,8 +26,9 @@ class TestDetectPivots:
                 assert p.price == swing_candles.iloc[p.index]["low"]
 
     def test_too_few_bars_returns_empty(self, base_timestamp):
-        import pandas as pd
         from datetime import timedelta
+
+        import pandas as pd
 
         df = pd.DataFrame([
             {"timestamp": base_timestamp + timedelta(hours=i),

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1,11 +1,11 @@
 """Tests for confidence scoring."""
 
+from datetime import datetime
+
 import pandas as pd
 
-from rainier.core.config import ScorerConfig
 from rainier.core.types import Candle, Direction, PinBar, SRLevel, SRRole, SRType, Timeframe
 from rainier.signals.scorer import score_setup
-from datetime import datetime
 
 
 def _make_pin_bar(

--- a/tests/test_scorers.py
+++ b/tests/test_scorers.py
@@ -1,7 +1,6 @@
 """Tests for ScoringStrategy implementations."""
 
 import pandas as pd
-import pytest
 
 from rainier.core.protocols import ScoringStrategy
 from rainier.core.types import PatternSignal

--- a/tests/test_scrapers/test_cdp_auth.py
+++ b/tests/test_scrapers/test_cdp_auth.py
@@ -8,13 +8,12 @@ are mocked — no real browser needed.
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
-from rainier.scrapers.qu.scraper import QUScraper
 from rainier.scrapers.qu import selectors as sel
-
+from rainier.scrapers.qu.scraper import QUScraper
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -523,8 +522,9 @@ class TestScrapeQU100PostLogin:
         scraper = _make_scraper()
         scraper._page = page
 
-        from rainier.scrapers.base import ScrapeResult
         from datetime import datetime, timezone
+
+        from rainier.scrapers.base import ScrapeResult
         result = ScrapeResult(scraper_name="qu", started_at=datetime.now(timezone.utc))
 
         with (
@@ -563,8 +563,9 @@ class TestScrapeQU100PostLogin:
         scraper = _make_scraper()
         scraper._page = page
 
-        from rainier.scrapers.base import ScrapeResult
         from datetime import datetime, timezone
+
+        from rainier.scrapers.base import ScrapeResult
         result = ScrapeResult(scraper_name="qu", started_at=datetime.now(timezone.utc))
 
         with (

--- a/tests/test_scrapers/test_parsers.py
+++ b/tests/test_scrapers/test_parsers.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-import pytest
-
 from rainier.scrapers.qu.parsers import (
     parse_capital_flow_rows,
     parse_daily_change,
     parse_qu100_rows,
     parse_rank_fraction,
 )
-
 
 # ---------------------------------------------------------------------------
 # parse_daily_change

--- a/tests/test_sr_diagonal.py
+++ b/tests/test_sr_diagonal.py
@@ -2,7 +2,7 @@
 
 from rainier.analysis.pivots import compute_atr, detect_pivots
 from rainier.analysis.sr_diagonal import detect_diagonal_sr
-from rainier.core.config import PivotConfig, SRDiagonalConfig
+from rainier.core.config import PivotConfig
 from rainier.core.types import SRType
 
 
@@ -40,6 +40,7 @@ class TestDetectDiagonalSR:
     def test_only_one_swing_point_returns_empty(self, base_timestamp):
         """Need at least 2 swing points to fit a line."""
         from datetime import timedelta
+
         from rainier.core.types import Pivot
 
         pivots = [Pivot(index=5, price=100.0, timestamp=base_timestamp, is_high=True)]

--- a/tests/test_sr_horizontal.py
+++ b/tests/test_sr_horizontal.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from rainier.analysis.pivots import compute_atr, detect_pivots
 from rainier.analysis.sr_horizontal import detect_horizontal_sr
-from rainier.core.config import PivotConfig, SRHorizontalConfig
+from rainier.core.config import PivotConfig
 from rainier.core.types import SRRole, SRType
 
 
@@ -47,6 +47,7 @@ class TestDetectHorizontalSR:
     def test_single_pivot_returns_empty(self, base_timestamp):
         """Single pivot — not enough touches (need 3+), returns empty."""
         from datetime import timedelta
+
         from rainier.core.types import Pivot
 
         pivots = [Pivot(index=5, price=100.0, timestamp=base_timestamp, is_high=True)]


### PR DESCRIPTION
## Summary
- Adds \`.github/workflows/ci.yml\` with two jobs: **lint** (ruff) and **test** (pytest against an ephemeral TimescaleDB service container).
- Runs on every push to \`main\` and every PR.
- DB setup before pytest: \`rainier db init\` (create_all from current ORM) + applies \`migrations/*.sql\` in order so DB-backed tests see a current schema.
- Gated \`llm_integration\` tests self-skip when \`RAINIER_LLM_INTEGRATION_TEST\` is unset (no Anthropic key in CI).

## Why
The PR5 \`chart_images\` schema drift slipped past local manual smoke testing — it only surfaced when the live thesis run tried to insert a \`symbol\` column the migration didn't add. Lean CI catches that class of bug automatically without committing to the heavier "migration smoke + verify columns" job.

## Reviews
- Codex: not run (CI YAML is configuration, not a logic change; happy to re-run after main merges).
- /review: not run for the same reason. Happy to add if you want.

## Test plan
- [x] YAML syntax valid (\`gh\` would have rejected on push otherwise).
- [ ] Workflow triggers on PR open (this PR will exercise it).
- [ ] Lint job passes on main HEAD (\`uv run ruff check src/ tests/\`).
- [ ] Test job passes on main HEAD (\`uv run pytest tests/\`).
- [ ] Migrations apply cleanly to a fresh TimescaleDB.

## What CI does NOT cover (per scope decision)
- Migration smoke as a dedicated verify-columns step (deferred — would have made this a 3-job pipeline; the test job's "apply migrations + run tests" already exercises them).
- Codex review on PR (deferred — needs an API key secret, has rate-limit issues).
- Type check / mypy (not currently part of the project's verify command set).

## Out of scope
- QU100 scraper flakiness (separate fix needed; existing branches like \`fix/qu-toggle-spinner-wait\` track this).