### PR TITLE
feat(cli): add `rainier debug post-fake-thesis` routing probe

### DIFF
--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2810,3 +2810,157 @@ def thesis_research_verdicts(days):
                 f"{verdict:<12} {hr.horizon:<8} {hr.n:<6} {hr.win_rate:<10.2%} "
                 f"{hr.avg_return_pct:+.4f}"
             )
+
+
+# ---------------------------------------------------------------------------
+# `rainier debug ...` — test utilities. NOT for normal operations.
+# ---------------------------------------------------------------------------
+#
+# This group hosts probes that exercise live integration points without
+# their usual upstream dependencies (scrape, screener, LLM). Today: one
+# command that POSTs a synthetic per-ticker thesis embed to Discord so the
+# operator can verify the PR #73 routing (llm_webhook_url vs
+# stock_webhook_url) end-to-end without waiting on a fresh scan.
+
+@cli.group()
+def debug():
+    """Test utilities — synthetic probes, no DB / LLM side effects."""
+
+
+# Verdicts allowed by `core.llm_thesis.schemas.TradeThesis.verdict`. Kept in
+# sync with the Literal there; importing from the schema at module load
+# time would force pydantic into the cli import path so we re-declare the
+# small enum here. A drift would be caught by `test_post_fake_thesis_help_shows_options`
+# (which exercises the click.Choice) the moment the schema adds a new verdict.
+_FAKE_THESIS_VERDICTS = ("setup_long", "watch", "no_setup")
+
+
+@debug.command("post-fake-thesis")
+@click.option(
+    "--symbol",
+    default="TSLA",
+    help="Ticker symbol stamped on the synthetic candidate + thesis.",
+)
+@click.option(
+    "--verdict",
+    default="setup_long",
+    type=click.Choice(_FAKE_THESIS_VERDICTS),
+    help="TradeThesis.verdict on the synthetic post.",
+)
+@click.option(
+    "--llm-webhook/--stock-webhook",
+    "use_llm_webhook",
+    default=True,
+    help=(
+        "--llm-webhook (default): natural routing — thesis embed goes to "
+        "llm_webhook_url. --stock-webhook: clear llm_webhook_url in-memory "
+        "so the thesis falls back to stock_webhook_url (verifies the "
+        "_resolve_llm_webhook_url fallback path)."
+    ),
+)
+@click.pass_context
+def debug_post_fake_thesis(ctx, symbol, verdict, use_llm_webhook):
+    """POST a synthetic thesis embed to Discord — routing-only probe.
+
+    Builds an in-memory StockCandidate + TradeThesis tagged with the
+    literal `[FAKE TEST POST]` marker, then calls send_stock_candidates
+    to exercise the same code path the scheduler uses. No DB I/O, no LLM
+    call, no chart attachment. Prints the resolved webhook URLs to stdout
+    so the operator can confirm routing without parsing Discord.
+
+    Exit code: 0 on successful POST(s); non-zero if no webhook is
+    configured or the underlying httpx call raises.
+    """
+    from rainier.alerts.discord import (
+        _resolve_llm_webhook_url,
+        _resolve_webhook_url,
+        send_stock_candidates,
+    )
+    from rainier.core.config import DiscordConfig, load_settings_fresh
+    from rainier.core.types import StockCandidate
+    from rainier.llm_thesis.schemas import TradeThesis
+
+    settings = load_settings_fresh(_settings_path(ctx))
+
+    # We never mutate the operator's live settings — clone the DiscordConfig
+    # so the --stock-webhook override stays in-process only. Pydantic v2's
+    # model_copy keeps validation invariants intact.
+    discord_cfg: DiscordConfig = settings.alerts.discord.model_copy()
+    # The probe always wants Discord on, even if the operator's config
+    # has alerts.discord.enabled=False (e.g. local dev where notifications
+    # are normally muted). The probe IS the notification.
+    discord_cfg.enabled = True
+    if not use_llm_webhook:
+        # --stock-webhook: clear llm_webhook_url so _resolve_llm_webhook_url
+        # falls back to stock_webhook_url (or webhook_url).
+        discord_cfg.llm_webhook_url = ""
+
+    # Resolve both URLs ahead of time so we can print + sanity-check before
+    # POSTing. Stays in sync with send_stock_candidates' own resolution.
+    stock_url = _resolve_webhook_url(discord_cfg)
+    thesis_url = _resolve_llm_webhook_url(discord_cfg)
+    if not stock_url and not thesis_url:
+        raise click.ClickException(
+            "No Discord webhook URLs configured (webhook_url, "
+            "stock_webhook_url, llm_webhook_url all empty). "
+            "Set DISCORD_*_WEBHOOK_URL in .env or alerts.discord.* in "
+            "settings.yaml."
+        )
+
+    # ---- synthetic candidate ------------------------------------------------
+    # Plausible-looking but obviously test values; the [FAKE TEST POST]
+    # marker is the load-bearing safety signal once this lands in Discord.
+    fake_symbol = symbol.upper()
+    candidate = StockCandidate(
+        symbol=fake_symbol,
+        rank=1,
+        rank_change=0,
+        long_short="Long in",
+        capital_flow_direction="+",
+        sector="[FAKE TEST POST] Synthetic",
+        signal_strength=0.85,
+        money_flow_score=70.0,
+        pattern_type="bull_flag",
+        pattern_direction="bullish",
+        pattern_status="confirmed",
+        pattern_confidence=0.85,
+        entry_price=100.0,
+        stop_loss=95.0,
+        target_price=115.0,
+        rr_ratio=3.0,
+        volume_confirmed=True,
+        current_price=100.0,
+        distance_to_entry_pct=0.0,
+        bars_since_breakout=0,
+    )
+
+    # ---- synthetic thesis ---------------------------------------------------
+    thesis_model = TradeThesis(
+        verdict=verdict,
+        setup_quality=8,
+        llm_confidence=7,
+        paragraph_radar="[FAKE TEST POST] synthetic",
+        paragraph_evidence="[FAKE TEST POST] synthetic",
+        paragraph_invalidation="[FAKE TEST POST] synthetic",
+        risks=["[FAKE TEST POST] synthetic risk"],
+        watch_items=["[FAKE TEST POST] synthetic watch"],
+        evidence_used=["rank_trajectory"],
+        signals_used=["rank_trajectory", "capital_flow_streak"],
+        patterns_in_chart_not_in_indicators="none",
+    )
+    thesis_dict = thesis_model.model_dump()
+
+    click.echo(f"Posting [FAKE TEST POST] thesis for {fake_symbol}...")
+    click.echo(f"  summary webhook (stock_webhook_url) : {stock_url or '(none)'}")
+    click.echo(f"  thesis  webhook (llm_webhook_url)   : {thesis_url or '(none)'}")
+    try:
+        send_stock_candidates(
+            [candidate],
+            discord_cfg,
+            theses={fake_symbol: thesis_dict},
+            dashboard_base_url=None,
+        )
+    except Exception as exc:
+        raise click.ClickException(f"Discord POST failed: {exc}") from exc
+
+    click.echo("done.")

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2843,6 +2843,45 @@ def _trade_thesis_verdicts() -> tuple[str, ...]:
 _FAKE_THESIS_VERDICTS = _trade_thesis_verdicts()
 
 
