### PR TITLE
feat(research): slice0 CLI scaffold + cost-pilot + survivorship gate

### DIFF
--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3205,3 +3205,12 @@ def sma_sweep(
             phase=phase,
         )
         click.echo("done.")
+
+
+# Composition root — wire the research engine's `llm-research` subgroup
+# onto the root `rainier` command. Per project CLAUDE.md the research
+# package never reaches into production CLI plumbing; we register it here
+# so research/cli.py stays free of imports from production modules.
+from rainier.research.cli import register as _register_llm_research  # noqa: E402
+
+_register_llm_research(cli)

--- a/src/rainier/research/archive/__init__.py
+++ b/src/rainier/research/archive/__init__.py
@@ -1,0 +1,3 @@
+"""L4 MAP-Elites archive package — full implementation lands in Slice 2."""
+
+SLICE_THIS_LANDS_IN: int = 2

--- a/src/rainier/research/bandit/__init__.py
+++ b/src/rainier/research/bandit/__init__.py
@@ -1,0 +1,3 @@
+"""L5 Thompson bandit package — full implementation lands in Slice 2."""
+
+SLICE_THIS_LANDS_IN: int = 2

--- a/src/rainier/research/cli.py
+++ b/src/rainier/research/cli.py
@@ -41,6 +41,11 @@ def _resolve_ledger_sha() -> str:
     Best-effort — falls back to ``"unknown"`` when git isn't available
     (e.g., when running from a wheel install). Live invocations re-stamp
     this when the parquet is persisted.
+
+    ``git rev-parse HEAD:<path>`` resolves <path> relative to the repo
+    root, NOT the cwd. We first ask git for the toplevel and make the
+    ledger path relative to that — otherwise calling the CLI from any
+    subdir silently stamps `ledger_sha: unknown`. codex iter-6 [P2].
     """
     import subprocess
 
@@ -48,8 +53,17 @@ def _resolve_ledger_sha() -> str:
         Path(__file__).parent / "data_availability.yaml"
     ).resolve()
     try:
+        toplevel = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=False, timeout=5,
+        )
+        if toplevel.returncode != 0:
+            return "unknown"
+        repo_root = Path(toplevel.stdout.strip()).resolve()
+        rel = ledger_path.relative_to(repo_root)
         out = subprocess.run(
-            ["git", "rev-parse", f"HEAD:{ledger_path.relative_to(Path.cwd())}"],
+            ["git", "rev-parse", f"HEAD:{rel}"],
+            cwd=repo_root,
             capture_output=True, text=True, check=False, timeout=5,
         )
         if out.returncode == 0:

--- a/src/rainier/research/cli.py
+++ b/src/rainier/research/cli.py
@@ -1,0 +1,273 @@
+"""``uv run rainier llm-research <cmd>`` subcommand group.
+
+Slice 0 ships four subcommands:
+  - ``providers test`` — auth + endpoint sanity check
+  - ``call --dry-run`` — deterministic prompt assembly
+  - ``cost-pilot`` — 500-call envelope measurement (live or fixture)
+  - ``survivorship-check`` — D-016 PASS gate against qu100_history
+
+Stdout discipline (D-034): the verbose paths write to a per-run log under
+``~/.rainier/research/runs/<run_id>/run.log``; stdout emits only the
+[D-031] summary block or the JSON-typed record the subcommand documents.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import date
+from pathlib import Path
+
+import click
+
+from rainier.research import (
+    cost_pilot as cost_pilot_mod,
+)
+from rainier.research import (
+    output_schema as output_schema_mod,
+)
+from rainier.research import (
+    providers as providers_mod,
+)
+from rainier.research import (
+    survivorship as survivorship_mod,
+)
+from rainier.research.evaluator.builder import assemble_dry_run_pack
+
+
+def _resolve_ledger_sha() -> str:
+    """Return the ledger SHA used to stamp archive rows (D-014 amendment).
+
+    Best-effort — falls back to ``"unknown"`` when git isn't available
+    (e.g., when running from a wheel install). Live invocations re-stamp
+    this when the parquet is persisted.
+    """
+    import subprocess
+
+    ledger_path = (
+        Path(__file__).parent / "data_availability.yaml"
+    ).resolve()
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", f"HEAD:{ledger_path.relative_to(Path.cwd())}"],
+            capture_output=True, text=True, check=False, timeout=5,
+        )
+        if out.returncode == 0:
+            return out.stdout.strip() or "unknown"
+    except (subprocess.SubprocessError, ValueError):
+        pass
+    return "unknown"
+
+
+@click.group(name="llm-research")
+def llm_research() -> None:
+    """LLM research engine — Slice 0 CLI surface."""
+
+
+# --------------------------------------------------------------------------- #
+# providers test
+# --------------------------------------------------------------------------- #
+
+
+@llm_research.group(name="providers")
+def providers_group() -> None:
+    """Manage LLM provider adapters."""
+
+
+@providers_group.command(name="test")
+@click.option("--provider", "provider_name", default=None,
+              type=click.Choice(["anthropic", "deepseek", "openai_compatible"]),
+              help="Test a single provider; default tests all three.")
+@click.option("--json", "as_json", is_flag=True, default=False,
+              help="Emit JSON to stdout (CI / subagent path).")
+def providers_test(provider_name: str | None, as_json: bool) -> None:
+    """Sanity-check API keys + endpoints for configured providers."""
+    names = [provider_name] if provider_name else providers_mod.list_providers()
+    results = [providers_mod.get_provider(n).test_auth() for n in names]
+    if as_json:
+        click.echo(json.dumps([r.as_dict() for r in results]))
+        return
+    for r in results:
+        line = f"  {r.provider:20s} auth={r.auth.value}"
+        if r.next_step:
+            line += f"  next-step: {r.next_step}"
+        click.echo(line)
+
+
+# --------------------------------------------------------------------------- #
+# call --dry-run
+# --------------------------------------------------------------------------- #
+
+
+@llm_research.command(name="call")
+@click.option("--skill", required=True, help="Skill id (e.g. baseline_opus_multimodal_v1).")
+@click.option("--ticker", required=True, help="Stock ticker.")
+@click.option("--day", required=True, help="Evaluation day YYYY-MM-DD.")
+@click.option("--dry-run", is_flag=True, default=False,
+              help="Assemble + print the prompt; do not call the LLM.")
+@click.option("--provider", default="anthropic",
+              type=click.Choice(["anthropic", "deepseek", "openai_compatible"]))
+@click.option("--model", default=None, help="Override provider default model.")
+def call_command(skill: str, ticker: str, day: str, dry_run: bool,
+                 provider: str, model: str | None) -> None:
+    """Single LLM call (or dry-run prompt assembly)."""
+    eval_day = date.fromisoformat(day)
+    if not dry_run:
+        # Slice 1 ships the real run path; until then we surface the
+        # operator-actionable next-step rather than silently failing.
+        raise click.ClickException(
+            "Real LLM dispatch lands in Slice 1. Re-run with --dry-run to "
+            "exercise the prompt-assembly + determinism contract."
+        )
+    pack = assemble_dry_run_pack(skill=skill, ticker=ticker, day=eval_day)
+    payload = {
+        "skill": skill,
+        "ticker": ticker,
+        "day": day,
+        "provider": provider,
+        "model": model,
+        "prompt": pack.as_prompt(),
+        "dry_run": True,
+    }
+    click.echo(json.dumps(payload, sort_keys=True))
+
+
+# --------------------------------------------------------------------------- #
+# cost-pilot
+# --------------------------------------------------------------------------- #
+
+
+@llm_research.command(name="cost-pilot")
+@click.option("--skill", "skill_id", default="cost_pilot_v0",
+              help="Skill id stamped on per-call rows (default cost_pilot_v0).")
+@click.option("--n", default=500, type=int, help="Number of calls to run.")
+@click.option("--providers", "provider_list", default="anthropic,deepseek,openai_compatible",
+              help="Comma-separated providers to dial against.")
+@click.option("--out", "out_parquet", default="data/cache/slice0_cost_pilot.parquet",
+              type=click.Path(), help="Per-call parquet output path.")
+@click.option("--report-html", default="docs/slice0-cost-report.html",
+              type=click.Path(), help="HTML report output path.")
+@click.option("--hard-cap-usd", default=cost_pilot_mod.DEFAULT_HARD_CAP_USD,
+              type=float, help="Abort if cumulative spend exceeds this cap.")
+@click.option("--envelope-mean-usd", default=cost_pilot_mod.DEFAULT_ENVELOPE_MEAN_USD,
+              type=float, help="Expected mean cost per the rationale doc.")
+@click.option("--fixture", "fixture_path", default=None, type=click.Path(exists=True),
+              help="Replay a recorded fixture instead of dialing the live providers.")
+def cost_pilot_command(skill_id: str, n: int, provider_list: str,
+                       out_parquet: str, report_html: str,
+                       hard_cap_usd: float, envelope_mean_usd: float,
+                       fixture_path: str | None) -> None:
+    """Run the cost-pilot — measures the spend envelope per D-015."""
+    if fixture_path is None:
+        # Slice 1 implements the live dispatcher; surface the next-step.
+        raise click.ClickException(
+            "Live cost-pilot dispatcher lands in Slice 1. Re-run with "
+            "--fixture <path-to-recorded-calls.json> to exercise the "
+            "summary / report / verdict math here in Slice 0."
+        )
+    raw = json.loads(Path(fixture_path).read_text())
+    calls = raw.get("calls", raw if isinstance(raw, list) else [])
+    ledger_sha = raw.get("ledger_sha") or _resolve_ledger_sha()
+    skill_id = raw.get("skill_id", skill_id)
+
+    materialized = cost_pilot_mod.run_calls(
+        calls,
+        hard_cap_usd=hard_cap_usd,
+        out_parquet=out_parquet,
+        skill_id=skill_id,
+        ledger_sha=ledger_sha,
+    )
+    # Drop the budget_aborted bookkeeping row before computing per-call stats.
+    real_calls = [c for c in materialized if c.get("outcome") != "budget_aborted"]
+    summary = cost_pilot_mod.summarize(real_calls)
+    per_provider = cost_pilot_mod.per_provider_stats(real_calls)
+    verdict = cost_pilot_mod.verdict_for(
+        summary,
+        hard_cap_usd=hard_cap_usd,
+        envelope_mean_usd=envelope_mean_usd,
+    )
+    cost_pilot_mod.render_report(
+        summary,
+        per_provider=per_provider,
+        verdict=verdict,
+        out_path=report_html,
+        skill_id=skill_id,
+        ledger_sha=ledger_sha,
+    )
+
+    block = cost_pilot_mod.summary_block(
+        summary,
+        verdict=verdict,
+        skill_id=skill_id,
+        report_html_path=report_html,
+        ledger_sha=ledger_sha,
+        calls_total=n,
+    )
+    click.echo(output_schema_mod.format_block("cost_pilot", block))
+
+
+# --------------------------------------------------------------------------- #
+# survivorship-check
+# --------------------------------------------------------------------------- #
+
+
+@llm_research.command(name="survivorship-check")
+@click.option("--from", "from_date", default="2025-01-01",
+              help="Start of survivorship window (YYYY-MM-DD).")
+@click.option("--to", "to_date", default="2026-05-01",
+              help="End of survivorship window (YYYY-MM-DD).")
+@click.option("--json", "as_json", is_flag=True, default=False,
+              help="Emit JSON to stdout (CI / subagent path).")
+def survivorship_check_command(from_date: str, to_date: str, as_json: bool) -> None:
+    """Validate qu100_history coverage + insert-only proof (D-016)."""
+    from_d = date.fromisoformat(from_date)
+    to_d = date.fromisoformat(to_date)
+
+    # Test override: an env-var sqlite path means we run against an isolated
+    # in-memory DB rather than the project DB. Lets CLI tests run without a
+    # live Postgres + lets the operator dry-run against a known-good fixture.
+    sqlite_path = os.environ.get("RAINIER_RESEARCH_SURVIVORSHIP_SQLITE")
+    if sqlite_path:
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import Session
+
+        engine = create_engine(f"sqlite:///{sqlite_path}", future=True)
+        survivorship_mod.bootstrap_sqlite(engine)
+        session = Session(engine, future=True)
+    else:
+        from rainier.core.database import get_session
+
+        session = get_session().__enter__()  # type: ignore[attr-defined]
+
+    try:
+        result = survivorship_mod.check(
+            session=session, from_date=from_d, to_date=to_d
+        )
+    finally:
+        session.close()
+
+    payload = result.as_dict()
+    if as_json:
+        click.echo(json.dumps(payload, sort_keys=True))
+        return
+    # Non-JSON path: print the verdict line + a YAML block (D-034 single-block).
+    click.echo(output_schema_mod.format_block(
+        "survivorship",
+        {
+            "from_date": payload["from_date"],
+            "to_date": payload["to_date"],
+            "verdict": payload["verdict"],
+            "delisted_tickers": payload["delisted_tickers"],
+            "missing_days": payload["missing_days"],
+            "next_step": payload["next_step"],
+        },
+    ))
+
+
+def register(root: click.Group) -> None:
+    """Register the `llm-research` subgroup on the root CLI.
+
+    Called from ``rainier.cli`` (the composition root). Keeps the
+    research package free of any imports from production CLI plumbing.
+    """
+    root.add_command(llm_research)

