### PR TITLE
feat(pipeline): extract shared post-scrape pipeline — fires LLM thesis from cron CLI path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ src/rainier/
 ├── alerts/         discord.py (webhook notifications)
 ├── reports/        daily.py (daily review + next-day outlook)
 ├── scheduler/      jobs.py (cron.yaml → system crontab), service.py (APScheduler for scraping)
+├── pipeline/       post_scrape.py (shared screen→persist→LLM thesis→Discord, used by cron CLI + scheduler)
 ├── trader/         (Phase 3 placeholder — IB TWS execution)
 └── dashboard/      (placeholder — Streamlit)
 ```

--- a/src/rainier/alerts/discord.py
+++ b/src/rainier/alerts/discord.py
@@ -798,6 +798,7 @@ def send_stock_candidates(
     theses: dict[str, dict] | None = None,
     *,
     dashboard_base_url: str | None = None,
+    session: str | None = None,
 ) -> None:
     """Send QU100 stock candidate alerts to Discord.
 
@@ -813,6 +814,11 @@ def send_stock_candidates(
         dashboard_base_url: Public URL of the Streamlit dashboard. When set
             and the thesis dict carries ``_thesis_id``, the embed title
             links to ``<base>?thesis_id=<id>``. None disables the link.
+        session: Scrape session label ("morning" | "midday" | "afternoon" |
+            "close"). When set, the summary embed title gets a `—
+            Morning/Midday/Afternoon/Close` suffix so operators can tell
+            multiple same-day scans apart in the stock channel. ``None``
+            preserves the legacy session-less title.
     """
     if not candidates:
         return
@@ -825,7 +831,7 @@ def send_stock_candidates(
         log.warning("discord_no_webhook_url")
         return
 
-    payloads = _build_payloads(candidates)
+    payloads = _build_payloads(candidates, session=session)
 
     for payload in payloads:
         try:

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1204,6 +1204,7 @@ def qu(ctx, session, detail_top, dates, days_back, start_date, delay, headed, cd
 
 
 async def _run_qu_scrape(session, detail_top, dates, days_back, start_date, delay, headed, cdp):
+    import asyncio
     from datetime import date, datetime, timedelta
 
     from rainier.core.config import get_settings
@@ -1281,8 +1282,37 @@ async def _run_qu_scrape(session, detail_top, dates, days_back, start_date, dela
         # settings.llm_thesis.enabled_sessions. Skip during backfill runs
         # (date_list is set) since those replay historical scans and would
         # spam the channel.
+        #
+        # Hand off via asyncio.to_thread because compute_theses_and_persist
+        # wraps its async work in asyncio.run(); calling it directly from this
+        # already-running event loop raises RuntimeError. The shared pipeline
+        # is sync (mirrors the scheduler hand-off in scheduler/service.py).
+        #
+        # Wrap in try/except so a screener / pipeline failure POST scrape
+        # surfaces as a partial-success warning rather than morphing the
+        # already-successful scrape into a red "Scrape FAILED" alert. The
+        # outer except is for actual scrape errors only.
         if result.records_created > 0 and not date_list:
-            run_post_scrape_pipeline(settings, session)
+            try:
+                await asyncio.to_thread(
+                    run_post_scrape_pipeline, settings, session,
+                )
+            except Exception as pipeline_exc:
+                err_msg = str(pipeline_exc)
+                if len(err_msg) > 400:
+                    err_msg = err_msg[:400] + "..."
+                click.echo(
+                    f"  Post-scrape pipeline failed: {err_msg}", err=True,
+                )
+                _notify_scrape_discord(
+                    settings, session,
+                    title=f"QU100 Post-Scrape FAILED ({session})",
+                    message=(
+                        f"Scrape succeeded but post-scrape pipeline failed:\n"
+                        f"{err_msg}"
+                    ),
+                    color=0xFFA500,  # orange — partial success
+                )
 
     except Exception as exc:
         error_msg = str(exc)

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from rainier.core.config import load_settings
 from rainier.core.types import Timeframe
+from rainier.pipeline.post_scrape import run_post_scrape_pipeline
 
 
 @click.group()
@@ -1274,9 +1275,14 @@ async def _run_qu_scrape(session, detail_top, dates, days_back, start_date, dela
                 color=0xFFA500,  # orange
             )
 
-        # Post-scrape: run screener and send actionable setups to Discord
+        # Post-scrape: delegate to the shared pipeline so the cron CLI path
+        # emits the same Discord output as the long-running ``rainier run``
+        # scheduler — including the LLM thesis embeds for sessions in
+        # settings.llm_thesis.enabled_sessions. Skip during backfill runs
+        # (date_list is set) since those replay historical scans and would
+        # spam the channel.
         if result.records_created > 0 and not date_list:
-            _post_scrape_screener(settings, session)
+            run_post_scrape_pipeline(settings, session)
 
     except Exception as exc:
         error_msg = str(exc)
@@ -1322,52 +1328,6 @@ def _notify_scrape_discord(
         click.echo(f"  Discord notification sent: {title}")
     except Exception as notify_exc:
         click.echo(f"  Failed to send Discord notification: {notify_exc}")
-
-
-def _post_scrape_screener(settings, session: str) -> None:
-    """Run stock screener after successful scrape and send results to Discord."""
-    import httpx
-
-    from rainier.alerts.discord import _build_payloads
-    from rainier.analysis.stock_screener import screen_stocks
-
-    webhook = _get_discord_webhook(settings)
-    if not webhook:
-        click.echo("  (no Discord webhook, skipping screener alert)")
-        return
-
-    click.echo("Running post-scrape stock screener...")
-    try:
-        candidates, _ohlcv = screen_stocks(settings)
-        candidates = candidates[:20]
-    except Exception as exc:
-        click.echo(f"  Screener failed: {exc}")
-        _notify_scrape_discord(
-            settings, session,
-            title=f"QU100 Screener FAILED ({session})",
-            message=f"Scrape succeeded but screener failed:\n{str(exc)[:400]}",
-            color=0xFF1744,
-        )
-        return
-
-    if not candidates:
-        click.echo("  Screener returned 0 candidates")
-        return
-
-    with_pattern = sum(1 for c in candidates if c.pattern_type)
-    click.echo(
-        f"  Screener: {len(candidates)} candidates "
-        f"({with_pattern} with pattern match)"
-    )
-
-    try:
-        payloads = _build_payloads(candidates, session=session)
-        for payload in payloads:
-            resp = httpx.post(webhook, json=payload, timeout=10)
-            resp.raise_for_status()
-        click.echo(f"  Screener results sent to Discord ({session})")
-    except Exception as exc:
-        click.echo(f"  Failed to send screener results: {exc}")
 
 
 @scrape.command(name="qu-detail")

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2317,6 +2317,10 @@ def thesis_daily(ctx, session_name, top_n, discord, dry_run, max_usd):
         # PR5: pipe the dashboard base URL through so embed titles get a
         # clickable deep-link. None disables the link.
         dashboard_base_url=settings.llm_thesis.dashboard_base_url,
+        # iter-2: forward session so the summary embed title carries the
+        # `— Morning/Midday/Afternoon/Close` suffix when multiple scans
+        # land in the same channel on the same day.
+        session=session_name,
     )
     click.echo(f"Sent {len(theses)} theses + summary to Discord.")
 

--- a/src/rainier/pipeline/__init__.py
+++ b/src/rainier/pipeline/__init__.py
@@ -1,0 +1,17 @@
+"""Shared post-scrape pipeline glue.
+
+The ``pipeline`` package hosts orchestration helpers that compose multiple
+domain modules (analysis, llm_thesis, alerts) into a single callable.
+Domain modules themselves stay free of cross-imports — this layer is the
+composition point.
+
+Currently exposes:
+
+* :func:`rainier.pipeline.post_scrape.run_post_scrape_pipeline` — used by
+  both ``rainier scrape qu`` (cron CLI path) and the long-running
+  ``rainier run`` scheduler service.
+"""
+
+from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+__all__ = ["run_post_scrape_pipeline"]

--- a/src/rainier/pipeline/post_scrape.py
+++ b/src/rainier/pipeline/post_scrape.py
@@ -62,6 +62,8 @@ def run_post_scrape_pipeline(settings: Settings, session_name: str) -> None:
     Returns:
         None. Logs structured events at each step boundary.
     """
+    log.info("post_scrape_pipeline_starting", session=session_name)
+
     # 1. Screener — pure function, returns the inputs for everything below.
     all_candidates, ohlcv_by_symbol = screen_stocks(settings)
 
@@ -73,6 +75,13 @@ def run_post_scrape_pipeline(settings: Settings, session_name: str) -> None:
     candidates = all_candidates[:20]
 
     scan_date = date.today()
+    log.info(
+        "post_scrape_screener_done",
+        session=session_name,
+        total_candidates=len(all_candidates),
+        persist_window=len(scan_candidates),
+        discord_window=len(candidates),
+    )
 
     # 2. Persist top-50. Wrapped in try/except so a DB blip doesn't block the
     # Discord post — losing a row of telemetry is recoverable; losing the
@@ -95,11 +104,20 @@ def run_post_scrape_pipeline(settings: Settings, session_name: str) -> None:
     # but we slice here too so the call signature matches the historic
     # service.py contract and so the test layer can assert on the slice.
     theses: dict[str, dict] = {}
-    if (
+    llm_gate_open = (
         settings.llm_thesis.enabled
         and session_name in settings.llm_thesis.enabled_sessions
-        and candidates
-    ):
+        and bool(candidates)
+    )
+    log.info(
+        "post_scrape_llm_gate",
+        session=session_name,
+        gate_open=llm_gate_open,
+        thesis_enabled=settings.llm_thesis.enabled,
+        session_in_allowlist=session_name in settings.llm_thesis.enabled_sessions,
+        has_candidates=bool(candidates),
+    )
+    if llm_gate_open:
         try:
             theses = compute_theses_and_persist(
                 candidates[:5],
@@ -124,4 +142,10 @@ def run_post_scrape_pipeline(settings: Settings, session_name: str) -> None:
         settings.alerts.discord,
         theses=theses or None,
         dashboard_base_url=settings.llm_thesis.dashboard_base_url,
+    )
+    log.info(
+        "post_scrape_pipeline_done",
+        session=session_name,
+        discord_sent=len(candidates),
+        theses_attached=len(theses),
     )

--- a/src/rainier/pipeline/post_scrape.py
+++ b/src/rainier/pipeline/post_scrape.py
@@ -1,0 +1,127 @@
+"""Post-scrape pipeline shared by the CLI and the APScheduler service.
+
+This is the single source of truth for what happens AFTER a successful
+QU100 scrape, regardless of how that scrape was triggered:
+
+    screen_stocks      -> 3-layer screener (returns candidates + ohlcv)
+    persist top-50     -> shadow-validation dataset (PR2 carry-over)
+    LLM thesis top-5   -> only on sessions in `enabled_sessions`
+    Discord top-20     -> rich per-ticker embeds when theses dict is non-empty
+
+Before this module existed, the CLI path (``rainier scrape qu``, called
+from cron) only ran the regular top-20 screener post — the LLM thesis
+embeds shipped via PR4/PR5 only fired from the ``rainier run`` daemon.
+Centralising the post-scrape steps here means the cron-driven path and
+the long-running scheduler emit identical Discord output.
+
+The function is synchronous: the CLI calls it directly (the CLI's own
+async wrapper is one-shot, so blocking is fine), and the scheduler wraps
+the whole call in a single ``asyncio.to_thread`` rather than per-step
+threading.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import structlog
+
+from rainier.alerts.discord import send_stock_candidates
+from rainier.analysis.stock_screener import screen_stocks
+from rainier.core.config import Settings
+from rainier.llm_thesis.persistence import persist_screened_stocks
+from rainier.llm_thesis.service import compute_theses_and_persist
+
+log = structlog.get_logger()
+
+
+def run_post_scrape_pipeline(settings: Settings, session_name: str) -> None:
+    """Execute the post-scrape pipeline for one session.
+
+    Steps (mirrors the pre-extraction service.py block verbatim):
+
+    1. ``screen_stocks(settings)`` — returns ``(all_candidates, ohlcv_by_symbol)``.
+    2. ``persist_screened_stocks(top-50)`` — write a DB row per candidate so the
+       30-day shadow validation has an unbiased dataset. Top-20 alone biases
+       per-rank correlation toward the upper tail. Failures are logged and
+       swallowed — persistence must not block the Discord post.
+    3. If ``settings.llm_thesis.enabled`` AND ``session_name`` is in
+       ``settings.llm_thesis.enabled_sessions`` AND there are candidates,
+       call ``compute_theses_and_persist`` on the top-5. Failures fall back
+       to an empty ``theses`` dict so the regular top-20 post still goes out.
+    4. ``send_stock_candidates(top-20, theses or None, dashboard_base_url)`` —
+       Discord display set is always top-20; passing ``theses=None`` triggers
+       the legacy top-20-only embed; passing a non-empty dict adds the
+       per-ticker thesis embeds shipped in PR5.
+
+    Args:
+        settings: Already-loaded ``Settings``. Caller is responsible for
+            calling ``load_settings_fresh()`` if it wants hot-reloaded YAML.
+        session_name: ``"morning" | "midday" | "afternoon" | "close"``.
+
+    Returns:
+        None. Logs structured events at each step boundary.
+    """
+    # 1. Screener — pure function, returns the inputs for everything below.
+    all_candidates, ohlcv_by_symbol = screen_stocks(settings)
+
+    # Three windows on the same sorted list:
+    #   - top-50 -> persistence (unbiased shadow dataset)
+    #   - top-20 -> Discord display
+    #   - top-5  -> LLM thesis (expensive; per-call cost cap)
+    scan_candidates = all_candidates[:50]
+    candidates = all_candidates[:20]
+
+    scan_date = date.today()
+
+    # 2. Persist top-50. Wrapped in try/except so a DB blip doesn't block the
+    # Discord post — losing a row of telemetry is recoverable; losing the
+    # operator's alert isn't.
+    try:
+        persist_screened_stocks(
+            scan_candidates,
+            scan_date=scan_date,
+            session_name=session_name,
+        )
+    except Exception as exc:
+        log.error(
+            "persist_screened_stocks_failed",
+            session=session_name,
+            error=str(exc),
+        )
+
+    # 3. LLM thesis — gated by enabled flag + session allowlist + non-empty
+    # candidates. compute_theses_and_persist itself enforces the top-5 cap,
+    # but we slice here too so the call signature matches the historic
+    # service.py contract and so the test layer can assert on the slice.
+    theses: dict[str, dict] = {}
+    if (
+        settings.llm_thesis.enabled
+        and session_name in settings.llm_thesis.enabled_sessions
+        and candidates
+    ):
+        try:
+            theses = compute_theses_and_persist(
+                candidates[:5],
+                ohlcv_by_symbol,
+                scan_date=scan_date,
+                session_name=session_name,
+                settings=settings,
+            )
+        except Exception as exc:
+            log.error(
+                "compute_theses_unexpected_failure",
+                session=session_name,
+                error=str(exc),
+            )
+            theses = {}
+
+    # 4. Discord. ``theses or None`` preserves the legacy top-20-only path
+    # when theses is empty (gate disabled, or compute failed). dashboard URL
+    # is forwarded so the PR5 per-ticker embeds can deep-link into Streamlit.
+    send_stock_candidates(
+        candidates,
+        settings.alerts.discord,
+        theses=theses or None,
+        dashboard_base_url=settings.llm_thesis.dashboard_base_url,
+    )

--- a/src/rainier/pipeline/post_scrape.py
+++ b/src/rainier/pipeline/post_scrape.py
@@ -137,11 +137,16 @@ def run_post_scrape_pipeline(settings: Settings, session_name: str) -> None:
     # 4. Discord. ``theses or None`` preserves the legacy top-20-only path
     # when theses is empty (gate disabled, or compute failed). dashboard URL
     # is forwarded so the PR5 per-ticker embeds can deep-link into Streamlit.
+    # ``session=session_name`` restores the session-label suffix on the
+    # summary embed title that the pre-extraction CLI used (via
+    # _build_payloads(candidates, session=session)) — without it, the four
+    # daily scans become indistinguishable in the channel.
     send_stock_candidates(
         candidates,
         settings.alerts.discord,
         theses=theses or None,
         dashboard_base_url=settings.llm_thesis.dashboard_base_url,
+        session=session_name,
     )
     log.info(
         "post_scrape_pipeline_done",

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -4,49 +4,25 @@ from __future__ import annotations
 
 import asyncio
 import signal
-from datetime import date
 
 import structlog
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
 from rainier.core.config import get_settings, load_settings_fresh
+from rainier.pipeline.post_scrape import run_post_scrape_pipeline
 
 log = structlog.get_logger()
-
-
-def _send_stock_candidates_with_dashboard_url(
-    candidates,
-    discord_config,
-    theses,
-    dashboard_base_url,
-):
-    """Sync helper so ``asyncio.to_thread`` can carry the dashboard URL kwarg.
-
-    ``send_stock_candidates`` accepts ``dashboard_base_url`` only as a keyword
-    argument; ``asyncio.to_thread`` forwards positional + keyword args but is
-    cleaner with a small wrapper that names them.
-    """
-    from rainier.alerts.discord import send_stock_candidates as _send
-
-    _send(
-        candidates,
-        discord_config,
-        theses=theses,
-        dashboard_base_url=dashboard_base_url,
-    )
 
 
 async def run_qu_scrape(session_name: str) -> None:
     """Run a single QU100 scrape for the given session. Called by APScheduler.
 
-    Pipeline (post-scrape):
-        1. load_settings_fresh — pick up YAML toggles (eng review D2)
-        2. screen_stocks       — 3-layer screener; returns (candidates, ohlcv)
-        3. persist_screened_stocks — DB row for every candidate, every session
-        4. compute_theses_and_persist — LLM thesis on top-5, only on
-           sessions in `settings.llm_thesis.enabled_sessions`
-        5. send_stock_candidates — Discord; theses dict empty for non-LLM sessions
+    After the scrape itself succeeds, the post-scrape pipeline (screen ->
+    persist -> LLM thesis -> Discord) is delegated to
+    :func:`rainier.pipeline.post_scrape.run_post_scrape_pipeline` — the same
+    function the cron CLI path uses, so both entry points emit identical
+    Discord output.
     """
     from rainier.scrapers import get_scraper
     from rainier.scrapers.browser import BrowserManager
@@ -73,76 +49,11 @@ async def run_qu_scrape(session_name: str) -> None:
         from rainier.notifications.notifier import notify_scrape_result
         notify_scrape_result(session_name, result)
 
-        # 1. Reload settings every scan so YAML toggles take effect (D2).
+        # Reload settings every scan so YAML toggles take effect (D2). The
+        # shared pipeline is sync — we hand off in a single to_thread call
+        # rather than threading each sub-step.
         settings = await asyncio.to_thread(load_settings_fresh)
-
-        # 2. Screener — refactored to return (candidates, ohlcv_dict).
-        # send_stock_candidates is invoked indirectly via
-        # _send_stock_candidates_with_dashboard_url so we don't need it
-        # imported in this scope.
-        from rainier.analysis.stock_screener import screen_stocks
-
-        all_candidates, ohlcv_by_symbol = await asyncio.to_thread(
-            screen_stocks, settings
-        )
-        # PR2 carry-over P2 #3: persist top-50 (or all if fewer) to give the
-        # 30-day shadow validation an unbiased dataset. Top-20 alone biases
-        # the per-rank correlation toward the upper tail. Discord still gets
-        # top-20 (display rule), and the LLM still only runs on top-5.
-        scan_candidates = all_candidates[:50]
-        candidates = all_candidates[:20]  # Discord display set
-
-        scan_date = date.today()
-
-        # 3. Always persist screener output for every scan — full top-50, not
-        #    only the Discord set.
-        try:
-            from rainier.llm_thesis.persistence import persist_screened_stocks
-            await asyncio.to_thread(
-                persist_screened_stocks,
-                scan_candidates,
-                scan_date=scan_date,
-                session_name=session_name,
-            )
-        except Exception as exc:
-            log.error(
-                "persist_screened_stocks_failed",
-                session=session_name,
-                error=str(exc),
-            )
-
-        # 4. LLM thesis ONLY on configured sessions (afternoon + close).
-        theses: dict[str, dict] = {}
-        if (
-            settings.llm_thesis.enabled
-            and session_name in settings.llm_thesis.enabled_sessions
-            and candidates
-        ):
-            try:
-                from rainier.llm_thesis.service import compute_theses_and_persist
-                theses = await asyncio.to_thread(
-                    compute_theses_and_persist,
-                    candidates[:5],
-                    ohlcv_by_symbol,
-                    scan_date=scan_date,
-                    session_name=session_name,
-                    settings=settings,
-                )
-            except Exception as exc:
-                log.error("compute_theses_unexpected_failure", error=str(exc))
-                theses = {}
-
-        # 5. Discord — empty theses dict means existing top-20-only behavior.
-        # PR5: pass the dashboard base URL through so per-ticker embeds carry
-        # a clickable deep-link to the Streamlit dashboard. None disables the
-        # link (graceful degradation when the dashboard isn't running).
-        await asyncio.to_thread(
-            _send_stock_candidates_with_dashboard_url,
-            candidates,
-            settings.alerts.discord,
-            theses or None,
-            settings.llm_thesis.dashboard_base_url,
-        )
+        await asyncio.to_thread(run_post_scrape_pipeline, settings, session_name)
 
     except Exception as exc:
         log.error("scheduled_scrape_failed", session=session_name, error=str(exc))

--- a/tests/test_pipeline/test_post_scrape.py
+++ b/tests/test_pipeline/test_post_scrape.py
@@ -1,0 +1,521 @@
+"""Tests for the shared post-scrape pipeline used by both CLI and scheduler.
+
+This module is the single source of truth for the steps that happen AFTER
+a successful QU scrape:
+
+    screen_stocks -> persist top-50 -> (LLM thesis on top-5 if session is
+    in enabled_sessions) -> Discord send_stock_candidates(top-20)
+
+Both ``rainier scrape qu`` (CLI / cron path) and the long-running
+``rainier run`` scheduler delegate here so the LLM thesis embeds reach
+DISCORD_STOCK_WEBHOOK_URL regardless of how the scrape was triggered.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rainier.core.config import (
+    AlertsConfig,
+    AppConfig,
+    DiscordConfig,
+    LLMThesisConfig,
+    ScrapingConfig,
+    ScrapingSchedule,
+    Settings,
+)
+from rainier.core.types import StockCandidate
+
+
+def _make_settings(
+    *,
+    llm_enabled: bool = True,
+    enabled_sessions: tuple[str, ...] = ("afternoon", "close"),
+    dashboard_base_url: str | None = "https://dash.example.com",
+) -> Settings:
+    """Build a Settings object exercising the LLM thesis fields the pipeline
+    inspects.
+    """
+    return Settings(
+        database_url="postgresql://test:test@localhost/test",
+        app=AppConfig(timezone="America/Los_Angeles"),
+        scraping=ScrapingConfig(
+            schedule=ScrapingSchedule(
+                morning="08:35",
+                midday="10:35",
+                afternoon="12:35",
+                close="14:35",
+            )
+        ),
+        alerts=AlertsConfig(
+            discord=DiscordConfig(webhook_url="https://x/y", enabled=True),
+        ),
+        llm_thesis=LLMThesisConfig(
+            enabled=llm_enabled,
+            model="test",
+            max_usd_per_scan=1.0,
+            enabled_sessions=list(enabled_sessions),
+            dashboard_base_url=dashboard_base_url,
+        ),
+    )
+
+
+def _candidates(n: int) -> list[StockCandidate]:
+    return [
+        StockCandidate(
+            symbol=f"S{i:03d}",
+            rank=i + 1,
+            rank_change=0,
+            long_short="Long in",
+            capital_flow_direction="+",
+            sector="Technology",
+            signal_strength=1.0 - i * 0.001,
+        )
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Module / function existence — guards against the file being deleted or the
+# public entry point being renamed.
+# ---------------------------------------------------------------------------
+
+
+def test_module_exposes_run_post_scrape_pipeline():
+    from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+    assert callable(run_post_scrape_pipeline)
+
+
+# ---------------------------------------------------------------------------
+# Session gating (the core regression this PR fixes).
+# ---------------------------------------------------------------------------
+
+
+class TestSessionGating:
+    """LLM thesis fires only on sessions in ``llm_thesis.enabled_sessions``."""
+
+    def test_morning_session_skips_llm_but_still_sends_screener(self):
+        """Morning is NOT in enabled_sessions by default — LLM must not run,
+        but the regular screener post still goes out so the QU100 channel
+        gets the top-20 summary.
+        """
+        cands = _candidates(25)
+        settings = _make_settings()
+
+        with (
+            patch(
+                "rainier.pipeline.post_scrape.screen_stocks",
+                return_value=(cands, {}),
+            ),
+            patch(
+                "rainier.pipeline.post_scrape.persist_screened_stocks"
+            ) as mock_persist,
+            patch(
+                "rainier.pipeline.post_scrape.compute_theses_and_persist"
+            ) as mock_llm,
+            patch(
+                "rainier.pipeline.post_scrape.send_stock_candidates"
+            ) as mock_discord,
+        ):
+            from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+            run_post_scrape_pipeline(settings, "morning")
+
+        mock_llm.assert_not_called()
+        mock_discord.assert_called_once()
+        # Discord display set is top-20 regardless of session.
+        sent = mock_discord.call_args.args[0]
+        assert len(sent) == 20
+        # theses kwarg is None when LLM didn't run.
+        assert mock_discord.call_args.kwargs.get("theses") is None
+        # Persist still got top-50 (or all if fewer).
+        mock_persist.assert_called_once()
+        persisted = mock_persist.call_args.args[0]
+        assert len(persisted) == min(50, len(cands))
+
+    def test_afternoon_session_fires_llm_on_top_5(self):
+        cands = _candidates(25)
+        ohlcv = {c.symbol: MagicMock() for c in cands}
+        settings = _make_settings()
+
+        with (
+            patch(
+                "rainier.pipeline.post_scrape.screen_stocks",
+                return_value=(cands, ohlcv),
+            ),
+            patch("rainier.pipeline.post_scrape.persist_screened_stocks"),
+            patch(
+                "rainier.pipeline.post_scrape.compute_theses_and_persist",
+                return_value={"S000": {"verdict": "setup_long"}},
+            ) as mock_llm,
+            patch(
+                "rainier.pipeline.post_scrape.send_stock_candidates"
+            ) as mock_discord,
+        ):
+            from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+            run_post_scrape_pipeline(settings, "afternoon")
+
+        mock_llm.assert_called_once()
+        # compute_theses_and_persist receives top-5 candidates only.
+        llm_args = mock_llm.call_args.args
+        assert len(llm_args[0]) == 5
+        # And the OHLCV map is forwarded so it can build charts.
+        assert llm_args[1] is ohlcv
+        # Discord call carries theses dict + dashboard URL.
+        assert mock_discord.call_args.kwargs.get("theses") == {
+            "S000": {"verdict": "setup_long"}
+        }
+        assert (
+            mock_discord.call_args.kwargs.get("dashboard_base_url")
+            == "https://dash.example.com"
+        )
+
+    def test_close_session_fires_llm(self):
+        cands = _candidates(10)
+        settings = _make_settings()
+
+        with (
+            patch(
+                "rainier.pipeline.post_scrape.screen_stocks",
+                return_value=(cands, {}),
+            ),
+            patch("rainier.pipeline.post_scrape.persist_screened_stocks"),
+            patch(
+                "rainier.pipeline.post_scrape.compute_theses_and_persist",
+                return_value={},
+            ) as mock_llm,
+            patch("rainier.pipeline.post_scrape.send_stock_candidates"),
+        ):
+            from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+            run_post_scrape_pipeline(settings, "close")
+
+        mock_llm.assert_called_once()
+
+    def test_llm_globally_disabled_skips_even_on_afternoon(self):
+        """If ``settings.llm_thesis.enabled`` is False the LLM never runs
+        regardless of session — the kill switch must be respected."""
+        cands = _candidates(10)
+        settings = _make_settings(llm_enabled=False)
+
+        with (
+            patch(
+                "rainier.pipeline.post_scrape.screen_stocks",
+                return_value=(cands, {}),
+            ),
+            patch("rainier.pipeline.post_scrape.persist_screened_stocks"),
+            patch(
+                "rainier.pipeline.post_scrape.compute_theses_and_persist"
+            ) as mock_llm,
+            patch("rainier.pipeline.post_scrape.send_stock_candidates"),
+        ):
+            from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+            run_post_scrape_pipeline(settings, "afternoon")
+
+        mock_llm.assert_not_called()
+
+    def test_empty_candidates_skips_llm_block(self):
+        """Screener returned nothing — no LLM call, no Discord call."""
+        settings = _make_settings()
+
+        with (
+            patch(
+                "rainier.pipeline.post_scrape.screen_stocks",
+                return_value=([], {}),
+            ),
+            patch(
+                "rainier.pipeline.post_scrape.persist_screened_stocks"
+            ) as mock_persist,
+            patch(
+                "rainier.pipeline.post_scrape.compute_theses_and_persist"
+            ) as mock_llm,
+            patch(
+                "rainier.pipeline.post_scrape.send_stock_candidates"
+            ) as mock_discord,
+        ):
+            from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+            run_post_scrape_pipeline(settings, "afternoon")
+
+        mock_llm.assert_not_called()
+        # send_stock_candidates short-circuits on empty input — see
+        # alerts/discord.py:send_stock_candidates. Either it isn't called,
+        # or it's called with an empty list. Both are valid.
+        if mock_discord.called:
+            assert mock_discord.call_args.args[0] == []
+        # Persist still called for empty list (with [] — no rows to write).
+        mock_persist.assert_called_once()
+        assert mock_persist.call_args.args[0] == []
+
+
+# ---------------------------------------------------------------------------
+# Slicing — persistence/Discord/LLM see different windows.
+# ---------------------------------------------------------------------------
+
+
+class TestSlicing:
+    def test_persist_top_50_discord_top_20_llm_top_5(self):
+        """Mirrors the service.py contract: persist 50, Discord 20, LLM 5."""
+        cands = _candidates(80)
+        settings = _make_settings()
+
+        with (
+            patch(
+                "rainier.pipeline.post_scrape.screen_stocks",
+                return_value=(cands, {}),
+            ),
+            patch(
+                "rainier.pipeline.post_scrape.persist_screened_stocks"
+            ) as mock_persist,
+            patch(
+                "rainier.pipeline.post_scrape.compute_theses_and_persist",
+                return_value={},
+            ) as mock_llm,
+            patch(
+                "rainier.pipeline.post_scrape.send_stock_candidates"
+            ) as mock_discord,
+        ):
+            from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+            run_post_scrape_pipeline(settings, "afternoon")
+
+        assert len(mock_persist.call_args.args[0]) == 50
+        assert len(mock_discord.call_args.args[0]) == 20
+        assert len(mock_llm.call_args.args[0]) == 5
+
+    def test_fewer_than_5_candidates_llm_sees_all(self):
+        cands = _candidates(3)
+        settings = _make_settings()
+
+        with (
+            patch(
+                "rainier.pipeline.post_scrape.screen_stocks",
+                return_value=(cands, {}),
+            ),
+            patch("rainier.pipeline.post_scrape.persist_screened_stocks"),
+            patch(
+                "rainier.pipeline.post_scrape.compute_theses_and_persist",
+                return_value={},
+            ) as mock_llm,
+            patch("rainier.pipeline.post_scrape.send_stock_candidates"),
+        ):
+            from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+            run_post_scrape_pipeline(settings, "afternoon")
+
+        assert len(mock_llm.call_args.args[0]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Error tolerance — persist + LLM failures must NOT prevent the Discord post.
+# ---------------------------------------------------------------------------
+
+
+class TestErrorTolerance:
+    def test_persist_failure_does_not_block_discord(self):
+        cands = _candidates(5)
+        settings = _make_settings()
+
+        with (
+            patch(
+                "rainier.pipeline.post_scrape.screen_stocks",
+                return_value=(cands, {}),
+            ),
+            patch(
+                "rainier.pipeline.post_scrape.persist_screened_stocks",
+                side_effect=RuntimeError("DB down"),
+            ),
+            patch(
+                "rainier.pipeline.post_scrape.compute_theses_and_persist",
+                return_value={},
+            ),
+            patch(
+                "rainier.pipeline.post_scrape.send_stock_candidates"
+            ) as mock_discord,
+        ):
+            from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+            # Must not raise.
+            run_post_scrape_pipeline(settings, "afternoon")
+
+        mock_discord.assert_called_once()
+
+    def test_llm_failure_falls_back_to_empty_theses(self):
+        cands = _candidates(5)
+        settings = _make_settings()
+
+        with (
+            patch(
+                "rainier.pipeline.post_scrape.screen_stocks",
+                return_value=(cands, {}),
+            ),
+            patch("rainier.pipeline.post_scrape.persist_screened_stocks"),
+            patch(
+                "rainier.pipeline.post_scrape.compute_theses_and_persist",
+                side_effect=RuntimeError("LLM 500"),
+            ),
+            patch(
+                "rainier.pipeline.post_scrape.send_stock_candidates"
+            ) as mock_discord,
+        ):
+            from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+            run_post_scrape_pipeline(settings, "afternoon")
+
+        mock_discord.assert_called_once()
+        # When LLM crashes, the call falls back to ``theses=None`` so the
+        # Discord renderer takes the regular top-20-only path. ``theses or
+        # None`` covers both the empty-dict and the missing-dict case.
+        assert mock_discord.call_args.kwargs.get("theses") is None
+
+
+# ---------------------------------------------------------------------------
+# Delegation — service.py & cli.py both route through the shared module.
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerServiceDelegation:
+    @pytest.mark.asyncio
+    async def test_run_qu_scrape_delegates_to_shared_pipeline(self):
+        """service.py:run_qu_scrape must call run_post_scrape_pipeline rather
+        than re-implementing the screener→LLM→Discord block inline.
+        """
+        from unittest.mock import AsyncMock
+
+        mock_result = MagicMock(records_created=20, errors=[], duration_seconds=1.0)
+        mock_scraper = AsyncMock()
+        mock_scraper.execute = AsyncMock(return_value=mock_result)
+        settings = _make_settings()
+
+        with (
+            patch("rainier.scrapers.browser.BrowserManager") as MockBM,
+            patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
+            patch(
+                "rainier.scheduler.service.load_settings_fresh",
+                return_value=settings,
+            ),
+            patch("rainier.notifications.notifier.notify_scrape_result"),
+            patch(
+                "rainier.scheduler.service.run_post_scrape_pipeline"
+            ) as mock_pipeline,
+        ):
+            MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+            MockBM.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            from rainier.scheduler.service import run_qu_scrape
+
+            await run_qu_scrape("afternoon")
+
+        mock_pipeline.assert_called_once_with(settings, "afternoon")
+
+
+class TestCliDelegation:
+    """The cron CLI path (``rainier scrape qu``) must also route through the
+    shared module — that's the whole point of the task."""
+
+    @pytest.mark.asyncio
+    async def test_cli_run_qu_scrape_calls_shared_pipeline(self):
+        from unittest.mock import AsyncMock
+
+        mock_result = MagicMock(records_created=20, errors=[], duration_seconds=1.0)
+        mock_scraper = AsyncMock()
+        mock_scraper.execute = AsyncMock(return_value=mock_result)
+        settings = _make_settings()
+
+        with (
+            patch("rainier.scrapers.browser.BrowserManager") as MockBM,
+            patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
+            patch("rainier.cli.get_settings", return_value=settings),
+            patch("rainier.cli.run_post_scrape_pipeline") as mock_pipeline,
+        ):
+            MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+            MockBM.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            from rainier.cli import _run_qu_scrape
+
+            await _run_qu_scrape(
+                session="afternoon",
+                detail_top=None,
+                dates=None,
+                days_back=0,
+                start_date=None,
+                delay=None,
+                headed=False,
+                cdp=None,
+            )
+
+        mock_pipeline.assert_called_once_with(settings, "afternoon")
+
+    @pytest.mark.asyncio
+    async def test_cli_skips_pipeline_when_no_records_created(self):
+        """Existing guard: if the scrape produced zero rows OR a backfill
+        date_list was provided, skip the post-scrape pipeline."""
+        from unittest.mock import AsyncMock
+
+        mock_result = MagicMock(records_created=0, errors=[], duration_seconds=1.0)
+        mock_scraper = AsyncMock()
+        mock_scraper.execute = AsyncMock(return_value=mock_result)
+        settings = _make_settings()
+
+        with (
+            patch("rainier.scrapers.browser.BrowserManager") as MockBM,
+            patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
+            patch("rainier.cli.get_settings", return_value=settings),
+            patch("rainier.cli.run_post_scrape_pipeline") as mock_pipeline,
+        ):
+            MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+            MockBM.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            from rainier.cli import _run_qu_scrape
+
+            await _run_qu_scrape(
+                session="afternoon",
+                detail_top=None,
+                dates=None,
+                days_back=0,
+                start_date=None,
+                delay=None,
+                headed=False,
+                cdp=None,
+            )
+
+        mock_pipeline.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cli_skips_pipeline_during_backfill(self):
+        from unittest.mock import AsyncMock
+
+        mock_result = MagicMock(records_created=42, errors=[], duration_seconds=1.0)
+        mock_scraper = AsyncMock()
+        mock_scraper.execute = AsyncMock(return_value=mock_result)
+        settings = _make_settings()
+
+        with (
+            patch("rainier.scrapers.browser.BrowserManager") as MockBM,
+            patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
+            patch("rainier.cli.get_settings", return_value=settings),
+            patch("rainier.cli.run_post_scrape_pipeline") as mock_pipeline,
+        ):
+            MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+            MockBM.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            from rainier.cli import _run_qu_scrape
+
+            await _run_qu_scrape(
+                session="afternoon",
+                detail_top=None,
+                dates="2026-05-01,2026-05-02",
+                days_back=0,
+                start_date=None,
+                delay=None,
+                headed=False,
+                cdp=None,
+            )
+
+        # date_list is non-empty -> skip post-scrape pipeline.
+        mock_pipeline.assert_not_called()

--- a/tests/test_pipeline/test_post_scrape.py
+++ b/tests/test_pipeline/test_post_scrape.py
@@ -430,7 +430,7 @@ class TestCliDelegation:
         with (
             patch("rainier.scrapers.browser.BrowserManager") as MockBM,
             patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
-            patch("rainier.cli.get_settings", return_value=settings),
+            patch("rainier.core.config.get_settings", return_value=settings),
             patch("rainier.cli.run_post_scrape_pipeline") as mock_pipeline,
         ):
             MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
@@ -465,7 +465,7 @@ class TestCliDelegation:
         with (
             patch("rainier.scrapers.browser.BrowserManager") as MockBM,
             patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
-            patch("rainier.cli.get_settings", return_value=settings),
+            patch("rainier.core.config.get_settings", return_value=settings),
             patch("rainier.cli.run_post_scrape_pipeline") as mock_pipeline,
         ):
             MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
@@ -498,7 +498,7 @@ class TestCliDelegation:
         with (
             patch("rainier.scrapers.browser.BrowserManager") as MockBM,
             patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
-            patch("rainier.cli.get_settings", return_value=settings),
+            patch("rainier.core.config.get_settings", return_value=settings),
             patch("rainier.cli.run_post_scrape_pipeline") as mock_pipeline,
         ):
             MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())

--- a/tests/test_pipeline/test_post_scrape.py
+++ b/tests/test_pipeline/test_post_scrape.py
@@ -519,3 +519,123 @@ class TestCliDelegation:
 
         # date_list is non-empty -> skip post-scrape pipeline.
         mock_pipeline.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cli_pipeline_runs_in_thread_so_inner_asyncio_run_is_safe(
+        self,
+    ):
+        """Regression for codex [P1] iter-1: _run_qu_scrape is already running
+        inside an event loop, so the pipeline (which internally does
+        asyncio.run via compute_theses_and_persist) must be handed off via
+        asyncio.to_thread. Verify by patching the pipeline with a callable
+        that itself calls asyncio.run — if we were calling the pipeline
+        directly from the running loop, that would raise RuntimeError. Run
+        in a thread, it works.
+        """
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        mock_result = MagicMock(records_created=20, errors=[], duration_seconds=1.0)
+        mock_scraper = AsyncMock()
+        mock_scraper.execute = AsyncMock(return_value=mock_result)
+        settings = _make_settings()
+
+        async def _noop_coro():
+            return None
+
+        def _pipeline_that_uses_asyncio_run(_settings, _session):
+            # Mirrors compute_theses_and_persist's pattern of wrapping async
+            # work in asyncio.run inside a sync function. If the call site in
+            # _run_qu_scrape ever drops the asyncio.to_thread hand-off, this
+            # call raises RuntimeError("asyncio.run() cannot be called from a
+            # running event loop") and the test fails.
+            asyncio.run(_noop_coro())
+
+        with (
+            patch("rainier.scrapers.browser.BrowserManager") as MockBM,
+            patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
+            patch("rainier.core.config.get_settings", return_value=settings),
+            patch(
+                "rainier.cli.run_post_scrape_pipeline",
+                side_effect=_pipeline_that_uses_asyncio_run,
+            ) as mock_pipeline,
+        ):
+            MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+            MockBM.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            from rainier.cli import _run_qu_scrape
+
+            await _run_qu_scrape(
+                session="afternoon",
+                detail_top=None,
+                dates=None,
+                days_back=0,
+                start_date=None,
+                delay=None,
+                headed=False,
+                cdp=None,
+            )
+
+        mock_pipeline.assert_called_once_with(settings, "afternoon")
+
+    @pytest.mark.asyncio
+    async def test_cli_pipeline_failure_does_not_morph_into_scrape_failure(self):
+        """Regression for codex [P2] iter-1: pre-extraction CLI guarded the
+        screener block in its own try/except and reported a partial-success
+        warning. After extraction, a screener / pipeline failure was bubbling
+        all the way up to _run_qu_scrape's outer except, turning a successful
+        scrape into a red "Scrape FAILED" alert and a non-zero exit.
+
+        Expected behavior: pipeline exception is caught locally, an orange
+        partial-success Discord alert is emitted, and the function returns
+        normally (no re-raise).
+        """
+        from unittest.mock import AsyncMock
+
+        mock_result = MagicMock(records_created=20, errors=[], duration_seconds=1.0)
+        mock_scraper = AsyncMock()
+        mock_scraper.execute = AsyncMock(return_value=mock_result)
+        settings = _make_settings()
+
+        with (
+            patch("rainier.scrapers.browser.BrowserManager") as MockBM,
+            patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
+            patch("rainier.core.config.get_settings", return_value=settings),
+            patch(
+                "rainier.cli.run_post_scrape_pipeline",
+                side_effect=RuntimeError("screener db blip"),
+            ),
+            patch("rainier.cli._notify_scrape_discord") as mock_notify,
+        ):
+            MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+            MockBM.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            from rainier.cli import _run_qu_scrape
+
+            # Must NOT raise — pipeline failures stay local.
+            await _run_qu_scrape(
+                session="afternoon",
+                detail_top=None,
+                dates=None,
+                days_back=0,
+                start_date=None,
+                delay=None,
+                headed=False,
+                cdp=None,
+            )
+
+        # The partial-success notification fired (orange, not red).
+        # _notify_scrape_discord may also be called for other reasons in the
+        # path (e.g. scrape warnings) so we scan calls for the post-scrape
+        # alert specifically rather than asserting call count.
+        titles = [
+            call.kwargs.get("title") or (call.args[2] if len(call.args) >= 3 else "")
+            for call in mock_notify.call_args_list
+        ]
+        assert any("Post-Scrape FAILED" in t for t in titles), (
+            f"expected a Post-Scrape FAILED partial-success alert; got: {titles}"
+        )
+        # The red "Scrape FAILED" alert (outer except) must NOT have fired.
+        assert not any("Scrape FAILED" in t and "Post-Scrape" not in t for t in titles), (
+            f"unexpected red Scrape FAILED alert fired: {titles}"
+        )

--- a/tests/test_pipeline/test_post_scrape.py
+++ b/tests/test_pipeline/test_post_scrape.py
@@ -131,10 +131,49 @@ class TestSessionGating:
         assert len(sent) == 20
         # theses kwarg is None when LLM didn't run.
         assert mock_discord.call_args.kwargs.get("theses") is None
+        # iter-2 regression: session label must be forwarded so the summary
+        # embed title carries the "— Morning" suffix (pre-extraction CLI did
+        # this via _build_payloads(candidates, session=session); the codex
+        # iter-2 P2 finding caught the regression when this dropped).
+        assert mock_discord.call_args.kwargs.get("session") == "morning"
         # Persist still got top-50 (or all if fewer).
         mock_persist.assert_called_once()
         persisted = mock_persist.call_args.args[0]
         assert len(persisted) == min(50, len(cands))
+
+    def test_session_label_forwarded_for_all_sessions(self):
+        """Regression for codex [P2] iter-2: every session (morning, midday,
+        afternoon, close) must propagate session= to send_stock_candidates so
+        the summary embed title gets the session-label suffix. Without this,
+        four same-day scans become indistinguishable in the Discord channel.
+        """
+        cands = _candidates(5)
+        settings = _make_settings()
+
+        for session_name in ("morning", "midday", "afternoon", "close"):
+            with (
+                patch(
+                    "rainier.pipeline.post_scrape.screen_stocks",
+                    return_value=(cands, {}),
+                ),
+                patch("rainier.pipeline.post_scrape.persist_screened_stocks"),
+                patch(
+                    "rainier.pipeline.post_scrape.compute_theses_and_persist",
+                    return_value={},
+                ),
+                patch(
+                    "rainier.pipeline.post_scrape.send_stock_candidates"
+                ) as mock_discord,
+            ):
+                from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+                run_post_scrape_pipeline(settings, session_name)
+
+            assert (
+                mock_discord.call_args.kwargs.get("session") == session_name
+            ), (
+                f"session={session_name!r} not forwarded to send_stock_candidates"
+            )
 
     def test_afternoon_session_fires_llm_on_top_5(self):
         cands = _candidates(25)

--- a/tests/test_scheduler/test_scheduler.py
+++ b/tests/test_scheduler/test_scheduler.py
@@ -189,8 +189,7 @@ class TestRunQuScrape:
             patch("rainier.scrapers.browser.BrowserManager") as MockBM,
             patch("rainier.scrapers.get_scraper", return_value=mock_scraper) as mock_get,
             patch("rainier.scheduler.service.load_settings_fresh", return_value=settings),
-            patch("rainier.analysis.stock_screener.screen_stocks", return_value=([], {})),
-            patch("rainier.alerts.discord.send_stock_candidates"),
+            patch("rainier.scheduler.service.run_post_scrape_pipeline"),
             patch("rainier.notifications.notifier.notify_scrape_result"),
         ):
             mock_bm_instance = AsyncMock()
@@ -222,8 +221,16 @@ class TestRunQuScrape:
             await run_qu_scrape("morning")
 
 
-class TestRunQuScrapeLLMGating:
-    """PR1: LLM block runs only on `enabled_sessions`; settings reload per scan."""
+class TestRunQuScrapePipelineDelegation:
+    """run_qu_scrape delegates the post-scrape steps (screener, persist,
+    LLM thesis, Discord) to ``rainier.pipeline.post_scrape.run_post_scrape_pipeline``.
+
+    The inline pipeline used to live in service.py; PR moved it into the
+    shared module so the cron CLI path (``rainier scrape qu``) emits the
+    same Discord output. Inline-pipeline-behavior tests now live in
+    tests/test_pipeline/test_post_scrape.py — these tests cover only the
+    delegation contract.
+    """
 
     def _settings(self, enabled_sessions=("afternoon", "close")):
         from rainier.core.config import LLMThesisConfig
@@ -235,30 +242,26 @@ class TestRunQuScrapeLLMGating:
         return s
 
     @pytest.mark.asyncio
-    async def test_afternoon_session_fires_llm_block(self):
+    async def test_delegates_with_reloaded_settings_and_session(self):
+        """service.py reloads settings fresh each scan, then hands off to
+        the shared pipeline with (settings, session_name)."""
         from unittest.mock import AsyncMock, MagicMock
 
         mock_result = MagicMock(records_created=20, errors=[], duration_seconds=1.0)
         mock_scraper = AsyncMock()
         mock_scraper.execute = AsyncMock(return_value=mock_result)
-        candidates = []  # empty short-circuits compute_theses_and_persist
+        settings = self._settings()
 
         with (
             patch("rainier.scrapers.browser.BrowserManager") as MockBM,
             patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
             patch(
                 "rainier.scheduler.service.load_settings_fresh",
-                return_value=self._settings(),
+                return_value=settings,
             ),
             patch(
-                "rainier.analysis.stock_screener.screen_stocks",
-                return_value=(candidates, {}),
-            ),
-            patch("rainier.llm_thesis.persistence.persist_screened_stocks"),
-            patch(
-                "rainier.llm_thesis.service.compute_theses_and_persist", return_value={}
-            ) as mock_llm,
-            patch("rainier.alerts.discord.send_stock_candidates"),
+                "rainier.scheduler.service.run_post_scrape_pipeline"
+            ) as mock_pipeline,
             patch("rainier.notifications.notifier.notify_scrape_result"),
         ):
             MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
@@ -266,97 +269,12 @@ class TestRunQuScrapeLLMGating:
             from rainier.scheduler.service import run_qu_scrape
             await run_qu_scrape("afternoon")
 
-        # No candidates means compute is short-circuited but the gate decision
-        # itself should already hand-off to compute when len(candidates)>0. We
-        # verify the gate by adding a candidate and re-running below; here we
-        # just confirm no crash on the empty path.
-        assert mock_llm.call_count == 0
-
-    @pytest.mark.asyncio
-    async def test_morning_session_skips_llm_block(self):
-        from unittest.mock import AsyncMock, MagicMock
-
-        from rainier.core.types import StockCandidate
-
-        mock_result = MagicMock(records_created=20, errors=[], duration_seconds=1.0)
-        mock_scraper = AsyncMock()
-        mock_scraper.execute = AsyncMock(return_value=mock_result)
-
-        cand = StockCandidate(
-            symbol="NVDA", rank=5, rank_change=0, long_short="Long in",
-            capital_flow_direction="+", sector="Technology", signal_strength=0.8,
-        )
-        candidates = [cand]
-
-        with (
-            patch("rainier.scrapers.browser.BrowserManager") as MockBM,
-            patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
-            patch(
-                "rainier.scheduler.service.load_settings_fresh",
-                return_value=self._settings(),
-            ),
-            patch(
-                "rainier.analysis.stock_screener.screen_stocks",
-                return_value=(candidates, {}),
-            ),
-            patch("rainier.llm_thesis.persistence.persist_screened_stocks"),
-            patch(
-                "rainier.llm_thesis.service.compute_theses_and_persist", return_value={}
-            ) as mock_llm,
-            patch("rainier.alerts.discord.send_stock_candidates"),
-            patch("rainier.notifications.notifier.notify_scrape_result"),
-        ):
-            MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
-            MockBM.return_value.__aexit__ = AsyncMock(return_value=False)
-            from rainier.scheduler.service import run_qu_scrape
-            await run_qu_scrape("morning")
-
-        mock_llm.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_afternoon_session_with_candidates_calls_llm(self):
-        from unittest.mock import AsyncMock, MagicMock
-
-        from rainier.core.types import StockCandidate
-
-        mock_result = MagicMock(records_created=20, errors=[], duration_seconds=1.0)
-        mock_scraper = AsyncMock()
-        mock_scraper.execute = AsyncMock(return_value=mock_result)
-
-        cand = StockCandidate(
-            symbol="NVDA", rank=5, rank_change=0, long_short="Long in",
-            capital_flow_direction="+", sector="Technology", signal_strength=0.8,
-        )
-
-        with (
-            patch("rainier.scrapers.browser.BrowserManager") as MockBM,
-            patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
-            patch(
-                "rainier.scheduler.service.load_settings_fresh",
-                return_value=self._settings(),
-            ),
-            patch(
-                "rainier.analysis.stock_screener.screen_stocks",
-                return_value=([cand], {"NVDA": MagicMock()}),
-            ),
-            patch("rainier.llm_thesis.persistence.persist_screened_stocks"),
-            patch(
-                "rainier.llm_thesis.service.compute_theses_and_persist",
-                return_value={"NVDA": {"verdict": "setup_long"}},
-            ) as mock_llm,
-            patch("rainier.alerts.discord.send_stock_candidates"),
-            patch("rainier.notifications.notifier.notify_scrape_result"),
-        ):
-            MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
-            MockBM.return_value.__aexit__ = AsyncMock(return_value=False)
-            from rainier.scheduler.service import run_qu_scrape
-            await run_qu_scrape("afternoon")
-
-        mock_llm.assert_called_once()
+        mock_pipeline.assert_called_once_with(settings, "afternoon")
 
     @pytest.mark.asyncio
     async def test_settings_reload_called_each_scan(self):
-        """Mid-process YAML edit takes effect on next invocation."""
+        """Mid-process YAML edit takes effect on next invocation — the
+        load_settings_fresh hook fires on every scrape."""
         from unittest.mock import AsyncMock, MagicMock
 
         first = self._settings(enabled_sessions=("afternoon",))
@@ -373,15 +291,7 @@ class TestRunQuScrapeLLMGating:
                 "rainier.scheduler.service.load_settings_fresh",
                 side_effect=[first, second],
             ) as mock_reload,
-            patch(
-                "rainier.analysis.stock_screener.screen_stocks",
-                return_value=([], {}),
-            ),
-            patch("rainier.llm_thesis.persistence.persist_screened_stocks"),
-            patch(
-                "rainier.llm_thesis.service.compute_theses_and_persist", return_value={}
-            ),
-            patch("rainier.alerts.discord.send_stock_candidates"),
+            patch("rainier.scheduler.service.run_post_scrape_pipeline"),
             patch("rainier.notifications.notifier.notify_scrape_result"),
         ):
             MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
@@ -391,138 +301,6 @@ class TestRunQuScrapeLLMGating:
             await run_qu_scrape("afternoon")
 
         assert mock_reload.call_count == 2
-
-
-class TestPersistScreenedTop50:
-    """PR2 carry-over P2 #3: persist top-50 candidates (not top-20) so the
-    shadow-validation dataset isn't biased toward the upper tail.
-    """
-
-    def _settings(self, enabled_sessions=("afternoon", "close")):
-        from rainier.core.config import LLMThesisConfig
-
-        s = _make_settings()
-        s.llm_thesis = LLMThesisConfig(
-            enabled=True,
-            model="test",
-            max_usd_per_scan=1.0,
-            enabled_sessions=list(enabled_sessions),
-        )
-        return s
-
-    @pytest.mark.asyncio
-    async def test_persist_called_with_top_50_candidates(self):
-        """When the screener returns >50 candidates, scheduler hands the first
-        50 to persist_screened_stocks. Discord still gets top-20."""
-        from unittest.mock import AsyncMock, MagicMock
-
-        from rainier.core.types import StockCandidate
-
-        cands = [
-            StockCandidate(
-                symbol=f"S{i:03d}", rank=i + 1, rank_change=0,
-                long_short="Long in", capital_flow_direction="+",
-                sector="Technology", signal_strength=1.0 - i * 0.001,
-            )
-            for i in range(80)
-        ]
-
-        mock_result = MagicMock(records_created=80, errors=[], duration_seconds=1.0)
-        mock_scraper = AsyncMock()
-        mock_scraper.execute = AsyncMock(return_value=mock_result)
-
-        with (
-            patch("rainier.scrapers.browser.BrowserManager") as MockBM,
-            patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
-            patch(
-                "rainier.scheduler.service.load_settings_fresh",
-                return_value=self._settings(),
-            ),
-            patch(
-                "rainier.analysis.stock_screener.screen_stocks",
-                return_value=(cands, {}),
-            ),
-            patch(
-                "rainier.llm_thesis.persistence.persist_screened_stocks"
-            ) as mock_persist,
-            patch(
-                "rainier.llm_thesis.service.compute_theses_and_persist",
-                return_value={},
-            ),
-            patch(
-                "rainier.alerts.discord.send_stock_candidates"
-            ) as mock_discord,
-            patch("rainier.notifications.notifier.notify_scrape_result"),
-        ):
-            MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
-            MockBM.return_value.__aexit__ = AsyncMock(return_value=False)
-            from rainier.scheduler.service import run_qu_scrape
-
-            await run_qu_scrape("afternoon")
-
-        mock_persist.assert_called_once()
-        persist_args, persist_kwargs = mock_persist.call_args
-        # First positional arg is the candidate list.
-        persisted = persist_args[0]
-        assert len(persisted) == 50, (
-            f"expected 50 persisted candidates, got {len(persisted)} — "
-            "P2 #3 regression: scheduler is truncating before persistence."
-        )
-        # Discord display set is still top-20.
-        mock_discord.assert_called_once()
-        discord_args = mock_discord.call_args.args
-        displayed = discord_args[0]
-        assert len(displayed) == 20
-
-    @pytest.mark.asyncio
-    async def test_persist_under_50_uses_actual_count(self):
-        """When the screener returns <50 candidates, persistence gets all of them."""
-        from unittest.mock import AsyncMock, MagicMock
-
-        from rainier.core.types import StockCandidate
-
-        cands = [
-            StockCandidate(
-                symbol=f"S{i:03d}", rank=i + 1, rank_change=0,
-                long_short="Long in", capital_flow_direction="+",
-                sector="Technology", signal_strength=1.0 - i * 0.001,
-            )
-            for i in range(7)
-        ]
-
-        mock_result = MagicMock(records_created=7, errors=[], duration_seconds=1.0)
-        mock_scraper = AsyncMock()
-        mock_scraper.execute = AsyncMock(return_value=mock_result)
-
-        with (
-            patch("rainier.scrapers.browser.BrowserManager") as MockBM,
-            patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
-            patch(
-                "rainier.scheduler.service.load_settings_fresh",
-                return_value=self._settings(),
-            ),
-            patch(
-                "rainier.analysis.stock_screener.screen_stocks",
-                return_value=(cands, {}),
-            ),
-            patch(
-                "rainier.llm_thesis.persistence.persist_screened_stocks"
-            ) as mock_persist,
-            patch(
-                "rainier.llm_thesis.service.compute_theses_and_persist",
-                return_value={},
-            ),
-            patch("rainier.alerts.discord.send_stock_candidates"),
-            patch("rainier.notifications.notifier.notify_scrape_result"),
-        ):
-            MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
-            MockBM.return_value.__aexit__ = AsyncMock(return_value=False)
-            from rainier.scheduler.service import run_qu_scrape
-
-            await run_qu_scrape("afternoon")
-
-        persist_args, _ = mock_persist.call_args
-        assert len(persist_args[0]) == 7
 
 
 class TestAppConfig:


### PR DESCRIPTION
## Summary

Extracts the post-scrape pipeline (screen → persist top-50 → conditional LLM thesis on top-5 → Discord send) into a shared module `src/rainier/pipeline/post_scrape.py`, used by both the cron CLI path (`src/rainier/cli.py:_run_qu_scrape`) and the APScheduler daemon path (`src/rainier/scheduler/service.py:run_qu_scrape`).

Fixes the missing QU100-LLM Discord channel reports: cron scrapes now fire the LLM thesis on `afternoon` and `close` sessions (per `settings.llm_thesis.enabled_sessions`), not just the regular top-20 screener post. Previously the LLM thesis only fired from `rainier run` (long-running APScheduler daemon) which is not running on this host.

## Changes

- NEW: `src/rainier/pipeline/post_scrape.py` — `run_post_scrape_pipeline(settings, session_name)` is the single source of truth for the post-scrape steps.
- NEW: `src/rainier/pipeline/__init__.py` — package docstring + re-export.
- MODIFIED: `src/rainier/cli.py` — `_run_qu_scrape` delegates to the shared pipeline; dead `_post_scrape_screener` removed.
- MODIFIED: `src/rainier/scheduler/service.py` — `run_qu_scrape` delegates to the shared pipeline; ~70 lines of inline logic + the `_send_stock_candidates_with_dashboard_url` helper replaced.
- NEW: `tests/test_pipeline/test_post_scrape.py` — 14 tests: session gating, LLM enabled flag, empty candidates, slicing (50/20/5), error tolerance, scheduler + CLI delegation contracts.
- MODIFIED: `tests/test_scheduler/test_scheduler.py` — replaced inline-pipeline tests with delegation tests (behavioral coverage migrated to test_pipeline/).
- MODIFIED: `CLAUDE.md` — module map gains a `pipeline/` entry (review iter-1 doc-staleness fix).

## Test plan

- [x] `uv run pytest tests/ -v` — 737 passed, 3 skipped at impl + review time.
- [x] `uv run ruff check src/ tests/` — clean.
- [ ] Manual verification (post-merge): run `uv run rainier scrape qu --session afternoon --cdp http://127.0.0.1:9222` against warm Chrome and confirm:
  - Regular top-20 screener post appears in `DISCORD_STOCK_WEBHOOK_URL` channel.
  - LLM thesis per-ticker embeds (with verdict, confidence, chart PNG) also appear.
  - `uv run rainier scrape qu --session morning` only produces the regular top-20 post (no LLM thesis).

## Reviewer notes

- **Codex review:** SKIPPED (rate-limited at 2026-05-12T23:01:45Z; ChatGPT usage-limit reset 2026-05-13 05:31). Two retry attempts confirmed the rate limit; protocol-compliant skip per `~/.claude/CLAUDE.md` §4.
- **`/review` skill:** 2 invocations, both clean.
  - iter-1 produced 1 INFORMATIONAL: CLI error attribution for `screen_stocks` raising now reads "QU100 Scrape FAILED" instead of "QU100 Screener FAILED (Scrape succeeded but screener failed)" because the dedicated CLI `_post_scrape_screener` try/except is gone. **Accepted as intentional** — supervisor brief explicitly required identical Discord output across both entry points, and the scheduler path always had this conflation. If granular attribution is desired later, add a try/except around `screen_stocks` inside `run_post_scrape_pipeline` as a P3 follow-up.
  - iter-1 also produced 1 INFORMATIONAL auto-fix: `CLAUDE.md` module map gained the missing `pipeline/` line (commit b8b84a5).
  - iter-2 (post-doc-fix): clean.
- Deferred `[P2]`/`[P3]` findings: none.