### PR TITLE
fix(scrapers/qu): recover from mid-iteration signin redirect (bottom100 timeout)

### DIFF
--- a/src/rainier/scrapers/qu/scraper.py
+++ b/src/rainier/scrapers/qu/scraper.py
@@ -319,6 +319,15 @@ class QUScraper(BaseScraper):
                 # Playwright stall on actionability checks until 30s timeout.
                 await self._wait_for_no_spinner()
 
+                # Mid-iteration auth check: the previous iteration's Search
+                # click can trigger a server-side redirect to /signin when the
+                # session cookie has expired silently. In that state, the
+                # `.select-button` toggle no longer exists on the page and
+                # clicking it stalls for the full default click timeout (30s),
+                # which is what was killing the midday + close cron runs.
+                # Recover by re-logging in and re-navigating before the click.
+                await self._recover_if_signin()
+
                 # Click toggle, then Search button (required per QU100 UI)
                 await page.click(button_sel)
                 search_btn = await page.query_selector(sel.SEARCH_BUTTON)
@@ -374,6 +383,39 @@ class QUScraper(BaseScraper):
             )
         except Exception as exc:
             self.log.warning("spinner_wait_timeout", error=str(exc))
+
+    async def _recover_if_signin(self) -> bool:
+        """If the page is on /signin, re-login and navigate back to QU100.
+
+        Returns True if recovery ran, False otherwise.
+
+        Background: between toggle iterations inside `_scrape_qu100`, the
+        previous Search click can produce a 401 from the API and cause the
+        SPA to redirect to /signin. The select-button toggle is then gone
+        from the DOM and the next iteration's `page.click(...)` hangs until
+        the default 30s timeout. This helper makes that path recoverable.
+        """
+        page = self._page
+        url = page.url or ""
+        if "signin" not in url:
+            return False
+
+        self.log.warning("mid_iter_signin_redirect", url=url)
+        await login(page)
+        await goto_with_retry(page, self._qu_config.url)
+        # After re-login, the Search button needs to be clicked again to
+        # repopulate the table. Wait for the button + table to be present.
+        try:
+            search_btn = await page.wait_for_selector(
+                sel.SEARCH_BUTTON, timeout=15000
+            )
+            if search_btn:
+                await search_btn.click()
+            await page.wait_for_selector(sel.QU100_TABLE, timeout=15000)
+        except Exception as exc:
+            self.log.warning("mid_iter_recover_failed", error=str(exc))
+        self.log.info("mid_iter_recovered")
+        return True
 
     async def _set_date(self, date_str: str) -> None:
         """Change the date picker to the given date and trigger search."""

--- a/tests/test_scrapers/test_cdp_auth.py
+++ b/tests/test_scrapers/test_cdp_auth.py
@@ -538,6 +538,104 @@ class TestScrapeQU100PostLogin:
         mock_login.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_signin_redirect_between_toggle_iterations_recovers(self):
