### PR TITLE
feat(ml): backtest feedback loop — train → backtest → compare (#44)

### DIFF
--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2157,8 +2157,12 @@ def ml_compare(ctx, csv_path, symbol, tf, model_path, start, end,
     operator can answer "would this model make more money?".
 
     Use --walk-forward to slide a (train, test) window through the data and
-    aggregate out-of-sample metrics — model is built from train_df at every
-    fold, so there is no lookahead leakage.
+    aggregate per-fold out-of-sample metrics. NOTE: this CLI does NOT refit
+    the ML model per fold; the model from --model is loaded once and
+    evaluated on each test window. Model retraining is offline via
+    ``rainier ml train``. Lookahead leakage is therefore only as good as the
+    training cut-off used to produce the model file — pass a model trained
+    strictly on data before the CSV's earliest test bar.
     """
     from rainier.core.config import ScorerConfig, SignalConfig
     from rainier.data.csv_provider import CSVProvider

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2127,6 +2127,128 @@ def ml_select_features(
         click.echo(f"Results saved to: {output_path}")
 
 
+@ml.command(name="compare")
+@click.option("--csv", "csv_path", required=True, type=click.Path(exists=True),
+              help="OHLCV CSV file")
+@click.option("--symbol", required=True, help="Instrument symbol (e.g. MES)")
+@click.option("--timeframe", "tf", default="1H",
+              type=click.Choice([t.value for t in Timeframe]),
+              help="Bar timeframe")
+@click.option("--model", "model_path", default=None, type=click.Path(exists=True),
+              help="Trained ML model path (XGBoost JSON). When omitted, only "
+                   "the BookScorer baseline is evaluated.")
+@click.option("--start", default=None, help="Start date (YYYY-MM-DD)")
+@click.option("--end", default=None, help="End date (YYYY-MM-DD)")
+@click.option("--walk-forward", "walk_forward", is_flag=True, default=False,
+              help="Run walk-forward backtest comparison instead of full-sample.")
+@click.option("--wf-train-bars", default=500, type=int,
+              help="Walk-forward training window size (bars).")
+@click.option("--wf-test-bars", default=100, type=int,
+              help="Walk-forward test window size (bars).")
+@click.option("--wf-step-bars", default=None, type=int,
+              help="Walk-forward step between folds (default: --wf-test-bars).")
+@click.pass_context
+def ml_compare(ctx, csv_path, symbol, tf, model_path, start, end,
+               walk_forward, wf_train_bars, wf_test_bars, wf_step_bars):
+    """Compare BookScorer vs MLScorer side-by-side on the same data.
+
+    Closes the ML feedback loop: takes a trained XGBoost model and runs it
+    through the backtest engine alongside the rule-based BookScorer so the
+    operator can answer "would this model make more money?".
+
+    Use --walk-forward to slide a (train, test) window through the data and
+    aggregate out-of-sample metrics — model is built from train_df at every
+    fold, so there is no lookahead leakage.
+    """
+    from rainier.core.config import ScorerConfig, SignalConfig
+    from rainier.data.csv_provider import CSVProvider
+    from rainier.features.extractor import FeatureExtractor
+    from rainier.ml.compare import (
+        compare_emitters,
+        format_comparison_table,
+        format_walkforward_table,
+        run_walkforward_compare,
+    )
+    from rainier.ml.scorers import MLScorer
+    from rainier.signals.emitter import PinBarSignalEmitter
+    from rainier.signals.ml_emitter import MLSignalEmitter
+
+    settings = ctx.obj["settings"]
+    timeframe = Timeframe(tf)
+    start_dt = datetime.strptime(start, "%Y-%m-%d") if start else None
+    end_dt = datetime.strptime(end, "%Y-%m-%d") if end else None
+
+    provider = CSVProvider(Path(csv_path).parent)
+    df = provider._read_csv(Path(csv_path), start_dt, end_dt)
+
+    if df is None or df.empty:
+        click.echo(f"No data loaded from {csv_path}")
+        return
+
+    bt_config = settings.backtest
+    sig_config = SignalConfig(
+        scorer=ScorerConfig(min_confidence=settings.signal.scorer.min_confidence),
+        min_rr_ratio=settings.signal.min_rr_ratio,
+    )
+    extractor = FeatureExtractor()
+
+    # Always include BookScorer baseline; ML scorer only if --model given.
+    def make_book_emitter(_train_df=None) -> PinBarSignalEmitter:
+        return PinBarSignalEmitter(settings.analysis, sig_config)
+
+    ml_factory = None
+    if model_path is not None:
+        ml_scorer = MLScorer(model_path=Path(model_path))
+
+        def _make_ml(_train_df=None) -> MLSignalEmitter:
+            # MLScorer is loaded once and reused across folds (the model
+            # itself doesn't refit; the caller refits offline via `ml train`).
+            return MLSignalEmitter(
+                scorer=ml_scorer,
+                feature_extractor=extractor,
+                analysis_config=settings.analysis,
+                signal_config=sig_config,
+            )
+
+        ml_factory = _make_ml
+
+    if walk_forward:
+        factories: dict = {"BookScorer": make_book_emitter}
+        if ml_factory is not None:
+            factories["MLScorer"] = ml_factory
+
+        click.echo(
+            f"Walk-forward compare: train={wf_train_bars}, test={wf_test_bars}, "
+            f"step={wf_step_bars or wf_test_bars}, n_bars={len(df)}"
+        )
+        wf_result = run_walkforward_compare(
+            df=df,
+            symbol=symbol,
+            timeframe=timeframe,
+            emitter_factories=factories,
+            train_bars=wf_train_bars,
+            test_bars=wf_test_bars,
+            step_bars=wf_step_bars,
+            config=bt_config,
+        )
+        click.echo(format_walkforward_table(wf_result))
+        return
+
+    emitters: dict = {"BookScorer": make_book_emitter()}
+    if ml_factory is not None:
+        emitters["MLScorer"] = ml_factory()
+
+    click.echo(f"Single-window compare: n_bars={len(df)}, emitters={list(emitters)}")
+    cmp_result = compare_emitters(
+        df=df,
+        symbol=symbol,
+        timeframe=timeframe,
+        emitters=emitters,
+        config=bt_config,
+    )
+    click.echo(format_comparison_table(cmp_result))
+
+
 # ---------------------------------------------------------------------------
 # `rainier thesis` — LLM thesis layer (PR1)
 # ---------------------------------------------------------------------------

--- a/src/rainier/core/protocols.py
+++ b/src/rainier/core/protocols.py
@@ -79,6 +79,23 @@ class ScoringStrategy(Protocol):
 
 
 # ---------------------------------------------------------------------------
+# Feature extraction boundary: AnalysisResult + DataFrame → feature DataFrame
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class FeatureExtractorProtocol(Protocol):
+    """Transforms an AnalysisResult + OHLCV DataFrame into ML-ready features.
+
+    Implemented by features/extractor.py:FeatureExtractor.
+    Defined as a protocol so signals/ and ml/ can depend on the contract
+    instead of importing features/ directly.
+    """
+
+    def extract(self, result: AnalysisResult, df: pd.DataFrame) -> pd.DataFrame: ...
+
+
+# ---------------------------------------------------------------------------
 # Backtest result contract (shared output type)
 # ---------------------------------------------------------------------------
 

--- a/src/rainier/ml/compare.py
+++ b/src/rainier/ml/compare.py
@@ -1,0 +1,139 @@
+"""Compare signal emitters by running backtests side-by-side.
+
+Answers the question: "Does the ML model produce better trading results
+than the rule-based BookScorer on the same historical data?"
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from rainier.backtest.engine import run_backtest
+from rainier.core.config import BacktestConfig
+from rainier.core.protocols import BacktestMetrics, SignalEmitter
+from rainier.core.types import Timeframe
+
+
+@dataclass
+class ComparisonResult:
+    """Side-by-side backtest results for multiple emitters."""
+
+    rows: list[tuple[str, BacktestMetrics]] = field(default_factory=list)
+
+    @property
+    def labels(self) -> list[str]:
+        return [label for label, _ in self.rows]
+
+    def get_metrics(self, label: str) -> BacktestMetrics | None:
+        for lbl, metrics in self.rows:
+            if lbl == label:
+                return metrics
+        return None
+
+
+def compare_emitters(
+    df: pd.DataFrame,
+    symbol: str,
+    timeframe: Timeframe,
+    emitters: dict[str, SignalEmitter],
+    config: BacktestConfig | None = None,
+) -> ComparisonResult:
+    """Run backtest with each emitter and collect results.
+
+    Args:
+        df: OHLCV DataFrame
+        symbol: Instrument symbol
+        timeframe: Bar timeframe
+        emitters: Mapping of label → SignalEmitter (e.g. "BookScorer" → emitter)
+        config: Shared backtest configuration
+
+    Returns:
+        ComparisonResult with one (label, BacktestMetrics) per emitter
+    """
+    if config is None:
+        config = BacktestConfig()
+
+    result = ComparisonResult()
+
+    for label, emitter in emitters.items():
+        metrics = run_backtest(df, symbol, timeframe, emitter, config)
+        result.rows.append((label, metrics))
+
+    return result
+
+
+def format_comparison_table(result: ComparisonResult) -> str:
+    """Format comparison results as a side-by-side ASCII table."""
+    if not result.rows:
+        return "No results to compare."
+
+    # Metrics to display
+    metric_defs = [
+        ("Total trades", lambda m: f"{m.total_trades}"),
+        ("Winners", lambda m: f"{m.winners}"),
+        ("Losers", lambda m: f"{m.losers}"),
+        ("Win rate", lambda m: f"{m.win_rate:.1%}"),
+        ("Profit factor", lambda m: f"{m.profit_factor:.2f}"),
+        ("Net P&L", lambda m: f"{m.total_net_pnl:+,.2f}"),
+        ("Gross P&L", lambda m: f"{m.total_gross_pnl:+,.2f}"),
+        ("Commission", lambda m: f"{m.total_commission:,.2f}"),
+        ("Slippage", lambda m: f"{m.total_slippage:,.2f}"),
+        ("Max drawdown", lambda m: f"{m.max_drawdown_pct:.1%}"),
+        ("Sharpe ratio", lambda m: f"{m.sharpe_ratio:.2f}"),
+        ("Avg win", lambda m: f"{m.avg_win:+,.2f}"),
+        ("Avg loss", lambda m: f"{m.avg_loss:+,.2f}"),
+        ("Avg hold bars", lambda m: f"{m.avg_hold_bars:.1f}"),
+        ("Largest win", lambda m: f"{m.largest_win:+,.2f}"),
+        ("Largest loss", lambda m: f"{m.largest_loss:+,.2f}"),
+        ("Final equity", lambda m: f"{m.final_equity:,.2f}"),
+    ]
+
+    labels = result.labels
+    col_width = max(14, *(len(label) + 2 for label in labels))
+    label_col_width = max(len(name) for name, _ in metric_defs) + 2
+
+    # Header
+    lines: list[str] = []
+    sep = "=" * (label_col_width + col_width * len(labels) + 4)
+    lines.append(sep)
+    lines.append("SCORER COMPARISON")
+    lines.append(sep)
+
+    # Column headers
+    header = f"{'':>{label_col_width}}"
+    for label in labels:
+        header += f"  {label:>{col_width}}"
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    # Rows
+    for metric_name, fmt_fn in metric_defs:
+        row = f"{metric_name:>{label_col_width}}"
+        for _, metrics in result.rows:
+            row += f"  {fmt_fn(metrics):>{col_width}}"
+        lines.append(row)
+
+    lines.append(sep)
+
+    # Delta summary (if exactly 2 emitters)
+    if len(result.rows) == 2:
+        _, m1 = result.rows[0]
+        _, m2 = result.rows[1]
+        lines.append("")
+        lines.append(f"Delta ({labels[1]} vs {labels[0]}):")
+
+        pf_delta = m2.profit_factor - m1.profit_factor
+        wr_delta = m2.win_rate - m1.win_rate
+        pnl_delta = m2.total_net_pnl - m1.total_net_pnl
+        dd_delta = m2.max_drawdown_pct - m1.max_drawdown_pct
+        sharpe_delta = m2.sharpe_ratio - m1.sharpe_ratio
+
+        lines.append(f"  Profit factor: {pf_delta:+.2f}")
+        lines.append(f"  Win rate:      {wr_delta:+.1%}")
+        lines.append(f"  Net P&L:       {pnl_delta:+,.2f}")
+        lines.append(f"  Max drawdown:  {dd_delta:+.1%}")
+        lines.append(f"  Sharpe ratio:  {sharpe_delta:+.2f}")
+
+    return "\n".join(lines)

--- a/src/rainier/ml/compare.py
+++ b/src/rainier/ml/compare.py
@@ -2,18 +2,29 @@
 
 Answers the question: "Does the ML model produce better trading results
 than the rule-based BookScorer on the same historical data?"
+
+Two modes:
+- ``compare_emitters`` — single full-sample backtest per emitter (fast,
+  good for sanity checks).
+- ``run_walkforward_compare`` — slides a (train, test) window through the
+  data, runs backtest on each test window, and aggregates per-emitter
+  metrics. Prevents lookahead leakage: emitter factories are given only
+  the train slice, and the engine sees only the test slice.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 import pandas as pd
 
 from rainier.backtest.engine import run_backtest
 from rainier.core.config import BacktestConfig
-from rainier.core.protocols import BacktestMetrics, SignalEmitter
+from rainier.core.protocols import BacktestMetrics, SignalEmitter, TradeRecord
 from rainier.core.types import Timeframe
+
+EmitterFactory = Callable[[pd.DataFrame], SignalEmitter]
 
 
 @dataclass
@@ -136,4 +147,226 @@ def format_comparison_table(result: ComparisonResult) -> str:
         lines.append(f"  Max drawdown:  {dd_delta:+.1%}")
         lines.append(f"  Sharpe ratio:  {sharpe_delta:+.2f}")
 
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward comparison
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WalkForwardWindow:
+    """Per-window record from a walk-forward backtest."""
+
+    fold: int
+    train_start: int
+    train_end: int  # exclusive
+    test_start: int
+    test_end: int  # exclusive
+    metrics_by_label: dict[str, BacktestMetrics] = field(default_factory=dict)
+
+
+@dataclass
+class WalkForwardResult:
+    """Aggregated walk-forward comparison results."""
+
+    windows: list[WalkForwardWindow] = field(default_factory=list)
+    aggregated: list[tuple[str, BacktestMetrics]] = field(default_factory=list)
+
+    @property
+    def labels(self) -> list[str]:
+        return [label for label, _ in self.aggregated]
+
+    def get_aggregate(self, label: str) -> BacktestMetrics | None:
+        for lbl, metrics in self.aggregated:
+            if lbl == label:
+                return metrics
+        return None
+
+
+def run_walkforward_compare(
+    df: pd.DataFrame,
+    symbol: str,
+    timeframe: Timeframe,
+    emitter_factories: dict[str, EmitterFactory],
+    train_bars: int,
+    test_bars: int,
+    step_bars: int | None = None,
+    config: BacktestConfig | None = None,
+) -> WalkForwardResult:
+    """Run a walk-forward comparison: slide a (train, test) window forward.
+
+    For each window:
+      - Slice df[train_start:train_end] as training data
+      - Build an emitter via emitter_factories[label](train_df) for each label
+      - Run backtest on df[test_start:test_end] with that emitter
+      - Record per-window metrics
+
+    Aggregates across windows by concatenating trade lists and recomputing
+    portfolio metrics (so profit factor / win rate reflect the full
+    out-of-sample series, not an average of fold-level summaries).
+
+    Args:
+        df: OHLCV DataFrame (must have 'timestamp', 'open', 'high', 'low',
+            'close' columns; sorted ascending by timestamp).
+        symbol: Instrument symbol.
+        timeframe: Bar timeframe.
+        emitter_factories: Mapping label → factory(train_df) → emitter.
+            BookScorer factories may ignore train_df; ML factories
+            typically refit / reload a model anchored on train_df.
+        train_bars: Length of training window in bars.
+        test_bars: Length of test (out-of-sample) window in bars.
+        step_bars: How far to advance between folds. Defaults to ``test_bars``
+            (non-overlapping test windows, i.e. classic walk-forward).
+        config: Shared backtest config across windows.
+
+    Returns:
+        WalkForwardResult with per-window records + aggregated metrics.
+
+    Raises:
+        ValueError: if train_bars/test_bars are non-positive, if the
+            dataset is shorter than one train+test span, or if
+            emitter_factories is empty.
+    """
+    if not emitter_factories:
+        raise ValueError("emitter_factories must be non-empty")
+    if train_bars <= 0 or test_bars <= 0:
+        raise ValueError("train_bars and test_bars must be positive")
+    if step_bars is None:
+        step_bars = test_bars
+    if step_bars <= 0:
+        raise ValueError("step_bars must be positive")
+
+    n = len(df)
+    if n < train_bars + test_bars:
+        raise ValueError(
+            f"DataFrame has {n} rows, need at least train_bars + test_bars "
+            f"= {train_bars + test_bars}"
+        )
+
+    if config is None:
+        config = BacktestConfig()
+
+    result = WalkForwardResult()
+    fold = 0
+    train_start = 0
+
+    while train_start + train_bars + test_bars <= n:
+        train_end = train_start + train_bars
+        test_start = train_end
+        test_end = test_start + test_bars
+
+        train_df = df.iloc[train_start:train_end].reset_index(drop=True)
+        test_df = df.iloc[test_start:test_end].reset_index(drop=True)
+
+        window = WalkForwardWindow(
+            fold=fold,
+            train_start=train_start,
+            train_end=train_end,
+            test_start=test_start,
+            test_end=test_end,
+        )
+
+        for label, factory in emitter_factories.items():
+            emitter = factory(train_df)
+            metrics = run_backtest(test_df, symbol, timeframe, emitter, config)
+            window.metrics_by_label[label] = metrics
+
+        result.windows.append(window)
+        fold += 1
+        train_start += step_bars
+
+    # Aggregate: concatenate per-window trades + recompute portfolio metrics
+    from rainier.backtest.engine import compute_metrics
+
+    for label in emitter_factories:
+        all_trades: list[TradeRecord] = []
+        equity_curve: list[float] = [config.initial_capital]
+        running = config.initial_capital
+        for window in result.windows:
+            metrics = window.metrics_by_label.get(label)
+            if metrics is None:
+                continue
+            for trade in metrics.trades:
+                all_trades.append(trade)
+                running += trade.net_pnl
+                equity_curve.append(running)
+        agg = compute_metrics(all_trades, equity_curve, config)
+        result.aggregated.append((label, agg))
+
+    return result
+
+
+def format_walkforward_table(result: WalkForwardResult) -> str:
+    """Format walk-forward results: per-window summary + aggregate row."""
+    if not result.windows or not result.aggregated:
+        return "No walk-forward results to display."
+
+    labels = result.labels
+    lines: list[str] = []
+
+    # Header
+    width = max(14, *(len(label) + 2 for label in labels))
+    fold_col = 8
+    sep_len = fold_col + 4 + width * len(labels) + 4
+    sep = "=" * sep_len
+
+    lines.append(sep)
+    lines.append("WALK-FORWARD COMPARISON (per-window net P&L)")
+    lines.append(sep)
+
+    header = f"{'Fold':>{fold_col}}"
+    for label in labels:
+        header += f"  {label:>{width}}"
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    for window in result.windows:
+        row = f"{window.fold:>{fold_col}}"
+        for label in labels:
+            metrics = window.metrics_by_label.get(label)
+            pnl = metrics.total_net_pnl if metrics is not None else 0.0
+            row += f"  {pnl:>+{width},.2f}"
+        lines.append(row)
+
+    lines.append("-" * len(header))
+
+    # Aggregate row
+    agg_header = f"{'Aggregate':>{fold_col}}"
+    for label in labels:
+        agg = result.get_aggregate(label)
+        pnl = agg.total_net_pnl if agg is not None else 0.0
+        agg_header += f"  {pnl:>+{width},.2f}"
+    lines.append(agg_header)
+
+    lines.append(sep)
+    lines.append("")
+    lines.append("Aggregate metrics (concatenated out-of-sample trades):")
+    lines.append("")
+
+    # Per-label aggregate detail
+    metric_defs = [
+        ("Total trades", lambda m: f"{m.total_trades}"),
+        ("Win rate", lambda m: f"{m.win_rate:.1%}"),
+        ("Profit factor", lambda m: f"{m.profit_factor:.2f}"),
+        ("Net P&L", lambda m: f"{m.total_net_pnl:+,.2f}"),
+        ("Max drawdown", lambda m: f"{m.max_drawdown_pct:.1%}"),
+        ("Sharpe ratio", lambda m: f"{m.sharpe_ratio:.2f}"),
+    ]
+    label_col = max(len(name) for name, _ in metric_defs) + 2
+    detail_header = f"{'':>{label_col}}"
+    for label in labels:
+        detail_header += f"  {label:>{width}}"
+    lines.append(detail_header)
+    lines.append("-" * len(detail_header))
+
+    for metric_name, fmt_fn in metric_defs:
+        row = f"{metric_name:>{label_col}}"
+        for label in labels:
+            agg = result.get_aggregate(label)
+            row += f"  {(fmt_fn(agg) if agg else 'n/a'):>{width}}"
+        lines.append(row)
+
+    lines.append(sep)
     return "\n".join(lines)

--- a/src/rainier/signals/ml_emitter.py
+++ b/src/rainier/signals/ml_emitter.py
@@ -1,0 +1,139 @@
+"""ML-augmented signal emitter — uses a trained model for confidence scoring.
+
+Replaces the rule-based score_setup() with an ML model's probability output
+while reusing the same pin bar detection and S/R level logic.
+
+Dependency injection: receives ScoringStrategy and FeatureExtractorProtocol
+via constructor so that signals/ does not import ml/ or features/ directly.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from rainier.analysis.analyzer import analyze
+from rainier.core.config import AnalysisConfig, SignalConfig
+from rainier.core.protocols import FeatureExtractorProtocol, ScoringStrategy
+from rainier.core.types import (
+    Direction,
+    PatternSignal,
+    PinBar,
+    Signal,
+    SignalStatus,
+    Timeframe,
+)
+from rainier.signals.generator import _compute_levels, _dedup_signals
+
+
+class MLSignalEmitter:
+    """Emits signals using ML model confidence instead of rule-based scoring.
+
+    Same pin bar detection as PinBarSignalEmitter, but replaces the
+    weighted sub-score with ScoringStrategy.score() (typically MLScorer).
+    """
+
+    def __init__(
+        self,
+        scorer: ScoringStrategy,
+        feature_extractor: FeatureExtractorProtocol,
+        analysis_config: AnalysisConfig | None = None,
+        signal_config: SignalConfig | None = None,
+    ) -> None:
+        self.scorer = scorer
+        self.feature_extractor = feature_extractor
+        self.analysis_config = analysis_config or AnalysisConfig()
+        self.signal_config = signal_config or SignalConfig()
+
+    def emit(
+        self,
+        df: pd.DataFrame,
+        symbol: str,
+        timeframe: Timeframe,
+    ) -> list[Signal]:
+        """Analyze OHLCV data and generate ML-scored pin bar signals."""
+        config = self.signal_config
+
+        # Step 1: Run analysis pipeline (same as PinBarSignalEmitter)
+        analysis = analyze(df, symbol, timeframe, self.analysis_config)
+
+        # Step 2: Extract features for the entire lookback window once
+        features = self.feature_extractor.extract(analysis, df)
+
+        # Step 3: Score each pin bar with ML model
+        all_signals: list[Signal] = []
+
+        for pin_bar in analysis.pin_bars:
+            # Compute entry/SL/TP levels
+            entry, sl, tp = _compute_levels(pin_bar, analysis.sr_levels, config)
+            if entry is None:
+                continue
+
+            # Check minimum R:R
+            risk = abs(entry - sl)
+            if risk <= 0:
+                continue
+            rr = abs(tp - entry) / risk
+            if rr < config.min_rr_ratio:
+                continue
+
+            # Build PatternSignal wrapper for the scorer
+            pattern = _pinbar_to_pattern_signal(pin_bar, entry, sl, tp, rr)
+
+            # Slice features up to pin bar's bar index
+            bar_idx = pin_bar.index
+            if bar_idx < len(features):
+                features_slice = features.iloc[: bar_idx + 1]
+            else:
+                features_slice = features
+
+            # Score with ML model
+            confidence = self.scorer.score(pattern, features_slice)
+
+            if confidence < config.scorer.min_confidence:
+                continue
+
+            all_signals.append(
+                Signal(
+                    symbol=analysis.symbol,
+                    timeframe=analysis.timeframe,
+                    direction=pin_bar.direction,
+                    entry_price=entry,
+                    stop_loss=sl,
+                    take_profit=tp,
+                    confidence=confidence,
+                    timestamp=pin_bar.candle.timestamp,
+                    status=SignalStatus.PENDING,
+                    pin_bar=pin_bar,
+                    sr_level=pin_bar.nearest_sr,
+                )
+            )
+
+        return _dedup_signals(all_signals)
+
+
+def _pinbar_to_pattern_signal(
+    pin_bar: PinBar,
+    entry: float,
+    stop_loss: float,
+    take_profit: float,
+    rr_ratio: float,
+) -> PatternSignal:
+    """Convert a PinBar + computed levels into a PatternSignal for the scorer."""
+    risk = abs(entry - stop_loss)
+    reward = abs(take_profit - entry)
+
+    return PatternSignal(
+        symbol="",
+        pattern_type="pin_bar",
+        direction="bullish" if pin_bar.direction == Direction.LONG else "bearish",
+        status="confirmed",
+        confidence=0.0,  # will be set by scorer
+        entry_price=entry,
+        stop_loss=stop_loss,
+        target_wave1=take_profit,
+        risk_pct=risk / entry if entry > 0 else 0.0,
+        reward_pct=reward / entry if entry > 0 else 0.0,
+        rr_ratio=rr_ratio,
+        volume_confirmed=pin_bar.candle.volume > 0 if pin_bar.candle.volume else False,
+        pattern_start_idx=pin_bar.index,
+    )

--- a/tests/test_cli_ml_compare.py
+++ b/tests/test_cli_ml_compare.py
@@ -1,0 +1,156 @@
+"""Tests for `rainier ml compare` CLI command.
+
+Composition-root verification: the CLI must wire BookScorer baseline (and
+optional MLScorer if --model is given) through compare_emitters or
+run_walkforward_compare without us needing to invoke a real XGBoost model.
+For the ML branch we substitute a fake MLScorer so the test stays fast and
+deterministic — model-loading fidelity is covered separately by
+test_ml_emitter / test_ml_compare unit tests.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+from click.testing import CliRunner
+
+from rainier.cli import cli
+
+
+def _write_csv(path: Path, n: int = 400) -> None:
+    """Write a synthetic OHLCV CSV the CSVProvider accepts."""
+    rows = []
+    price = 100.0
+    base = datetime(2025, 1, 1)
+    for i in range(n):
+        cycle = i % 40
+        move = 1.0 if cycle < 20 else -1.0
+        rows.append({
+            "timestamp": (base + timedelta(hours=i)).strftime("%Y-%m-%d %H:%M:%S"),
+            "open": price,
+            "high": price + abs(move) + 1.0,
+            "low": price - abs(move) - 0.5,
+            "close": price + move,
+            "volume": 1000 + (i % 10) * 100,
+        })
+        price = price + move
+    pd.DataFrame(rows).to_csv(path, index=False)
+
+
+class _FakeMLScorer:
+    """Stand-in for ml.scorers.MLScorer that needs no XGBoost model."""
+
+    def __init__(self, model_path=None):
+        self.model_path = model_path
+
+    def score(self, pattern, features) -> float:
+        return 0.5
+
+
+class TestMLCompareCLI:
+    """The composition-root wiring of `rainier ml compare`."""
+
+    def test_baseline_only_runs_without_model(self, tmp_path):
+        csv_path = tmp_path / "MES_1H.csv"
+        _write_csv(csv_path, n=300)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "ml", "compare",
+                "--csv", str(csv_path),
+                "--symbol", "MES",
+                "--timeframe", "1H",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "BookScorer" in result.output
+        assert "SCORER COMPARISON" in result.output
+
+    def test_with_model_runs_both_scorers(self, tmp_path):
+        csv_path = tmp_path / "MES_1H.csv"
+        _write_csv(csv_path, n=300)
+        # We don't actually need a real model file (MLScorer is faked) but
+        # click validates --model with exists=True, so write a placeholder.
+        model_path = tmp_path / "model.json"
+        model_path.write_text("{}")
+
+        runner = CliRunner()
+        with patch("rainier.ml.scorers.MLScorer", _FakeMLScorer):
+            result = runner.invoke(
+                cli,
+                [
+                    "ml", "compare",
+                    "--csv", str(csv_path),
+                    "--symbol", "MES",
+                    "--timeframe", "1H",
+                    "--model", str(model_path),
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert "BookScorer" in result.output
+        assert "MLScorer" in result.output
+
+    def test_walk_forward_baseline_only(self, tmp_path):
+        csv_path = tmp_path / "MES_1H.csv"
+        _write_csv(csv_path, n=600)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "ml", "compare",
+                "--csv", str(csv_path),
+                "--symbol", "MES",
+                "--timeframe", "1H",
+                "--walk-forward",
+                "--wf-train-bars", "200",
+                "--wf-test-bars", "100",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "WALK-FORWARD COMPARISON" in result.output
+        assert "Aggregate" in result.output
+
+    def test_walk_forward_with_model(self, tmp_path):
+        csv_path = tmp_path / "MES_1H.csv"
+        _write_csv(csv_path, n=600)
+        model_path = tmp_path / "model.json"
+        model_path.write_text("{}")
+
+        runner = CliRunner()
+        with patch("rainier.ml.scorers.MLScorer", _FakeMLScorer):
+            result = runner.invoke(
+                cli,
+                [
+                    "ml", "compare",
+                    "--csv", str(csv_path),
+                    "--symbol", "MES",
+                    "--timeframe", "1H",
+                    "--model", str(model_path),
+                    "--walk-forward",
+                    "--wf-train-bars", "200",
+                    "--wf-test-bars", "100",
+                    "--wf-step-bars", "100",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert "WALK-FORWARD COMPARISON" in result.output
+        assert "BookScorer" in result.output
+        assert "MLScorer" in result.output
+
+    def test_missing_csv_fails_cleanly(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "ml", "compare",
+                "--csv", str(tmp_path / "does_not_exist.csv"),
+                "--symbol", "MES",
+                "--timeframe", "1H",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "does_not_exist" in result.output or "Path" in result.output

--- a/tests/test_ml_compare.py
+++ b/tests/test_ml_compare.py
@@ -1,0 +1,181 @@
+"""Tests for ml/compare.py — side-by-side backtest comparison."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+
+from rainier.core.config import BacktestConfig
+from rainier.core.protocols import BacktestMetrics
+from rainier.core.types import Signal, Timeframe
+from rainier.ml.compare import ComparisonResult, compare_emitters, format_comparison_table
+
+# ---------------------------------------------------------------------------
+# Fake emitters for deterministic testing
+# ---------------------------------------------------------------------------
+
+
+class _FixedEmitter:
+    """Emits a fixed set of signals regardless of input."""
+
+    def __init__(self, signals: list[Signal] | None = None):
+        self._signals = signals or []
+
+    def emit(self, df, symbol, timeframe) -> list[Signal]:
+        # Return signals whose timestamp falls within the df range
+        if self._signals:
+            ts_set = set(df["timestamp"].tolist())
+            return [s for s in self._signals if s.timestamp in ts_set]
+        return []
+
+
+class _NeverEmitter:
+    """Emits zero signals — baseline for comparison."""
+
+    def emit(self, df, symbol, timeframe) -> list[Signal]:
+        return []
+
+
+def _make_df(n: int = 200) -> pd.DataFrame:
+    """Simple trending dataset for backtest."""
+    rows = []
+    price = 100.0
+    base = datetime(2025, 1, 1)
+    for i in range(n):
+        cycle = i % 40
+        move = 1.0 if cycle < 20 else -1.0
+        o = price
+        h = price + abs(move) + 1.0
+        low = price - abs(move) - 0.5
+        c = price + move
+        rows.append({
+            "timestamp": base + timedelta(hours=i),
+            "open": o, "high": h, "low": low, "close": c,
+            "volume": 1000.0 + (i % 10) * 100,
+        })
+        price = c
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompareEmitters:
+    """compare_emitters runs backtest with each emitter."""
+
+    def test_returns_result_for_each_emitter(self):
+        df = _make_df()
+        result = compare_emitters(
+            df=df,
+            symbol="TEST",
+            timeframe=Timeframe.H1,
+            emitters={"A": _NeverEmitter(), "B": _NeverEmitter()},
+            config=BacktestConfig(),
+        )
+        assert len(result.rows) == 2
+        assert result.labels == ["A", "B"]
+
+    def test_metrics_have_correct_type(self):
+        df = _make_df()
+        result = compare_emitters(
+            df=df,
+            symbol="TEST",
+            timeframe=Timeframe.H1,
+            emitters={"Base": _NeverEmitter()},
+            config=BacktestConfig(),
+        )
+        _, metrics = result.rows[0]
+        assert isinstance(metrics, BacktestMetrics)
+
+    def test_no_signals_yields_zero_trades(self):
+        df = _make_df()
+        result = compare_emitters(
+            df=df,
+            symbol="TEST",
+            timeframe=Timeframe.H1,
+            emitters={"Empty": _NeverEmitter()},
+            config=BacktestConfig(),
+        )
+        _, metrics = result.rows[0]
+        assert metrics.total_trades == 0
+
+    def test_get_metrics_by_label(self):
+        df = _make_df()
+        result = compare_emitters(
+            df=df,
+            symbol="TEST",
+            timeframe=Timeframe.H1,
+            emitters={"A": _NeverEmitter(), "B": _NeverEmitter()},
+            config=BacktestConfig(),
+        )
+        assert result.get_metrics("A") is not None
+        assert result.get_metrics("B") is not None
+        assert result.get_metrics("C") is None
+
+
+class TestComparisonResult:
+    """ComparisonResult dataclass methods."""
+
+    def test_labels_property(self):
+        m = BacktestMetrics()
+        result = ComparisonResult(rows=[("X", m), ("Y", m)])
+        assert result.labels == ["X", "Y"]
+
+    def test_empty_result(self):
+        result = ComparisonResult()
+        assert result.labels == []
+        assert result.get_metrics("anything") is None
+
+
+class TestFormatComparisonTable:
+    """format_comparison_table produces readable output."""
+
+    def test_empty_result(self):
+        result = ComparisonResult()
+        output = format_comparison_table(result)
+        assert "No results" in output
+
+    def test_single_emitter(self):
+        metrics = BacktestMetrics(
+            total_trades=10, winners=6, losers=4,
+            win_rate=0.6, profit_factor=1.5,
+            total_net_pnl=1500.0, total_gross_pnl=2000.0,
+            total_commission=300.0, total_slippage=200.0,
+            max_drawdown_pct=0.05, sharpe_ratio=1.2,
+            avg_win=500.0, avg_loss=-250.0, avg_hold_bars=8.0,
+            largest_win=1000.0, largest_loss=-500.0,
+            final_equity=101500.0,
+        )
+        result = ComparisonResult(rows=[("BookScorer", metrics)])
+        output = format_comparison_table(result)
+
+        assert "SCORER COMPARISON" in output
+        assert "BookScorer" in output
+        assert "10" in output  # total_trades
+        assert "60.0%" in output  # win_rate
+        assert "1.50" in output  # profit_factor
+
+    def test_two_emitters_shows_delta(self):
+        m1 = BacktestMetrics(
+            total_trades=10, win_rate=0.5, profit_factor=1.2,
+            total_net_pnl=1000.0, max_drawdown_pct=0.08, sharpe_ratio=0.8,
+        )
+        m2 = BacktestMetrics(
+            total_trades=8, win_rate=0.625, profit_factor=1.6,
+            total_net_pnl=2000.0, max_drawdown_pct=0.05, sharpe_ratio=1.1,
+        )
+        result = ComparisonResult(rows=[("Book", m1), ("ML", m2)])
+        output = format_comparison_table(result)
+
+        assert "Delta" in output
+        assert "Profit factor" in output
+        assert "Win rate" in output
+
+    def test_three_emitters_no_delta(self):
+        m = BacktestMetrics()
+        result = ComparisonResult(rows=[("A", m), ("B", m), ("C", m)])
+        output = format_comparison_table(result)
+        assert "Delta" not in output

--- a/tests/test_ml_compare.py
+++ b/tests/test_ml_compare.py
@@ -5,11 +5,20 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 
 import pandas as pd
+import pytest
 
 from rainier.core.config import BacktestConfig
 from rainier.core.protocols import BacktestMetrics
 from rainier.core.types import Signal, Timeframe
-from rainier.ml.compare import ComparisonResult, compare_emitters, format_comparison_table
+from rainier.ml.compare import (
+    ComparisonResult,
+    WalkForwardResult,
+    WalkForwardWindow,
+    compare_emitters,
+    format_comparison_table,
+    format_walkforward_table,
+    run_walkforward_compare,
+)
 
 # ---------------------------------------------------------------------------
 # Fake emitters for deterministic testing
@@ -179,3 +188,185 @@ class TestFormatComparisonTable:
         result = ComparisonResult(rows=[("A", m), ("B", m), ("C", m)])
         output = format_comparison_table(result)
         assert "Delta" not in output
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward tests
+# ---------------------------------------------------------------------------
+
+
+class _ConstantEmitter:
+    """Emits zero signals — gives deterministic backtest with no trades."""
+
+    def emit(self, df, symbol, timeframe) -> list[Signal]:
+        return []
+
+
+class TestRunWalkforwardCompare:
+    """run_walkforward_compare slides train/test windows and aggregates."""
+
+    def test_yields_expected_window_count(self):
+        df = _make_df(500)
+        # train=200, test=100, step=100 → folds at train_starts 0,100,200
+        # need train_start + 300 <= 500 → 0,100,200 valid
+        result = run_walkforward_compare(
+            df=df,
+            symbol="TEST",
+            timeframe=Timeframe.H1,
+            emitter_factories={"empty": lambda _train: _ConstantEmitter()},
+            train_bars=200,
+            test_bars=100,
+            step_bars=100,
+            config=BacktestConfig(),
+        )
+        assert len(result.windows) == 3
+
+    def test_default_step_equals_test_bars(self):
+        df = _make_df(400)
+        # train=200, test=100, default step=100 → folds at 0, 100
+        result = run_walkforward_compare(
+            df=df,
+            symbol="TEST",
+            timeframe=Timeframe.H1,
+            emitter_factories={"empty": lambda _train: _ConstantEmitter()},
+            train_bars=200,
+            test_bars=100,
+            config=BacktestConfig(),
+        )
+        assert len(result.windows) == 2
+
+    def test_window_indices_are_correct(self):
+        df = _make_df(400)
+        result = run_walkforward_compare(
+            df=df,
+            symbol="TEST",
+            timeframe=Timeframe.H1,
+            emitter_factories={"empty": lambda _train: _ConstantEmitter()},
+            train_bars=200,
+            test_bars=100,
+            step_bars=100,
+            config=BacktestConfig(),
+        )
+        w0 = result.windows[0]
+        assert (w0.train_start, w0.train_end) == (0, 200)
+        assert (w0.test_start, w0.test_end) == (200, 300)
+        w1 = result.windows[1]
+        assert (w1.train_start, w1.train_end) == (100, 300)
+        assert (w1.test_start, w1.test_end) == (300, 400)
+
+    def test_factory_receives_train_slice_only(self):
+        """Factory must be called with the training slice, not the full df."""
+        df = _make_df(400)
+        captured: list[int] = []
+
+        def factory(train_df):
+            captured.append(len(train_df))
+            return _ConstantEmitter()
+
+        run_walkforward_compare(
+            df=df,
+            symbol="TEST",
+            timeframe=Timeframe.H1,
+            emitter_factories={"e": factory},
+            train_bars=200,
+            test_bars=100,
+            step_bars=100,
+            config=BacktestConfig(),
+        )
+        assert captured == [200, 200]  # called once per fold with train_bars
+
+    def test_aggregates_per_label(self):
+        df = _make_df(400)
+        result = run_walkforward_compare(
+            df=df,
+            symbol="TEST",
+            timeframe=Timeframe.H1,
+            emitter_factories={
+                "A": lambda _train: _ConstantEmitter(),
+                "B": lambda _train: _ConstantEmitter(),
+            },
+            train_bars=200,
+            test_bars=100,
+            step_bars=100,
+            config=BacktestConfig(),
+        )
+        assert result.labels == ["A", "B"]
+        assert result.get_aggregate("A") is not None
+        assert result.get_aggregate("B") is not None
+        # No signals → 0 trades aggregated
+        assert result.get_aggregate("A").total_trades == 0
+
+    def test_raises_on_empty_factories(self):
+        df = _make_df(400)
+        with pytest.raises(ValueError, match="non-empty"):
+            run_walkforward_compare(
+                df=df,
+                symbol="TEST",
+                timeframe=Timeframe.H1,
+                emitter_factories={},
+                train_bars=200,
+                test_bars=100,
+            )
+
+    def test_raises_on_too_short_data(self):
+        df = _make_df(100)
+        with pytest.raises(ValueError, match="need at least"):
+            run_walkforward_compare(
+                df=df,
+                symbol="TEST",
+                timeframe=Timeframe.H1,
+                emitter_factories={"e": lambda _t: _ConstantEmitter()},
+                train_bars=200,
+                test_bars=100,
+            )
+
+    def test_raises_on_invalid_bar_counts(self):
+        df = _make_df(400)
+        with pytest.raises(ValueError, match="must be positive"):
+            run_walkforward_compare(
+                df=df,
+                symbol="TEST",
+                timeframe=Timeframe.H1,
+                emitter_factories={"e": lambda _t: _ConstantEmitter()},
+                train_bars=0,
+                test_bars=100,
+            )
+
+
+class TestWalkForwardResult:
+    def test_empty_result(self):
+        result = WalkForwardResult()
+        assert result.labels == []
+        assert result.get_aggregate("anything") is None
+
+    def test_window_dataclass(self):
+        w = WalkForwardWindow(
+            fold=0, train_start=0, train_end=200,
+            test_start=200, test_end=300,
+        )
+        assert w.fold == 0
+        assert w.metrics_by_label == {}
+
+
+class TestFormatWalkforwardTable:
+    def test_empty_returns_message(self):
+        out = format_walkforward_table(WalkForwardResult())
+        assert "No walk-forward" in out
+
+    def test_renders_per_window_and_aggregate(self):
+        df = _make_df(400)
+        result = run_walkforward_compare(
+            df=df,
+            symbol="TEST",
+            timeframe=Timeframe.H1,
+            emitter_factories={"Book": lambda _t: _ConstantEmitter()},
+            train_bars=200,
+            test_bars=100,
+            step_bars=100,
+            config=BacktestConfig(),
+        )
+        out = format_walkforward_table(result)
+        assert "WALK-FORWARD COMPARISON" in out
+        assert "Book" in out
+        assert "Aggregate" in out
+        assert "Profit factor" in out

--- a/tests/test_ml_emitter.py
+++ b/tests/test_ml_emitter.py
@@ -1,0 +1,219 @@
+"""Tests for MLSignalEmitter — ML-augmented signal generation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+
+from rainier.core.config import ScorerConfig, SignalConfig
+from rainier.core.protocols import FeatureExtractorProtocol, SignalEmitter
+from rainier.core.types import AnalysisResult, Direction, PatternSignal, Timeframe
+from rainier.features.extractor import FeatureExtractor
+from rainier.signals.ml_emitter import MLSignalEmitter, _pinbar_to_pattern_signal
+
+# ---------------------------------------------------------------------------
+# Fake scorer / extractor for testing
+# ---------------------------------------------------------------------------
+
+
+class FakeScorer:
+    """Always returns a fixed score."""
+
+    def __init__(self, score: float = 0.75):
+        self._score = score
+
+    def score(self, pattern: PatternSignal, features: pd.DataFrame) -> float:
+        return self._score
+
+
+class FakeExtractor:
+    """Returns a minimal features DataFrame with the same index as df."""
+
+    def extract(self, result: AnalysisResult, df: pd.DataFrame) -> pd.DataFrame:
+        n = len(df)
+        return pd.DataFrame({
+            "body_size": [1.0] * n,
+            "atr_14": [2.0] * n,
+            "volume_ratio": [1.0] * n,
+            "is_bullish": [1.0] * n,
+        })
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_zigzag_df(n_bars: int = 200) -> pd.DataFrame:
+    """Zigzag dataset that produces pin bars at reversals."""
+    rows = []
+    price = 100.0
+    base = datetime(2025, 1, 1)
+
+    for i in range(n_bars):
+        cycle = i % 40
+        move = 1.0 if cycle < 20 else -1.0
+
+        o = price
+        h = price + abs(move) + 1.0
+        low = price - abs(move) - 0.5
+        c = price + move
+
+        rows.append({
+            "timestamp": base + timedelta(hours=i),
+            "open": o, "high": h, "low": low, "close": c,
+            "volume": 1000.0 + (i % 10) * 100,
+        })
+        price = c
+
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMLSignalEmitterProtocol:
+    """MLSignalEmitter satisfies the SignalEmitter protocol."""
+
+    def test_implements_protocol(self):
+        emitter = MLSignalEmitter(
+            scorer=FakeScorer(),
+            feature_extractor=FakeExtractor(),
+        )
+        assert isinstance(emitter, SignalEmitter)
+
+    def test_emit_returns_list(self):
+        emitter = MLSignalEmitter(
+            scorer=FakeScorer(),
+            feature_extractor=FakeExtractor(),
+        )
+        df = _make_zigzag_df(200)
+        signals = emitter.emit(df, "TEST", Timeframe.H1)
+        assert isinstance(signals, list)
+
+
+class TestFeatureExtractorProtocolContract:
+    """FeatureExtractor satisfies the FeatureExtractorProtocol contract.
+
+    This protects against drift: if FeatureExtractor.extract() ever changes
+    shape, the runtime_checkable protocol will catch it here before the
+    MLSignalEmitter (which depends on the protocol) breaks at call time.
+    """
+
+    def test_concrete_extractor_satisfies_protocol(self):
+        assert isinstance(FeatureExtractor(), FeatureExtractorProtocol)
+
+    def test_fake_extractor_satisfies_protocol(self):
+        # The test fake we use throughout this file must also satisfy
+        # the protocol, otherwise our other tests are misleading.
+        assert isinstance(FakeExtractor(), FeatureExtractorProtocol)
+
+
+class TestMLSignalEmitterFiltering:
+    """ML emitter respects confidence and R:R filters."""
+
+    def test_low_confidence_filtered(self):
+        """Scorer returns 0.3 but min_confidence=0.5 → no signals."""
+        emitter = MLSignalEmitter(
+            scorer=FakeScorer(score=0.3),
+            feature_extractor=FakeExtractor(),
+            signal_config=SignalConfig(
+                scorer=ScorerConfig(min_confidence=0.5),
+                min_rr_ratio=1.0,
+            ),
+        )
+        df = _make_zigzag_df(200)
+        signals = emitter.emit(df, "TEST", Timeframe.H1)
+        assert len(signals) == 0
+
+    def test_high_confidence_passes(self):
+        """Scorer returns 0.9 with min_confidence=0.5 → signals pass."""
+        emitter = MLSignalEmitter(
+            scorer=FakeScorer(score=0.9),
+            feature_extractor=FakeExtractor(),
+            signal_config=SignalConfig(
+                scorer=ScorerConfig(min_confidence=0.5),
+                min_rr_ratio=0.5,  # low bar so we get signals
+            ),
+        )
+        df = _make_zigzag_df(200)
+        signals = emitter.emit(df, "TEST", Timeframe.H1)
+        # May or may not produce signals depending on pin bar detection,
+        # but confidence filter is not blocking
+        for sig in signals:
+            assert sig.confidence == 0.9
+
+    def test_high_rr_filter(self):
+        """With min_rr_ratio=10.0 → almost no signals pass."""
+        emitter = MLSignalEmitter(
+            scorer=FakeScorer(score=0.9),
+            feature_extractor=FakeExtractor(),
+            signal_config=SignalConfig(
+                scorer=ScorerConfig(min_confidence=0.1),
+                min_rr_ratio=10.0,
+            ),
+        )
+        df = _make_zigzag_df(200)
+        signals = emitter.emit(df, "TEST", Timeframe.H1)
+        # Very high R:R bar means most signals filtered
+        assert len(signals) == 0 or all(
+            abs(s.take_profit - s.entry_price) / abs(s.entry_price - s.stop_loss) >= 10.0
+            for s in signals
+        )
+
+
+class TestPinbarToPatternSignal:
+    """_pinbar_to_pattern_signal produces correct PatternSignal."""
+
+    def test_basic_conversion(self):
+        from rainier.core.types import Candle, PinBar
+
+        candle = Candle(
+            timestamp=datetime(2025, 1, 1),
+            open=100.0, high=105.0, low=98.0, close=104.0,
+            volume=1000.0,
+        )
+        pin_bar = PinBar(
+            candle=candle,
+            index=5,
+            direction=Direction.LONG,
+            wick_ratio=3.0,
+            nearest_sr=None,
+        )
+
+        ps = _pinbar_to_pattern_signal(
+            pin_bar, entry=99.0, stop_loss=97.0, take_profit=103.0, rr_ratio=2.0,
+        )
+
+        assert ps.pattern_type == "pin_bar"
+        assert ps.direction == "bullish"
+        assert ps.entry_price == 99.0
+        assert ps.stop_loss == 97.0
+        assert ps.target_wave1 == 103.0
+        assert ps.rr_ratio == 2.0
+        assert ps.volume_confirmed is True
+
+    def test_bearish_direction(self):
+        from rainier.core.types import Candle, PinBar
+
+        candle = Candle(
+            timestamp=datetime(2025, 1, 1),
+            open=100.0, high=102.0, low=95.0, close=96.0,
+            volume=1000.0,
+        )
+        pin_bar = PinBar(
+            candle=candle,
+            index=5,
+            direction=Direction.SHORT,
+            wick_ratio=3.0,
+            nearest_sr=None,
+        )
+
+        ps = _pinbar_to_pattern_signal(
+            pin_bar, entry=101.0, stop_loss=103.0, take_profit=97.0, rr_ratio=2.0,
+        )
+
+        assert ps.direction == "bearish"


### PR DESCRIPTION
Closes #44.

## Summary
Closes the ML feedback loop. Train a pattern scorer with `rainier ml train`, then run it through the backtest engine alongside the rule-based BookScorer with one command and read off side-by-side metrics. Without this, all ML training work was blind: CV accuracy / F1 don't answer "would this model make more money than the book strategy?"

- `MLSignalEmitter` — wraps `analyze()` + a `ScoringStrategy` (typically `MLScorer`) into a `SignalEmitter`. Replaces `score_setup()` with model probability while reusing pin bar detection + S/R levels from the existing pipeline.
- `FeatureExtractorProtocol` in `core/protocols.py` so signals/ and ml/ can depend on the contract instead of importing features/ directly.
- `compare_emitters()` + `format_comparison_table()` — single full-sample side-by-side backtest with delta row when exactly 2 emitters.
- `run_walkforward_compare()` + `format_walkforward_table()` — slides a (train, test) window through the data, calls each emitter factory with the train slice, runs backtest on the test slice, aggregates by concatenating per-window trades and recomputing portfolio metrics.
- `rainier ml compare` CLI — composition root that wires BookScorer baseline + optional MLScorer (when `--model` is given) through compare or walk-forward.

```bash
rainier ml compare --csv data/csv/MES_1H.csv --symbol MES --timeframe 1H \
    --model models/pattern_scorer.json

rainier ml compare --csv data.csv --model model.json --walk-forward \
    --wf-train-bars 500 --wf-test-bars 100
```

## Module dependency rules (per CLAUDE.md)
- `signals/ml_emitter.py` imports only from `core/`, `analysis/`, `signals/` — clean.
- `ml/compare.py` imports `backtest.engine.run_backtest` + `compute_metrics` (forward dependency, not the disallowed reverse).
- `cli.py` remains the composition root.

## Walk-forward semantics (read carefully)
The CLI does NOT refit the ML model per fold. The model file is loaded once via `--model` and evaluated on each test window. Retraining is offline via `rainier ml train`. Lookahead leakage prevention rests on the training cut-off the operator chose when producing the model — pass a model trained strictly on data before the CSV's earliest test bar. The underlying `run_walkforward_compare` API does support per-fold refit (it calls a factory with the train slice each fold), but that's left as a future enhancement when we wire automated retraining.

## Test plan
- [x] Unit tests for `MLSignalEmitter` — protocol satisfaction, confidence/RR filtering, pinbar→PatternSignal conversion (9 tests).
- [x] Protocol contract test — `FeatureExtractor()` and the test fake both satisfy `FeatureExtractorProtocol`.
- [x] Unit tests for `compare_emitters` + `format_comparison_table` — multi-emitter shape, delta-only-when-2, three-emitter no delta (10 tests).
- [x] Unit tests for `run_walkforward_compare` — window count, default step=test_bars, window indices, factory train-slice isolation, multi-label aggregation, ValueError on empty/short/invalid (8 tests + 3 helpers).
- [x] CLI tests via CliRunner — baseline-only, model+baseline, walk-forward (both modes), missing-CSV failure (5 tests).
- [x] Full project test suite: `uv run pytest tests/ -q` — 726 passed, 3 skipped.
- [x] Lint clean: `uv run ruff check src/ tests/`.

## Review

Codex review: SKIPPED (rate-limited at 2026-05-09T20:08Z; usage limit lifts 2026-05-13T05:31). Two attempts, both returned `You've hit your usage limit`. Re-run `codex review --base main` after the limit clears if you want a second-model pass.

`/review` skill: 2 invocations. Iter 1 fixed a misleading docstring on the walk-forward CLI command (it implied per-fold model retraining). Iter 2 clean. Two consecutive clean runs.

## Out of scope (deferred)
- Per-fold ML model refit driven from the CLI (the engine API supports it; needs `ml train` to be reentrant).
- Per-feature-set comparison as a separate command (already supported by passing arbitrary scorer/feature combos through the `emitters` dict).