--- a/src/rainier/research/cli.py
+++ b/src/rainier/research/cli.py
@@ -189,7 +189,19 @@ def cost_pilot_command(skill_id: str, n: int, provider_list: str,
     # may contain more records than --n (e.g., reusing a 500-call recording
     # for a 50-call smoke run); without this truncation we'd process the
     # entire fixture while still reporting calls_total=n in the summary.
-    bounded_calls = list(calls)[: max(0, int(n))]
+    #
+    # Conversely, if the fixture is SHORTER than --n we fail-fast rather
+    # than silently emit a "calls_total: 500" summary backed by 10 calls.
+    # The operator should either lower --n or supply a larger fixture.
+    calls_list = list(calls)
+    if len(calls_list) < n:
+        raise click.ClickException(
+            f"fixture has {len(calls_list)} call records but --n is {n}; "
+            f"either lower --n to {len(calls_list)} or supply a larger "
+            f"fixture. Refusing to emit a calls_total={n} summary backed "
+            f"by {len(calls_list)} real calls."
+        )
+    bounded_calls = calls_list[: max(0, int(n))]
     materialized = cost_pilot_mod.run_calls(
         bounded_calls,
         hard_cap_usd=hard_cap_usd,

--- a/src/rainier/research/cli.py
+++ b/src/rainier/research/cli.py
@@ -185,8 +185,13 @@ def cost_pilot_command(skill_id: str, n: int, provider_list: str,
             f"{type(raw).__name__}."
         )
 
+    # Bound the replay to the operator's requested call count. The fixture
+    # may contain more records than --n (e.g., reusing a 500-call recording
+    # for a 50-call smoke run); without this truncation we'd process the
+    # entire fixture while still reporting calls_total=n in the summary.
+    bounded_calls = list(calls)[: max(0, int(n))]
     materialized = cost_pilot_mod.run_calls(
-        calls,
+        bounded_calls,
         hard_cap_usd=hard_cap_usd,
         out_parquet=out_parquet,
         skill_id=skill_id,

--- a/src/rainier/research/cli.py
+++ b/src/rainier/research/cli.py
@@ -166,9 +166,24 @@ def cost_pilot_command(skill_id: str, n: int, provider_list: str,
             "summary / report / verdict math here in Slice 0."
         )
     raw = json.loads(Path(fixture_path).read_text())
-    calls = raw.get("calls", raw if isinstance(raw, list) else [])
-    ledger_sha = raw.get("ledger_sha") or _resolve_ledger_sha()
-    skill_id = raw.get("skill_id", skill_id)
+    # Two supported fixture shapes per the cost_pilot_10call fixture +
+    # the hand-recorded list shape: either {calls, ledger_sha, skill_id}
+    # or a bare top-level list of call records. Dispatch by type first;
+    # `raw.get` against a list would AttributeError, hiding the bug
+    # behind a confusing traceback.
+    if isinstance(raw, list):
+        calls = raw
+        ledger_sha = _resolve_ledger_sha()
+    elif isinstance(raw, dict):
+        calls = raw.get("calls", [])
+        ledger_sha = raw.get("ledger_sha") or _resolve_ledger_sha()
+        skill_id = raw.get("skill_id", skill_id)
+    else:
+        raise click.ClickException(
+            f"--fixture must be a JSON list of call records or a "
+            f"{{calls: [...], ledger_sha, skill_id}} object; got "
+            f"{type(raw).__name__}."
+        )
 
     materialized = cost_pilot_mod.run_calls(
         calls,

--- a/src/rainier/research/cost_pilot.py
+++ b/src/rainier/research/cost_pilot.py
@@ -155,7 +155,6 @@ def run_calls(
     """
     materialized: list[dict[str, Any]] = []
     running_total = 0.0
-    aborted = False
     for r in calls:
         cost = float(r["cost_usd"])
         materialized.append(dict(r))
@@ -175,11 +174,7 @@ def run_calls(
                     "outcome": "budget_aborted",
                 }
             )
-            aborted = True
             break
-    # Silence "unused variable" — `aborted` is part of the documented contract
-    # if a caller later wants the abort signal; keep it bound for readability.
-    del aborted
     persist_parquet(
         materialized, out_parquet, skill_id=skill_id, ledger_sha=ledger_sha
     )

--- a/src/rainier/research/cost_pilot.py
+++ b/src/rainier/research/cost_pilot.py
@@ -1,0 +1,309 @@
+"""Cost-pilot runner — 500-call envelope measurement (D-015).
+
+Slice 0 does NOT make real LLM calls from the test suite. The runner here
+takes a list of pre-recorded call records (provider/model/cost/outcome)
+and produces:
+  - summary statistics (mean / p95 / p99 cost, schema-retry-rate, cache-hit-rate)
+  - per-provider table
+  - PASS/CONDITIONAL/FAIL verdict
+  - parquet ledger of per-call rows
+  - rendered HTML report
+  - D-031 summary block for stdout
+
+The operator-driven live pilot writes its 500 records to
+``data/cache/slice0_cost_pilot.parquet`` and runs the same code path —
+the fixture and live modes share the same surface.
+"""
+
+from __future__ import annotations
+
+import html
+import statistics
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+# Verdict thresholds — concrete values chosen so the CONDITIONAL band is
+# meaningful but not trip-happy. Operator can override via CLI flags.
+DEFAULT_HARD_CAP_USD = 50.0
+DEFAULT_ENVELOPE_MEAN_USD = 0.10  # docs/RESEARCH-cost-pilot-rationale.html
+
+
+@dataclass(frozen=True)
+class CostSummary:
+    calls_completed: int
+    mean_cost_usd: float
+    p95_cost_usd: float
+    p99_cost_usd: float
+    schema_retry_rate: float
+    cache_hit_rate: float
+    total_spend_usd: float
+
+
+def _percentile(values: Sequence[float], pct: float) -> float:
+    """Nearest-rank percentile (deterministic; no numpy)."""
+    if not values:
+        return 0.0
+    sorted_vals = sorted(values)
+    if pct <= 0:
+        return sorted_vals[0]
+    if pct >= 100:
+        return sorted_vals[-1]
+    # 1-indexed nearest-rank.
+    rank = max(1, int(round(pct / 100.0 * len(sorted_vals))))
+    return sorted_vals[rank - 1]
+
+
+def summarize(calls: Iterable[dict[str, Any]]) -> CostSummary:
+    """Aggregate per-call records into a :class:`CostSummary`."""
+    records = list(calls)
+    n = len(records)
+    if n == 0:
+        return CostSummary(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    costs = [float(r["cost_usd"]) for r in records]
+    retries = sum(int(r.get("schema_retries", 0)) > 0 for r in records)
+    hits = sum(1 for r in records if bool(r.get("cache_hit", False)))
+    total = sum(costs)
+    return CostSummary(
+        calls_completed=n,
+        mean_cost_usd=round(total / n, 6),
+        p95_cost_usd=round(_percentile(costs, 95), 6),
+        p99_cost_usd=round(_percentile(costs, 99), 6),
+        schema_retry_rate=round(retries / n, 6),
+        cache_hit_rate=round(hits / n, 6),
+        total_spend_usd=round(total, 6),
+    )
+
+
+def per_provider_stats(calls: Iterable[dict[str, Any]]) -> dict[str, dict[str, float]]:
+    """One row per (provider, model) showing mean / p95 / p99 / count."""
+    rows = list(calls)
+    buckets: dict[str, list[float]] = {}
+    for r in rows:
+        key = f"{r['provider']}/{r['model']}"
+        buckets.setdefault(key, []).append(float(r["cost_usd"]))
+    out: dict[str, dict[str, float]] = {}
+    for key, costs in buckets.items():
+        out[key] = {
+            "count": len(costs),
+            "mean_usd": round(statistics.fmean(costs), 6),
+            "p95_usd": round(_percentile(costs, 95), 6),
+            "p99_usd": round(_percentile(costs, 99), 6),
+            "total_usd": round(sum(costs), 6),
+        }
+    return out
+
+
+def verdict_for(
+    summary: CostSummary,
+    hard_cap_usd: float = DEFAULT_HARD_CAP_USD,
+    envelope_mean_usd: float = DEFAULT_ENVELOPE_MEAN_USD,
+) -> str:
+    """Map a :class:`CostSummary` to PASS / CONDITIONAL / FAIL.
+
+    - FAIL when total spend exceeded the operator-set hard cap (D-015 mitigation).
+    - CONDITIONAL when mean cost is > 2x the rationale-doc envelope.
+    - PASS otherwise.
+    """
+    if summary.total_spend_usd > hard_cap_usd:
+        return "FAIL"
+    if summary.mean_cost_usd > 2 * envelope_mean_usd:
+        return "CONDITIONAL"
+    return "PASS"
+
+
+def persist_parquet(
+    calls: Iterable[dict[str, Any]],
+    out_path: str | Path,
+    *,
+    skill_id: str,
+    ledger_sha: str,
+) -> Path:
+    """Write per-call records as parquet (one row per call).
+
+    Adds ``skill_id`` + ``ledger_sha`` columns to every row so the file is
+    self-describing (the operator-review step doesn't need a separate
+    manifest).
+    """
+    rows = [
+        {**r, "skill_id": skill_id, "ledger_sha": ledger_sha}
+        for r in calls
+    ]
+    df = pd.DataFrame(rows)
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(out, index=False)
+    return out
+
+
+def run_calls(
+    calls: Iterable[dict[str, Any]],
+    *,
+    hard_cap_usd: float,
+    out_parquet: str | Path,
+    skill_id: str,
+    ledger_sha: str,
+) -> list[dict[str, Any]]:
+    """Replay a list of per-call records honoring the hard-cap stop-condition.
+
+    The live pilot replaces this with a function that streams from an LLM
+    provider; the contract is identical. When cumulative spend crosses the
+    hard cap, a ``budget_aborted`` row is appended and iteration stops.
+    """
+    materialized: list[dict[str, Any]] = []
+    running_total = 0.0
+    aborted = False
+    for r in calls:
+        cost = float(r["cost_usd"])
+        materialized.append(dict(r))
+        running_total += cost
+        # Crossing the cap inside this call means the next iteration must
+        # abort — we still record this call's outcome so the partial-spend
+        # is auditable, then append the budget_aborted marker and stop.
+        if running_total > hard_cap_usd:
+            materialized.append(
+                {
+                    "call_id": "budget-abort",
+                    "provider": "n/a",
+                    "model": "n/a",
+                    "cost_usd": 0.0,
+                    "schema_retries": 0,
+                    "cache_hit": False,
+                    "outcome": "budget_aborted",
+                }
+            )
+            aborted = True
+            break
+    # Silence "unused variable" — `aborted` is part of the documented contract
+    # if a caller later wants the abort signal; keep it bound for readability.
+    del aborted
+    persist_parquet(
+        materialized, out_parquet, skill_id=skill_id, ledger_sha=ledger_sha
+    )
+    return materialized
+
+
+def summary_block(
+    summary: CostSummary,
+    *,
+    verdict: str,
+    skill_id: str,
+    report_html_path: str | Path,
+    ledger_sha: str,
+    calls_total: int | None = None,
+) -> dict[str, Any]:
+    """Build the D-031 cost-pilot summary-block payload."""
+    return {
+        "slice": 0,
+        "skill_id": skill_id,
+        "calls_total": calls_total if calls_total is not None else summary.calls_completed,
+        "calls_completed": summary.calls_completed,
+        "mean_cost_usd": float(summary.mean_cost_usd),
+        "p95_cost_usd": float(summary.p95_cost_usd),
+        "p99_cost_usd": float(summary.p99_cost_usd),
+        "schema_retry_rate": float(summary.schema_retry_rate),
+        "cache_hit_rate": float(summary.cache_hit_rate),
+        "total_spend_usd": float(summary.total_spend_usd),
+        "verdict": verdict,
+        "report_html": str(report_html_path),
+        "ledger_sha": ledger_sha,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# HTML report — operator-readable artifact (D-014 / RESEARCH-cost-pilot-rationale).
+# --------------------------------------------------------------------------- #
+
+
+_REPORT_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Slice 0 cost-pilot report</title>
+<style>
+  body {{ font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 820px; margin: 40px auto; padding: 0 24px; color: #1f2937; }}
+  h1 {{ font-size: 22px; }}
+  table {{ border-collapse: collapse; margin: 16px 0; width: 100%; }}
+  th, td {{ border: 1px solid #e5e7eb; padding: 6px 10px; text-align: right; }}
+  th:first-child, td:first-child {{ text-align: left; }}
+  .verdict {{ font-weight: 700; padding: 6px 12px; border-radius: 4px; display: inline-block; }}
+  .verdict.PASS {{ background: #d1fae5; color: #065f46; }}
+  .verdict.CONDITIONAL {{ background: #fef3c7; color: #92400e; }}
+  .verdict.FAIL {{ background: #fee2e2; color: #991b1b; }}
+  .meta {{ color: #6b7280; font-size: 13px; }}
+</style>
+</head>
+<body>
+<h1>Slice 0 cost-pilot report</h1>
+<p class="meta">skill_id: <code>{skill_id}</code> · ledger_sha: <code>{ledger_sha}</code></p>
+<p>Verdict: <span class="verdict {verdict}">{verdict}</span></p>
+
+<h2>Aggregate</h2>
+<table>
+  <tr><th>Calls completed</th><td>{calls_completed}</td></tr>
+  <tr><th>Mean cost ($)</th><td>{mean_cost_usd:.6f}</td></tr>
+  <tr><th>P95 cost ($)</th><td>{p95_cost_usd:.6f}</td></tr>
+  <tr><th>P99 cost ($)</th><td>{p99_cost_usd:.6f}</td></tr>
+  <tr><th>Schema retry rate</th><td>{schema_retry_rate:.4f}</td></tr>
+  <tr><th>Cache hit rate</th><td>{cache_hit_rate:.4f}</td></tr>
+  <tr><th>Total spend ($)</th><td>{total_spend_usd:.4f}</td></tr>
+</table>
+
+<h2>Per-provider</h2>
+<table>
+  <tr><th>provider / model</th><th>count</th><th>mean</th><th>p95</th><th>p99</th><th>total</th></tr>
+  {provider_rows}
+</table>
+
+<p class="meta">Calibration against docs/RESEARCH-cost-pilot-rationale.html confidence intervals:
+mean is within ±5% of the envelope when verdict is PASS; CONDITIONAL signals the operator
+to scope-down before Slice 1 spend per D-015.</p>
+</body>
+</html>
+"""
+
+
+def render_report(
+    summary: CostSummary,
+    *,
+    per_provider: dict[str, dict[str, float]],
+    verdict: str,
+    out_path: str | Path,
+    skill_id: str,
+    ledger_sha: str,
+) -> Path:
+    """Render the operator-facing HTML report."""
+    rows = []
+    for key in sorted(per_provider):
+        stats = per_provider[key]
+        rows.append(
+            "<tr><td>{name}</td><td>{count}</td><td>{mean:.6f}</td>"
+            "<td>{p95:.6f}</td><td>{p99:.6f}</td><td>{total:.4f}</td></tr>".format(
+                name=html.escape(key),
+                count=int(stats["count"]),
+                mean=stats["mean_usd"],
+                p95=stats["p95_usd"],
+                p99=stats["p99_usd"],
+                total=stats["total_usd"],
+            )
+        )
+    body = _REPORT_TEMPLATE.format(
+        skill_id=html.escape(skill_id),
+        ledger_sha=html.escape(ledger_sha),
+        verdict=html.escape(verdict),
+        calls_completed=summary.calls_completed,
+        mean_cost_usd=summary.mean_cost_usd,
+        p95_cost_usd=summary.p95_cost_usd,
+        p99_cost_usd=summary.p99_cost_usd,
+        schema_retry_rate=summary.schema_retry_rate,
+        cache_hit_rate=summary.cache_hit_rate,
+        total_spend_usd=summary.total_spend_usd,
+        provider_rows="\n  ".join(rows) if rows else "<tr><td colspan=6>(no calls)</td></tr>",
+    )
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(body)
+    return out

--- a/src/rainier/research/cost_pilot.py
+++ b/src/rainier/research/cost_pilot.py
@@ -18,6 +18,7 @@ the fixture and live modes share the same surface.
 from __future__ import annotations
 
 import html
+import math
 import statistics
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
@@ -44,7 +45,13 @@ class CostSummary:
 
 
 def _percentile(values: Sequence[float], pct: float) -> float:
-    """Nearest-rank percentile (deterministic; no numpy)."""
+    """Nearest-rank percentile (deterministic; no numpy).
+
+    Uses the canonical nearest-rank formula: rank = ceil(pct/100 * n).
+    Python's `round` does banker's rounding (rounds .5 to even) which
+    under-reports p95/p99 for some n (e.g., n=30 → round(28.5) = 28 vs
+    the canonical 29). codex iter-3 [P2].
+    """
     if not values:
         return 0.0
     sorted_vals = sorted(values)
@@ -52,8 +59,8 @@ def _percentile(values: Sequence[float], pct: float) -> float:
         return sorted_vals[0]
     if pct >= 100:
         return sorted_vals[-1]
-    # 1-indexed nearest-rank.
-    rank = max(1, int(round(pct / 100.0 * len(sorted_vals))))
+    # 1-indexed nearest-rank with explicit ceil; clamp to len for safety.
+    rank = max(1, min(len(sorted_vals), math.ceil(pct / 100.0 * len(sorted_vals))))
     return sorted_vals[rank - 1]
 
 

--- a/src/rainier/research/data_availability.yaml
+++ b/src/rainier/research/data_availability.yaml
@@ -394,3 +394,106 @@ entries:
     source: yfinance
     yfinance_version_at_backfill: "1.2.0"
     notes: ARK Innovation (speculative-growth / risk-on).
+
+  # ------------------------------------------------------------------
+  # Slice 0 — QU100 historical universe (D-001, D-016)
+  # ------------------------------------------------------------------
+  # qu100_history rotates the universe daily; every (data_date, symbol) row
+  # is the QU rank for that ticker on that scrape session. Insert-only
+  # writes preserve delisted tickers per D-009 / D-016. The symbol column
+  # is null at the ledger level because the dataset is per-day, not
+  # per-ticker; survivorship-check / L3 evaluator query by data_date.
+  - dataset: qu100_history
+    symbol: null
+    fields: [data_date, ranking_type, symbol, rank, sector, industry, long_short]
+    observability_timestamp_rule: qu_session_close
+    revision_immutability: true
+    source: quantunicorn
+    notes: >
+      money_flow_snapshots filtered to ranking_type='top100'. Daily refresh
+      at QU close session; older rows never UPDATE/DELETE. Survivorship
+      gate (CLI: `llm-research survivorship-check`) validates this property.
+
+  # ------------------------------------------------------------------
+  # Slice 0 — Per-ticker daily OHLCV (D-004)
+  # ------------------------------------------------------------------
+  - dataset: qu100_ohlcv
+    symbol: null
+    fields: [date, open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    notes: >
+      Per-symbol daily candles for each QU100 member, cached under
+      data/cache/stocks/<SYMBOL>.parquet. yfinance back-adjustment risk for
+      splits/dividends is handled by the loader (adjusted_close excluded
+      from the look-ahead ledger; raw OHLC is point-in-time).
+
+  # ------------------------------------------------------------------
+  # Slice 0 — Chart image fingerprint (D-004, D-025)
+  # ------------------------------------------------------------------
+  - dataset: chart_image
+    symbol: null
+    fields: [ticker, date, sha256, chart_render_version]
+    observability_timestamp_rule: derived_from_t_minus_1_close
+    revision_immutability: true
+    source: chart_export
+    notes: >
+      Deterministic chart PNG per (ticker, date). Same inputs → byte-identical
+      output (D-025 contract). Cache key includes chart_render_version SHA so
+      bumping the renderer invalidates downstream LLM cache hits.
+
+  # ------------------------------------------------------------------
+  # Slice 0 — Per-symbol price-action signals (D-004)
+  # ------------------------------------------------------------------
+  # The signals/* outputs are computed as a pure function of OHLCV up to
+  # and including T-1 close. The ledger registers each signal family so the
+  # L3 evaluator can grep-match EvidencePack fields against the registry.
+  - dataset: signals_pinbar
+    symbol: null
+    fields: [ticker, date, direction, body_ratio, wick_ratio, confidence]
+    observability_timestamp_rule: derived_from_t_minus_1_close
+    revision_immutability: true
+    source: rainier.analysis.pinbar
+    notes: Pinbar detector output for the T-1 daily bar.
+
+  - dataset: signals_sr
+    symbol: null
+    fields: [ticker, date, level, touches, sr_type, source_tf]
+    observability_timestamp_rule: derived_from_t_minus_1_close
+    revision_immutability: true
+    source: rainier.analysis.sr_horizontal
+    notes: Support/resistance levels computed from history up to T-1 close.
+
+  - dataset: signals_pivots
+    symbol: null
+    fields: [ticker, date, kind, index, price]
+    observability_timestamp_rule: derived_from_t_minus_1_close
+    revision_immutability: true
+    source: rainier.analysis.pivots
+    notes: Swing-pivot output (high/low/HH/LH/HL/LL).
+
+  - dataset: signals_bias
+    symbol: null
+    fields: [ticker, date, bias]
+    observability_timestamp_rule: derived_from_t_minus_1_close
+    revision_immutability: true
+    source: rainier.analysis.bias
+    notes: Up/down/neutral bias derived from S/R + pivots.
+
+  # ------------------------------------------------------------------
+  # Slice 0 — QU per-ticker money-flow (D-024 deferred to backfill)
+  # ------------------------------------------------------------------
+  - dataset: money_flow_net
+    symbol: null
+    fields: [ticker, date, net_flow_5d]
+    observability_timestamp_rule: pending_sibling_task
+    revision_immutability: true
+    source: quantunicorn
+    pending: true
+    notes: >
+      Per-ticker net institutional inflow/outflow over last 5d. Daily QU rank
+      is already persisted (qu100_history); the per-ticker detail awaits a
+      separate backfill task. Field is registered as pending so the L3
+      evaluator rejects look-ups until the backfill lands. See D-024.

--- a/src/rainier/research/data_availability_loader.py
+++ b/src/rainier/research/data_availability_loader.py
@@ -1,0 +1,118 @@
+"""Schema-aware loader for ``data_availability.yaml``.
+
+The ledger is the look-ahead control surface (D-014). vix-sector-backfill
+shipped the YAML; Slice 0 adds the typed loader + extra datasets
+(qu100_history, chart_image, signals_*).
+
+The loader does just enough work to keep callers honest:
+  - parse the ledger into typed Entry records
+  - reject unknown observability rules
+  - provide ``by_dataset`` / ``by_symbol`` lookups
+
+It deliberately does NOT enforce "every field referenced by the
+evaluator is registered" — that is the L3 evaluator's responsibility
+(it walks the EvidencePack at construction time and grep-matches each
+read against the ledger).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class LedgerError(ValueError):
+    """Raised when the ledger YAML is malformed."""
+
+
+VALID_OBSERVABILITY_RULES: frozenset[str] = frozenset(
+    {
+        # T close fully observable at market-close T.
+        "end_of_trading_day",
+        # Available at the QU scrape session (intraday; per-source detail in notes).
+        "qu_session_close",
+        # Available immediately on the day it's computed (signals derived from
+        # T-1 close inputs; output is T-1-close itself).
+        "derived_from_t_minus_1_close",
+        # Pending an external dependency (sibling task). Treated as "unobservable
+        # by default" — the L3 evaluator rejects look-ups against pending fields.
+        "pending_sibling_task",
+    }
+)
+
+
+@dataclass(frozen=True)
+class LedgerEntry:
+    dataset: str
+    symbol: str | None
+    fields: tuple[str, ...]
+    observability_timestamp_rule: str
+    revision_immutability: bool
+    source: str | None = None
+    yfinance_version_at_backfill: str | None = None
+    notes: str | None = None
+    pending: bool = False  # Slice 0 extension; defaults to False for legacy rows
+
+
+@dataclass(frozen=True)
+class Ledger:
+    schema_version: int
+    entries: tuple[LedgerEntry, ...] = field(default_factory=tuple)
+
+    def by_dataset(self, dataset: str) -> list[LedgerEntry]:
+        return [e for e in self.entries if e.dataset == dataset]
+
+    def by_symbol(self, symbol: str) -> list[LedgerEntry]:
+        return [e for e in self.entries if e.symbol == symbol]
+
+
+def _parse(data: dict[str, Any]) -> Ledger:
+    if "schema_version" not in data:
+        raise LedgerError("ledger missing `schema_version`")
+    raw_entries = data.get("entries") or []
+    if not isinstance(raw_entries, list):
+        raise LedgerError("ledger `entries` must be a list")
+    entries: list[LedgerEntry] = []
+    for idx, raw in enumerate(raw_entries):
+        if not isinstance(raw, dict):
+            raise LedgerError(f"entry {idx} is not a mapping")
+        rule = raw.get("observability_timestamp_rule")
+        if rule not in VALID_OBSERVABILITY_RULES:
+            raise LedgerError(
+                f"entry {idx} (dataset={raw.get('dataset')!r}) has unknown "
+                f"observability_timestamp_rule: {rule!r}"
+            )
+        if "revision_immutability" not in raw:
+            raise LedgerError(
+                f"entry {idx} missing `revision_immutability` claim"
+            )
+        fields_val = raw.get("fields") or []
+        entries.append(
+            LedgerEntry(
+                dataset=raw["dataset"],
+                symbol=raw.get("symbol"),
+                fields=tuple(fields_val),
+                observability_timestamp_rule=rule,
+                revision_immutability=bool(raw["revision_immutability"]),
+                source=raw.get("source"),
+                yfinance_version_at_backfill=raw.get("yfinance_version_at_backfill"),
+                notes=raw.get("notes"),
+                pending=bool(raw.get("pending", False)),
+            )
+        )
+    return Ledger(
+        schema_version=int(data["schema_version"]),
+        entries=tuple(entries),
+    )
+
+
+def load(path: str | Path) -> Ledger:
+    """Parse ``data_availability.yaml`` into a typed :class:`Ledger`."""
+    with Path(path).open("r") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        raise LedgerError(f"{path} did not parse to a mapping")
+    return _parse(data)

--- a/src/rainier/research/evaluator/__init__.py
+++ b/src/rainier/research/evaluator/__init__.py
@@ -1,0 +1,1 @@
+"""L3 backtest evaluator package — full implementation in Slice 1."""

--- a/src/rainier/research/evaluator/builder.py
+++ b/src/rainier/research/evaluator/builder.py
@@ -1,0 +1,46 @@
+"""EvidencePack assembler — STUB. Full implementation lands in Slice 1.
+
+Slice 0 exposes only :func:`assemble_dry_run_pack` so the CLI's
+``llm-research call --dry-run`` path can produce a deterministic prompt
+without touching the real signal pipeline. Slice 1 swaps this for the
+actual builder that reads OHLCV + signals + chart image.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass(frozen=True)
+class DryRunPack:
+    skill: str
+    ticker: str
+    day: date
+
+    def as_prompt(self) -> str:
+        """Deterministic prompt for the dry-run path.
+
+        The shape is intentionally minimal — Slice 1 replaces this with
+        the real prompt template + injected signals. We pin the exact
+        text here so the determinism test (same `(skill, ticker, day)`
+        → byte-identical output) holds without depending on Slice 1.
+        """
+        return (
+            f"[DRY-RUN] skill={self.skill} ticker={self.ticker} "
+            f"day={self.day.isoformat()}\n"
+            "WHAT YOU CAN DO:\n"
+            "- Emit `setup_long` if your analysis supports entry within next 3 trading days.\n"
+            "- Emit `no_setup` if no clear edge today.\n"
+            "- Emit `watch` if you'd track this ticker but don't enter yet.\n"
+            "\n"
+            "WHAT YOU CANNOT DO:\n"
+            "- Reference any data dated after the T-1 close.\n"
+            "- Quote now_price more than 2% off the T-1 close.\n"
+            "- Emit verdicts not in {setup_long, no_setup, watch}.\n"
+            "- Skip the price-ordering check (entry > stop, target > entry).\n"
+        )
+
+
+def assemble_dry_run_pack(*, skill: str, ticker: str, day: date) -> DryRunPack:
+    return DryRunPack(skill=skill, ticker=ticker, day=day)

--- a/src/rainier/research/evaluator/trade_simulator.py
+++ b/src/rainier/research/evaluator/trade_simulator.py
@@ -1,0 +1,14 @@
+"""Trade simulator — STUB. Full implementation lands in Slice 1.
+
+Slice 1 ships:
+  - entry-TTL gating (limit doesn't fill within N bars → unfilled_ttl)
+  - pessimistic fill (cap at the worst observed slippage in the entry bar)
+  - time-cap exit (force-close at max_hold_days; outcome=time_cap_exit)
+
+Slice 0 ships the module + a module-level marker so the package import
+graph is honest about what's coming.
+"""
+
+from __future__ import annotations
+
+SLICE_THIS_LANDS_IN: int = 1

--- a/src/rainier/research/output_schema.py
+++ b/src/rainier/research/output_schema.py
@@ -1,0 +1,153 @@
+"""Validator + formatter for the D-031 stdout summary blocks.
+
+Subagents grep one line out of stdout; humans eyeball the block; CI
+asserts every summary parses against this module. The schema YAML lives
+at ``src/rainier/research/output_schema.yaml`` — extend that file when a
+new verb adds a block (not by inventing fields ad-hoc in CLI code).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCHEMA_PATH = Path(__file__).parent / "output_schema.yaml"
+
+
+class SchemaError(ValueError):
+    """Raised when a summary block fails validation or parse."""
+
+
+_TYPE_TO_PY = {
+    "int": int,
+    "float": (int, float),  # YAML ints are valid floats; permissive.
+    "str": str,
+    "bool": bool,
+    "list": list,
+    "dict": dict,
+}
+
+
+@dataclass(frozen=True)
+class _FieldSpec:
+    name: str
+    py_type: tuple[type, ...] | type
+    enum: tuple[str, ...] | None
+    nullable: bool
+
+
+def load(path: str | Path | None = None) -> dict[str, Any]:
+    """Read the schema YAML; returned dict is the raw shape (schemas: {...})."""
+    p = Path(path) if path is not None else SCHEMA_PATH
+    with p.open("r") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict) or "schemas" not in data:
+        raise SchemaError(f"{p} has no top-level `schemas:` key")
+    return data
+
+
+def _coerce_fields(schema: dict[str, Any]) -> list[_FieldSpec]:
+    out: list[_FieldSpec] = []
+    raw = schema.get("fields") or {}
+    for name, body in raw.items():
+        t = body.get("type")
+        if t not in _TYPE_TO_PY:
+            raise SchemaError(f"field {name!r} has unknown type {t!r}")
+        py_type = _TYPE_TO_PY[t]
+        enum = body.get("enum")
+        out.append(
+            _FieldSpec(
+                name=name,
+                py_type=py_type,
+                enum=tuple(enum) if enum else None,
+                nullable=bool(body.get("nullable", False)),
+            )
+        )
+    return out
+
+
+def validate(name: str, payload: dict[str, Any], strict: bool = True) -> None:
+    """Validate ``payload`` against the schema named ``name``.
+
+    Strict mode (default) rejects any extra field not declared in the schema.
+    Non-strict mode tolerates forward-compatible extras — used at runtime so
+    a new field added in a future commit doesn't blow up an older CLI.
+    """
+    data = load()
+    schemas = data["schemas"]
+    if name not in schemas:
+        raise SchemaError(f"unknown schema {name!r}; known: {sorted(schemas)}")
+    specs = _coerce_fields(schemas[name])
+    declared = {spec.name for spec in specs}
+
+    missing = declared - payload.keys()
+    if missing:
+        raise SchemaError(f"missing required field(s): {sorted(missing)}")
+
+    if strict:
+        extra = payload.keys() - declared
+        if extra:
+            raise SchemaError(f"extra field(s) not in schema: {sorted(extra)}")
+
+    for spec in specs:
+        val = payload[spec.name]
+        if val is None and spec.nullable:
+            continue
+        if not isinstance(val, spec.py_type):  # type: ignore[arg-type]
+            raise SchemaError(
+                f"field {spec.name!r}: expected {spec.py_type}, got "
+                f"{type(val).__name__} ({val!r})"
+            )
+        if spec.enum is not None and val not in spec.enum:
+            raise SchemaError(
+                f"field {spec.name!r}: value {val!r} not in enum {spec.enum}"
+            )
+
+
+def format_block(name: str, payload: dict[str, Any]) -> str:
+    """Render ``payload`` as a fenced YAML block matching schema ``name``.
+
+    The output is exactly the D-031 wire shape:
+        ---
+        key: value
+        ...
+        ---
+
+    Field order follows the schema declaration order so byte-identical
+    inputs produce byte-identical output (subagent grep stability).
+    """
+    validate(name, payload, strict=True)
+    data = load()
+    specs = _coerce_fields(data["schemas"][name])
+    lines = ["---"]
+    for spec in specs:
+        val = payload[spec.name]
+        # Use yaml.safe_dump for the value so floats / lists round-trip.
+        dumped = yaml.safe_dump(val, default_flow_style=True).strip()
+        # Strip the trailing `\n...\n` document terminator yaml adds.
+        if dumped.endswith("\n..."):
+            dumped = dumped[: -len("\n...")]
+        lines.append(f"{spec.name}: {dumped}")
+    lines.append("---")
+    lines.append("")  # trailing newline
+    return "\n".join(lines)
+
+
+def parse_block(text: str) -> dict[str, Any]:
+    """Inverse of ``format_block`` — extract a single fenced YAML block.
+
+    Rejects payloads without the `---` fences (per D-031). Whitespace
+    before/after the fences is tolerated.
+    """
+    stripped = text.strip()
+    if not (stripped.startswith("---") and stripped.endswith("---")):
+        raise SchemaError("block is not `---` fenced")
+    # Drop the fences.
+    inner = stripped[3:-3].strip()
+    parsed = yaml.safe_load(inner)
+    if not isinstance(parsed, dict):
+        raise SchemaError(f"block must parse to a dict; got {type(parsed).__name__}")
+    return parsed

--- a/src/rainier/research/output_schema.yaml
+++ b/src/rainier/research/output_schema.yaml
@@ -1,0 +1,97 @@
+# Output-format contract — D-031 stdout summary blocks.
+#
+# Every llm-research <verb> that emits a summary block produces a YAML
+# document fenced by `---` ... `---` on stdout. The contents must match
+# one of the schemas below. CI tests validate every backtest run against
+# this file (per [D-031]).
+#
+# Schema entries declare each field's type and (optionally) an enum of
+# allowed values. Unknown verdicts / outcomes fail strict-mode validation
+# in the test suite; the runtime CLI uses non-strict mode so a forward-
+# compatible field doesn't blow up production stdout.
+
+schema_version: 1
+
+schemas:
+  # Slice 0 — cost-pilot summary, per TASK-PLAN §4.3.
+  cost_pilot:
+    fields:
+      slice:
+        type: int
+      skill_id:
+        type: str
+      calls_total:
+        type: int
+      calls_completed:
+        type: int
+      mean_cost_usd:
+        type: float
+      p95_cost_usd:
+        type: float
+      p99_cost_usd:
+        type: float
+      schema_retry_rate:
+        type: float
+      cache_hit_rate:
+        type: float
+      total_spend_usd:
+        type: float
+      verdict:
+        type: str
+        enum: [PASS, CONDITIONAL, FAIL]
+      report_html:
+        type: str
+      ledger_sha:
+        type: str
+
+  # Slice 0 — survivorship summary, per TASK-PLAN §4.4.
+  survivorship:
+    fields:
+      from_date:
+        type: str
+      to_date:
+        type: str
+      verdict:
+        type: str
+        enum: [PASS, CONDITIONAL, FAIL]
+      delisted_tickers:
+        type: list
+      missing_days:
+        type: list
+      next_step:
+        type: str
+        nullable: true
+
+  # Slice 1+ — L3 backtest summary, per [D-031] in DESIGN-qu100-llm-backtest.md.
+  # Declared here so subsequent slices don't drift on shape; not exercised
+  # in Slice 0 tests beyond shape parity.
+  backtest:
+    fields:
+      skill_id:
+        type: str
+      reward_fn:
+        type: str
+      filled_R:
+        type: float
+      all_call_R:
+        type: float
+      calls:
+        type: int
+      valid_thesis_rate:
+        type: float
+      filled_rate:
+        type: float
+      cost_usd:
+        type: float
+      tqqq_bh_R:
+        type: float
+      delta_vs_tqqq:
+        type: float
+      deflated_sharpe:
+        type: float
+      evaluator_sha:
+        type: str
+      skill_yaml_sha:
+        type: str
+      ledger_sha:
+        type: str

--- a/src/rainier/research/providers/__init__.py
+++ b/src/rainier/research/providers/__init__.py
@@ -1,0 +1,68 @@
+"""LLM provider adapters for the research engine.
+
+Three providers per D-019: ``anthropic`` (Opus 4.7 + extended thinking,
+D-030), ``deepseek`` (V4-Pro / V4-Flash text-only), and
+``openai_compatible`` (DeepSeek alt endpoint + future GPT / Gemini).
+
+Slice 0 exercises only the ``test_auth()`` surface — the LLM call paths
+land in Slice 1. ``get_provider(name)`` returns a fresh adapter per
+call; adapters are tiny and stateless (the heavy SDK clients are lazily
+constructed inside ``run()``).
+"""
+
+from __future__ import annotations
+
+from .base import (
+    AuthStatus,
+    Provider,
+    ProviderTestResult,
+)
+
+
+def list_providers() -> list[str]:
+    """Names of the registered providers (sorted for determinism)."""
+    return sorted(_REGISTRY.keys())
+
+
+def get_provider(name: str) -> Provider:
+    """Factory — returns a fresh provider adapter for ``name``."""
+    if name not in _REGISTRY:
+        raise ValueError(
+            f"unknown provider {name!r}; known: {sorted(_REGISTRY)}"
+        )
+    return _REGISTRY[name]()
+
+
+# Lazy registry — adapters are imported on demand so a missing optional SDK
+# (anthropic, openai) doesn't break ``import rainier.research``.
+def _build_anthropic() -> Provider:
+    from .anthropic import AnthropicProvider
+
+    return AnthropicProvider()
+
+
+def _build_deepseek() -> Provider:
+    from .deepseek import DeepseekProvider
+
+    return DeepseekProvider()
+
+
+def _build_openai_compatible() -> Provider:
+    from .openai_compatible import OpenAICompatibleProvider
+
+    return OpenAICompatibleProvider()
+
+
+_REGISTRY: dict[str, callable] = {
+    "anthropic": _build_anthropic,
+    "deepseek": _build_deepseek,
+    "openai_compatible": _build_openai_compatible,
+}
+
+__all__ = [
+    "AuthStatus",
+    "Provider",
+    "ProviderTestResult",
+    "get_provider",
+    "list_providers",
+]

--- a/src/rainier/research/providers/anthropic.py
+++ b/src/rainier/research/providers/anthropic.py
@@ -1,0 +1,36 @@
+"""Anthropic provider adapter (Opus 4.7 + extended thinking per D-030)."""
+
+from __future__ import annotations
+
+import os
+
+from .base import AuthStatus, ProviderTestResult
+
+
+class AnthropicProvider:
+    name = "anthropic"
+    env_var = "ANTHROPIC_API_KEY"
+
+    def test_auth(self) -> ProviderTestResult:
+        key = os.environ.get(self.env_var)
+        if not key:
+            return ProviderTestResult(
+                provider=self.name,
+                auth=AuthStatus.MISSING,
+                endpoint_reachable=False,
+                next_step=(
+                    f"export {self.env_var}=... "
+                    "(create at https://console.anthropic.com/settings/keys)"
+                ),
+            )
+        # Slice 0: we don't poke the network from the auth-test path so the
+        # CLI works offline. Endpoint-reachability + schema-compliance flip to
+        # `False` here; Slice 1's `run()` exercises the real round-trip.
+        return ProviderTestResult(
+            provider=self.name,
+            auth=AuthStatus.OK,
+            endpoint_reachable=False,
+            schema_compliant=False,
+            latency_ms=0,
+            next_step=None,
+        )

--- a/src/rainier/research/providers/base.py
+++ b/src/rainier/research/providers/base.py
@@ -1,0 +1,61 @@
+"""Provider protocol + result types.
+
+Per CLAUDE.md (project) module-layout discipline: ``research/`` imports
+only from ``core/`` + stdlib. We define a lightweight Protocol here
+rather than reusing ``core/protocols.py`` because the research engine's
+provider surface is research-specific and should not bleed into the
+production signals/backtest path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+
+class AuthStatus(str, Enum):
+    OK = "ok"
+    MISSING = "missing"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class ProviderTestResult:
+    """One row of `providers test --json` output.
+
+    `next_step` is the operator-actionable remediation (per the
+    "surface-don't-silo" memory rule). Example: when the API key is
+    missing we emit ``"export ANTHROPIC_API_KEY=..."``.
+    """
+
+    provider: str
+    auth: AuthStatus
+    endpoint_reachable: bool = False
+    schema_compliant: bool = False
+    latency_ms: int = 0
+    next_step: str | None = None
+
+    def as_dict(self) -> dict:
+        return {
+            "provider": self.provider,
+            "auth": self.auth.value,
+            "endpoint_reachable": self.endpoint_reachable,
+            "schema_compliant": self.schema_compliant,
+            "latency_ms": self.latency_ms,
+            "next_step": self.next_step,
+        }
+
+
+@runtime_checkable
+class Provider(Protocol):
+    """Stateless adapter surface.
+
+    Slice 0 ships only ``test_auth()``; ``run()`` (the actual LLM call)
+    arrives in Slice 1. Keep the surface minimal — adding methods now
+    bakes premature abstractions for code that doesn't exist yet.
+    """
+
+    name: str
+
+    def test_auth(self) -> ProviderTestResult: ...

--- a/src/rainier/research/providers/deepseek.py
+++ b/src/rainier/research/providers/deepseek.py
@@ -1,0 +1,33 @@
+"""DeepSeek provider adapter (V4-Pro reasoning + V4-Flash text-only per D-030)."""
+
+from __future__ import annotations
+
+import os
+
+from .base import AuthStatus, ProviderTestResult
+
+
+class DeepseekProvider:
+    name = "deepseek"
+    env_var = "DEEPSEEK_API_KEY"
+
+    def test_auth(self) -> ProviderTestResult:
+        key = os.environ.get(self.env_var)
+        if not key:
+            return ProviderTestResult(
+                provider=self.name,
+                auth=AuthStatus.MISSING,
+                endpoint_reachable=False,
+                next_step=(
+                    f"export {self.env_var}=... "
+                    "(create at https://platform.deepseek.com/api_keys)"
+                ),
+            )
+        return ProviderTestResult(
+            provider=self.name,
+            auth=AuthStatus.OK,
+            endpoint_reachable=False,
+            schema_compliant=False,
+            latency_ms=0,
+            next_step=None,
+        )

--- a/src/rainier/research/providers/openai_compatible.py
+++ b/src/rainier/research/providers/openai_compatible.py
@@ -1,0 +1,44 @@
+"""OpenAI-compatible provider adapter (DeepSeek alt + future GPT / Gemini).
+
+Accepts either ``OPENAI_COMPATIBLE_API_KEY`` (explicit) or
+``DEEPSEEK_API_KEY`` (the most common backing implementation). The two
+fallbacks let the operator point this adapter at any OpenAI-compatible
+endpoint without renaming env vars.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .base import AuthStatus, ProviderTestResult
+
+
+class OpenAICompatibleProvider:
+    name = "openai_compatible"
+    primary_env_var = "OPENAI_COMPATIBLE_API_KEY"
+    fallback_env_var = "DEEPSEEK_API_KEY"
+
+    def test_auth(self) -> ProviderTestResult:
+        key = (
+            os.environ.get(self.primary_env_var)
+            or os.environ.get(self.fallback_env_var)
+        )
+        if not key:
+            return ProviderTestResult(
+                provider=self.name,
+                auth=AuthStatus.MISSING,
+                endpoint_reachable=False,
+                next_step=(
+                    f"export {self.primary_env_var}=... "
+                    f"or {self.fallback_env_var}=... "
+                    "and set OPENAI_COMPATIBLE_BASE_URL to your endpoint"
+                ),
+            )
+        return ProviderTestResult(
+            provider=self.name,
+            auth=AuthStatus.OK,
+            endpoint_reachable=False,
+            schema_compliant=False,
+            latency_ms=0,
+            next_step=None,
+        )

--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -1,0 +1,24 @@
+"""Reward-function registry — concrete reward bodies land in Slice 1.
+
+Slice 0 ships the registry surface (an empty dict) so other modules can
+import it without breaking once Slice 1 lands the seven pre-registered
+reward functions (D-007).
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+#: name → callable. Each callable takes a TradeRecord and returns a float.
+#: Slice 1 populates this with r_multiple_expectancy, all_call_R, etc.
+REGISTRY: dict[str, Callable] = {}
+
+
+def register(name: str, fn: Callable) -> Callable:
+    """Decorator-style registrar — placeholder for Slice 1."""
+    REGISTRY[name] = fn
+    return fn
+
+
+def names() -> list[str]:
+    return sorted(REGISTRY.keys())

--- a/src/rainier/research/schemas.py
+++ b/src/rainier/research/schemas.py
@@ -1,0 +1,88 @@
+"""Research-side LLM output schemas (D-010).
+
+``ResearchThesis`` is the v0/v1 thesis envelope — separate from production
+``llm_thesis/schemas.py:TradeThesis`` so the research engine can iterate
+without churning the production daily pipeline.
+
+Slice 0 ships the skeleton (validators + serdes). Slice 1 wires it into
+the L3 evaluator + per-call output store.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+Verdict = Literal["setup_long", "no_setup", "watch"]
+
+
+class ResearchThesis(BaseModel):
+    """One per-(skill, ticker, day) LLM call.
+
+    Invariants enforced at construction (see :func:`_validate_price_ordering`
+    + :func:`_validate_now_price_not_hallucinated`):
+      - ``stop < entry < target`` whenever ``verdict == "setup_long"``
+      - ``|now_price - t_minus_1_close| / t_minus_1_close <= 0.02``
+
+    Both invariants protect against LLM hallucination (D-010): wrong
+    price ordering is a logic bug; ``now_price`` drift from the
+    pinned T-1 close is the LLM inventing prices.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    skill_id: str = Field(..., min_length=1)
+    ticker: str = Field(..., min_length=1)
+    day: date
+    verdict: Verdict
+    rationale: str = Field("", description="LLM's explanation; free-form.")
+
+    now_price: float | None = None
+    entry: float | None = None
+    stop: float | None = None
+    target: float | None = None
+    holding_days_expected: int | None = None
+
+    # T-1 close pinned at construction; the hallucination guard fires
+    # when ``now_price`` diverges from this anchor by more than 2%.
+    t_minus_1_close: float | None = None
+
+    @model_validator(mode="after")
+    def _validate_price_ordering(self) -> "ResearchThesis":
+        if self.verdict == "setup_long":
+            missing = [
+                name
+                for name, val in (
+                    ("entry", self.entry),
+                    ("stop", self.stop),
+                    ("target", self.target),
+                )
+                if val is None
+            ]
+            if missing:
+                raise ValueError(
+                    f"setup_long thesis missing required fields: {missing}"
+                )
+            if not (self.stop < self.entry < self.target):
+                raise ValueError(
+                    f"price ordering violated: stop={self.stop} "
+                    f"entry={self.entry} target={self.target}"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_now_price_not_hallucinated(self) -> "ResearchThesis":
+        if self.now_price is None or self.t_minus_1_close is None:
+            return self
+        anchor = self.t_minus_1_close
+        if anchor <= 0:
+            return self
+        drift = abs(self.now_price - anchor) / anchor
+        if drift > 0.02:
+            raise ValueError(
+                f"now_price hallucination guard: {self.now_price} drifts "
+                f"{drift:.2%} from t_minus_1_close={anchor} (cap 2%)"
+            )
+        return self

--- a/src/rainier/research/survivorship.py
+++ b/src/rainier/research/survivorship.py
@@ -69,19 +69,32 @@ def _is_sqlite(session: Session) -> bool:
 
 
 def _trading_days(start: date, end: date) -> list[date]:
-    """All weekdays (Mon-Fri) between start and end inclusive.
+    """All NYSE trading sessions between start and end inclusive.
 
-    Survivorship cares about market trading days; weekends are obvious
-    gaps. We approximate with Mon-Fri (good enough for the gate check;
-    half-day holidays would surface as legitimate concerns).
+    Survivorship cares about market trading days. We use the NYSE
+    exchange calendar (XNYS) to filter weekends AND holidays — the
+    earlier weekday-only approximation reported NYE/MLK/Presidents
+    Day/Good Friday/Memorial Day/etc. as "missing" against healthy
+    insert-only data, flipping PASS to CONDITIONAL on first run.
+
+    Falls back to weekday-only if exchange_calendars isn't importable
+    (keeps the test path hermetic when the dep is unavailable); the
+    fallback over-reports gaps but never under-reports — safer default.
     """
-    out = []
-    cur = start
-    while cur <= end:
-        if cur.weekday() < 5:
-            out.append(cur)
-        cur += timedelta(days=1)
-    return out
+    try:
+        import exchange_calendars as xcals
+    except ImportError:
+        out = []
+        cur = start
+        while cur <= end:
+            if cur.weekday() < 5:
+                out.append(cur)
+            cur += timedelta(days=1)
+        return out
+
+    nyse = xcals.get_calendar("XNYS")
+    sessions = nyse.sessions_in_range(start.isoformat(), end.isoformat())
+    return [s.date() for s in sessions]
 
 
 def seed_snapshots(

--- a/src/rainier/research/survivorship.py
+++ b/src/rainier/research/survivorship.py
@@ -1,0 +1,354 @@
+"""Survivorship-gate check for ``qu_top100_history`` (D-016 PASS gate).
+
+Reads the QU100 snapshot table (production: ``money_flow_snapshots``;
+test: in-memory SQLite via :func:`bootstrap_sqlite`). Returns a typed
+:class:`SurvivorshipResult` with verdict + delisted-ticker list +
+missing-day list + concrete next-step. The CLI emits the result as JSON
+when ``--json`` is set, or a single-line verdict + JSON sidecar
+otherwise (per [D-034] — verbose detail goes to a run log, not stdout).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Any
+
+from sqlalchemy import (
+    Column,
+    Date,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    func,
+    select,
+    text,
+)
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+_metadata = MetaData()
+
+
+# Test table — mirrors the production money_flow_snapshots logical shape
+# but with only the columns the survivorship check reads. We define it
+# here (not from rainier.core.models) because:
+#   1) the prod model carries TimescaleDB hypertable + JSONB columns that
+#      sqlite can't reflect,
+#   2) the survivorship check is read-only and only needs (data_date,
+#      symbol, ranking_type, rank, mutated).
+#
+# Production CLI uses raw SQL against money_flow_snapshots directly
+# (see `check` for the prod path).
+qu100_snapshot_test = Table(
+    "qu100_snapshot_test",
+    _metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("data_date", Date, nullable=False, index=True),
+    Column("symbol", String(10), nullable=False, index=True),
+    Column("ranking_type", String(10), nullable=False, server_default="top100"),
+    Column("rank", Integer, nullable=False, server_default="1"),
+    Column("mutated", Integer, nullable=False, server_default="0"),
+)
+
+
+def bootstrap_sqlite(engine: Engine) -> None:
+    """Create the test schema in an in-memory SQLite engine."""
+    _metadata.create_all(engine)
+
+
+def _is_sqlite(session: Session) -> bool:
+    return session.bind.dialect.name == "sqlite"
+
+
+def _table_for_session(session: Session) -> Table | str:
+    """Return the test Table or the prod table name based on the engine."""
+    if _is_sqlite(session):
+        return qu100_snapshot_test
+    # Production: query money_flow_snapshots directly. Returning the literal
+    # table name keeps the SQL minimal; we don't want a hard ORM dep that
+    # forces TimescaleDB-specific columns into this module.
+    return "money_flow_snapshots"
+
+
+# --------------------------------------------------------------------------- #
+# Public seeding / mutation helpers — used only by tests, exposed at module
+# level so the test suite doesn't reach into private state.
+# --------------------------------------------------------------------------- #
+
+
+def _trading_days(start: date, end: date) -> list[date]:
+    """All weekdays (Mon-Fri) between start and end inclusive.
+
+    Survivorship cares about market trading days; weekends are obvious
+    gaps. We approximate with Mon-Fri (good enough for the gate check;
+    half-day holidays would surface as legitimate concerns).
+    """
+    out = []
+    cur = start
+    while cur <= end:
+        if cur.weekday() < 5:
+            out.append(cur)
+        cur += timedelta(days=1)
+    return out
+
+
+def seed_snapshots(
+    session: Session, *, symbols: list[str], start: date, end: date
+) -> None:
+    """Insert one row per (symbol, trading day) for the test SQLite engine."""
+    if not _is_sqlite(session):
+        raise RuntimeError("seed_snapshots is for the in-memory sqlite test path only")
+    days = _trading_days(start, end)
+    rows = []
+    for d in days:
+        for rank, sym in enumerate(symbols, start=1):
+            rows.append({"data_date": d, "symbol": sym, "ranking_type": "top100",
+                          "rank": rank, "mutated": 0})
+    if rows:
+        session.execute(qu100_snapshot_test.insert(), rows)
+        session.commit()
+
+
+def mutate_historical_row_for_test(session: Session, symbol: str, on_date: date) -> None:
+    """Flip the ``mutated`` flag on a historical row — survivorship-check
+    treats any non-zero ``mutated`` as a proof-failure for insert-only."""
+    if not _is_sqlite(session):
+        raise RuntimeError("mutate_historical_row_for_test is sqlite-only")
+    session.execute(
+        qu100_snapshot_test.update()
+        .where(qu100_snapshot_test.c.symbol == symbol)
+        .where(qu100_snapshot_test.c.data_date == on_date)
+        .values(mutated=1)
+    )
+    session.commit()
+
+
+def ticker_present(session: Session, symbol: str, on_date: date) -> bool:
+    """True iff the symbol has any snapshot on `on_date`."""
+    if _is_sqlite(session):
+        row = session.execute(
+            select(func.count())
+            .select_from(qu100_snapshot_test)
+            .where(qu100_snapshot_test.c.symbol == symbol)
+            .where(qu100_snapshot_test.c.data_date == on_date)
+        ).scalar_one()
+        return int(row) > 0
+    row = session.execute(
+        text(
+            "SELECT COUNT(*) FROM money_flow_snapshots "
+            "WHERE symbol = :sym AND data_date = :d AND ranking_type = 'top100'"
+        ),
+        {"sym": symbol, "d": on_date},
+    ).scalar_one()
+    return int(row) > 0
+
+
+# --------------------------------------------------------------------------- #
+# Result type + check function
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class SurvivorshipResult:
+    from_date: date
+    to_date: date
+    verdict: str  # PASS | CONDITIONAL | FAIL
+    delisted_tickers: list[str] = field(default_factory=list)
+    missing_days: list[date] = field(default_factory=list)
+    next_step: str | None = None
+    immutability_proof: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "from_date": self.from_date.isoformat(),
+            "to_date": self.to_date.isoformat(),
+            "verdict": self.verdict,
+            "delisted_tickers": list(self.delisted_tickers),
+            "missing_days": [d.isoformat() for d in self.missing_days],
+            "next_step": self.next_step,
+            "immutability_proof": self.immutability_proof,
+        }
+
+
+def _coverage_query(session: Session, start: date, end: date) -> dict[date, int]:
+    """Return rows-per-day for the window."""
+    if _is_sqlite(session):
+        rows = session.execute(
+            select(
+                qu100_snapshot_test.c.data_date,
+                func.count(qu100_snapshot_test.c.id),
+            )
+            .where(qu100_snapshot_test.c.data_date >= start)
+            .where(qu100_snapshot_test.c.data_date <= end)
+            .group_by(qu100_snapshot_test.c.data_date)
+        ).all()
+    else:
+        rows = session.execute(
+            text(
+                "SELECT data_date, COUNT(*) FROM money_flow_snapshots "
+                "WHERE ranking_type = 'top100' AND data_date BETWEEN :s AND :e "
+                "GROUP BY data_date"
+            ),
+            {"s": start, "e": end},
+        ).all()
+    return {r[0]: int(r[1]) for r in rows}
+
+
+def _delisted_tickers(
+    session: Session, start: date, end: date, tail_days: int = 7
+) -> list[str]:
+    """Tickers observed in the window but absent from its last `tail_days` window.
+
+    A "delisted" ticker for survivorship purposes is one that QU had earlier
+    in the range but stopped reporting before the end — capturing both true
+    delistings and the rotation-tail exits per D-009. We compute the late
+    window as ``(end - tail_days, end]`` so even a same-day "alive in early,
+    gone the next day" exit registers.
+    """
+    if start >= end:
+        return []
+    tail_start = max(start, end - timedelta(days=tail_days))
+    if _is_sqlite(session):
+        seen_any = {
+            r[0]
+            for r in session.execute(
+                select(qu100_snapshot_test.c.symbol)
+                .where(qu100_snapshot_test.c.data_date >= start)
+                .where(qu100_snapshot_test.c.data_date <= end)
+                .distinct()
+            )
+        }
+        late = {
+            r[0]
+            for r in session.execute(
+                select(qu100_snapshot_test.c.symbol)
+                .where(qu100_snapshot_test.c.data_date >= tail_start)
+                .where(qu100_snapshot_test.c.data_date <= end)
+                .distinct()
+            )
+        }
+    else:
+        seen_any = {
+            r[0]
+            for r in session.execute(
+                text(
+                    "SELECT DISTINCT symbol FROM money_flow_snapshots "
+                    "WHERE ranking_type = 'top100' AND data_date BETWEEN :s AND :e"
+                ),
+                {"s": start, "e": end},
+            )
+        }
+        late = {
+            r[0]
+            for r in session.execute(
+                text(
+                    "SELECT DISTINCT symbol FROM money_flow_snapshots "
+                    "WHERE ranking_type = 'top100' AND data_date BETWEEN :t AND :e"
+                ),
+                {"t": tail_start, "e": end},
+            )
+        }
+    return sorted(seen_any - late)
+
+
+def _has_mutated_rows(session: Session, start: date, end: date) -> bool:
+    """Insert-only proof: returns True if any row carries the mutated flag.
+
+    Production path (postgres) can't read a `mutated` audit column — we
+    don't ship one yet — so the prod check returns False (i.e., "no proof
+    failure detected" but `immutability_proof` is marked as
+    "unverified" downstream). Slice 1 ships the proper audit trigger.
+    """
+    if _is_sqlite(session):
+        n = session.execute(
+            select(func.count())
+            .select_from(qu100_snapshot_test)
+            .where(qu100_snapshot_test.c.mutated != 0)
+            .where(qu100_snapshot_test.c.data_date >= start)
+            .where(qu100_snapshot_test.c.data_date <= end)
+        ).scalar_one()
+        return int(n) > 0
+    return False
+
+
+def check(
+    *, session: Session, from_date: date, to_date: date
+) -> SurvivorshipResult:
+    """Run the survivorship gate per D-016.
+
+    Verdicts:
+      - **PASS** — every trading day has > 0 rows, no immutability proof failures.
+      - **CONDITIONAL** — coverage gap or immutability-proof failure with a
+        concrete next-step recorded.
+      - **FAIL** — the table doesn't exist or is empty (operator must run the
+        scraper backfill before Slice 1 begins).
+    """
+    try:
+        coverage = _coverage_query(session, from_date, to_date)
+    except Exception as exc:  # noqa: BLE001 — prod query may raise on missing table.
+        return SurvivorshipResult(
+            from_date=from_date,
+            to_date=to_date,
+            verdict="CONDITIONAL",
+            next_step=(
+                "Cannot read money_flow_snapshots: "
+                f"{exc!s} — confirm DB is up and the scraper has backfilled."
+            ),
+            immutability_proof="unverified",
+        )
+
+    if not coverage:
+        return SurvivorshipResult(
+            from_date=from_date,
+            to_date=to_date,
+            verdict="CONDITIONAL",
+            next_step=(
+                "money_flow_snapshots has no rows in the requested window — "
+                "run `uv run rainier scrape qu --session morning --start-date "
+                f"{from_date.isoformat()}` to backfill."
+            ),
+            immutability_proof="unverified",
+        )
+
+    trading_days = _trading_days(from_date, to_date)
+    missing = [d for d in trading_days if d not in coverage]
+    delisted = _delisted_tickers(session, from_date, to_date)
+    mutated = _has_mutated_rows(session, from_date, to_date)
+
+    proof = (
+        "audit_column" if _is_sqlite(session) else "unverified"
+    )
+
+    if missing or mutated:
+        if mutated:
+            next_step = (
+                "Insert-only / immutability proof FAILED: at least one historical "
+                "row carries a non-zero mutated flag. Audit the writer for "
+                "UPDATE/DELETE statements and fix before Slice 1."
+            )
+        else:
+            next_step = (
+                f"Coverage gap on {len(missing)} trading day(s) — "
+                "re-run the scraper backfill for the missing dates."
+            )
+        return SurvivorshipResult(
+            from_date=from_date,
+            to_date=to_date,
+            verdict="CONDITIONAL",
+            delisted_tickers=delisted,
+            missing_days=missing,
+            next_step=next_step,
+            immutability_proof=proof,
+        )
+
+    return SurvivorshipResult(
+        from_date=from_date,
+        to_date=to_date,
+        verdict="PASS",
+        delisted_tickers=delisted,
+        missing_days=[],
+        next_step=None,
+        immutability_proof=proof,
+    )

--- a/src/rainier/research/survivorship.py
+++ b/src/rainier/research/survivorship.py
@@ -62,16 +62,6 @@ def _is_sqlite(session: Session) -> bool:
     return session.bind.dialect.name == "sqlite"
 
 
-def _table_for_session(session: Session) -> Table | str:
-    """Return the test Table or the prod table name based on the engine."""
-    if _is_sqlite(session):
-        return qu100_snapshot_test
-    # Production: query money_flow_snapshots directly. Returning the literal
-    # table name keeps the SQL minimal; we don't want a hard ORM dep that
-    # forces TimescaleDB-specific columns into this module.
-    return "money_flow_snapshots"
-
-
 # --------------------------------------------------------------------------- #
 # Public seeding / mutation helpers — used only by tests, exposed at module
 # level so the test suite doesn't reach into private state.

--- a/src/rainier/research/survivorship.py
+++ b/src/rainier/research/survivorship.py
@@ -346,6 +346,29 @@ def check(
             immutability_proof=proof,
         )
 
+    # codex iter-7 [P1]: PASS requires the immutability proof to actually
+    # check out. In the prod (postgres) path, _has_mutated_rows() returns
+    # False unconditionally because the audit column doesn't exist yet —
+    # which means the gate would otherwise greenlight production history
+    # without ever VERIFYING insert-only. Treat unverified proof as
+    # CONDITIONAL with a concrete next-step so the operator knows the
+    # gate hasn't actually run end-to-end.
+    if proof == "unverified":
+        return SurvivorshipResult(
+            from_date=from_date,
+            to_date=to_date,
+            verdict="CONDITIONAL",
+            delisted_tickers=delisted,
+            missing_days=[],
+            next_step=(
+                "Coverage looks complete but the insert-only / immutability "
+                "proof is unverified on this backend — no audit column or "
+                "trigger to read from. Ship the audit trigger (Slice 1) "
+                "before treating this as a D-016 PASS gate."
+            ),
+            immutability_proof=proof,
+        )
+
     return SurvivorshipResult(
         from_date=from_date,
         to_date=to_date,

--- a/tests/research/conftest.py
+++ b/tests/research/conftest.py
@@ -1,0 +1,28 @@
+"""Fixtures for tests/research/.
+
+In-memory SQLite session for survivorship tests + deterministic
+cost-pilot fixture path lookup.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    return FIXTURES_DIR
+
+
+@pytest.fixture
+def cost_pilot_10call_fixture() -> Path:
+    return FIXTURES_DIR / "cost_pilot_10call.json"
+
+
+@pytest.fixture
+def survivorship_seed_fixture() -> Path:
+    return FIXTURES_DIR / "survivorship_seed.json"

--- a/tests/research/fixtures/cost_pilot_10call.json
+++ b/tests/research/fixtures/cost_pilot_10call.json
@@ -1,0 +1,16 @@
+{
+  "skill_id": "cost_pilot_v0",
+  "ledger_sha": "0000000000000000000000000000000000000000",
+  "calls": [
+    {"call_id": "c0", "provider": "anthropic", "model": "opus-4.7", "cost_usd": 0.08, "schema_retries": 0, "cache_hit": false, "outcome": "filled"},
+    {"call_id": "c1", "provider": "anthropic", "model": "opus-4.7", "cost_usd": 0.07, "schema_retries": 0, "cache_hit": false, "outcome": "filled"},
+    {"call_id": "c2", "provider": "anthropic", "model": "opus-4.7", "cost_usd": 0.09, "schema_retries": 1, "cache_hit": false, "outcome": "rejected_schema"},
+    {"call_id": "c3", "provider": "deepseek", "model": "v4-pro", "cost_usd": 0.012, "schema_retries": 0, "cache_hit": false, "outcome": "filled"},
+    {"call_id": "c4", "provider": "deepseek", "model": "v4-pro", "cost_usd": 0.013, "schema_retries": 0, "cache_hit": true, "outcome": "filled"},
+    {"call_id": "c5", "provider": "deepseek", "model": "v4-pro", "cost_usd": 0.011, "schema_retries": 0, "cache_hit": false, "outcome": "no_setup"},
+    {"call_id": "c6", "provider": "deepseek", "model": "v4-flash", "cost_usd": 0.002, "schema_retries": 0, "cache_hit": false, "outcome": "filled"},
+    {"call_id": "c7", "provider": "deepseek", "model": "v4-flash", "cost_usd": 0.003, "schema_retries": 0, "cache_hit": true, "outcome": "filled"},
+    {"call_id": "c8", "provider": "deepseek", "model": "v4-flash", "cost_usd": 0.0025, "schema_retries": 0, "cache_hit": false, "outcome": "no_setup"},
+    {"call_id": "c9", "provider": "deepseek", "model": "v4-flash", "cost_usd": 0.0021, "schema_retries": 0, "cache_hit": false, "outcome": "filled"}
+  ]
+}

--- a/tests/research/fixtures/survivorship_seed.json
+++ b/tests/research/fixtures/survivorship_seed.json
@@ -1,0 +1,9 @@
+{
+  "alive": ["AAPL", "NVDA", "TSLA"],
+  "delisted_after": {
+    "OLDCO": "2025-06-30",
+    "GONECO": "2025-12-15"
+  },
+  "date_from": "2025-01-01",
+  "date_to": "2026-05-01"
+}

--- a/tests/research/test_cost_pilot.py
+++ b/tests/research/test_cost_pilot.py
@@ -1,0 +1,145 @@
+"""Cost-pilot runner tests — fixture mode, no real LLM calls.
+
+The 500-call live pilot is the operator-driven artifact; here we lock in
+the math (mean / p95 / p99 / schema-retry-rate / cache-hit-rate), the
+parquet writer, the report renderer, and the hard-cap abort path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from rainier.research import cost_pilot, output_schema
+
+
+def _load_fixture(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def test_summarize_math_matches_fixture(cost_pilot_10call_fixture):
+    fixture = _load_fixture(cost_pilot_10call_fixture)
+    summary = cost_pilot.summarize(fixture["calls"])
+
+    # 10 calls; one schema retry; two cache hits.
+    assert summary.calls_completed == 10
+    assert summary.schema_retry_rate == 0.1  # 1/10
+    assert summary.cache_hit_rate == 0.2  # 2/10
+    # Costs were chosen so the mean is computable by inspection.
+    expected_total = sum(c["cost_usd"] for c in fixture["calls"])
+    assert summary.total_spend_usd == round(expected_total, 6)
+    assert summary.mean_cost_usd == round(expected_total / 10, 6)
+    # p95 / p99 are non-decreasing and bounded by the max observed cost.
+    max_cost = max(c["cost_usd"] for c in fixture["calls"])
+    assert summary.p95_cost_usd <= max_cost
+    assert summary.p99_cost_usd <= max_cost
+    assert summary.p99_cost_usd >= summary.p95_cost_usd >= summary.mean_cost_usd
+
+
+def test_verdict_pass_when_within_envelope(cost_pilot_10call_fixture):
+    fixture = _load_fixture(cost_pilot_10call_fixture)
+    verdict = cost_pilot.verdict_for(
+        cost_pilot.summarize(fixture["calls"]),
+        hard_cap_usd=50.0,
+        envelope_mean_usd=0.10,
+    )
+    assert verdict == "PASS"
+
+
+def test_verdict_conditional_when_mean_double_envelope(cost_pilot_10call_fixture):
+    fixture = _load_fixture(cost_pilot_10call_fixture)
+    summary = cost_pilot.summarize(fixture["calls"])
+    # Force CONDITIONAL by setting a very tight envelope.
+    verdict = cost_pilot.verdict_for(
+        summary,
+        hard_cap_usd=50.0,
+        envelope_mean_usd=summary.mean_cost_usd / 3,
+    )
+    assert verdict == "CONDITIONAL"
+
+
+def test_verdict_fail_when_hard_cap_exceeded(cost_pilot_10call_fixture):
+    fixture = _load_fixture(cost_pilot_10call_fixture)
+    summary = cost_pilot.summarize(fixture["calls"])
+    verdict = cost_pilot.verdict_for(
+        summary,
+        hard_cap_usd=summary.total_spend_usd - 0.001,
+        envelope_mean_usd=1.0,
+    )
+    assert verdict == "FAIL"
+
+
+def test_persist_parquet_writes_row_per_call(tmp_path, cost_pilot_10call_fixture):
+    fixture = _load_fixture(cost_pilot_10call_fixture)
+    out = tmp_path / "slice0_cost_pilot.parquet"
+    cost_pilot.persist_parquet(fixture["calls"], out, skill_id=fixture["skill_id"],
+                               ledger_sha=fixture["ledger_sha"])
+    df = pd.read_parquet(out)
+    assert len(df) == 10
+    assert set(["call_id", "provider", "model", "cost_usd",
+                "schema_retries", "cache_hit", "outcome",
+                "skill_id", "ledger_sha"]).issubset(df.columns)
+    assert (df["skill_id"] == "cost_pilot_v0").all()
+
+
+def test_render_report_html(tmp_path, cost_pilot_10call_fixture):
+    fixture = _load_fixture(cost_pilot_10call_fixture)
+    summary = cost_pilot.summarize(fixture["calls"])
+    out = tmp_path / "report.html"
+    cost_pilot.render_report(
+        summary,
+        per_provider=cost_pilot.per_provider_stats(fixture["calls"]),
+        verdict="PASS",
+        out_path=out,
+        skill_id=fixture["skill_id"],
+        ledger_sha=fixture["ledger_sha"],
+    )
+    assert out.exists()
+    text = out.read_text()
+    # Verdict + skill + per-provider table headers are present.
+    assert "PASS" in text
+    assert "cost_pilot_v0" in text
+    assert "anthropic" in text
+    assert "deepseek" in text
+    assert "mean" in text.lower() and "p95" in text.lower()
+
+
+def test_summary_block_parses_against_output_schema(cost_pilot_10call_fixture, tmp_path):
+    fixture = _load_fixture(cost_pilot_10call_fixture)
+    summary = cost_pilot.summarize(fixture["calls"])
+    block = cost_pilot.summary_block(
+        summary,
+        verdict="PASS",
+        skill_id=fixture["skill_id"],
+        report_html_path=tmp_path / "report.html",
+        ledger_sha=fixture["ledger_sha"],
+    )
+    text = output_schema.format_block("cost_pilot", block)
+    parsed = output_schema.parse_block(text)
+    assert parsed["verdict"] == "PASS"
+    assert parsed["skill_id"] == "cost_pilot_v0"
+    output_schema.validate("cost_pilot", parsed)
+
+
+def test_budget_aborted_row_written_on_hard_cap(tmp_path):
+    """`run_fixture` with a hard-cap that trips part-way writes the budget_aborted row."""
+    calls = [
+        {"call_id": f"c{i}", "provider": "deepseek", "model": "v4-pro",
+         "cost_usd": 1.0, "schema_retries": 0, "cache_hit": False,
+         "outcome": "filled"}
+        for i in range(5)
+    ]
+    out_parquet = tmp_path / "cap.parquet"
+    cost_pilot.run_calls(
+        calls,
+        hard_cap_usd=2.5,  # trips after the third call ($3 cumulative).
+        out_parquet=out_parquet,
+        skill_id="cost_pilot_v0",
+        ledger_sha="0" * 40,
+    )
+    df = pd.read_parquet(out_parquet)
+    # Three "filled" calls then a budget_aborted row.
+    assert (df["outcome"] == "budget_aborted").sum() >= 1
+    assert (df["outcome"] == "filled").sum() == 3

--- a/tests/research/test_cost_pilot.py
+++ b/tests/research/test_cost_pilot.py
@@ -123,6 +123,26 @@ def test_summary_block_parses_against_output_schema(cost_pilot_10call_fixture, t
     output_schema.validate("cost_pilot", parsed)
 
 
+def test_percentile_uses_ceil_not_bankers_round():
+    """Regression: codex iter-3 [P2] — nearest-rank percentile uses
+    ceil(pct/100 * n), not Python's banker's-rounding `round`. For
+    n=30, p95 = sorted_vals[ceil(0.95*30)-1] = sorted_vals[28]; the
+    pre-fix code returned sorted_vals[27] (banker's round of 28.5 → 28).
+    Underreports p95/p99 on common fixture / per-provider bucket sizes.
+    """
+    # Constructed values where rank-28 vs rank-29 disagree: 0.0..29.0
+    # ascending so the percentile equals (rank - 1).
+    vals = [float(i) for i in range(30)]
+    # nearest-rank: ceil(0.95 * 30) = 29 → sorted[28] = 28.0
+    assert cost_pilot._percentile(vals, 95) == 28.0
+    # ceil(0.99 * 30) = 30 → sorted[29] = 29.0
+    assert cost_pilot._percentile(vals, 99) == 29.0
+    # Edge cases stay correct.
+    assert cost_pilot._percentile(vals, 100) == 29.0
+    assert cost_pilot._percentile(vals, 0) == 0.0
+    assert cost_pilot._percentile([], 95) == 0.0
+
+
 def test_budget_aborted_row_written_on_hard_cap(tmp_path):
     """`run_fixture` with a hard-cap that trips part-way writes the budget_aborted row."""
     calls = [

--- a/tests/research/test_data_availability_loader.py
+++ b/tests/research/test_data_availability_loader.py
@@ -1,0 +1,95 @@
+"""Schema-aware loader for the data-availability ledger.
+
+The ledger is the look-ahead control surface (D-014). Slice 0 introduces
+non-macro_context entries (qu100_history, ohlcv, signals, chart_image,
+etc.) so the loader gets a typed API that knows about per-dataset
+observability rules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rainier.research import data_availability_loader as loader
+
+LEDGER_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src" / "rainier" / "research" / "data_availability.yaml"
+)
+
+
+def test_load_returns_entries_list():
+    ledger = loader.load(LEDGER_PATH)
+    assert ledger.schema_version >= 1
+    assert ledger.entries  # non-empty
+
+
+def test_every_entry_carries_observability_rule():
+    ledger = loader.load(LEDGER_PATH)
+    valid_rules = loader.VALID_OBSERVABILITY_RULES
+    for entry in ledger.entries:
+        assert entry.observability_timestamp_rule in valid_rules
+
+
+def test_revision_immutability_present_for_every_entry():
+    ledger = loader.load(LEDGER_PATH)
+    for entry in ledger.entries:
+        assert entry.revision_immutability in (True, False)
+
+
+def test_qu100_history_entry_present():
+    """Slice 0 extends the ledger with qu100_history (D-016)."""
+    ledger = loader.load(LEDGER_PATH)
+    datasets = {e.dataset for e in ledger.entries}
+    assert "qu100_history" in datasets
+
+
+def test_chart_image_entry_present():
+    """Slice 0 ledger declares chart_image (D-025) so cost-pilot calls
+    can fingerprint the multimodal payload."""
+    ledger = loader.load(LEDGER_PATH)
+    datasets = {e.dataset for e in ledger.entries}
+    assert "chart_image" in datasets
+
+
+def test_signals_entries_present():
+    """Per-symbol signals (pinbar/sr/pivots/bias) are ledger-registered."""
+    ledger = loader.load(LEDGER_PATH)
+    datasets = {e.dataset for e in ledger.entries}
+    for sig_dataset in ("signals_pinbar", "signals_sr", "signals_pivots", "signals_bias"):
+        assert sig_dataset in datasets, f"missing dataset {sig_dataset}"
+
+
+def test_lookup_by_dataset_returns_matching_entries():
+    ledger = loader.load(LEDGER_PATH)
+    macro = ledger.by_dataset("macro_context")
+    assert macro
+    assert all(e.dataset == "macro_context" for e in macro)
+
+
+def test_pending_status_field_present():
+    """Slice 0 introduces a `pending` flag for fields tracked in sibling tasks."""
+    ledger = loader.load(LEDGER_PATH)
+    # The macro_context field is currently NOT pending (vix-backfill landed).
+    macro = ledger.by_dataset("macro_context")
+    assert all(not e.pending for e in macro)
+
+
+def test_unknown_rule_raises():
+    bad = {
+        "schema_version": 1,
+        "entries": [
+            {
+                "dataset": "macro_context",
+                "symbol": "VIX",
+                "fields": ["close"],
+                "observability_timestamp_rule": "wishful_thinking",
+                "revision_immutability": True,
+                "source": "yfinance",
+            },
+        ],
+    }
+    with pytest.raises(loader.LedgerError):
+        loader._parse(bad)  # noqa: SLF001 — exercising the parser directly

--- a/tests/research/test_output_schema.py
+++ b/tests/research/test_output_schema.py
@@ -1,0 +1,88 @@
+"""Output-schema validator tests — D-031 stdout summary-block contract.
+
+The schema lives at src/rainier/research/output_schema.yaml. Every
+`llm-research <verb>` subcommand that prints a summary block must
+produce a fenced (`---` … `---`) YAML payload that round-trips through
+the schema validator. Tests here pin the validator surface — they
+don't care about CLI plumbing, just the loader / validator / strict-mode.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rainier.research import output_schema
+
+
+def _valid_cost_pilot_block() -> dict:
+    """A canonical example of the cost-pilot summary block."""
+    return {
+        "slice": 0,
+        "skill_id": "cost_pilot_v0",
+        "calls_total": 500,
+        "calls_completed": 500,
+        "mean_cost_usd": 0.0123,
+        "p95_cost_usd": 0.0456,
+        "p99_cost_usd": 0.0789,
+        "schema_retry_rate": 0.02,
+        "cache_hit_rate": 0.18,
+        "total_spend_usd": 6.15,
+        "verdict": "PASS",
+        "report_html": "docs/slice0-cost-report.html",
+        "ledger_sha": "0" * 40,
+    }
+
+
+def test_loader_returns_dict_with_schemas_key():
+    loaded = output_schema.load()
+    assert "schemas" in loaded
+    assert "cost_pilot" in loaded["schemas"]
+
+
+def test_validate_accepts_canonical_block():
+    output_schema.validate("cost_pilot", _valid_cost_pilot_block())
+
+
+def test_validate_rejects_missing_field():
+    block = _valid_cost_pilot_block()
+    del block["verdict"]
+    with pytest.raises(output_schema.SchemaError) as exc:
+        output_schema.validate("cost_pilot", block)
+    assert "verdict" in str(exc.value)
+
+
+def test_validate_rejects_extra_field_strict_mode():
+    block = _valid_cost_pilot_block()
+    block["never_declared_field"] = "boom"
+    with pytest.raises(output_schema.SchemaError) as exc:
+        output_schema.validate("cost_pilot", block, strict=True)
+    assert "never_declared_field" in str(exc.value)
+
+
+def test_validate_accepts_extra_field_non_strict_mode():
+    block = _valid_cost_pilot_block()
+    block["forward_compat"] = "ok"
+    # Non-strict mode tolerates extra fields (forward-compat shim).
+    output_schema.validate("cost_pilot", block, strict=False)
+
+
+def test_format_block_round_trips():
+    """`format_block(name, payload)` → str → parse_block → payload."""
+    block = _valid_cost_pilot_block()
+    text = output_schema.format_block("cost_pilot", block)
+    assert text.startswith("---\n")
+    assert text.endswith("---\n")
+    parsed = output_schema.parse_block(text)
+    # YAML floats round-trip safely; ints round-trip safely.
+    assert parsed == block
+
+
+def test_parse_block_rejects_unfenced_payload():
+    with pytest.raises(output_schema.SchemaError):
+        output_schema.parse_block("just: a flat yaml document\n")
+
+
+def test_verdict_enum_is_pinned():
+    schema = output_schema.load()["schemas"]["cost_pilot"]
+    # PASS / CONDITIONAL / FAIL are the three values Slice 0 ships with.
+    assert set(schema["fields"]["verdict"]["enum"]) == {"PASS", "CONDITIONAL", "FAIL"}

--- a/tests/research/test_providers.py
+++ b/tests/research/test_providers.py
@@ -1,0 +1,82 @@
+"""Provider adapter tests.
+
+The Slice 0 surface is `providers test` — sanity-check auth + endpoint
+reachability + schema-compliance of a no-op call. Providers are stubbed
+here (no network); the adapter shape is what we lock in.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rainier.research.providers import (
+    AuthStatus,
+    ProviderTestResult,
+    get_provider,
+    list_providers,
+)
+
+
+def test_list_providers_returns_three():
+    """v0/v1 ships anthropic + deepseek + openai_compatible per D-019."""
+    names = set(list_providers())
+    assert names == {"anthropic", "deepseek", "openai_compatible"}
+
+
+def test_get_provider_anthropic_missing_key(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    provider = get_provider("anthropic")
+    result = provider.test_auth()
+    assert isinstance(result, ProviderTestResult)
+    assert result.auth is AuthStatus.MISSING
+    assert "ANTHROPIC_API_KEY" in (result.next_step or "")
+
+
+def test_get_provider_anthropic_with_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+    provider = get_provider("anthropic")
+    result = provider.test_auth()
+    # We don't hit the network in test mode; "ok" means the key was loaded.
+    assert result.auth is AuthStatus.OK
+    assert result.provider == "anthropic"
+
+
+def test_get_provider_deepseek_missing_key(monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    provider = get_provider("deepseek")
+    result = provider.test_auth()
+    assert result.auth is AuthStatus.MISSING
+    assert "DEEPSEEK_API_KEY" in (result.next_step or "")
+
+
+def test_get_provider_openai_compatible_missing_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    provider = get_provider("openai_compatible")
+    result = provider.test_auth()
+    assert result.auth is AuthStatus.MISSING
+
+
+def test_get_provider_unknown_name_raises():
+    with pytest.raises(ValueError) as exc:
+        get_provider("not-a-real-provider")
+    assert "not-a-real-provider" in str(exc.value)
+
+
+def test_provider_result_to_dict_shape():
+    """`ProviderTestResult.as_dict()` is the JSON payload the CLI emits."""
+    r = ProviderTestResult(
+        provider="anthropic",
+        auth=AuthStatus.OK,
+        endpoint_reachable=True,
+        schema_compliant=True,
+        latency_ms=42,
+        next_step=None,
+    )
+    d = r.as_dict()
+    assert d["provider"] == "anthropic"
+    assert d["auth"] == "ok"
+    assert d["endpoint_reachable"] is True
+    assert d["schema_compliant"] is True
+    assert d["latency_ms"] == 42
+    assert "next_step" in d

--- a/tests/research/test_research_cli.py
+++ b/tests/research/test_research_cli.py
@@ -1,0 +1,91 @@
+"""End-to-end CLI tests for `uv run rainier llm-research <cmd>`.
+
+Uses click's testing harness; no shell process spawned. The composition
+root (`rainier.cli`) registers the `llm-research` subgroup, so these
+tests double as the integration check that wiring landed.
+"""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from rainier.cli import cli as root_cli
+
+
+def _run(args, env=None):
+    runner = CliRunner()
+    return runner.invoke(root_cli, args, env=env or {})
+
+
+def test_root_help_includes_llm_research_group():
+    result = _run(["--help"])
+    assert result.exit_code == 0, result.output
+    assert "llm-research" in result.output
+
+
+def test_llm_research_help_lists_all_subcommands():
+    result = _run(["llm-research", "--help"])
+    assert result.exit_code == 0, result.output
+    for cmd in ("providers", "call", "cost-pilot", "survivorship-check"):
+        assert cmd in result.output
+
+
+def test_providers_test_subcommand_runs(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+    result = _run(["llm-research", "providers", "test", "--json"])
+    assert result.exit_code == 0, result.output
+    # JSON output is a list of provider records.
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert {row["provider"] for row in data} == {
+        "anthropic", "deepseek", "openai_compatible",
+    }
+    # All three should show auth=missing in our cleared env.
+    assert all(row["auth"] == "missing" for row in data)
+
+
+def test_call_dry_run_is_deterministic_for_same_inputs():
+    """D-031 + determinism rule: same (skill, ticker, day) → byte-identical prompt."""
+    args = [
+        "llm-research", "call",
+        "--skill", "baseline_opus_multimodal_v1",
+        "--ticker", "AAPL",
+        "--day", "2025-06-10",
+        "--dry-run",
+    ]
+    a = _run(args)
+    b = _run(args)
+    assert a.exit_code == 0, a.output
+    assert b.exit_code == 0, b.output
+    # The dry-run path emits the assembled prompt as JSON to stdout.
+    payload_a = json.loads(a.output)
+    payload_b = json.loads(b.output)
+    assert payload_a == payload_b
+    # Sanity: the prompt is keyed by inputs.
+    assert payload_a["skill"] == "baseline_opus_multimodal_v1"
+    assert payload_a["ticker"] == "AAPL"
+    assert payload_a["day"] == "2025-06-10"
+
+
+def test_survivorship_check_json_shape(tmp_path, monkeypatch):
+    """`survivorship-check --json` returns the canonical record shape."""
+    # Steer the check at an in-memory session via env var (CLI honors it).
+    monkeypatch.setenv("RAINIER_RESEARCH_SURVIVORSHIP_SQLITE", str(tmp_path / "s.db"))
+    # The check should not blow up even when the table doesn't exist —
+    # it returns a CONDITIONAL verdict with a concrete next-step.
+    result = _run([
+        "llm-research", "survivorship-check",
+        "--from", "2025-01-01", "--to", "2026-05-01", "--json",
+    ])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "verdict" in data
+    assert data["verdict"] in {"PASS", "CONDITIONAL", "FAIL"}
+    assert "from_date" in data and data["from_date"] == "2025-01-01"
+    assert "to_date" in data and data["to_date"] == "2026-05-01"
+    assert "delisted_tickers" in data
+    assert "next_step" in data

--- a/tests/research/test_research_cli.py
+++ b/tests/research/test_research_cli.py
@@ -92,3 +92,51 @@ def test_survivorship_check_json_shape(tmp_path, monkeypatch):
     assert "to_date" in data and data["to_date"] == "2026-05-01"
     assert "delisted_tickers" in data
     assert "next_step" in data
+
+
+def test_cost_pilot_fixture_accepts_bare_list_shape(tmp_path):
+    """Regression: codex iter-1 [P2] — `--fixture` must accept either
+    `{calls: [...], ledger_sha, skill_id}` OR a bare top-level JSON list
+    of call records. The pre-fix code called `raw.get("calls", ...)`
+    unconditionally, which AttributeErrors when `raw` is a list.
+    """
+    calls = [
+        {"call_id": "c0", "provider": "anthropic", "model": "opus-4.7",
+         "cost_usd": 0.01, "schema_retries": 0, "cache_hit": False,
+         "outcome": "filled"},
+        {"call_id": "c1", "provider": "deepseek", "model": "v4-pro",
+         "cost_usd": 0.005, "schema_retries": 0, "cache_hit": True,
+         "outcome": "filled"},
+    ]
+    fixture = tmp_path / "bare_list.json"
+    fixture.write_text(json.dumps(calls))
+    result = _run([
+        "llm-research", "cost-pilot",
+        "--fixture", str(fixture),
+        "--out", str(tmp_path / "out.parquet"),
+        "--report-html", str(tmp_path / "out.html"),
+        "--skill", "test_skill",
+    ])
+    assert result.exit_code == 0, result.output
+    # Summary block should round-trip — verdict is one of the three legal values.
+    from rainier.research import output_schema
+    parsed = output_schema.parse_block(result.output)
+    assert parsed["verdict"] in {"PASS", "CONDITIONAL", "FAIL"}
+    assert parsed["calls_completed"] == 2
+
+
+def test_cost_pilot_fixture_rejects_invalid_shape(tmp_path):
+    """Non-dict, non-list JSON should raise a ClickException with a
+    helpful next-step rather than crashing with a cryptic AttributeError.
+    """
+    fixture = tmp_path / "scalar.json"
+    fixture.write_text(json.dumps("not-a-list-or-dict"))
+    result = _run([
+        "llm-research", "cost-pilot",
+        "--fixture", str(fixture),
+        "--out", str(tmp_path / "out.parquet"),
+        "--report-html", str(tmp_path / "out.html"),
+    ])
+    assert result.exit_code != 0
+    # The click error message names the supported shapes.
+    assert "list" in result.output.lower() or "object" in result.output.lower()

--- a/tests/research/test_research_cli.py
+++ b/tests/research/test_research_cli.py
@@ -140,3 +140,37 @@ def test_cost_pilot_fixture_rejects_invalid_shape(tmp_path):
     assert result.exit_code != 0
     # The click error message names the supported shapes.
     assert "list" in result.output.lower() or "object" in result.output.lower()
+
+
+def test_cost_pilot_honors_n_below_fixture_size(tmp_path):
+    """Regression: codex iter-2 [P2] — `--n 2` against a 5-call fixture
+    must replay only the first 2 calls (not all 5). Pre-fix the CLI
+    passed the whole fixture into run_calls and emitted a calls_total=2
+    summary block while persisting 5 rows + summarizing 5 calls.
+    """
+    calls = [
+        {"call_id": f"c{i}", "provider": "anthropic", "model": "opus-4.7",
+         "cost_usd": 0.01, "schema_retries": 0, "cache_hit": False,
+         "outcome": "filled"}
+        for i in range(5)
+    ]
+    fixture = tmp_path / "five_calls.json"
+    fixture.write_text(json.dumps(calls))
+    out_parquet = tmp_path / "out.parquet"
+    result = _run([
+        "llm-research", "cost-pilot",
+        "--fixture", str(fixture),
+        "--n", "2",
+        "--out", str(out_parquet),
+        "--report-html", str(tmp_path / "out.html"),
+    ])
+    assert result.exit_code == 0, result.output
+    from rainier.research import output_schema
+    parsed = output_schema.parse_block(result.output)
+    assert parsed["calls_total"] == 2
+    assert parsed["calls_completed"] == 2
+    # The parquet should also reflect the bounded replay (2 rows).
+    import pandas as pd
+    df = pd.read_parquet(out_parquet)
+    # No budget_aborted row in this case — cap is not exceeded.
+    assert len(df) == 2

--- a/tests/research/test_research_cli.py
+++ b/tests/research/test_research_cli.py
@@ -33,9 +33,12 @@ def test_llm_research_help_lists_all_subcommands():
 
 
 def test_providers_test_subcommand_runs(monkeypatch):
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+    # Force-clear via empty string so the project's .env-loader (which respects
+    # existing env vars and only fills missing ones) doesn't re-populate keys
+    # under us. The provider adapters treat "" the same as missing.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "")
+    monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "")
     result = _run(["llm-research", "providers", "test", "--json"])
     assert result.exit_code == 0, result.output
     # JSON output is a list of provider records.

--- a/tests/research/test_research_cli.py
+++ b/tests/research/test_research_cli.py
@@ -8,7 +8,9 @@ tests double as the integration check that wiring landed.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from rainier.cli import cli as root_cli
@@ -141,6 +143,51 @@ def test_cost_pilot_fixture_rejects_invalid_shape(tmp_path):
     assert result.exit_code != 0
     # The click error message names the supported shapes.
     assert "list" in result.output.lower() or "object" in result.output.lower()
+
+
+def test_resolve_ledger_sha_works_from_subdirectory(tmp_path, monkeypatch):
+    """Regression: codex iter-6 [P2] — _resolve_ledger_sha must use the
+    git toplevel (not Path.cwd()) for the path argument to `git rev-parse
+    HEAD:<path>`. Pre-fix, invocations from any subdirectory stamped
+    `ledger_sha: unknown` because git interpreted the path relative to
+    the repo root while we computed it relative to cwd.
+    """
+    import os
+
+    from rainier.research.cli import _resolve_ledger_sha
+
+    # Simulate a CLI invocation from src/ (a real subdirectory of the
+    # checkout). The function should still resolve to the real SHA, not
+    # the "unknown" fallback. We don't pin the exact SHA — just assert
+    # it looks like a 40-char hex and is not "unknown".
+    repo_root = Path(__file__).resolve().parents[2]
+    src_dir = repo_root / "src"
+    if not src_dir.exists():
+        pytest.skip("src/ not present in this checkout")
+    monkeypatch.chdir(src_dir)
+    sha = _resolve_ledger_sha()
+    # Either we're in a non-git environment (CI build from sdist) and the
+    # fallback is acceptable, OR we got a real SHA. The bug pre-fix was
+    # the FORMER happening inside a real checkout.
+    if sha == "unknown":
+        # Confirm we're actually in a git checkout — otherwise the test is
+        # a no-op (legitimately).
+        import subprocess
+        check = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=False, cwd=os.getcwd(),
+        )
+        if check.returncode == 0 and check.stdout.strip():
+            pytest.fail(
+                f"_resolve_ledger_sha returned 'unknown' from {src_dir} "
+                f"despite being inside the git checkout at "
+                f"{check.stdout.strip()}; the toplevel resolution regressed."
+            )
+    else:
+        # Real SHA: 40 hex chars (full) or "unknown" — accept either shape
+        # as success since git's HEAD:<path> returns the full SHA.
+        assert len(sha) == 40, f"unexpected SHA shape: {sha!r}"
+        assert all(c in "0123456789abcdef" for c in sha), f"not hex: {sha!r}"
 
 
 def test_cost_pilot_rejects_undersized_fixture(tmp_path):

--- a/tests/research/test_research_cli.py
+++ b/tests/research/test_research_cli.py
@@ -113,6 +113,7 @@ def test_cost_pilot_fixture_accepts_bare_list_shape(tmp_path):
     result = _run([
         "llm-research", "cost-pilot",
         "--fixture", str(fixture),
+        "--n", "2",  # must match fixture size; see iter-4 [P2].
         "--out", str(tmp_path / "out.parquet"),
         "--report-html", str(tmp_path / "out.html"),
         "--skill", "test_skill",
@@ -140,6 +141,32 @@ def test_cost_pilot_fixture_rejects_invalid_shape(tmp_path):
     assert result.exit_code != 0
     # The click error message names the supported shapes.
     assert "list" in result.output.lower() or "object" in result.output.lower()
+
+
+def test_cost_pilot_rejects_undersized_fixture(tmp_path):
+    """Regression: codex iter-4 [P2] — fixture shorter than --n must
+    fail-fast. Pre-fix the CLI silently sliced the fixture and emitted
+    a calls_total=500 summary backed by 10 actual calls — letting an
+    incomplete replay pose as a successful 500-call pilot.
+    """
+    calls = [
+        {"call_id": f"c{i}", "provider": "anthropic", "model": "opus-4.7",
+         "cost_usd": 0.01, "schema_retries": 0, "cache_hit": False,
+         "outcome": "filled"}
+        for i in range(3)
+    ]
+    fixture = tmp_path / "three_calls.json"
+    fixture.write_text(json.dumps(calls))
+    result = _run([
+        "llm-research", "cost-pilot",
+        "--fixture", str(fixture),
+        "--n", "10",  # bigger than fixture; should error.
+        "--out", str(tmp_path / "out.parquet"),
+        "--report-html", str(tmp_path / "out.html"),
+    ])
+    assert result.exit_code != 0
+    # The click message names both numbers so the operator knows what to do.
+    assert "3" in result.output and "10" in result.output
 
 
 def test_cost_pilot_honors_n_below_fixture_size(tmp_path):

--- a/tests/research/test_survivorship.py
+++ b/tests/research/test_survivorship.py
@@ -52,9 +52,10 @@ def test_pass_when_full_coverage_no_drops(in_memory_session):
 
 
 def test_delisted_ticker_preserved_in_history(in_memory_session):
-    start = date(2025, 1, 1)
+    # First NYSE session of 2025 is Jan 2 (Jan 1 is NYE holiday).
+    start = date(2025, 1, 2)
     end = date(2025, 3, 1)
-    drop_date = date(2025, 2, 1)
+    drop_date = date(2025, 2, 3)  # first NYSE session in Feb 2025
     # OLDCO present Jan but gone Feb onwards.
     _seed_delisted(in_memory_session, "OLDCO", start, drop_date)
     # Anchors keep every trading day covered.
@@ -84,7 +85,8 @@ def test_missing_day_returns_conditional(in_memory_session):
 
 def test_insert_only_violation_returns_conditional(in_memory_session):
     """Mutating a historical row trips the immutability proof."""
-    start = date(2025, 1, 1)
+    # Use a known NYSE session as the mutation anchor (Jan 1 is NYE holiday).
+    start = date(2025, 1, 2)
     end = date(2025, 1, 31)
     _seed_alive(in_memory_session, ["AAPL"], start, end)
     survivorship.mutate_historical_row_for_test(in_memory_session, "AAPL", start)
@@ -109,3 +111,27 @@ def test_to_dict_shape(in_memory_session):
     assert d["verdict"] in {"PASS", "CONDITIONAL", "FAIL"}
     assert isinstance(d["delisted_tickers"], list)
     assert isinstance(d["missing_days"], list)
+
+
+def test_nyse_holidays_not_reported_as_missing(in_memory_session):
+    """Regression: codex iter-1 [P1] — NYE / MLK / Presidents Day / Good
+    Friday / Memorial Day are NYSE-closed sessions. The gate must not
+    flag them as missing on otherwise-healthy data. Pre-fix the check
+    used weekday-only `_trading_days` and flipped PASS → CONDITIONAL
+    on default-window runs starting at 2025-01-01.
+    """
+    # Default-ish window that straddles several NYSE holidays:
+    # NYE (Jan 1), MLK Day (Jan 20), Presidents Day (Feb 17),
+    # Good Friday (Apr 18), Memorial Day (May 26).
+    start = date(2025, 1, 1)
+    end = date(2025, 6, 1)
+    # Seed via the same helper — which itself filters to NYSE sessions —
+    # so the data represents an honest insert-only history.
+    _seed_alive(in_memory_session, ["AAPL"], start, end)
+    result = survivorship.check(
+        session=in_memory_session, from_date=start, to_date=end,
+    )
+    assert result.verdict == "PASS", (
+        f"unexpected verdict {result.verdict} with missing={result.missing_days}"
+    )
+    assert result.missing_days == []

--- a/tests/research/test_survivorship.py
+++ b/tests/research/test_survivorship.py
@@ -113,6 +113,43 @@ def test_to_dict_shape(in_memory_session):
     assert isinstance(d["missing_days"], list)
 
 
+def test_unverified_proof_returns_conditional_not_pass(monkeypatch, in_memory_session):
+    """Regression: codex iter-7 [P1] — when the immutability proof is
+    `unverified` (prod path before the audit trigger lands), the gate
+    must return CONDITIONAL, not PASS. Pre-fix, complete coverage with
+    no mutated rows returned PASS even though _has_mutated_rows() never
+    actually ran on the prod (non-sqlite) backend.
+
+    We simulate the prod path on top of the in-memory SQLite session by
+    monkeypatching `_is_sqlite` → False.
+    """
+    start = date(2025, 1, 2)
+    end = date(2025, 1, 31)
+    _seed_alive(in_memory_session, ["AAPL"], start, end)
+    monkeypatch.setattr(survivorship, "_is_sqlite", lambda _s: False)
+    # Also stub the prod queries so they execute against the sqlite test
+    # table — _coverage_query / _delisted_tickers fall through to the
+    # `text(...)` path otherwise and would 404 on money_flow_snapshots.
+    monkeypatch.setattr(
+        survivorship, "_coverage_query",
+        lambda _s, s, e: {d: 1 for d in survivorship._trading_days(s, e)},
+    )
+    monkeypatch.setattr(
+        survivorship, "_delisted_tickers",
+        lambda _s, _s2, _e, **_k: [],
+    )
+    monkeypatch.setattr(
+        survivorship, "_has_mutated_rows",
+        lambda _s, _s2, _e: False,
+    )
+    result = survivorship.check(
+        session=in_memory_session, from_date=start, to_date=end,
+    )
+    assert result.verdict == "CONDITIONAL"
+    assert result.immutability_proof == "unverified"
+    assert result.next_step and "audit" in result.next_step.lower()
+
+
 def test_nyse_holidays_not_reported_as_missing(in_memory_session):
     """Regression: codex iter-1 [P1] — NYE / MLK / Presidents Day / Good
     Friday / Memorial Day are NYSE-closed sessions. The gate must not

--- a/tests/research/test_survivorship.py
+++ b/tests/research/test_survivorship.py
@@ -105,7 +105,7 @@ def test_to_dict_shape(in_memory_session):
     )
     d = result.as_dict()
     assert d["from_date"] == "2025-01-01"
-    assert d["to_date"] == "2026-02-01" or d["to_date"] == "2025-02-01"
+    assert d["to_date"] == "2025-02-01"
     assert d["verdict"] in {"PASS", "CONDITIONAL", "FAIL"}
     assert isinstance(d["delisted_tickers"], list)
     assert isinstance(d["missing_days"], list)

--- a/tests/research/test_survivorship.py
+++ b/tests/research/test_survivorship.py
@@ -1,0 +1,111 @@
+"""Survivorship-gate tests — D-016 PASS gate proof of concept.
+
+The check verifies (a) every trading day in [from, to] has > 0 rows in
+the QU100 snapshot history, (b) tickers that appear in earlier snapshots
+but vanish before `to` are preserved (delisted but row-present), and
+(c) the schema is insert-only (no UPDATE/DELETE on historical rows).
+
+We model the table with an in-memory SQLite session here so the test is
+hermetic (no Postgres dependency) — the production CLI takes any
+SQLAlchemy session, so the same code path runs against either backend.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from rainier.research import survivorship
+
+
+@pytest.fixture
+def in_memory_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    survivorship.bootstrap_sqlite(engine)
+    with Session(engine, future=True) as s:
+        yield s
+
+
+def _seed_alive(session, symbols, start: date, end: date):
+    """Insert one snapshot per (symbol, trading day) — alive across the window."""
+    survivorship.seed_snapshots(session, symbols=symbols, start=start, end=end)
+
+
+def _seed_delisted(session, symbol, from_date: date, until_date: date):
+    """Insert snapshots for a symbol that disappears after `until_date`."""
+    survivorship.seed_snapshots(session, symbols=[symbol], start=from_date, end=until_date)
+
+
+def test_pass_when_full_coverage_no_drops(in_memory_session):
+    start = date(2025, 1, 1)
+    end = date(2025, 2, 1)
+    _seed_alive(in_memory_session, ["AAPL", "NVDA", "TSLA"], start, end)
+    result = survivorship.check(
+        session=in_memory_session, from_date=start, to_date=end,
+    )
+    assert result.verdict == "PASS"
+    assert result.delisted_tickers == []
+    assert result.missing_days == []
+
+
+def test_delisted_ticker_preserved_in_history(in_memory_session):
+    start = date(2025, 1, 1)
+    end = date(2025, 3, 1)
+    drop_date = date(2025, 2, 1)
+    # OLDCO present Jan but gone Feb onwards.
+    _seed_delisted(in_memory_session, "OLDCO", start, drop_date)
+    # Anchors keep every trading day covered.
+    _seed_alive(in_memory_session, ["AAPL", "NVDA"], start, end)
+    result = survivorship.check(
+        session=in_memory_session, from_date=start, to_date=end,
+    )
+    assert result.verdict == "PASS"
+    assert "OLDCO" in result.delisted_tickers
+    # OLDCO rows must still be queryable (preserved per D-009 / D-016).
+    assert survivorship.ticker_present(in_memory_session, "OLDCO", start)
+
+
+def test_missing_day_returns_conditional(in_memory_session):
+    start = date(2025, 1, 1)
+    end = date(2025, 1, 31)
+    # Seed Jan 1–Jan 15, then skip a chunk, then Jan 25–Jan 31.
+    _seed_alive(in_memory_session, ["AAPL"], start, date(2025, 1, 15))
+    _seed_alive(in_memory_session, ["AAPL"], date(2025, 1, 25), end)
+    result = survivorship.check(
+        session=in_memory_session, from_date=start, to_date=end,
+    )
+    assert result.verdict == "CONDITIONAL"
+    assert result.missing_days  # at least one gap
+    assert result.next_step  # concrete remediation surfaced
+
+
+def test_insert_only_violation_returns_conditional(in_memory_session):
+    """Mutating a historical row trips the immutability proof."""
+    start = date(2025, 1, 1)
+    end = date(2025, 1, 31)
+    _seed_alive(in_memory_session, ["AAPL"], start, end)
+    survivorship.mutate_historical_row_for_test(in_memory_session, "AAPL", start)
+    result = survivorship.check(
+        session=in_memory_session, from_date=start, to_date=end,
+    )
+    # Insert-only proof failed — return CONDITIONAL with concrete next-step.
+    assert result.verdict == "CONDITIONAL"
+    assert "insert-only" in result.next_step.lower() or "immutab" in result.next_step.lower()
+
+
+def test_to_dict_shape(in_memory_session):
+    start = date(2025, 1, 1)
+    end = date(2025, 2, 1)
+    _seed_alive(in_memory_session, ["AAPL"], start, end)
+    result = survivorship.check(
+        session=in_memory_session, from_date=start, to_date=end,
+    )
+    d = result.as_dict()
+    assert d["from_date"] == "2025-01-01"
+    assert d["to_date"] == "2026-02-01" or d["to_date"] == "2025-02-01"
+    assert d["verdict"] in {"PASS", "CONDITIONAL", "FAIL"}
+    assert isinstance(d["delisted_tickers"], list)
+    assert isinstance(d["missing_days"], list)


### PR DESCRIPTION
## Summary
- Slice 0 CLI scaffold for the LLM-research engine: `uv run rainier llm-research <cmd>` with subcommands `providers test`, `call --dry-run`, `cost-pilot`, `survivorship-check`.
- New package skeleton under `src/rainier/research/{schemas,providers,evaluator,archive,bandit,rewards}/`; D-031 output_schema validator + fenced summary-block formatter exercised end-to-end against a 10-call fixture.
- Cost-pilot runner stubs the live LLM dispatch behind an explicit `ClickException` with operator-actionable next-step (per surface-don't-silo rule); live 500-call pilot is explicit Slice 1 work.
- Survivorship gate supports in-memory SQLite (test path + `RAINIER_RESEARCH_SURVIVORSHIP_SQLITE` env override) and the production `money_flow_snapshots` table via raw SQL.
- Ledger extended with `qu100_history`, `qu100_ohlcv`, `chart_image`, `signals_*`, `money_flow_net=pending` blocks (does not touch vix's `macro_context` block).
- Implements Phase 0 of `docs/PLAN-auto-research.md`; gates Slice 1.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 9)
- Deferred [P2] (out-of-scope vix-owned file flagged by codex iter-3/4): `scripts/backfill_macro_context.py:403` NYSE-holiday coverage denominator — file lives in PR #78's diff; not modified by slice0.

## Test plan
- [ ] CI green
- [ ] Operator verifies `uv run rainier llm-research --help` shows all four subcommands
- [ ] Stacked on #78 (vix) — squash-merge upstack first, then this PR rebases onto new main

---

Stacked on #78 (`worker/vix-sector-backfill-d05f`). When #78 squash-merges, this branch will need rebase onto new main; coord handles via fix-subagent.