### PR TITLE
feat(alerts): route LLM thesis embeds to dedicated Discord channel

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -67,6 +67,7 @@ alerts:
   discord:
     webhook_url: ""              # Set via DISCORD_WEBHOOK_URL in .env
     stock_webhook_url: ""        # Set via DISCORD_STOCK_WEBHOOK_URL in .env (falls back to webhook_url)
+    llm_webhook_url: ""          # Set via DISCORD_LLM_WEBHOOK_URL in .env; dedicated channel for per-ticker LLM thesis embeds (falls back to stock_webhook_url)
     enabled: true
 
 # --- Stock scraping (QuantUnicorn) ---

--- a/src/rainier/alerts/discord.py
+++ b/src/rainier/alerts/discord.py
@@ -84,6 +84,23 @@ def _resolve_webhook_url(config: DiscordConfig) -> str | None:
     return config.stock_webhook_url or config.webhook_url or None
 
 
+def _resolve_llm_webhook_url(config: DiscordConfig) -> str | None:
+    """Get the webhook URL for per-ticker LLM thesis embeds.
+
+    Routing precedence: ``llm_webhook_url`` (dedicated QU100-LLM channel) →
+    ``stock_webhook_url`` (general QU100 channel) → ``webhook_url`` (catch-all)
+    → ``None``. The dedicated LLM channel is opt-in; leaving it empty keeps
+    legacy behavior where rich thesis embeds and the top-20 screener post
+    share the stock channel.
+    """
+    return (
+        config.llm_webhook_url
+        or config.stock_webhook_url
+        or config.webhook_url
+        or None
+    )
+
+
 # Session → display label
 SESSION_LABELS: dict[str, str] = {
     "morning": "Morning (ET 11:30)",
@@ -843,6 +860,15 @@ def send_stock_candidates(
     if not theses:
         return
 
+    # Per-ticker rich thesis embeds route to the LLM-dedicated channel when
+    # configured (DISCORD_LLM_WEBHOOK_URL), otherwise fall back to the stock
+    # channel. Note the regular top-20 screener payload above always stays on
+    # the stock channel (`webhook_url`) regardless of llm_webhook_url state.
+    llm_webhook_url = _resolve_llm_webhook_url(config)
+    if not llm_webhook_url:
+        log.warning("discord_no_webhook_url_llm")
+        return
+
     # Per-ticker rich thesis embeds — top 5 only, in candidate order.
     for candidate in candidates[:5]:
         thesis = theses.get(candidate.symbol)
@@ -860,7 +886,7 @@ def send_stock_candidates(
                 chart_filename=chart_filename if chart_bytes else None,
             )
             _post_thesis_embed(
-                webhook_url=webhook_url,
+                webhook_url=llm_webhook_url,
                 embed=embed,
                 chart_bytes=chart_bytes,
                 chart_filename=chart_filename,

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -134,6 +134,7 @@ class IBKRConfig(BaseModel):
 class DiscordConfig(BaseModel):
     webhook_url: str = ""
     stock_webhook_url: str = ""  # Separate channel for stock alerts; falls back to webhook_url
+    llm_webhook_url: str = ""  # Separate channel for per-ticker LLM thesis embeds; falls back to stock_webhook_url
     enabled: bool = False
 
 
@@ -353,6 +354,7 @@ class Settings(BaseSettings):
     polygon_api_key: str = ""
     discord_webhook_url: str = ""
     discord_stock_webhook_url: str = ""
+    discord_llm_webhook_url: str = ""
     discord_backtest_webhook_url: str = ""
     notify_urls: str = ""  # Apprise URL(s), comma-separated
     x_api_bearer_token: str = ""  # X/Twitter API v2 bearer token
@@ -479,6 +481,8 @@ def load_settings(config_path: Path | None = None) -> Settings:
         settings.alerts.discord.webhook_url = settings.discord_webhook_url
     if settings.discord_stock_webhook_url and not settings.alerts.discord.stock_webhook_url:
         settings.alerts.discord.stock_webhook_url = settings.discord_stock_webhook_url
+    if settings.discord_llm_webhook_url and not settings.alerts.discord.llm_webhook_url:
+        settings.alerts.discord.llm_webhook_url = settings.discord_llm_webhook_url
 
     return settings
 

--- a/tests/test_alerts/test_discord_attachment.py
+++ b/tests/test_alerts/test_discord_attachment.py
@@ -188,3 +188,266 @@ class TestMultipartAttachment:
         assert len(thesis_calls) == 1
         embed = thesis_calls[0].kwargs["json"]["embeds"][0]
         assert embed["url"] == "http://dashboard.local?thesis_id=999"
+
+
+# ---------------------------------------------------------------------------
+# LLM-channel routing — DISCORD_LLM_WEBHOOK_URL splits LLM thesis embeds from
+# the regular QU100 top-20 screener payload.
+# ---------------------------------------------------------------------------
+
+
+class TestLLMChannelRouting:
+    """Routing per `_resolve_llm_webhook_url`:
+
+    - Top-20 summary embed: always uses stock_webhook_url (or webhook_url
+      fallback).
+    - Per-ticker LLM thesis embed: uses llm_webhook_url when set; otherwise
+      falls back to stock_webhook_url; otherwise webhook_url.
+    """
+
+    def _classify_calls(self, call_args_list):
+        """Split httpx.post calls into (summary_calls, thesis_calls).
+
+        Summary calls carry json={"embeds": [...]} where at least one embed
+        contains a description with a ```code block``` (the QU100 table).
+        Thesis calls either ride on multipart (files=, data=payload_json)
+        OR carry a single embed whose title starts with the verdict label.
+        """
+        summary_calls = []
+        thesis_calls = []
+        for call in call_args_list:
+            kwargs = call.kwargs
+            if "files" in kwargs:
+                thesis_calls.append(call)
+                continue
+            payload = kwargs.get("json")
+            if not isinstance(payload, dict):
+                continue
+            embeds = payload.get("embeds") or []
+            if not embeds:
+                continue
+            # Thesis embed: single embed, title starts with verdict label.
+            if len(embeds) == 1 and embeds[0].get("title", "").startswith(
+                ("setup_long", "watch", "no_setup")
+            ):
+                thesis_calls.append(call)
+            else:
+                summary_calls.append(call)
+        return summary_calls, thesis_calls
+
+    def test_thesis_embed_routes_to_llm_webhook_when_set(self):
+        config = DiscordConfig(
+            enabled=True,
+            webhook_url="https://main/hook",
+            stock_webhook_url="https://stock/hook",
+            llm_webhook_url="https://llm/hook",
+        )
+        with patch(
+            "rainier.alerts.discord.httpx.post"
+        ) as mock_post, patch(
+            "rainier.alerts.discord._load_chart_bytes_for_thesis",
+            return_value=None,
+        ):
+            mock_post.return_value = MagicMock(status_code=204)
+            send_stock_candidates(
+                [_candidate("NVDA")],
+                config,
+                theses={"NVDA": _thesis()},
+            )
+        summary_calls, thesis_calls = self._classify_calls(
+            mock_post.call_args_list
+        )
+        assert summary_calls, "expected at least one summary POST"
+        assert thesis_calls, "expected at least one thesis POST"
+        for call in summary_calls:
+            assert call.args[0] == "https://stock/hook"
+        for call in thesis_calls:
+            assert call.args[0] == "https://llm/hook"
+
+    def test_thesis_embed_falls_back_to_stock_webhook_when_llm_empty(self):
+        config = DiscordConfig(
+            enabled=True,
+            webhook_url="https://main/hook",
+            stock_webhook_url="https://stock/hook",
+            llm_webhook_url="",
+        )
+        with patch(
+            "rainier.alerts.discord.httpx.post"
+        ) as mock_post, patch(
+            "rainier.alerts.discord._load_chart_bytes_for_thesis",
+            return_value=None,
+        ):
+            mock_post.return_value = MagicMock(status_code=204)
+            send_stock_candidates(
+                [_candidate("NVDA")],
+                config,
+                theses={"NVDA": _thesis()},
+            )
+        summary_calls, thesis_calls = self._classify_calls(
+            mock_post.call_args_list
+        )
+        assert summary_calls and thesis_calls
+        for call in summary_calls:
+            assert call.args[0] == "https://stock/hook"
+        for call in thesis_calls:
+            assert call.args[0] == "https://stock/hook"
+
+    def test_thesis_embed_falls_back_to_webhook_when_stock_and_llm_empty(self):
+        config = DiscordConfig(
+            enabled=True,
+            webhook_url="https://main/hook",
+            stock_webhook_url="",
+            llm_webhook_url="",
+        )
+        with patch(
+            "rainier.alerts.discord.httpx.post"
+        ) as mock_post, patch(
+            "rainier.alerts.discord._load_chart_bytes_for_thesis",
+            return_value=None,
+        ):
+            mock_post.return_value = MagicMock(status_code=204)
+            send_stock_candidates(
+                [_candidate("NVDA")],
+                config,
+                theses={"NVDA": _thesis()},
+            )
+        summary_calls, thesis_calls = self._classify_calls(
+            mock_post.call_args_list
+        )
+        assert summary_calls and thesis_calls
+        for call in summary_calls:
+            assert call.args[0] == "https://main/hook"
+        for call in thesis_calls:
+            assert call.args[0] == "https://main/hook"
+
+    def test_regular_candidates_only_use_stock_webhook_regardless_of_llm(self):
+        """No `theses=` arg — all calls should land on the stock channel
+        even when llm_webhook_url is set."""
+        config = DiscordConfig(
+            enabled=True,
+            webhook_url="https://main/hook",
+            stock_webhook_url="https://stock/hook",
+            llm_webhook_url="https://llm/hook",
+        )
+        with patch("rainier.alerts.discord.httpx.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=204)
+            send_stock_candidates([_candidate("NVDA")], config)
+        # No theses → no thesis-embed POSTs; every call must go to stock URL.
+        assert mock_post.call_count >= 1
+        for call in mock_post.call_args_list:
+            assert call.args[0] == "https://stock/hook"
+
+    def test_multipart_thesis_post_uses_llm_webhook(self):
+        """When a chart attachment rides on multipart, the destination still
+        flips to llm_webhook_url."""
+        config = DiscordConfig(
+            enabled=True,
+            webhook_url="https://main/hook",
+            stock_webhook_url="https://stock/hook",
+            llm_webhook_url="https://llm/hook",
+        )
+        png_bytes = b"\x89PNG\r\n\x1a\nFAKE"
+        with patch(
+            "rainier.alerts.discord.httpx.post"
+        ) as mock_post, patch(
+            "rainier.alerts.discord._load_chart_bytes_for_thesis",
+            return_value=png_bytes,
+        ):
+            mock_post.return_value = MagicMock(status_code=204)
+            send_stock_candidates(
+                [_candidate("NVDA")],
+                config,
+                theses={"NVDA": _thesis()},
+            )
+        multipart_calls = [
+            c for c in mock_post.call_args_list if "files" in c.kwargs
+        ]
+        assert len(multipart_calls) == 1
+        assert multipart_calls[0].args[0] == "https://llm/hook"
+
+
+class TestResolveLLMWebhookUrl:
+    """Direct coverage of the `_resolve_llm_webhook_url` helper."""
+
+    def test_returns_llm_when_set(self):
+        from rainier.alerts.discord import _resolve_llm_webhook_url
+
+        cfg = DiscordConfig(
+            webhook_url="https://main/hook",
+            stock_webhook_url="https://stock/hook",
+            llm_webhook_url="https://llm/hook",
+        )
+        assert _resolve_llm_webhook_url(cfg) == "https://llm/hook"
+
+    def test_falls_back_to_stock_when_llm_empty(self):
+        from rainier.alerts.discord import _resolve_llm_webhook_url
+
+        cfg = DiscordConfig(
+            webhook_url="https://main/hook",
+            stock_webhook_url="https://stock/hook",
+            llm_webhook_url="",
+        )
+        assert _resolve_llm_webhook_url(cfg) == "https://stock/hook"
+
+    def test_falls_back_to_webhook_when_stock_and_llm_empty(self):
+        from rainier.alerts.discord import _resolve_llm_webhook_url
+
+        cfg = DiscordConfig(
+            webhook_url="https://main/hook",
+            stock_webhook_url="",
+            llm_webhook_url="",
+        )
+        assert _resolve_llm_webhook_url(cfg) == "https://main/hook"
+
+    def test_returns_none_when_all_empty(self):
+        from rainier.alerts.discord import _resolve_llm_webhook_url
+
+        cfg = DiscordConfig(
+            webhook_url="",
+            stock_webhook_url="",
+            llm_webhook_url="",
+        )
+        assert _resolve_llm_webhook_url(cfg) is None
+
+
+class TestSettingsPlumbing:
+    """`DISCORD_LLM_WEBHOOK_URL` env var → `Settings.alerts.discord.llm_webhook_url`."""
+
+    def test_env_var_populates_nested_field(self, monkeypatch, tmp_path):
+        from rainier.core.config import load_settings
+
+        yaml_path = tmp_path / "settings.yaml"
+        yaml_path.write_text(
+            "alerts:\n  discord:\n    enabled: true\n",
+            encoding="utf-8",
+        )
+        # The loader also reads .env via load_dotenv; chdir to a clean tmp
+        # path so the project's real .env doesn't leak into the test.
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv(
+            "DISCORD_LLM_WEBHOOK_URL", "https://llm-channel.example/hook"
+        )
+        settings = load_settings(config_path=yaml_path)
+        assert (
+            settings.alerts.discord.llm_webhook_url
+            == "https://llm-channel.example/hook"
+        )
+
+    def test_yaml_value_wins_when_env_empty(self, monkeypatch, tmp_path):
+        from rainier.core.config import load_settings
+
+        yaml_path = tmp_path / "settings.yaml"
+        yaml_path.write_text(
+            "alerts:\n"
+            "  discord:\n"
+            "    enabled: true\n"
+            "    llm_webhook_url: https://yaml.example/hook\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DISCORD_LLM_WEBHOOK_URL", raising=False)
+        settings = load_settings(config_path=yaml_path)
+        assert (
+            settings.alerts.discord.llm_webhook_url
+            == "https://yaml.example/hook"
+        )


### PR DESCRIPTION
## Summary

Splits the Discord webhook routing so the rich per-ticker LLM thesis embeds (verdict + confidence + chart PNG + dashboard link) post to a dedicated channel (`DISCORD_LLM_WEBHOOK_URL` → operator's QU100-LLM channel), while the regular top-20 screener post continues to land in the general QU100 channel via `DISCORD_STOCK_WEBHOOK_URL`.

Completes the QU100-LLM channel work started by PR #71 (scraper recovery) and PR #72 (LLM thesis pipeline shared between cron CLI + scheduler).

## Changes

- NEW config field: `alerts.discord.llm_webhook_url` (Pydantic + settings.yaml default).
- NEW top-level env mapping: `DISCORD_LLM_WEBHOOK_URL` plumbs through to `alerts.discord.llm_webhook_url` via the same pattern as `discord_stock_webhook_url`.
- NEW helper `_resolve_llm_webhook_url(config)` returning `llm_webhook_url → stock_webhook_url → webhook_url → None`.
- `send_stock_candidates` now routes per-ticker thesis embeds through the LLM resolver; regular top-20 candidate list still uses the stock resolver (no behavior change for non-LLM sessions).
- `.gitignore`: ignore `docs/research_papers/*.pdf` (index README still committed).
- `.env` updated locally (gitignored) with the operator-supplied webhook URL.

## Reviewer status

- /review: PASS (1 iteration, narrow-diff single-round per skill rule, 0 findings)
- Codex review: PASS (2 consecutive runs, 0 [P0]/[P1])

## Deferred findings

- [P2] (codex, both passes) `src/rainier/alerts/discord.py:846-849` — LLM-only configuration (operator sets ONLY `DISCORD_LLM_WEBHOOK_URL` and leaves both `DISCORD_STOCK_WEBHOOK_URL` and `DISCORD_WEBHOOK_URL` empty) silently sends nothing because `send_stock_candidates` returns early at `_resolve_webhook_url(config)` before `_resolve_llm_webhook_url` is consulted. Edge case — the operator's intended deployment sets both `stock` and `llm`, so this PR is functionally correct. Follow-up issue should split the early-return so thesis embeds can ship without a stock channel.

## Test plan

- [x] `uv run pytest tests/ -v` — passes (751 passed / 2 skipped at impl time).
- [x] `uv run ruff check src/ tests/` — clean.
- [x] Unit tests assert routing: thesis embeds → LLM URL when set, fall back to stock URL when unset, fall back to main URL when both unset; top-20 list always → stock URL; multipart (chart attachment) thesis post also routes to LLM URL.
- [x] Settings plumbing test: `DISCORD_LLM_WEBHOOK_URL` env var → `Settings.alerts.discord.llm_webhook_url`; yaml value preserved when env empty.
- [ ] Manual verification (post-merge): next afternoon scrape (12:45 PT) should post regular top-20 to general QU100 channel AND per-ticker LLM embeds to QU100-LLM channel. Or test immediately via `uv run rainier scrape qu --session afternoon --cdp http://127.0.0.1:9222` against warm Chrome (PR #72 cron-wiring is merged).