+        """The Search click inside the top100 iteration can trigger a server-side
+        redirect to /signin (session expired silently). The next iteration's
+        toggle click must NOT fire blind — the scraper must detect the signin
+        URL, re-login, navigate back, and only then click the bottom100 toggle.
+
+        This is the production failure mode that kills 50% of cron runs:
+        - top100 Search → server 401 → page redirects to /signin
+        - `.select-button span:text-is('后100')` no longer exists on the page
+        - default 30s click timeout fires, scraper returns records_created=0
+        """
+        page, page_url = _make_mock_page(
+            url="https://www.quantunicorn.com/products#qu100"
+        )
+
+        # Track every page.click call so we can correlate URL vs. toggle clicks.
+        click_targets: list[str] = []
+
+        async def fake_click(selector, *args, **kwargs):
+            click_targets.append(selector)
+            # When the SEARCH button is clicked the first time, simulate the
+            # server redirecting the SPA to /signin (session expired silently).
+            if selector == sel.SEARCH_BUTTON and click_targets.count(sel.SEARCH_BUTTON) == 1:
+                page_url["value"] = (
+                    "https://www.quantunicorn.com/signin?next=%2Fproducts%23qu100"
+                )
+
+        page.click = AsyncMock(side_effect=fake_click)
+
+        # wait_for_selector returns truthy elements for everything.
+        page.wait_for_selector = AsyncMock(return_value=AsyncMock())
+        # query_selector for SEARCH_BUTTON returns a clickable element.
+        search_btn = AsyncMock()
+        search_btn.click = AsyncMock(side_effect=lambda: None)
+        page.query_selector = AsyncMock(return_value=search_btn)
+        page.get_attribute = AsyncMock(return_value="2026-04-09")
+        page.evaluate = AsyncMock(return_value=[
+            {"rank": "1", "symbol": "NVDA", "daily_change": "▲5",
+             "sector": "Tech", "industry": "Semi", "long_short": "多"}
+        ])
+
+        scraper = _make_scraper()
+        scraper._page = page
+
+        async def fake_goto(p, url):
+            # After re-login + navigate, URL settles on products again.
+            page_url["value"] = url
+
+        login_calls = {"n": 0}
+
+        async def fake_login(p):
+            # Login also returns us to the products URL.
+            login_calls["n"] += 1
+            page_url["value"] = "https://www.quantunicorn.com/products#qu100"
+
+        from datetime import datetime, timezone
+
+        from rainier.scrapers.base import ScrapeResult
+        result = ScrapeResult(scraper_name="qu", started_at=datetime.now(timezone.utc))
+
+        with (
+            patch("rainier.scrapers.qu.scraper.goto_with_retry",
+                  new_callable=AsyncMock, side_effect=fake_goto),
+            patch("rainier.scrapers.qu.scraper.login",
+                  new_callable=AsyncMock, side_effect=fake_login),
+            patch.object(scraper, "_persist_qu100", return_value=1),
+            # Stub the spinner wait so the test runs instantly.
+            patch.object(scraper, "_wait_for_no_spinner",
+                         new_callable=AsyncMock),
+        ):
+            await scraper._scrape_qu100(
+                "afternoon", datetime.now(timezone.utc), result
+            )
+
+        # Recovery happened: login was called at least once mid-scrape.
+        assert login_calls["n"] >= 1, (
+            "Scraper must re-login when session redirects mid-iteration; "
+            f"got login_calls={login_calls['n']}"
+        )
+
+        # Both toggle clicks were dispatched (no silent skip).
+        assert sel.TOP100_BUTTON in click_targets
+        assert sel.BOTTOM100_BUTTON in click_targets
+
+        # And critically: the bottom100 click was AFTER the recovery — i.e.
+        # the URL was on /products at the time of the bottom100 click. We
+        # encode that by asserting login fired BEFORE the bottom100 click.
+        bottom100_idx = click_targets.index(sel.BOTTOM100_BUTTON)
+        # Login is invoked by the scraper, not by page.click, so its presence
+        # is observed via login_calls. The structural assertion: at the time
+        # of bottom100 click, signin URL must have been resolved. Validate by
+        # checking that recovery (login) occurred AT LEAST ONCE before the
+        # iteration completed and bottom100 was reached.
+        assert bottom100_idx > click_targets.index(sel.SEARCH_BUTTON), (
+            "bottom100 must be clicked after the (recovering) Search click"
+        )
+
+    @pytest.mark.asyncio
     async def test_search_button_uses_wait_for_selector(self):
         """_scrape_qu100 uses wait_for_selector for Search button (PR #47 fix)."""
         page, page_url = _make_mock_page(

--- a/tests/test_scrapers/test_cdp_auth.py
+++ b/tests/test_scrapers/test_cdp_auth.py
@@ -558,26 +558,54 @@ class TestScrapeQU100PostLogin:
 
         async def fake_click(selector, *args, **kwargs):
             click_targets.append(selector)
-            # When the SEARCH button is clicked the first time, simulate the
-            # server redirecting the SPA to /signin (session expired silently).
-            if selector == sel.SEARCH_BUTTON and click_targets.count(sel.SEARCH_BUTTON) == 1:
+
+        page.click = AsyncMock(side_effect=fake_click)
+
+        # The Search button is obtained via wait_for_selector/query_selector
+        # and `.click()` is called on the handle (NOT page.click). The toggle
+        # iteration's Search click is what triggers the silent signin redirect.
+        search_btn = AsyncMock()
+        search_click_count = {"n": 0}
+
+        async def fake_search_click(*args, **kwargs):
+            search_click_count["n"] += 1
+            # The SECOND search click is the one inside the top100 toggle
+            # iteration (first was the initial table load). Simulate the
+            # server-side redirect to /signin happening then.
+            if search_click_count["n"] == 2:
                 page_url["value"] = (
                     "https://www.quantunicorn.com/signin?next=%2Fproducts%23qu100"
                 )
 
-        page.click = AsyncMock(side_effect=fake_click)
+        search_btn.click = AsyncMock(side_effect=fake_search_click)
 
-        # wait_for_selector returns truthy elements for everything.
-        page.wait_for_selector = AsyncMock(return_value=AsyncMock())
-        # query_selector for SEARCH_BUTTON returns a clickable element.
-        search_btn = AsyncMock()
-        search_btn.click = AsyncMock(side_effect=lambda: None)
+        # wait_for_selector returns the search button for SEARCH_BUTTON and a
+        # generic mock for everything else.
+        async def fake_wait_for_selector(selector, *args, **kwargs):
+            if selector == sel.SEARCH_BUTTON:
+                return search_btn
+            return AsyncMock()
+
+        page.wait_for_selector = AsyncMock(side_effect=fake_wait_for_selector)
+        # query_selector for SEARCH_BUTTON (inside the toggle loop) returns
+        # the same handle.
         page.query_selector = AsyncMock(return_value=search_btn)
         page.get_attribute = AsyncMock(return_value="2026-04-09")
-        page.evaluate = AsyncMock(return_value=[
-            {"rank": "1", "symbol": "NVDA", "daily_change": "▲5",
-             "sector": "Tech", "industry": "Semi", "long_short": "多"}
-        ])
+
+        # Make `evaluate` return a different first symbol on each call so the
+        # "table refresh" polling loop exits quickly instead of running its
+        # full 15s timeout (this is purely to keep the unit test fast).
+        eval_counter = {"n": 0}
+
+        async def fake_evaluate(*args, **kwargs):
+            eval_counter["n"] += 1
+            return [
+                {"rank": "1", "symbol": f"SYM{eval_counter['n']}",
+                 "daily_change": "▲5", "sector": "Tech",
+                 "industry": "Semi", "long_short": "多"}
+            ]
+
+        page.evaluate = AsyncMock(side_effect=fake_evaluate)
 
         scraper = _make_scraper()
         scraper._page = page
@@ -618,21 +646,21 @@ class TestScrapeQU100PostLogin:
             f"got login_calls={login_calls['n']}"
         )
 