+def _mask_webhook_url(url: str | None) -> str:
+    """Redact a Discord webhook URL for stdout logging.
+
+    Discord webhook URLs are bearer credentials: anyone with the full URL
+    can post into the channel. The routing probe needs to tell the
+    operator WHICH channel was resolved (so they can verify a config
+    change took effect) without leaking the credential into shared
+    shells, CI logs, or debugging transcripts.
+
+    Format: ``https://<host>/api/webhooks/<channel_id>/****<last6>``
+    Channel ID is non-secret (visible in Discord's UI); the token tail
+    gives the operator a stable 6-char fingerprint they can compare
+    against their .env to confirm the right URL was picked without
+    exposing the full secret.
+
+    Returns ``"(none)"`` for empty / missing URLs, and the literal input
+    (with a fallback redaction) for malformed URLs that don't match the
+    Discord webhook shape — we never echo a non-empty URL verbatim.
+    """
+    if not url:
+        return "(none)"
+    # Discord webhook URL: https://discord.com/api/webhooks/<channel_id>/<token>
+    # Token is the secret. Channel ID is public-equivalent (visible in UI).
+    marker = "/api/webhooks/"
+    idx = url.find(marker)
+    if idx == -1:
+        # Not a Discord webhook URL — could be a proxy / smee.io / custom
+        # relay. Don't trust the format; redact aggressively.
+        return f"<non-discord webhook, {len(url)} chars, ...{url[-6:]}>"
+    prefix = url[: idx + len(marker)]
+    tail = url[idx + len(marker) :]
+    parts = tail.split("/", 1)
+    if len(parts) != 2 or not parts[1]:
+        return f"{prefix}<malformed>"
+    channel_id, token = parts
+    token_tail = token[-6:] if len(token) > 6 else "****"
+    return f"{prefix}{channel_id}/****{token_tail}"
+
+
 @debug.command("post-fake-thesis")
 @click.option(
     "--symbol",
@@ -2972,8 +3011,8 @@ def debug_post_fake_thesis(ctx, symbol, verdict, use_llm_webhook):
     thesis_dict = thesis_model.model_dump()
 
     click.echo(f"Posting [FAKE TEST POST] thesis for {fake_symbol}...")
-    click.echo(f"  summary webhook (stock_webhook_url) : {stock_url or '(none)'}")
-    click.echo(f"  thesis  webhook (llm_webhook_url)   : {thesis_url or '(none)'}")
+    click.echo(f"  summary webhook (stock_webhook_url) : {_mask_webhook_url(stock_url)}")
+    click.echo(f"  thesis  webhook (llm_webhook_url)   : {_mask_webhook_url(thesis_url)}")
     try:
         send_stock_candidates(
             [candidate],

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2911,11 +2911,20 @@ def debug_post_fake_thesis(ctx, symbol, verdict, use_llm_webhook):
     # POSTing. Stays in sync with send_stock_candidates' own resolution.
     stock_url = _resolve_webhook_url(discord_cfg)
     thesis_url = _resolve_llm_webhook_url(discord_cfg)
-    if not stock_url and not thesis_url:
+    # send_stock_candidates bails at its first line when stock_url is empty
+    # (it needs the summary channel to fire even if only the thesis is
+    # actually interesting to us). Catch that here so the probe doesn't
+    # exit 0 having sent nothing — the canonical false-success failure
+    # mode for routing diagnostics. A config with ONLY llm_webhook_url
+    # set is supported by the dataclass but unusable by the renderer; the
+    # operator wants to know that immediately.
+    if not stock_url:
         raise click.ClickException(
-            "No Discord webhook URLs configured (webhook_url, "
-            "stock_webhook_url, llm_webhook_url all empty). "
-            "Set DISCORD_*_WEBHOOK_URL in .env or alerts.discord.* in "
+            "No summary Discord webhook configured (stock_webhook_url + "
+            "webhook_url both empty). send_stock_candidates requires a "
+            "summary channel even when llm_webhook_url is set; the thesis "
+            "embed would never POST. Set DISCORD_STOCK_WEBHOOK_URL (or "
+            "DISCORD_WEBHOOK_URL) in .env or alerts.discord.* in "
             "settings.yaml."
         )
 

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3033,6 +3033,22 @@ def debug_post_fake_thesis(ctx, symbol, verdict, use_llm_webhook):
 
     captor = _DiscordFailureCaptor(level=_stdlib_logging.ERROR)
     discord_logger = _stdlib_logging.getLogger("rainier.alerts.discord")
+    # Logger.isEnabledFor() is the gate BEFORE handlers run — if the
+    # caller (CI wrapper, structlog config, etc.) raised the discord
+    # logger to CRITICAL, ERROR records get dropped at the logger and
+    # the captor never sees them. Temporarily lower the level to ERROR
+    # so log.exception(...) calls inside send_stock_candidates reach
+    # our handler, then restore on the way out so we don't perturb the
+    # operator's logging config beyond this call.
+    saved_level = discord_logger.level
+    saved_disabled = discord_logger.disabled
+    saved_propagate = discord_logger.propagate
+    discord_logger.setLevel(_stdlib_logging.ERROR)
+    discord_logger.disabled = False
+    # propagate=False so our captured records don't also fire on parent
+    # handlers (which might surface stack traces the operator doesn't
+    # need for the routing diagnostic). The captor is our only sink.
+    discord_logger.propagate = False
     discord_logger.addHandler(captor)
     try:
         send_stock_candidates(
@@ -3045,6 +3061,9 @@ def debug_post_fake_thesis(ctx, symbol, verdict, use_llm_webhook):
         raise click.ClickException(f"Discord POST failed: {exc}") from exc
     finally:
         discord_logger.removeHandler(captor)
+        discord_logger.setLevel(saved_level)
+        discord_logger.disabled = saved_disabled
+        discord_logger.propagate = saved_propagate
 
     if captured_failures:
         # Render a terse one-line summary of each captured failure so the

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2915,12 +2915,14 @@ def debug_post_fake_thesis(ctx, symbol, verdict, use_llm_webhook):
     call, no chart attachment. Prints the resolved webhook URLs to stdout
     so the operator can confirm routing without parsing Discord.
 
-    Exit code: 0 unless no Discord webhook is configured at all (in which
-    case the command exits non-zero before POSTing). Note that the
-    underlying ``send_stock_candidates`` catches httpx exceptions
-    internally (logged via ``log.exception``), so a 4xx/5xx Discord
-    response will still exit 0 — verify the Discord channel directly
-    rather than relying on the exit code as a post-success signal.
+    Exit code: 0 on successful POST(s). Non-zero on (a) missing
+    summary-channel webhook config, (b) ``send_stock_candidates``
+    raising synchronously, or (c) a Discord HTTP failure (4xx/5xx,
+    timeout, connection error) that ``send_stock_candidates`` would
+    otherwise swallow as ``log.exception(...)``. The probe attaches a
+    logging captor to ``rainier.alerts.discord`` so swallowed httpx
+    failures surface as a ClickException, preserving the routing
+    probe's value as a real end-to-end diagnostic.
     """
     from rainier.alerts.discord import (
         _resolve_llm_webhook_url,
@@ -3013,6 +3015,25 @@ def debug_post_fake_thesis(ctx, symbol, verdict, use_llm_webhook):
     click.echo(f"Posting [FAKE TEST POST] thesis for {fake_symbol}...")
     click.echo(f"  summary webhook (stock_webhook_url) : {_mask_webhook_url(stock_url)}")
     click.echo(f"  thesis  webhook (llm_webhook_url)   : {_mask_webhook_url(thesis_url)}")
+
+    # send_stock_candidates() catches httpx exceptions internally
+    # (`log.exception(...)`) and returns normally, so a 4xx/5xx Discord
+    # response would otherwise let this probe exit 0 with "done." — the
+    # exact false-success path operators use this command to diagnose.
+    # Attach a captor handler to the discord logger so we can detect
+    # those swallowed failures and surface them as a non-zero exit.
+    import logging as _stdlib_logging
+
+    captured_failures: list[_stdlib_logging.LogRecord] = []
+
+    class _DiscordFailureCaptor(_stdlib_logging.Handler):
+        def emit(self, record: _stdlib_logging.LogRecord) -> None:
+            if record.levelno >= _stdlib_logging.ERROR:
+                captured_failures.append(record)
+
+    captor = _DiscordFailureCaptor(level=_stdlib_logging.ERROR)
+    discord_logger = _stdlib_logging.getLogger("rainier.alerts.discord")
+    discord_logger.addHandler(captor)
     try:
         send_stock_candidates(
             [candidate],
@@ -3020,7 +3041,27 @@ def debug_post_fake_thesis(ctx, symbol, verdict, use_llm_webhook):
             theses={fake_symbol: thesis_dict},
             dashboard_base_url=None,
         )
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 — synthetic-payload bugs surface here
         raise click.ClickException(f"Discord POST failed: {exc}") from exc
+    finally:
+        discord_logger.removeHandler(captor)
+
+    if captured_failures:
+        # Render a terse one-line summary of each captured failure so the
+        # operator can tell which endpoint failed (summary vs thesis)
+        # without having to grep the structured log. We do NOT echo the
+        # full webhook URL — only the logger event name + exception
+        # class. The URL has already been printed in masked form above.
+        summaries = []
+        for rec in captured_failures:
+            exc_type = (
+                rec.exc_info[0].__name__ if rec.exc_info and rec.exc_info[0] else "?"
+            )
+            summaries.append(f"{rec.getMessage()} ({exc_type})")
+        raise click.ClickException(
+            "Discord POST failed (send_stock_candidates swallowed the "
+            "error internally; the probe surfaced it): "
+            + "; ".join(summaries)
+        )
 
     click.echo("done.")

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2827,12 +2827,20 @@ def debug():
     """Test utilities — synthetic probes, no DB / LLM side effects."""
 
 
-# Verdicts allowed by `core.llm_thesis.schemas.TradeThesis.verdict`. Kept in
-# sync with the Literal there; importing from the schema at module load
-# time would force pydantic into the cli import path so we re-declare the
-# small enum here. A drift would be caught by `test_post_fake_thesis_help_shows_options`
-# (which exercises the click.Choice) the moment the schema adds a new verdict.
-_FAKE_THESIS_VERDICTS = ("setup_long", "watch", "no_setup")
+# Verdicts allowed by `core.llm_thesis.schemas.TradeThesis.verdict`. Derived
+# from the Literal annotation at module load so a schema change (new verdict,
+# rename, removal) automatically flows through to the click.Choice without a
+# manual edit here. The import does pull pydantic into the cli import path,
+# but that's already true via core.config → BaseSettings, so the cost is zero.
+def _trade_thesis_verdicts() -> tuple[str, ...]:
+    from typing import get_args
+
+    from rainier.llm_thesis.schemas import TradeThesis
+
+    return tuple(get_args(TradeThesis.model_fields["verdict"].annotation))
+
+
+_FAKE_THESIS_VERDICTS = _trade_thesis_verdicts()
 
 
 @debug.command("post-fake-thesis")
@@ -2868,8 +2876,12 @@ def debug_post_fake_thesis(ctx, symbol, verdict, use_llm_webhook):
     call, no chart attachment. Prints the resolved webhook URLs to stdout
     so the operator can confirm routing without parsing Discord.
 
-    Exit code: 0 on successful POST(s); non-zero if no webhook is
-    configured or the underlying httpx call raises.
+    Exit code: 0 unless no Discord webhook is configured at all (in which
+    case the command exits non-zero before POSTing). Note that the
+    underlying ``send_stock_candidates`` catches httpx exceptions
+    internally (logged via ``log.exception``), so a 4xx/5xx Discord
+    response will still exit 0 — verify the Discord channel directly
+    rather than relying on the exit code as a post-success signal.
     """
     from rainier.alerts.discord import (
         _resolve_llm_webhook_url,

--- a/tests/test_cli/test_debug_post_fake_thesis.py
+++ b/tests/test_cli/test_debug_post_fake_thesis.py
@@ -242,6 +242,33 @@ def test_synthetic_post_contains_fake_test_marker():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Schema drift guard — _FAKE_THESIS_VERDICTS must track TradeThesis.verdict
+# ---------------------------------------------------------------------------
+
+
+def test_fake_thesis_verdicts_match_schema():
+    """`_FAKE_THESIS_VERDICTS` must mirror `TradeThesis.verdict` Literal args
+    so the click.Choice on `--verdict` never drifts away from the schema.
+
+    The CLI derives the tuple from the schema at module load
+    (`_trade_thesis_verdicts`), so any new verdict added to the Literal will
+    automatically expand the click.Choice. This test pins that invariant so
+    a refactor that hardcodes the tuple back to a literal trips immediately
+    rather than silently dropping a verdict from the probe.
+    """
+    from typing import get_args
+
+    from rainier.cli import _FAKE_THESIS_VERDICTS
+    from rainier.llm_thesis.schemas import TradeThesis
+
+    schema_verdicts = tuple(get_args(TradeThesis.model_fields["verdict"].annotation))
+    assert _FAKE_THESIS_VERDICTS == schema_verdicts, (
+        f"CLI verdict choice drifted from schema: cli={_FAKE_THESIS_VERDICTS!r} "
+        f"schema={schema_verdicts!r}"
+    )
+
+
 def test_command_does_not_import_llm_client():
     """The command must not call any LLM provider — it's a routing-only
     probe. We assert by checking that send_stock_candidates was the entry

--- a/tests/test_cli/test_debug_post_fake_thesis.py
+++ b/tests/test_cli/test_debug_post_fake_thesis.py
@@ -1,0 +1,267 @@
+"""Tests for `rainier debug post-fake-thesis` — synthetic Discord routing probe.
+
+This command exists to verify the per-ticker thesis embed routing introduced
+by PR #73 (`DiscordConfig.llm_webhook_url` + `_resolve_llm_webhook_url`)
+END-TO-END against the live webhook URLs without requiring a scrape,
+screener candidates, or a real LLM call. The unit tests below pin down the
+behavior that makes that probe trustworthy:
+
+* the synthetic candidate carries the `[FAKE TEST POST]` marker (so the
+  post lands in Discord as obviously test data, not a real signal),
+* default flags route the thesis embed to ``llm_webhook_url`` and the
+  top-N summary to ``stock_webhook_url`` (matches production wiring),
+* ``--stock-webhook`` clears ``llm_webhook_url`` in-process so the thesis
+  embed falls back to ``stock_webhook_url`` (exercises the same fallback
+  path operations rely on when the dedicated channel isn't configured),
+* missing webhook URLs produce a clear non-zero exit so operators don't
+  silently lose the post.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from rainier.cli import cli
+from rainier.core.config import (
+    AlertsConfig,
+    DiscordConfig,
+    Settings,
+)
+
+
+def _settings_with_discord(
+    *,
+    webhook_url: str = "",
+    stock_webhook_url: str = "https://stock.example/hook",
+    llm_webhook_url: str = "https://llm.example/hook",
+    enabled: bool = True,
+) -> Settings:
+    """Build a Settings instance with just enough wiring for the debug command.
+
+    The CLI root constructs Settings via load_settings(); we patch the root
+    loader and the per-command `load_settings_fresh()` so neither touches
+    disk. Both helpers must return the same shape so the command sees the
+    Discord URLs we configured here.
+    """
+    discord = DiscordConfig(
+        webhook_url=webhook_url,
+        stock_webhook_url=stock_webhook_url,
+        llm_webhook_url=llm_webhook_url,
+        enabled=enabled,
+    )
+    return Settings(
+        database_url="postgresql://test:test@localhost/test",
+        alerts=AlertsConfig(discord=discord),
+    )
+
+
+def _invoke(args: list[str], settings: Settings, mock_post: MagicMock):
+    """Run the CLI with patched settings + httpx.post.
+
+    We patch BOTH `rainier.cli.load_settings` (cli root) and
+    `rainier.core.config.load_settings_fresh` (the per-command fresh
+    loader) so the debug command sees the same stub regardless of which
+    path it picks. httpx.post is patched at the module that actually
+    issues the POST — `rainier.alerts.discord.httpx.post` — which both
+    the summary embed and the thesis embed routes call into.
+    """
+    runner = CliRunner()
+    mock_post.return_value = MagicMock(status_code=204)
+    with patch("rainier.cli.load_settings", return_value=settings), \
+         patch("rainier.core.config.load_settings_fresh", return_value=settings), \
+         patch("rainier.alerts.discord.httpx.post", mock_post):
+        result = runner.invoke(cli, args)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Help / discoverability
+# ---------------------------------------------------------------------------
+
+
+def test_debug_group_exposes_post_fake_thesis():
+    """`rainier debug --help` lists the post-fake-thesis subcommand."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["debug", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "post-fake-thesis" in result.output
+
+
+def test_post_fake_thesis_help_shows_options():
+    """The command's `--help` mentions every flag in the spec."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["debug", "post-fake-thesis", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "--symbol" in result.output
+    assert "--verdict" in result.output
+    assert "--llm-webhook" in result.output
+    assert "--stock-webhook" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Default routing — thesis embed → llm_webhook_url, summary → stock_webhook_url
+# ---------------------------------------------------------------------------
+
+
+def test_default_routes_thesis_to_llm_webhook_summary_to_stock_webhook():
+    """With llm_webhook_url set, the thesis embed POSTs to the LLM channel
+    and the top-N summary POSTs to the stock channel.
+
+    The renderer issues two distinct httpx.post calls:
+      1. The summary embed payload (top-20-list) → stock_webhook_url.
+      2. The per-ticker thesis embed → llm_webhook_url.
+
+    We capture the URLs from `mock_post.call_args_list` and assert they
+    match the configured destinations. Order matters: the summary goes
+    out first inside `send_stock_candidates`, then thesis embeds.
+    """
+    settings = _settings_with_discord()
+    mock_post = MagicMock()
+    result = _invoke(
+        ["debug", "post-fake-thesis", "--symbol", "TSLA"],
+        settings,
+        mock_post,
+    )
+
+    assert result.exit_code == 0, result.output
+
+    # Collect every URL httpx.post was called with (positional arg 0 in
+    # the current send_stock_candidates implementation).
+    urls = [call.args[0] for call in mock_post.call_args_list]
+    assert len(urls) == 2, f"expected 2 POSTs (summary + thesis), got {urls!r}"
+    assert urls[0] == "https://stock.example/hook"  # summary → stock channel
+    assert urls[1] == "https://llm.example/hook"    # thesis → LLM channel
+
+
+def test_default_stdout_reports_resolved_urls():
+    """The operator-facing stdout prints BOTH resolved webhook URLs so the
+    operator can visually confirm routing without parsing Discord."""
+    settings = _settings_with_discord()
+    mock_post = MagicMock()
+    result = _invoke(
+        ["debug", "post-fake-thesis", "--symbol", "TSLA"],
+        settings,
+        mock_post,
+    )
+    assert result.exit_code == 0, result.output
+    assert "https://llm.example/hook" in result.output
+    assert "https://stock.example/hook" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --stock-webhook fallback — clears llm_webhook_url; thesis falls back to stock
+# ---------------------------------------------------------------------------
+
+
+def test_stock_webhook_flag_routes_thesis_to_stock_channel():
+    """--stock-webhook overrides the in-memory llm_webhook_url so the thesis
+    embed routes to stock_webhook_url instead. Verifies the documented
+    fallback path in `_resolve_llm_webhook_url`."""
+    settings = _settings_with_discord()
+    mock_post = MagicMock()
+    result = _invoke(
+        ["debug", "post-fake-thesis", "--symbol", "TSLA", "--stock-webhook"],
+        settings,
+        mock_post,
+    )
+
+    assert result.exit_code == 0, result.output
+    urls = [call.args[0] for call in mock_post.call_args_list]
+    assert len(urls) == 2, f"expected 2 POSTs (summary + thesis), got {urls!r}"
+    assert urls[0] == "https://stock.example/hook"
+    assert urls[1] == "https://stock.example/hook"  # thesis fell back
+
+
+# ---------------------------------------------------------------------------
+# Error path — no webhook configured at all → non-zero exit
+# ---------------------------------------------------------------------------
+
+
+def test_no_webhooks_configured_exits_nonzero_with_message():
+    """With every webhook URL empty, the command must fail loudly — never
+    silently swallow a missing-webhook configuration."""
+    settings = _settings_with_discord(
+        webhook_url="",
+        stock_webhook_url="",
+        llm_webhook_url="",
+    )
+    mock_post = MagicMock()
+    result = _invoke(
+        ["debug", "post-fake-thesis", "--symbol", "TSLA"],
+        settings,
+        mock_post,
+    )
+    assert result.exit_code != 0, result.output
+    assert "webhook" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Synthetic content sanity — `[FAKE TEST POST]` marker must reach Discord
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_post_contains_fake_test_marker():
+    """At least one POSTed payload must contain the literal `[FAKE TEST POST]`
+    marker so the post is unambiguously test data once it lands in Discord.
+
+    We don't enforce which embed carries it (the synthetic candidate's
+    title/headline OR the thesis paragraphs) — only that the marker is
+    present somewhere in the outgoing JSON envelope across the two POSTs.
+    """
+    import json as _json
+
+    settings = _settings_with_discord()
+    mock_post = MagicMock()
+    result = _invoke(
+        ["debug", "post-fake-thesis", "--symbol", "TSLA"],
+        settings,
+        mock_post,
+    )
+    assert result.exit_code == 0, result.output
+
+    # send_stock_candidates uses keyword `json=` for plain-JSON POSTs; the
+    # multipart chart-attachment path uses `data={"payload_json": ...}` but
+    # the debug command never attaches a chart (image_bytes=None) so every
+    # POST should be JSON.
+    serialized_blobs: list[str] = []
+    for call in mock_post.call_args_list:
+        payload = call.kwargs.get("json")
+        if payload is not None:
+            serialized_blobs.append(_json.dumps(payload, default=str))
+    assert serialized_blobs, "no JSON payloads captured from httpx.post"
+    combined = "\n".join(serialized_blobs)
+    assert "[FAKE TEST POST]" in combined, (
+        f"expected [FAKE TEST POST] marker in outgoing payloads, got:\n{combined}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# No LLM calls — pure routing probe must never touch litellm/anthropic
+# ---------------------------------------------------------------------------
+
+
+def test_command_does_not_import_llm_client():
+    """The command must not call any LLM provider — it's a routing-only
+    probe. We assert by checking that send_stock_candidates was the entry
+    point (already verified by httpx.post being called twice with the
+    Discord URLs) AND that the thesis was built purely from synthetic
+    constants. The structural guarantee: TradeThesis.model_dump() is
+    called locally; no provider client is instantiated.
+
+    Cheap defensive check: the command's stdout should NOT contain
+    "litellm" / "anthropic" trace strings. (If a future refactor pulls
+    in a provider, this catches it.)
+    """
+    settings = _settings_with_discord()
+    mock_post = MagicMock()
+    result = _invoke(
+        ["debug", "post-fake-thesis", "--symbol", "TSLA"],
+        settings,
+        mock_post,
+    )
+    assert result.exit_code == 0, result.output
+    lowered = result.output.lower()
+    assert "litellm" not in lowered
+    assert "anthropic" not in lowered

--- a/tests/test_cli/test_debug_post_fake_thesis.py
+++ b/tests/test_cli/test_debug_post_fake_thesis.py
@@ -370,6 +370,50 @@ def test_discord_post_failure_exits_nonzero_and_does_not_print_done():
     assert "discord post failed" in lowered or "discord_send_failed" in lowered
 
 
+def test_failure_surfaces_even_when_discord_logger_is_silenced():
+    """The probe must detect swallowed httpx failures even when the
+    process has raised the ``rainier.alerts.discord`` logger to
+    CRITICAL (a common CI / wrapper-script default). Without this,
+    `logger.isEnabledFor(ERROR)` returns False and the captor handler
+    is never invoked.
+
+    Regression test for codex iter-5 [P2]: the probe lowers the logger
+    level to ERROR for its own duration and restores the prior level
+    on exit so the operator's logging config isn't perturbed.
+    """
+    import logging
+
+    import httpx
+
+    settings = _settings_with_discord()
+    mock_post = MagicMock()
+    mock_post.side_effect = httpx.HTTPError("simulated 500 internal")
+
+    # Caller (CI / wrapper) silences the discord logger.
+    discord_logger = logging.getLogger("rainier.alerts.discord")
+    saved_level = discord_logger.level
+    saved_disabled = discord_logger.disabled
+    discord_logger.setLevel(logging.CRITICAL)
+    try:
+        result = _invoke(
+            ["debug", "post-fake-thesis", "--symbol", "TSLA"],
+            settings,
+            mock_post,
+        )
+        assert result.exit_code != 0, (
+            "probe must surface the failure even when the caller silenced "
+            "the discord logger"
+        )
+        assert "done." not in result.output
+        # And the probe must NOT permanently change the caller's level.
+        assert discord_logger.level == logging.CRITICAL, (
+            f"probe leaked its logger-level override: level={discord_logger.level}"
+        )
+    finally:
+        discord_logger.setLevel(saved_level)
+        discord_logger.disabled = saved_disabled
+
+
 def test_thesis_post_failure_alone_still_surfaces():
     """If only the thesis embed POST fails (summary succeeds), the probe
     still exits non-zero — partial-delivery is a routing-misconfig

--- a/tests/test_cli/test_debug_post_fake_thesis.py
+++ b/tests/test_cli/test_debug_post_fake_thesis.py
@@ -195,6 +195,69 @@ def test_no_webhooks_configured_exits_nonzero_with_message():
     )
     assert result.exit_code != 0, result.output
     assert "webhook" in result.output.lower()
+    # No POSTs should have fired — the preflight gate is upstream of the renderer.
+    assert mock_post.call_count == 0, (
+        f"expected zero httpx.post calls on no-webhook config, got "
+        f"{mock_post.call_args_list!r}"
+    )
+
+
+def test_only_llm_webhook_configured_exits_nonzero():
+    """With ONLY ``llm_webhook_url`` set, send_stock_candidates would bail at
+    its first line (no summary webhook) and the thesis embed would never
+    POST — exactly the false-success failure mode the probe exists to
+    surface. The command must exit non-zero and explain why.
+
+    Regression test for codex iter-1: the original preflight accepted
+    "any webhook URL set" which let a llm-only config slide past, then
+    silently sent nothing.
+    """
+    settings = _settings_with_discord(
+        webhook_url="",
+        stock_webhook_url="",
+        llm_webhook_url="https://llm.example/hook",
+    )
+    mock_post = MagicMock()
+    result = _invoke(
+        ["debug", "post-fake-thesis", "--symbol", "TSLA"],
+        settings,
+        mock_post,
+    )
+    assert result.exit_code != 0, result.output
+    # Error message must point the operator at the missing summary channel,
+    # not just say "no webhook" — the LLM webhook IS set; the message has
+    # to disambiguate.
+    lowered = result.output.lower()
+    assert "summary" in lowered or "stock_webhook_url" in lowered, (
+        f"error must name the missing summary channel, got: {result.output}"
+    )
+    # And no POSTs fired.
+    assert mock_post.call_count == 0
+
+
+def test_webhook_url_fallback_summary_channel_accepted():
+    """If ``stock_webhook_url`` is empty but the generic ``webhook_url``
+    catch-all is set, the preflight accepts it — _resolve_webhook_url
+    falls through stock→webhook. Pins the fallback contract so the
+    iter-1 fix can't over-narrow and reject legitimate single-channel
+    operator configs.
+    """
+    settings = _settings_with_discord(
+        webhook_url="https://catchall.example/hook",
+        stock_webhook_url="",
+        llm_webhook_url="",
+    )
+    mock_post = MagicMock()
+    result = _invoke(
+        ["debug", "post-fake-thesis", "--symbol", "TSLA"],
+        settings,
+        mock_post,
+    )
+    assert result.exit_code == 0, result.output
+    urls = [call.args[0] for call in mock_post.call_args_list]
+    # Summary fires to the catch-all. The thesis embed also resolves to
+    # the catch-all via the llm→stock→webhook fallback chain.
+    assert urls and urls[0] == "https://catchall.example/hook"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli/test_debug_post_fake_thesis.py
+++ b/tests/test_cli/test_debug_post_fake_thesis.py
@@ -334,6 +334,71 @@ def test_synthetic_post_contains_fake_test_marker():
 
 
 # ---------------------------------------------------------------------------
+# Failure surfacing — swallowed Discord errors must produce non-zero exit
+# ---------------------------------------------------------------------------
+
+
+def test_discord_post_failure_exits_nonzero_and_does_not_print_done():
+    """If httpx raises (network error, 4xx/5xx, timeout), the probe must
+    surface it as non-zero exit even though ``send_stock_candidates``
+    catches the exception internally.
+
+    Regression test for codex iter-4 [P2]: the probe used to print
+    ``done.`` and exit 0 in this scenario — the exact false-success
+    path operators use this command to diagnose.
+    """
+    import httpx
+
+    settings = _settings_with_discord()
+    mock_post = MagicMock()
+    # First POST (summary) raises — simulates Discord rejecting a
+    # rotated webhook URL with a 401. send_stock_candidates catches
+    # this internally via log.exception; the probe's captor must
+    # convert it into a ClickException.
+    mock_post.side_effect = httpx.HTTPError("simulated 401 Unauthorized")
+    result = _invoke(
+        ["debug", "post-fake-thesis", "--symbol", "TSLA"],
+        settings,
+        mock_post,
+    )
+    assert result.exit_code != 0, result.output
+    assert "done." not in result.output, (
+        "false-success path triggered: probe printed 'done.' on a failed POST"
+    )
+    # Error output must point the operator at the actual failure path.
+    lowered = result.output.lower()
+    assert "discord post failed" in lowered or "discord_send_failed" in lowered
+
+
+def test_thesis_post_failure_alone_still_surfaces():
+    """If only the thesis embed POST fails (summary succeeds), the probe
+    still exits non-zero — partial-delivery is a routing-misconfig
+    signal worth catching."""
+    import httpx
+
+    settings = _settings_with_discord()
+    mock_post = MagicMock()
+
+    call_count = {"n": 0}
+
+    def _side_effect(url, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return MagicMock(status_code=204, raise_for_status=lambda: None)
+        # Second call is the thesis embed → raise.
+        raise httpx.HTTPError("simulated thesis-channel 404")
+
+    mock_post.side_effect = _side_effect
+    result = _invoke(
+        ["debug", "post-fake-thesis", "--symbol", "TSLA"],
+        settings,
+        mock_post,
+    )
+    assert result.exit_code != 0, result.output
+    assert call_count["n"] == 2, "both summary and thesis POSTs should fire"
+
+
+# ---------------------------------------------------------------------------
 # Webhook URL masking — credential safety guard
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cli/test_debug_post_fake_thesis.py
+++ b/tests/test_cli/test_debug_post_fake_thesis.py
@@ -30,12 +30,18 @@ from rainier.core.config import (
     Settings,
 )
 
+# Discord-shaped webhook URLs so the mask helper hits its real path. The
+# token tails are stable strings the tests can match against the masked
+# output. Real Discord webhooks are <channel_id>/<token-of-~68-chars>.
+_FAKE_STOCK_WEBHOOK = "https://discord.com/api/webhooks/111/STOCKTOKENSTOCKTOKEN"
+_FAKE_LLM_WEBHOOK = "https://discord.com/api/webhooks/222/LLMTOKENLLMTOKENLLMTOKEN"
+
 
 def _settings_with_discord(
     *,
     webhook_url: str = "",
-    stock_webhook_url: str = "https://stock.example/hook",
-    llm_webhook_url: str = "https://llm.example/hook",
+    stock_webhook_url: str = _FAKE_STOCK_WEBHOOK,
+    llm_webhook_url: str = _FAKE_LLM_WEBHOOK,
     enabled: bool = True,
 ) -> Settings:
     """Build a Settings instance with just enough wiring for the debug command.
@@ -128,16 +134,25 @@ def test_default_routes_thesis_to_llm_webhook_summary_to_stock_webhook():
     assert result.exit_code == 0, result.output
 
     # Collect every URL httpx.post was called with (positional arg 0 in
-    # the current send_stock_candidates implementation).
+    # the current send_stock_candidates implementation). These are the
+    # FULL URLs — the mask only applies to stdout, not the actual HTTP
+    # call (the renderer needs the credential to POST).
     urls = [call.args[0] for call in mock_post.call_args_list]
     assert len(urls) == 2, f"expected 2 POSTs (summary + thesis), got {urls!r}"
-    assert urls[0] == "https://stock.example/hook"  # summary → stock channel
-    assert urls[1] == "https://llm.example/hook"    # thesis → LLM channel
+    assert urls[0] == _FAKE_STOCK_WEBHOOK  # summary → stock channel
+    assert urls[1] == _FAKE_LLM_WEBHOOK    # thesis → LLM channel
 
 
-def test_default_stdout_reports_resolved_urls():
-    """The operator-facing stdout prints BOTH resolved webhook URLs so the
-    operator can visually confirm routing without parsing Discord."""
+def test_default_stdout_reports_resolved_urls_masked():
+    """The operator-facing stdout prints MASKED webhook URLs (channel_id
+    + last-6 token tail) so the operator can confirm routing without
+    leaking bearer credentials into shared shells, CI logs, or pasted
+    debugging transcripts.
+
+    Regression test for codex iter-2 [P1]: the original implementation
+    printed the full URL — anyone who saw the terminal output could
+    reuse it to post into the channel.
+    """
     settings = _settings_with_discord()
     mock_post = MagicMock()
     result = _invoke(
@@ -146,8 +161,20 @@ def test_default_stdout_reports_resolved_urls():
         mock_post,
     )
     assert result.exit_code == 0, result.output
-    assert "https://llm.example/hook" in result.output
-    assert "https://stock.example/hook" in result.output
+    # Channel IDs (public-equivalent in Discord UI) appear masked-form.
+    # Token tails are the last 6 chars of the URL token segment:
+    #   stock token "STOCKTOKENSTOCKTOKEN" → tail "KTOKEN"
+    #   llm   token "LLMTOKENLLMTOKENLLMTOKEN" → tail "MTOKEN"
+    assert "111/****KTOKEN" in result.output, result.output
+    assert "222/****MTOKEN" in result.output, result.output
+    # And the full tokens NEVER appear verbatim — this is the
+    # credential-leak regression guard.
+    assert "STOCKTOKENSTOCKTOKEN" not in result.output, (
+        "full stock webhook token leaked to stdout"
+    )
+    assert "LLMTOKENLLMTOKENLLMTOKEN" not in result.output, (
+        "full llm webhook token leaked to stdout"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -170,8 +197,8 @@ def test_stock_webhook_flag_routes_thesis_to_stock_channel():
     assert result.exit_code == 0, result.output
     urls = [call.args[0] for call in mock_post.call_args_list]
     assert len(urls) == 2, f"expected 2 POSTs (summary + thesis), got {urls!r}"
-    assert urls[0] == "https://stock.example/hook"
-    assert urls[1] == "https://stock.example/hook"  # thesis fell back
+    assert urls[0] == _FAKE_STOCK_WEBHOOK
+    assert urls[1] == _FAKE_STOCK_WEBHOOK  # thesis fell back
 
 
 # ---------------------------------------------------------------------------
@@ -242,8 +269,9 @@ def test_webhook_url_fallback_summary_channel_accepted():
     iter-1 fix can't over-narrow and reject legitimate single-channel
     operator configs.
     """
+    catchall = "https://discord.com/api/webhooks/333/CATCHALLTOKENCATCHALL"
     settings = _settings_with_discord(
-        webhook_url="https://catchall.example/hook",
+        webhook_url=catchall,
         stock_webhook_url="",
         llm_webhook_url="",
     )
@@ -257,7 +285,7 @@ def test_webhook_url_fallback_summary_channel_accepted():
     urls = [call.args[0] for call in mock_post.call_args_list]
     # Summary fires to the catch-all. The thesis embed also resolves to
     # the catch-all via the llm→stock→webhook fallback chain.
-    assert urls and urls[0] == "https://catchall.example/hook"
+    assert urls and urls[0] == catchall
 
 
 # ---------------------------------------------------------------------------
@@ -303,6 +331,46 @@ def test_synthetic_post_contains_fake_test_marker():
 # ---------------------------------------------------------------------------
 # No LLM calls — pure routing probe must never touch litellm/anthropic
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Webhook URL masking — credential safety guard
+# ---------------------------------------------------------------------------
+
+
+def test_mask_webhook_url_redacts_discord_token():
+    """``_mask_webhook_url`` keeps the channel ID (public-equivalent) and a
+    6-char token tail, redacts the rest. This is the load-bearing
+    credential-leak guard for stdout logging.
+    """
+    from rainier.cli import _mask_webhook_url
+
+    full = "https://discord.com/api/webhooks/123456/SECRETtokenLONG123456abcd"
+    masked = _mask_webhook_url(full)
+    assert "SECRETtokenLONG" not in masked
+    assert "123456/****" in masked  # channel id + redaction marker
+    assert masked.endswith("234abcd"[-6:]) or masked.endswith("56abcd")  # token tail
+
+
+def test_mask_webhook_url_handles_empty_and_none():
+    """Missing URLs render as a clear placeholder, not an empty string
+    (so the operator-facing output stays unambiguous)."""
+    from rainier.cli import _mask_webhook_url
+
+    assert _mask_webhook_url(None) == "(none)"
+    assert _mask_webhook_url("") == "(none)"
+
+
+def test_mask_webhook_url_redacts_non_discord_relay():
+    """A non-Discord relay URL (smee.io, custom proxy) still gets
+    redacted — we never echo a non-empty URL verbatim."""
+    from rainier.cli import _mask_webhook_url
+
+    relay = "https://smee.io/abcdefghijklmnop"
+    masked = _mask_webhook_url(relay)
+    assert "abcdefghij" not in masked
+    assert "mnop" in masked  # last-6 tail preserved
+    assert "non-discord" in masked.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New `rainier debug post-fake-thesis` subcommand POSTs a synthetic per-ticker thesis embed to Discord without scrape/screener/LLM dependencies, verifying the PR #73 routing (llm_webhook_url vs stock_webhook_url) end-to-end against real webhooks.
- Every synthetic field carries a literal `[FAKE TEST POST]` marker so the post is unambiguously test data. `--stock-webhook` clears `llm_webhook_url` in an in-memory `DiscordConfig` copy to exercise the fallback path.
- Hardening: fail-fast when only `llm_webhook_url` is set, mask webhook URLs in stdout, surface swallowed Discord HTTP failures, and temporarily force the discord logger to ERROR (restored via `finally`) so caller log-level config can't suppress the probe's failure detection.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 7)

## Test plan
- [ ] CI green
- [ ] verify locally