-        # Both toggle clicks were dispatched (no silent skip).
+        # Both toggle clicks were dispatched (no silent skip on bottom100).
         assert sel.TOP100_BUTTON in click_targets
         assert sel.BOTTOM100_BUTTON in click_targets
 
-        # And critically: the bottom100 click was AFTER the recovery — i.e.
-        # the URL was on /products at the time of the bottom100 click. We
-        # encode that by asserting login fired BEFORE the bottom100 click.
-        bottom100_idx = click_targets.index(sel.BOTTOM100_BUTTON)
-        # Login is invoked by the scraper, not by page.click, so its presence
-        # is observed via login_calls. The structural assertion: at the time
-        # of bottom100 click, signin URL must have been resolved. Validate by
-        # checking that recovery (login) occurred AT LEAST ONCE before the
-        # iteration completed and bottom100 was reached.
-        assert bottom100_idx > click_targets.index(sel.SEARCH_BUTTON), (
-            "bottom100 must be clicked after the (recovering) Search click"
+        # And critically: the bottom100 toggle came AFTER top100 in dispatch
+        # order — the scraper didn't bail out after the signin redirect.
+        # Recovery returned control to the loop and let it continue.
+        assert click_targets.index(sel.TOP100_BUTTON) < click_targets.index(
+            sel.BOTTOM100_BUTTON
+        ), f"toggle order broken: {click_targets}"
+
+        # And the recorded error list on the result must NOT contain a
+        # bottom100 click failure — the recovery should have prevented it.
+        assert not any("bottom100" in e for e in result.errors), (
+            f"bottom100 should not fail after recovery; errors={result.errors}"
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes the 50% cron failure rate for QU100 midday + close scrapes. The bottom100 toggle click was hitting Playwright's 30s default timeout because the page had silently been redirected to `/signin` mid-scrape (the QU100 `.select-button` toggle no longer existed on the DOM).

## Root cause

Reproduced locally with a warm CDP Chrome session via `scripts`-style probes:

1. The QuantUnicorn `session` cookie has a short rolling expiration (~30-120 min).
2. The page's HTML render of `/products#qu100` succeeds with an expired session (the SPA boots and renders the cached table).
3. When the scraper clicks Search, the resulting `/api` call returns 401 and the SPA does an in-app redirect to `/signin?next=/products%23qu100`. The entire `.qu100` DOM (including `.select-button` toggles) is replaced by the signin form.
4. The bottom100 click then waits forever on `.select-button span:text-is('后100')` — element no longer exists.
5. Default `page.click` timeout (30s) fires; `qu100_failed` logged; scrape ends with `records_created=0`, so the post-scrape Discord post is also skipped (`cli.py:1278` guard).

Signature in `data/qu-scrape.log`: `top100 rows=0` (extracted from a stale or now-signin DOM) followed by 30s click timeout on `后100`. Failures cluster on warm-Chrome runs (midday 10:45, close 15:00) where the session has aged ~2 hours past the last fresh login.

## Fix

Surgical addition in `src/rainier/scrapers/qu/scraper.py`:

- New `_recover_if_signin()` helper that detects `/signin` in `page.url`, re-logs in, navigates back to QU100, and clicks Search to repopulate the table.
- Called immediately before each toggle's `page.click()` in `_scrape_qu100`'s iteration loop — between the existing `_wait_for_no_spinner()` and the toggle click.
- Best-effort post-login Search click is wrapped in try/except — a stuck recovery won't propagate beyond the iteration's outer `try/except`, matching the existing failure-mode pattern.

The change is one new helper (~30 lines) and one new call site. BrowserManager and other scrapers are untouched.

## Tests

- New regression test `test_signin_redirect_between_toggle_iterations_recovers` in `tests/test_scrapers/test_cdp_auth.py` simulates the exact failure: the second Search click flips the mock URL to `/signin`, the test asserts the scraper re-logs in and continues to dispatch the bottom100 toggle without entering the click timeout.
- All existing scraper tests still green: `uv run pytest tests/ -v` — 727 passed, 3 skipped.
- `uv run ruff check src/ tests/` — clean.

## Manual verification

Two back-to-back `uv run rainier scrape qu --session midday --cdp http://127.0.0.1:9222` against warm Chrome:
- Run 1: `records_created=200` (triggered the upfront login path).
- Run 2: `records_created=200` in 2 seconds (warm session, no redirect needed).

Acceptance criterion (`records_created>0` for two consecutive warm-Chrome scrapes) met.

## Review status

- `/review` GATE: PASS — initial structured pass + adversarial self-pass returned no P0/P1.
- `codex review`: SKIPPED (rate-limited at 2026-05-12T17:04:37Z; reset May 13 05:31). Per dispatch contract §4, /review remains the load-bearing reviewer; codex was best-effort.

## Test plan

- [x] Unit test reproduces the failure on parent commit and passes on fix commit.
- [x] All existing tests pass.
- [x] `ruff check` clean.
- [x] Two consecutive `rainier scrape qu` runs against warm Chrome both succeed with `records_created>0`.
- [ ] Next cron cycle (midday 10:45 / close 15:00) succeeds end-to-end and posts the QU100 Discord update. (Cannot verify in this session; will be observable in `data/qu-scrape.log` over the next 24 hours.)