### PR TITLE
feat(breadth): thematic universe substrate — YAML + OHLCV backfill + registries + log (Phase A)

### DIFF
--- a/config/thematic_universe.yaml
+++ b/config/thematic_universe.yaml
@@ -1,0 +1,127 @@
+# Industry / Thematic ranks universe (Phase A).
+#
+# Operator-owned. Adding/removing a ticker is a one-line edit; the backfill
+# and ranking pipeline re-read this file each run and the universe-state log
+# captures the SHA so historical centile ranks remain reproducible.
+#
+# Tickers are normalized — no BATS:/NYSE:/NASDAQ: prefixes; yfinance is
+# symbol-only. Section bucket names are display-only; ranking is
+# universe-global per DESIGN [D-002]/[D-003].
+#
+# Design refs:
+#   docs/DESIGN-thematic-ranks-dashboard.md §4 ([D-001])
+#   docs/TASK-PLAN-thematic-backfill-fd88.md §3
+#
+# Seed source: TheMarketMemo Industry/Thematic sheet snapshot 2026-05-22.
+# Edits ship as a single commit with no code changes needed.
+version: 1
+schema: thematic_universe.v1
+asof_seeded: 2026-05-22
+
+universe:
+  communication_service:
+    - XLC
+    - IYZ
+    - SOCL
+    - HERO
+  consumer_discretionary:
+    - XLY
+    - ITB
+    - XHB
+    - IBUY
+    - ONLN
+    - PEJ
+  consumer_staples:
+    - XLP
+    - XRT
+  energy:
+    - XLE
+    - GUNR
+    - FCG
+    - XOP
+    - ICLN
+    - QCLN
+    - OIH
+    - TAN
+    - NLR
+  finance:
+    - XLF
+    - VFH
+    - KRE
+    - KBE
+    - IAI
+    - KIE
+    - IPAY
+  healthcare:
+    - XLV
+    - IBB
+    - XBI
+    - IHI
+    - IHF
+    - XHE
+    - XPH
+    - MJ
+  industrials:
+    - XLI
+    - ITA
+    - ROKT
+    - UFO
+    - SHLD
+    - BOTZ
+    - IYT
+    - JETS
+    - SNSR
+    - DRIV
+  materials:
+    - XLB
+    - GDX
+    - SIL
+    - COPX
+    - XME
+    - LIT
+    - IYM
+    - URA
+    - REMX
+  real_estate:
+    - XLRE
+    - VNQ
+    - VNQI
+    - REET
+    - REM
+  technology:
+    - XLK
+    - CHAT
+    - AIQ
+    - IXN
+    - QTEC
+    - QTUM
+    - VGT
+    - SOXX
+    - SMH
+    - DRAM
+    - IGV
+    - FDN
+    - KWEB
+    - CIBR
+    - HACK
+    - SKYY
+    - METV
+    - FINX
+    - XT
+  utilities:
+    - XLU
+    - IGF
+    - PAVE
+    - GRID
+  thematic:
+    - MEME
+    - DXYZ
+    - BLOK
+    - IPO
+    - MOAT
+    - MOO
+    - ARKK
+    - ARKW
+    - ARKF
+    - ARKX
+    - ARKQ

--- a/scripts/backfill_thematic_universe.py
+++ b/scripts/backfill_thematic_universe.py
@@ -1,0 +1,481 @@
+"""One-off thematic-universe OHLCV cache backfill.
+
+Fetches daily OHLCV for the ~94-ticker Phase A universe loaded from
+``config/thematic_universe.yaml`` into
+``data/cache/thematic_universe.parquet`` — the substrate the Phase B
+ranking layer reads.
+
+The script is **operator-run, not CI-run**. It hits ``yfinance`` when
+invoked from the CLI. Tests inject a stub ``fetch_fn`` to keep CI offline.
+
+Mirrors ``scripts/backfill_macro_context.py`` (vix worker). Key differences:
+
+  * SYMBOLS are loaded from YAML at run time, not hard-coded.
+  * ``adjusted_close`` is intentionally NOT stored — yfinance back-adjusts
+    it for future splits/dividends. The thematic universe is ranked on
+    ``close`` only (look-ahead-clean), so we skip the column entirely.
+
+Design refs:
+    docs/DESIGN-thematic-ranks-dashboard.md §5.0 [D-005] [D-011]
+    docs/TASK-PLAN-thematic-backfill-fd88.md §3
+
+Usage:
+    python scripts/backfill_thematic_universe.py \\
+        --start 2024-10-01 --end 2026-05-01 \\
+        --out data/cache/thematic_universe.parquet
+    python scripts/backfill_thematic_universe.py --dry-run  # plan only
+    python scripts/backfill_thematic_universe.py --force    # new cohort
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_YAML = ROOT / "config" / "thematic_universe.yaml"
+DEFAULT_OUT = Path("data/cache/thematic_universe.parquet")
+DEFAULT_START = "2024-10-01"
+DEFAULT_END = "2026-05-01"
+
+# Parquet column order — kept stable so the on-disk schema is deterministic.
+_COLUMN_ORDER: tuple[str, ...] = (
+    "symbol",
+    "date",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "fetched_at",
+    "yfinance_version",
+)
+
+
+# ---------------------------------------------------------------------------
+# YAML loader
+# ---------------------------------------------------------------------------
+
+
+def load_symbols_from_yaml(yaml_path: Path) -> list[str]:
+    """Return the flat ticker list from ``thematic_universe.yaml``.
+
+    Preserves YAML iteration order (sector buckets, then within-bucket order).
+    Section bucket names themselves are display-only and not returned.
+    """
+    with Path(yaml_path).open("r") as fh:
+        parsed = yaml.safe_load(fh)
+    out: list[str] = []
+    for tickers in (parsed.get("universe") or {}).values():
+        if not isinstance(tickers, list):
+            raise ValueError(
+                f"universe block in {yaml_path} must be sector -> list[ticker]; "
+                f"got {type(tickers).__name__}"
+            )
+        out.extend(tickers)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Fetch (production)
+# ---------------------------------------------------------------------------
+
+
+def _yfinance_fetch(
+    symbols: Iterable[str], start: str, end: str
+) -> dict[str, pd.DataFrame]:
+    """Production fetcher. Hits the network. Not used in tests.
+
+    NOTE on end-bound semantics:
+        ``yfinance.download(..., end=X)`` treats ``end`` as EXCLUSIVE. To
+        match a single-sided operator contract (``--end 2026-05-01`` should
+        include 2026-05-01 if it's a trading day), we bump the wire ``end``
+        by +1 calendar day before the call. Same convention vix worker uses.
+    """
+    import yfinance as yf  # local import — keeps test collection offline-safe
+
+    end_wire = (pd.to_datetime(end).date() + timedelta(days=1)).isoformat()
+
+    out: dict[str, pd.DataFrame] = {}
+    for sym in symbols:
+        df = yf.download(
+            sym,
+            start=start,
+            end=end_wire,
+            progress=False,
+            auto_adjust=False,
+            actions=False,
+        )
+        if df is None or df.empty:
+            out[sym] = pd.DataFrame(
+                columns=["date", "open", "high", "low", "close", "volume"]
+            )
+            continue
+
+        if isinstance(df.columns, pd.MultiIndex):
+            df.columns = [c[0] for c in df.columns]
+
+        df = df.reset_index().rename(
+            columns={
+                "Date": "date",
+                "Open": "open",
+                "High": "high",
+                "Low": "low",
+                "Close": "close",
+                "Volume": "volume",
+                # Adj Close intentionally dropped per DESIGN §5.0 — look-ahead-leaky.
+            }
+        )
+        if "volume" not in df.columns:
+            df["volume"] = 0
+        df["date"] = pd.to_datetime(df["date"]).dt.date
+        out[sym] = df[["date", "open", "high", "low", "close", "volume"]]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Normalize + atomic write
+# ---------------------------------------------------------------------------
+
+
+def _to_normalized_frame(
+    fetched: dict[str, pd.DataFrame],
+    yfinance_version: str,
+    fetched_at: datetime,
+) -> pd.DataFrame:
+    """Stack per-symbol frames into the canonical thematic_universe schema."""
+    rows: list[pd.DataFrame] = []
+    for sym, df in fetched.items():
+        if df.empty:
+            continue
+        sub = df.copy()
+        sub["symbol"] = sym
+        sub["volume"] = sub["volume"].astype("int64")
+        sub["fetched_at"] = fetched_at
+        sub["yfinance_version"] = yfinance_version
+        rows.append(sub)
+
+    if not rows:
+        return pd.DataFrame(columns=_COLUMN_ORDER)
+
+    out = pd.concat(rows, ignore_index=True)
+    out = out.sort_values(["symbol", "date"]).reset_index(drop=True)
+    out = out[list(_COLUMN_ORDER)]
+    return out
+
+
+def _write_parquet_atomic(df: pd.DataFrame, out_path: Path) -> None:
+    """pyarrow write + os.replace; never leaves a half-written file visible."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_suffix(out_path.suffix + ".tmp")
+    schema = pa.schema(
+        [
+            ("symbol", pa.string()),
+            ("date", pa.date32()),
+            ("open", pa.float64()),
+            ("high", pa.float64()),
+            ("low", pa.float64()),
+            ("close", pa.float64()),
+            ("volume", pa.int64()),
+            ("fetched_at", pa.timestamp("ns", tz="UTC")),
+            ("yfinance_version", pa.string()),
+        ]
+    )
+    table = pa.Table.from_pandas(df, schema=schema, preserve_index=False)
+    try:
+        pq.write_table(table, tmp, compression="snappy")
+        os.replace(tmp, out_path)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+def _cohort_path(out_path: Path, fetched_at: datetime) -> Path:
+    """``--force`` writes a sibling cohort, never overwriting in place.
+
+    Microsecond resolution + collision-avoidance suffix so two ``--force``
+    runs in the same second cannot silently overwrite each other and violate
+    the ledger's ``revision_immutability: true`` claim. Same shape vix
+    worker landed (codex iter-2).
+    """
+    stamp = fetched_at.strftime("%Y%m%d_%H%M%S_%f")
+    candidate = out_path.with_name(f"{out_path.stem}_{stamp}{out_path.suffix}")
+    if not candidate.exists():
+        return candidate
+    for n in range(1, 1000):
+        bumped = out_path.with_name(
+            f"{out_path.stem}_{stamp}_{n}{out_path.suffix}"
+        )
+        if not bumped.exists():
+            return bumped
+    raise RuntimeError(
+        f"could not find an unused cohort path next to {out_path} after 1000 "
+        "attempts; refusing to overwrite existing cohort (revision_immutability)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation (same tiers vix worker landed)
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_MIN_COVERAGE_RATIO = 0.90
+"""Per-symbol minimum row count relative to ``pd.bdate_range(start, end)``.
+
+Same heuristic vix worker landed: 0.90 absorbs ~9 NYSE holidays/year on a
+~252-day calendar with margin. The thematic universe has more newer ETFs
+(DXYZ listed 2024; some ARK variants thin) → operator may need
+``--allow-gaps`` for those.
+"""
+
+
+def _validate_coverage(
+    fetched: dict[str, pd.DataFrame],
+    symbols: list[str],
+    start: str,
+    end: str,
+    allow_empty: set[str],
+    allow_gaps: set[str],
+    min_coverage: float,
+) -> None:
+    """Two-tier validation.
+
+    Simpler than the macro_context (vix) validator because the thematic
+    universe has no single anchor symbol — every member is a sector/theme
+    ETF. The 4-tier anchor-symbol calendar-exactness gate vix landed is
+    overkill here; per-symbol row-count ratio + empty-symbol fail-fast
+    catches the same outages without needing an anchor.
+
+    Tier 1: any requested symbol with **zero** rows → ``ValueError`` unless
+    in ``allow_empty``. Catches outright outages / bad tickers.
+
+    Tier 2: any symbol with ``row_count / bdays < min_coverage`` →
+    ``ValueError`` unless in ``allow_gaps``. Catches catastrophic provider
+    partials (rate-limit / outage).
+    """
+    # Tier 1: empty symbols.
+    empty_missing = [
+        sym
+        for sym in symbols
+        if sym not in allow_empty and (sym not in fetched or fetched[sym].empty)
+    ]
+    if empty_missing:
+        raise ValueError(
+            f"backfill returned zero rows for {len(empty_missing)} symbol(s): "
+            f"{sorted(empty_missing)}. Re-run when the provider is healthy or "
+            f"pass --allow-empty SYMBOL[,SYMBOL...] to permit known gaps."
+        )
+
+    # Tier 2: row-count ratio.
+    bdays = len(pd.bdate_range(start=start, end=end))
+    if bdays == 0:
+        return
+
+    partial: list[tuple[str, int, float]] = []
+    for sym in symbols:
+        if sym in allow_gaps:
+            continue
+        df = fetched.get(sym)
+        if df is None or df.empty:
+            continue
+        ratio = len(df) / bdays
+        if ratio < min_coverage:
+            partial.append((sym, len(df), ratio))
+
+    if partial:
+        details = ", ".join(
+            f"{sym} ({n_rows} rows, {ratio:.0%} coverage)"
+            for sym, n_rows, ratio in sorted(partial)
+        )
+        raise ValueError(
+            f"backfill coverage below threshold {min_coverage:.0%} for "
+            f"{len(partial)} symbol(s) in window {start}..{end} "
+            f"({bdays} business days): {details}. Re-run when the provider "
+            f"is healthy or pass --allow-gaps SYMBOL[,SYMBOL...] to permit "
+            f"known-sparse tickers."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def backfill(
+    symbols: Iterable[str],
+    start: str,
+    end: str,
+    out_path: Path,
+    force: bool = False,
+    dry_run: bool = False,
+    fetch_fn: Callable[[Iterable[str], str, str], dict[str, pd.DataFrame]]
+    | None = None,
+    allow_empty: Iterable[str] | None = None,
+    allow_gaps: Iterable[str] | None = None,
+    min_coverage: float = DEFAULT_MIN_COVERAGE_RATIO,
+) -> Path | dict[str, object]:
+    """Run the backfill.
+
+    Returns the parquet path actually written (a sibling cohort path when
+    ``force=True`` and the destination already exists). In ``dry_run`` mode
+    returns the planned ticker × date matrix without touching the network or
+    the filesystem.
+    """
+    symbols = list(symbols)
+    fetch_fn = fetch_fn or _yfinance_fetch
+    out_path = Path(out_path)
+    allow_empty_set: set[str] = set(allow_empty or ())
+    allow_gaps_set: set[str] = set(allow_gaps or ())
+
+    if dry_run:
+        return {
+            "symbols": symbols,
+            "start": start,
+            "end": end,
+            "planned_out": str(out_path),
+        }
+
+    if out_path.exists() and not force:
+        raise FileExistsError(
+            f"{out_path} already exists. Pass --force to write a new cohort."
+        )
+
+    fetched_at = datetime.now(tz=timezone.utc)
+    try:
+        import yfinance as yf
+
+        yfinance_version = yf.__version__
+    except Exception:
+        yfinance_version = "stub"
+
+    fetched = fetch_fn(symbols, start, end)
+
+    _validate_coverage(
+        fetched=fetched,
+        symbols=symbols,
+        start=start,
+        end=end,
+        allow_empty=allow_empty_set,
+        allow_gaps=allow_gaps_set,
+        min_coverage=min_coverage,
+    )
+
+    df = _to_normalized_frame(fetched, yfinance_version, fetched_at)
+
+    target = (
+        _cohort_path(out_path, fetched_at)
+        if (out_path.exists() and force)
+        else out_path
+    )
+    _write_parquet_atomic(df, target)
+    return target
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=(
+            "Backfill the thematic_universe parquet cache (~94-ticker universe "
+            "loaded from config/thematic_universe.yaml)."
+        )
+    )
+    p.add_argument(
+        "--yaml",
+        default=str(DEFAULT_YAML),
+        help="Path to thematic universe yaml. Default: config/thematic_universe.yaml.",
+    )
+    p.add_argument(
+        "--symbols",
+        default=None,
+        help=(
+            "Comma-separated tickers. If omitted (default), read from --yaml. "
+            "Operator only needs this for ad-hoc one-off subset backfills."
+        ),
+    )
+    p.add_argument("--start", default=DEFAULT_START)
+    p.add_argument("--end", default=DEFAULT_END)
+    p.add_argument("--out", default=str(DEFAULT_OUT))
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="When the cache exists, write a timestamped sibling cohort.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the planned ticker × date matrix; do not fetch or write.",
+    )
+    p.add_argument("--allow-empty", default="")
+    p.add_argument("--allow-gaps", default="")
+    p.add_argument(
+        "--min-coverage",
+        type=float,
+        default=DEFAULT_MIN_COVERAGE_RATIO,
+        help=(
+            "Per-symbol minimum row count as a fraction of business days in "
+            "the window. Default %(default).2f absorbs ~9 NYSE holidays/year."
+        ),
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = _parse_args(argv)
+    if ns.symbols:
+        symbols = [s.strip() for s in ns.symbols.split(",") if s.strip()]
+    else:
+        symbols = load_symbols_from_yaml(Path(ns.yaml))
+    allow_empty = [s.strip() for s in ns.allow_empty.split(",") if s.strip()]
+    allow_gaps = [s.strip() for s in ns.allow_gaps.split(",") if s.strip()]
+    out_path = Path(ns.out)
+    result = backfill(
+        symbols=symbols,
+        start=ns.start,
+        end=ns.end,
+        out_path=out_path,
+        force=ns.force,
+        dry_run=ns.dry_run,
+        allow_empty=allow_empty,
+        allow_gaps=allow_gaps,
+        min_coverage=ns.min_coverage,
+    )
+    if ns.dry_run:
+        plan = result  # type: ignore[assignment]
+        print(
+            f"DRY-RUN: would fetch {len(symbols)} symbols "
+            f"{ns.start}..{ns.end} -> {plan['planned_out']}"  # type: ignore[index]
+        )
+        for sym in symbols:
+            print(f"  {sym}")
+    else:
+        path = result  # type: ignore[assignment]
+        df = pd.read_parquet(path)
+        per_sym = df.groupby("symbol").size().to_dict()
+        print(f"wrote {len(df)} rows -> {path}")
+        for sym in sorted(per_sym):
+            print(f"  {sym:8s}  {per_sym[sym]:4d} rows")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3207,6 +3207,212 @@ def sma_sweep(
         click.echo("done.")
 
 
+# ---------------------------------------------------------------------------
+# thematic — Industry/Thematic ranks substrate (Phase A: data only)
+# ---------------------------------------------------------------------------
+#
+# Phase A surface: `backfill` and `snapshot-universe`. The compute / render /
+# run-daily subcommands ship in Phase B (`thematic-ranks-dashboard-d245`).
+#
+# ASCII flow:
+#     thematic backfill         -> load YAML -> yfinance OHLCV -> parquet cache
+#                                  + seed ticker_registry + sector_registry
+#     thematic snapshot-universe -> SHA-diff YAML vs log -> append row if changed
+
+
+@cli.group()
+def thematic() -> None:
+    """Industry / Thematic ranks dashboard substrate (DESIGN §5)."""
+
+
+@thematic.command("backfill")
+@click.option(
+    "--yaml",
+    "yaml_path",
+    type=click.Path(exists=True),
+    default="config/thematic_universe.yaml",
+    show_default=True,
+    help="Path to the thematic universe YAML.",
+)
+@click.option("--start", default=None, help="Window start (YYYY-MM-DD).")
+@click.option("--end", default=None, help="Window end (YYYY-MM-DD, inclusive).")
+@click.option(
+    "--out",
+    "out_path",
+    type=click.Path(),
+    default="data/cache/thematic_universe.parquet",
+    show_default=True,
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="When the cache exists, write a timestamped sibling cohort.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the planned ticker x date matrix; do not fetch or write.",
+)
+@click.option(
+    "--allow-empty",
+    default="",
+    help="Comma-separated symbols permitted to return zero rows.",
+)
+@click.option(
+    "--allow-gaps",
+    default="",
+    help="Comma-separated symbols permitted to return partial coverage.",
+)
+@click.option(
+    "--min-coverage",
+    type=float,
+    default=None,
+    help="Per-symbol minimum row count as a fraction of business days.",
+)
+@click.option(
+    "--ticker-registry",
+    type=click.Path(),
+    default="data/cache/ticker_registry.parquet",
+    show_default=True,
+)
+@click.option(
+    "--sector-registry",
+    type=click.Path(),
+    default="data/cache/sector_registry.parquet",
+    show_default=True,
+)
+def thematic_backfill(
+    yaml_path: str,
+    start: str | None,
+    end: str | None,
+    out_path: str,
+    force: bool,
+    dry_run: bool,
+    allow_empty: str,
+    allow_gaps: str,
+    min_coverage: float | None,
+    ticker_registry: str,
+    sector_registry: str,
+) -> None:
+    """Backfill the OHLCV cache + seed ticker/sector registries.
+
+    Operator-run, not CI-run. Hits the yfinance network.
+    """
+    import importlib.util
+    from datetime import date as _date
+
+    from rainier.research.breadth import registry as _reg
+    from rainier.research.breadth import universe_loader as _ul
+
+    # Load the script as a module — it lives in `scripts/`, not under `src/`,
+    # because it's a one-off operator tool (same pattern as macro_context).
+    root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "backfill_thematic_universe",
+        root / "scripts" / "backfill_thematic_universe.py",
+    )
+    if spec is None or spec.loader is None:
+        raise click.ClickException(
+            "could not load scripts/backfill_thematic_universe.py"
+        )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    yaml_p = Path(yaml_path)
+    symbols = module.load_symbols_from_yaml(yaml_p)
+    spec_obj = _ul.load_universe(yaml_p)
+
+    start_eff = start or module.DEFAULT_START
+    end_eff = end or module.DEFAULT_END
+    coverage = (
+        min_coverage if min_coverage is not None else module.DEFAULT_MIN_COVERAGE_RATIO
+    )
+
+    result = module.backfill(
+        symbols=symbols,
+        start=start_eff,
+        end=end_eff,
+        out_path=Path(out_path),
+        force=force,
+        dry_run=dry_run,
+        allow_empty=[s.strip() for s in allow_empty.split(",") if s.strip()],
+        allow_gaps=[s.strip() for s in allow_gaps.split(",") if s.strip()],
+        min_coverage=coverage,
+    )
+
+    if dry_run:
+        plan = result
+        click.echo(
+            f"DRY-RUN: would fetch {len(symbols)} symbols "
+            f"{start_eff}..{end_eff} -> {plan['planned_out']}"
+        )
+        for sym in symbols:
+            click.echo(f"  {sym}")
+        return
+
+    written_path = result
+    click.echo(f"wrote OHLCV cache -> {written_path}")
+
+    # Seed registries with the just-fetched universe. Idempotent — re-running
+    # backfill does not change existing IDs (per [D-015]).
+    today = _date.today()
+    _reg.seed_registries_from_universe(
+        spec_obj.sectors,
+        asof=today,
+        ticker_registry_path=Path(ticker_registry),
+        sector_registry_path=Path(sector_registry),
+    )
+    click.echo(f"seeded ticker registry  -> {ticker_registry}")
+    click.echo(f"seeded sector registry  -> {sector_registry}")
+
+
+@thematic.command("snapshot-universe")
+@click.option(
+    "--yaml",
+    "yaml_path",
+    type=click.Path(exists=True),
+    default="config/thematic_universe.yaml",
+    show_default=True,
+)
+@click.option(
+    "--log",
+    "log_path",
+    type=click.Path(),
+    default="data/cache/thematic_universe_log.parquet",
+    show_default=True,
+)
+@click.option(
+    "--effective-from",
+    default=None,
+    help="First asof_date the universe applies to (YYYY-MM-DD). Default: today.",
+)
+@click.option("--note", default="", help="Free-form change note.")
+def thematic_snapshot_universe(
+    yaml_path: str,
+    log_path: str,
+    effective_from: str | None,
+    note: str,
+) -> None:
+    """Append a row to thematic_universe_log if the YAML SHA changed."""
+    from datetime import date as _date
+
+    from rainier.research.breadth import universe_loader as _ul
+
+    eff = _date.fromisoformat(effective_from) if effective_from else _date.today()
+    appended = _ul.snapshot_universe(
+        yaml_path=Path(yaml_path),
+        log_path=Path(log_path),
+        effective_from=eff,
+        note=note,
+    )
+    if appended:
+        click.echo(f"appended new row -> {log_path}")
+    else:
+        click.echo(f"no-op: yaml SHA unchanged; {log_path} untouched")
+
+
 # Composition root — wire the research engine's `llm-research` subgroup
 # onto the root `rainier` command. Per project CLAUDE.md the research
 # package never reaches into production CLI plumbing; we register it here

--- a/src/rainier/research/breadth/__init__.py
+++ b/src/rainier/research/breadth/__init__.py
@@ -1,0 +1,16 @@
+"""Breadth / thematic-ranks support package.
+
+Phase A (this PR) ships the data substrate: universe loader, ticker /
+sector registries, universe-state log writer.
+
+Phase B (`thematic-ranks-dashboard-d245`) adds `ranks.py`, `loaders.py`,
+`ml_builders.py`, and the dashboard renderer on top.
+
+Design ref: docs/DESIGN-thematic-ranks-dashboard.md
+"""
+
+from __future__ import annotations
+
+from rainier.research.breadth import registry, universe_loader
+
+__all__ = ["registry", "universe_loader"]

--- a/src/rainier/research/breadth/registry.py
+++ b/src/rainier/research/breadth/registry.py
@@ -1,0 +1,221 @@
+"""Stable-ID registries for tickers and sectors.
+
+Per DESIGN-thematic-ranks-dashboard.md §5.4 + [D-015]: integer IDs are
+assigned on first observation and **never reused or remapped**. The model
+that learned ``ticker_id=42 → SMH`` keeps that mapping even if the YAML
+universe shrinks — embeddings stay valid.
+
+Each registry is an append-only parquet with three columns
+``(<id_col>, <name_col>, first_seen)``. The next-available ID is
+``max(existing) + 1`` (start at 1, never 0 — keeps 0 reserved as a
+padding/unknown sentinel for embedding layers).
+
+Implementation notes
+--------------------
+* Reads are cheap (whole file, < 1MB even at full universe).
+* Writes are atomic (pyarrow → tmp → ``os.replace``) so a process kill mid-write
+  cannot leave a half-written parquet visible.
+* Functions accept explicit ``registry_path`` to keep tests isolated from
+  ``data/cache/`` and to let the operator point at a non-default location.
+
+ASCII flow:
+
+    get_or_assign_ticker_id("XLK", asof, path)
+            |
+            v
+        load_ticker_registry(path)   <- {} if file missing
+            |
+            v
+        is symbol present?
+           /        \\
+          yes        no
+           |          \\
+       return id    next_id = max(ids)+1 (or 1 if empty)
+                         |
+                         v
+                  append (id, symbol, first_seen)
+                         |
+                         v
+                  atomic parquet write
+                         |
+                         v
+                     return next_id
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+_TICKER_SCHEMA = pa.schema(
+    [
+        ("ticker_id", pa.int16()),
+        ("symbol", pa.string()),
+        ("first_seen", pa.date32()),
+    ]
+)
+
+_SECTOR_SCHEMA = pa.schema(
+    [
+        ("sector_id", pa.int16()),
+        ("sector_name", pa.string()),
+        ("first_seen", pa.date32()),
+    ]
+)
+
+
+def _empty_df(id_col: str, name_col: str) -> pd.DataFrame:
+    return pd.DataFrame(columns=[id_col, name_col, "first_seen"])
+
+
+# ---------------------------------------------------------------------------
+# Generic helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_registry(path: Path, id_col: str, name_col: str) -> pd.DataFrame:
+    if not path.exists():
+        return _empty_df(id_col, name_col)
+    df = pd.read_parquet(path)
+    # Defensive: enforce expected columns even on user-edited files.
+    for col in (id_col, name_col, "first_seen"):
+        if col not in df.columns:
+            raise ValueError(
+                f"registry parquet at {path} is missing column {col!r}; "
+                f"refusing to mutate."
+            )
+    return df
+
+
+def _write_registry_atomic(df: pd.DataFrame, path: Path, schema: pa.Schema) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    table = pa.Table.from_pandas(df, schema=schema, preserve_index=False)
+    try:
+        pq.write_table(table, tmp, compression="snappy")
+        os.replace(tmp, path)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+def _get_or_assign_id(
+    name: str,
+    asof: date,
+    registry_path: Path,
+    id_col: str,
+    name_col: str,
+    schema: pa.Schema,
+) -> int:
+    """Shared core for ticker + sector registries."""
+    df = _read_registry(registry_path, id_col, name_col)
+    if not df.empty:
+        hits = df.loc[df[name_col] == name, id_col]
+        if not hits.empty:
+            return int(hits.iloc[0])
+
+    # Next available id; start at 1 so 0 stays as embedding-padding sentinel.
+    next_id = int(df[id_col].max()) + 1 if not df.empty else 1
+    new_row = pd.DataFrame(
+        [{id_col: next_id, name_col: name, "first_seen": asof}]
+    )
+    out = pd.concat([df, new_row], ignore_index=True)
+    _write_registry_atomic(out, registry_path, schema)
+    return next_id
+
+
+# ---------------------------------------------------------------------------
+# Ticker registry
+# ---------------------------------------------------------------------------
+
+
+def get_or_assign_ticker_id(
+    symbol: str,
+    asof: date,
+    registry_path: Path,
+) -> int:
+    """Return the stable ``ticker_id`` for ``symbol``; assign if first-seen."""
+    return _get_or_assign_id(
+        name=symbol,
+        asof=asof,
+        registry_path=Path(registry_path),
+        id_col="ticker_id",
+        name_col="symbol",
+        schema=_TICKER_SCHEMA,
+    )
+
+
+def load_ticker_registry(registry_path: Path) -> dict[str, int]:
+    """Return the full ``{symbol: ticker_id}`` mapping (empty if file missing)."""
+    df = _read_registry(Path(registry_path), "ticker_id", "symbol")
+    if df.empty:
+        return {}
+    return {row.symbol: int(row.ticker_id) for row in df.itertuples(index=False)}
+
+
+# ---------------------------------------------------------------------------
+# Sector registry
+# ---------------------------------------------------------------------------
+
+
+def get_or_assign_sector_id(
+    sector_name: str,
+    asof: date,
+    registry_path: Path,
+) -> int:
+    """Return the stable ``sector_id`` for ``sector_name``; assign if first-seen."""
+    return _get_or_assign_id(
+        name=sector_name,
+        asof=asof,
+        registry_path=Path(registry_path),
+        id_col="sector_id",
+        name_col="sector_name",
+        schema=_SECTOR_SCHEMA,
+    )
+
+
+def load_sector_registry(registry_path: Path) -> dict[str, int]:
+    """Return the full ``{sector_name: sector_id}`` mapping (empty if missing)."""
+    df = _read_registry(Path(registry_path), "sector_id", "sector_name")
+    if df.empty:
+        return {}
+    return {
+        row.sector_name: int(row.sector_id) for row in df.itertuples(index=False)
+    }
+
+
+# ---------------------------------------------------------------------------
+# Bulk seeding from a universe dict
+# ---------------------------------------------------------------------------
+
+
+def seed_registries_from_universe(
+    universe: dict[str, list[str]],
+    asof: date,
+    ticker_registry_path: Path,
+    sector_registry_path: Path,
+) -> None:
+    """Register every (sector_name, symbol) pair from ``universe``.
+
+    Idempotent: re-running with the same universe is a no-op. Order of
+    assignment follows iteration order of the dict (Python 3.7+ guarantees
+    insertion order), so two runs with identically-ordered YAML produce
+    identical ID assignments.
+    """
+    for sector_name, tickers in universe.items():
+        get_or_assign_sector_id(sector_name, asof, sector_registry_path)
+        for sym in tickers:
+            get_or_assign_ticker_id(sym, asof, ticker_registry_path)

--- a/src/rainier/research/breadth/universe_loader.py
+++ b/src/rainier/research/breadth/universe_loader.py
@@ -1,0 +1,189 @@
+"""Loader for `config/thematic_universe.yaml` + universe-state log writer.
+
+Two responsibilities:
+
+  1. ``load_universe(path)`` — parse the YAML into a deterministic
+     ``UniverseSpec`` dataclass carrying ``sectors``, ``all_tickers`` (flat),
+     and ``yaml_sha`` (SHA-1 of the raw file bytes). Pure function;
+     byte-identical inputs → byte-identical output.
+
+  2. ``snapshot_universe(yaml_path, log_path, effective_from, note)`` —
+     append-only Layer C audit. First call seeds a row capturing the
+     current YAML SHA + ticker list. Subsequent calls are no-ops if the
+     SHA is unchanged; appended only when the YAML mutates.
+
+The SHA is computed over the raw bytes (not the parsed dict) so reordering
+the YAML — which doesn't change the semantic universe — still appends a new
+log row. That's intentional: it matches the operator's mental model
+("I edited the file → I want to see the edit recorded").
+
+Design ref:
+    docs/DESIGN-thematic-ranks-dashboard.md §4 §5.3 ([D-001] [D-011])
+    docs/TASK-PLAN-thematic-backfill-fd88.md §3
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+# ---------------------------------------------------------------------------
+# Parse
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class UniverseSpec:
+    """Parsed universe contents.
+
+    Attributes
+    ----------
+    sectors:
+        Mapping of sector_name -> ordered list of ticker symbols. Order is
+        preserved from the YAML so per-sector display layouts can rely on it.
+    all_tickers:
+        Flat list of all tickers in YAML appearance order. Useful for the
+        backfill script which doesn't care about sector grouping.
+    yaml_sha:
+        Hex SHA-1 of the raw YAML file bytes. The log table keys off this.
+    version:
+        The integer ``version:`` field from the YAML (currently always 1).
+    """
+
+    sectors: dict[str, list[str]]
+    all_tickers: list[str]
+    yaml_sha: str
+    version: int
+
+
+def load_universe(yaml_path: Path) -> UniverseSpec:
+    """Parse ``yaml_path`` into a ``UniverseSpec``.
+
+    The SHA is computed over the file bytes as read from disk — this
+    captures whitespace edits + reorderings the operator may have made,
+    matching the "I edited this file" mental model.
+    """
+    path = Path(yaml_path)
+    raw = path.read_bytes()
+    sha = hashlib.sha1(raw).hexdigest()
+    parsed = yaml.safe_load(raw)
+
+    sectors_raw = parsed.get("universe", {}) or {}
+    sectors: dict[str, list[str]] = {}
+    all_tickers: list[str] = []
+    for sector, tickers in sectors_raw.items():
+        if not isinstance(tickers, list):
+            raise ValueError(
+                f"sector {sector!r} must map to a list of tickers, got "
+                f"{type(tickers).__name__}"
+            )
+        sectors[sector] = list(tickers)
+        all_tickers.extend(tickers)
+
+    version = int(parsed.get("version", 1))
+    return UniverseSpec(
+        sectors=sectors,
+        all_tickers=all_tickers,
+        yaml_sha=sha,
+        version=version,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Universe-state log (Layer C)
+# ---------------------------------------------------------------------------
+
+
+_LOG_SCHEMA = pa.schema(
+    [
+        ("effective_from", pa.date32()),
+        ("yaml_sha", pa.string()),
+        ("universe_size", pa.int16()),
+        ("tickers", pa.list_(pa.string())),
+        ("note", pa.string()),
+    ]
+)
+
+
+def _read_log(log_path: Path) -> pd.DataFrame:
+    if not log_path.exists():
+        return pd.DataFrame(
+            columns=["effective_from", "yaml_sha", "universe_size", "tickers", "note"]
+        )
+    return pd.read_parquet(log_path)
+
+
+def _write_log_atomic(df: pd.DataFrame, log_path: Path) -> None:
+    """pyarrow write + os.replace — never leaves a half-written parquet visible."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = log_path.with_suffix(log_path.suffix + ".tmp")
+    table = pa.Table.from_pandas(df, schema=_LOG_SCHEMA, preserve_index=False)
+    try:
+        pq.write_table(table, tmp, compression="snappy")
+        os.replace(tmp, log_path)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+def snapshot_universe(
+    yaml_path: Path,
+    log_path: Path,
+    effective_from: date,
+    note: str = "",
+) -> bool:
+    """Append a row to the universe-state log if the YAML SHA changed.
+
+    Returns ``True`` if a new row was appended, ``False`` if the SHA matched
+    the most recent log entry (no-op).
+
+    The log is append-only — never updates or deletes existing rows. Historical
+    centile ranks can be reproduced by looking up the YAML state in force at
+    any given ``asof_date``.
+
+    Parameters
+    ----------
+    yaml_path:
+        Path to ``config/thematic_universe.yaml`` (or an operator-supplied
+        fork).
+    log_path:
+        Parquet to append to (typically ``data/cache/thematic_universe_log.parquet``).
+    effective_from:
+        First trading day this universe applies to. Operator-supplied; the
+        function does not infer "today" because the cron job may be running
+        late or running a backfill against a historical date.
+    note:
+        Free-form human-readable note ("added SOXX", "removed dead ETF").
+    """
+    spec = load_universe(yaml_path)
+    existing = _read_log(log_path)
+
+    if not existing.empty and (existing["yaml_sha"] == spec.yaml_sha).any():
+        # SHA already on record → no-op (universe content unchanged).
+        return False
+
+    new_row = pd.DataFrame(
+        [
+            {
+                "effective_from": effective_from,
+                "yaml_sha": spec.yaml_sha,
+                "universe_size": len(spec.all_tickers),
+                "tickers": list(spec.all_tickers),
+                "note": note,
+            }
+        ]
+    )
+    out = pd.concat([existing, new_row], ignore_index=True)
+    _write_log_atomic(out, log_path)
+    return True

--- a/src/rainier/research/breadth/universe_loader.py
+++ b/src/rainier/research/breadth/universe_loader.py
@@ -143,14 +143,17 @@ def snapshot_universe(
     effective_from: date,
     note: str = "",
 ) -> bool:
-    """Append a row to the universe-state log if the YAML SHA changed.
+    """Append a row to the universe-state log if the YAML SHA is new.
 
-    Returns ``True`` if a new row was appended, ``False`` if the SHA matched
-    the most recent log entry (no-op).
+    Returns ``True`` if a new row was appended, ``False`` if the SHA is
+    already present anywhere in the log (no-op). Matching any historical
+    row — not just the most recent — handles accidental YAML revert /
+    cherry-pick scenarios deterministically: re-applying an old universe
+    state does NOT append a duplicate row.
 
     The log is append-only — never updates or deletes existing rows. Historical
     centile ranks can be reproduced by looking up the YAML state in force at
-    any given ``asof_date``.
+    any given ``asof_date`` via ``yaml_sha``.
 
     Parameters
     ----------

--- a/src/rainier/research/data_availability.yaml
+++ b/src/rainier/research/data_availability.yaml
@@ -497,3 +497,801 @@ entries:
       is already persisted (qu100_history); the per-ticker detail awaits a
       separate backfill task. Field is registered as pending so the L3
       evaluator rejects look-ups until the backfill lands. See D-024.
+
+  # ==================================================================
+  # thematic_universe dataset — operator-owned universe loaded from
+  # config/thematic_universe.yaml. Per DESIGN-thematic-ranks-dashboard.md
+  # §5.5: registers OHLCV observability for the ~94-ticker sector/theme
+  # ETF universe ranked by the dashboard (Phase B will compute Layer A
+  # features and add the thematic_features_daily + thematic_labels_daily
+  # blocks). adjusted_close intentionally NOT in fields[] — yfinance
+  # back-adjusts and the cache does not store it (see §5.0).
+  # ==================================================================
+  # ------------------------------------------------------------------
+  # communication_service (4)
+  # ------------------------------------------------------------------
+  - dataset: thematic_universe
+    symbol: XLC
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: communication_service
+  - dataset: thematic_universe
+    symbol: IYZ
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: communication_service
+  - dataset: thematic_universe
+    symbol: SOCL
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: communication_service
+  - dataset: thematic_universe
+    symbol: HERO
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: communication_service
+  # ------------------------------------------------------------------
+  # consumer_discretionary (6)
+  # ------------------------------------------------------------------
+  - dataset: thematic_universe
+    symbol: XLY
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: consumer_discretionary
+  - dataset: thematic_universe
+    symbol: ITB
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: consumer_discretionary
+  - dataset: thematic_universe
+    symbol: XHB
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: consumer_discretionary
+  - dataset: thematic_universe
+    symbol: IBUY
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: consumer_discretionary
+  - dataset: thematic_universe
+    symbol: ONLN
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: consumer_discretionary
+  - dataset: thematic_universe
+    symbol: PEJ
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: consumer_discretionary
+  # ------------------------------------------------------------------
+  # consumer_staples (2)
+  # ------------------------------------------------------------------
+  - dataset: thematic_universe
+    symbol: XLP
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: consumer_staples
+  - dataset: thematic_universe
+    symbol: XRT
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: consumer_staples
+  # ------------------------------------------------------------------
+  # energy (9)
+  # ------------------------------------------------------------------
+  - dataset: thematic_universe
+    symbol: XLE
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: energy
+  - dataset: thematic_universe
+    symbol: GUNR
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: energy
+  - dataset: thematic_universe
+    symbol: FCG
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: energy
+  - dataset: thematic_universe
+    symbol: XOP
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: energy
+  - dataset: thematic_universe
+    symbol: ICLN
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: energy
+  - dataset: thematic_universe
+    symbol: QCLN
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: energy
+  - dataset: thematic_universe
+    symbol: OIH
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: energy
+  - dataset: thematic_universe
+    symbol: TAN
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: energy
+  - dataset: thematic_universe
+    symbol: NLR
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: energy
+  # ------------------------------------------------------------------
+  # finance (7)
+  # ------------------------------------------------------------------
+  - dataset: thematic_universe
+    symbol: XLF
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: finance
+  - dataset: thematic_universe
+    symbol: VFH
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: finance
+  - dataset: thematic_universe
+    symbol: KRE
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: finance
+  - dataset: thematic_universe
+    symbol: KBE
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: finance
+  - dataset: thematic_universe
+    symbol: IAI
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: finance
+  - dataset: thematic_universe
+    symbol: KIE
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: finance
+  - dataset: thematic_universe
+    symbol: IPAY
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: finance
+  # ------------------------------------------------------------------
+  # healthcare (8)
+  # ------------------------------------------------------------------
+  - dataset: thematic_universe
+    symbol: XLV
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: healthcare
+  - dataset: thematic_universe
+    symbol: IBB
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: healthcare
+  - dataset: thematic_universe
+    symbol: XBI
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: healthcare
+  - dataset: thematic_universe
+    symbol: IHI
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: healthcare
+  - dataset: thematic_universe
+    symbol: IHF
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: healthcare
+  - dataset: thematic_universe
+    symbol: XHE
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: healthcare
+  - dataset: thematic_universe
+    symbol: XPH
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: healthcare
+  - dataset: thematic_universe
+    symbol: MJ
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: healthcare
+  # ------------------------------------------------------------------
+  # industrials (10)
+  # ------------------------------------------------------------------
+  - dataset: thematic_universe
+    symbol: XLI
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: industrials
+  - dataset: thematic_universe
+    symbol: ITA
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: industrials
+  - dataset: thematic_universe
+    symbol: ROKT
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: industrials
+  - dataset: thematic_universe
+    symbol: UFO
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: industrials
+  - dataset: thematic_universe
+    symbol: SHLD
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: industrials
+  - dataset: thematic_universe
+    symbol: BOTZ
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: industrials
+  - dataset: thematic_universe
+    symbol: IYT
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: industrials
+  - dataset: thematic_universe
+    symbol: JETS
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: industrials
+  - dataset: thematic_universe
+    symbol: SNSR
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: industrials
+  - dataset: thematic_universe
+    symbol: DRIV
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: industrials
+  # ------------------------------------------------------------------
+  # materials (9)
+  # ------------------------------------------------------------------
+  - dataset: thematic_universe
+    symbol: XLB
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: materials
+  - dataset: thematic_universe
+    symbol: GDX
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: materials
+  - dataset: thematic_universe
+    symbol: SIL
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: materials
+  - dataset: thematic_universe
+    symbol: COPX
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: materials
+  - dataset: thematic_universe
+    symbol: XME
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: materials
+  - dataset: thematic_universe
+    symbol: LIT
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: materials
+  - dataset: thematic_universe
+    symbol: IYM
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: materials
+  - dataset: thematic_universe
+    symbol: URA
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: materials
+  - dataset: thematic_universe
+    symbol: REMX
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: materials
+  # ------------------------------------------------------------------
+  # real_estate (5)
+  # ------------------------------------------------------------------
+  - dataset: thematic_universe
+    symbol: XLRE
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: real_estate
+  - dataset: thematic_universe
+    symbol: VNQ
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: real_estate
+  - dataset: thematic_universe
+    symbol: VNQI
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: real_estate
+  - dataset: thematic_universe
+    symbol: REET
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: real_estate
+  - dataset: thematic_universe
+    symbol: REM
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: real_estate
+  # ------------------------------------------------------------------
+  # technology (19)
+  # ------------------------------------------------------------------
+  - dataset: thematic_universe
+    symbol: XLK
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: CHAT
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: AIQ
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: IXN
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: QTEC
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: QTUM
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: VGT
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: SOXX
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: SMH
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: DRAM
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: IGV
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: FDN
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: KWEB
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: CIBR
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: HACK
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: SKYY
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: METV
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: FINX
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  - dataset: thematic_universe
+    symbol: XT
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: technology
+  # ------------------------------------------------------------------
+  # utilities (4)
+  # ------------------------------------------------------------------
+  - dataset: thematic_universe
+    symbol: XLU
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: utilities
+  - dataset: thematic_universe
+    symbol: IGF
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: utilities
+  - dataset: thematic_universe
+    symbol: PAVE
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: utilities
+  - dataset: thematic_universe
+    symbol: GRID
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: utilities
+  # ------------------------------------------------------------------
+  # thematic (11)
+  # ------------------------------------------------------------------
+  - dataset: thematic_universe
+    symbol: MEME
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: thematic
+  - dataset: thematic_universe
+    symbol: DXYZ
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: thematic
+  - dataset: thematic_universe
+    symbol: BLOK
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: thematic
+  - dataset: thematic_universe
+    symbol: IPO
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: thematic
+  - dataset: thematic_universe
+    symbol: MOAT
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: thematic
+  - dataset: thematic_universe
+    symbol: MOO
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: thematic
+  - dataset: thematic_universe
+    symbol: ARKK
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: thematic
+  - dataset: thematic_universe
+    symbol: ARKW
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: thematic
+  - dataset: thematic_universe
+    symbol: ARKF
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: thematic
+  - dataset: thematic_universe
+    symbol: ARKX
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: thematic
+  - dataset: thematic_universe
+    symbol: ARKQ
+    fields: [open, high, low, close, volume]
+    observability_timestamp_rule: end_of_trading_day
+    revision_immutability: true
+    source: yfinance
+    yfinance_version_at_backfill: "1.2.0"
+    sector: thematic

--- a/tests/research/test_backfill_thematic_universe.py
+++ b/tests/research/test_backfill_thematic_universe.py
@@ -1,0 +1,323 @@
+"""Unit tests for scripts/backfill_thematic_universe.py.
+
+Mirrors the shape of `tests/test_backfill_macro_context.py` (vix worker).
+Same fail-modes — empty fetch, partial coverage, --force cohort collision,
+atomic-write tmp leak. Difference: SYMBOLS is loaded from
+`config/thematic_universe.yaml` at call time, not hard-coded.
+
+The script never hits the network in tests — `fetch_fn` injection point
+keeps CI offline.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+import pyarrow.parquet as pq
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "backfill_thematic_universe.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "backfill_thematic_universe", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+@pytest.fixture
+def backfill_mod():
+    return _load_module()
+
+
+def _stub_fetch(symbols, start, end):
+    """Deterministic fixture: 5 trading days x N symbols, monotonic prices.
+
+    Mirrors the vix worker's stub: a real dict so the script does not depend
+    on yfinance's multi-index DataFrame internally.
+    """
+    days = pd.date_range("2024-10-01", periods=5, freq="B").date.tolist()
+    out: dict[str, pd.DataFrame] = {}
+    for i, sym in enumerate(symbols):
+        base = 100.0 + i * 10.0
+        rows = []
+        for j, d in enumerate(days):
+            rows.append(
+                {
+                    "date": d,
+                    "open": base + j,
+                    "high": base + j + 0.5,
+                    "low": base + j - 0.5,
+                    "close": base + j + 0.25,
+                    "volume": 1000 * (j + 1),
+                }
+            )
+        out[sym] = pd.DataFrame(rows)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Determinism + atomic write
+# ---------------------------------------------------------------------------
+
+
+def test_stub_determinism(backfill_mod, tmp_path):
+    """Backfill on a stub fixture is byte-deterministic modulo `fetched_at`."""
+    out_a = tmp_path / "a.parquet"
+    out_b = tmp_path / "b.parquet"
+
+    backfill_mod.backfill(
+        symbols=["XLK", "XLE", "XLF"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out_a,
+        force=False,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+    backfill_mod.backfill(
+        symbols=["XLK", "XLE", "XLF"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out_b,
+        force=False,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+
+    df_a = pd.read_parquet(out_a)
+    df_b = pd.read_parquet(out_b)
+
+    # Sort key (symbol, date) ascending.
+    assert list(df_a["symbol"].unique()) == sorted(df_a["symbol"].unique().tolist())
+    for sym in df_a["symbol"].unique():
+        dates = df_a.loc[df_a["symbol"] == sym, "date"].tolist()
+        assert dates == sorted(dates), f"date order broken for {sym}"
+
+    stable_cols = [c for c in df_a.columns if c not in {"fetched_at", "yfinance_version"}]
+    pd.testing.assert_frame_equal(
+        df_a[stable_cols].reset_index(drop=True),
+        df_b[stable_cols].reset_index(drop=True),
+    )
+
+
+def test_atomic_write_no_tmp_leak(backfill_mod, tmp_path):
+    out = tmp_path / "thematic.parquet"
+    backfill_mod.backfill(
+        symbols=["XLK", "SMH"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=False,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+    leftovers = list(tmp_path.glob("*.tmp"))
+    assert leftovers == [], f"tmp leak: {leftovers}"
+
+
+def test_parquet_schema_columns(backfill_mod, tmp_path):
+    out = tmp_path / "thematic.parquet"
+    backfill_mod.backfill(
+        symbols=["XLK", "SMH", "XLE"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=False,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+
+    schema = pq.read_schema(out)
+    names = set(schema.names)
+    required = {
+        "symbol",
+        "date",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "fetched_at",
+        "yfinance_version",
+    }
+    assert required.issubset(names), f"missing columns: {required - names}"
+    # adjusted_close intentionally NOT stored (look-ahead-leaky per DESIGN).
+    assert "adjusted_close" not in names, (
+        "adjusted_close is back-adjusted by yfinance — must not be in the "
+        "thematic_universe cache (DESIGN-thematic-ranks-dashboard §5.0)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# --force cohort + overwrite refusal
+# ---------------------------------------------------------------------------
+
+
+def test_refuses_overwrite_without_force(backfill_mod, tmp_path):
+    out = tmp_path / "thematic.parquet"
+    backfill_mod.backfill(
+        symbols=["XLK"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=False,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+    with pytest.raises(FileExistsError):
+        backfill_mod.backfill(
+            symbols=["XLK"],
+            start="2024-10-01",
+            end="2024-10-08",
+            out_path=out,
+            force=False,
+            fetch_fn=_stub_fetch,
+        )
+
+
+def test_force_writes_dated_cohort(backfill_mod, tmp_path):
+    """--force does NOT overwrite in place; writes a sibling cohort file."""
+    out = tmp_path / "thematic.parquet"
+    backfill_mod.backfill(
+        symbols=["XLK"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=False,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+    cohort = backfill_mod.backfill(
+        symbols=["XLK"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=True,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+
+    assert out.exists()
+    assert cohort != out
+    assert cohort.exists()
+    assert cohort.parent == out.parent
+
+
+def test_dry_run_does_not_write(backfill_mod, tmp_path):
+    out = tmp_path / "thematic.parquet"
+    result = backfill_mod.backfill(
+        symbols=["XLK", "XLF"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=False,
+        dry_run=True,
+        fetch_fn=_stub_fetch,
+    )
+    assert not out.exists()
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# YAML-driven SYMBOLS
+# ---------------------------------------------------------------------------
+
+
+def test_load_symbols_from_yaml(backfill_mod):
+    """`load_symbols_from_yaml(path)` returns the flat ticker list from YAML."""
+    import yaml as _yaml
+    from io import StringIO
+
+    sample = """\
+version: 1
+schema: thematic_universe.v1
+asof_seeded: 2026-05-22
+universe:
+  technology:
+    - XLK
+    - SMH
+  energy:
+    - XLE
+"""
+    # Write to a temp path because the loader takes a Path.
+    import tempfile
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as fh:
+        fh.write(sample)
+        path = Path(fh.name)
+    try:
+        symbols = backfill_mod.load_symbols_from_yaml(path)
+        # Round-trip parse to confirm the loader matches yaml.safe_load shape.
+        parsed = _yaml.safe_load(StringIO(sample))
+        expected = []
+        for buckets in parsed["universe"].values():
+            expected.extend(buckets)
+        assert sorted(symbols) == sorted(expected)
+    finally:
+        path.unlink()
+
+
+def test_default_yaml_drives_seed_universe(backfill_mod):
+    """When called with no --symbols, the script reads
+    `config/thematic_universe.yaml` and the seed has 94 tickers per DESIGN §4.
+    """
+    default_yaml = ROOT / "config" / "thematic_universe.yaml"
+    symbols = backfill_mod.load_symbols_from_yaml(default_yaml)
+    assert len(symbols) == 94
+
+
+# ---------------------------------------------------------------------------
+# Empty-symbol fail-fast (mirrors vix worker codex iter-1)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_symbol_raises_unless_allowlisted(backfill_mod, tmp_path):
+    def partial_fetch(symbols, start, end):
+        full = _stub_fetch(["XLK"], start, end)
+        full["DEAD"] = pd.DataFrame(
+            columns=["date", "open", "high", "low", "close", "volume"]
+        )
+        return full
+
+    out = tmp_path / "thematic.parquet"
+    with pytest.raises(ValueError, match="DEAD"):
+        backfill_mod.backfill(
+            symbols=["XLK", "DEAD"],
+            start="2024-10-01",
+            end="2024-10-08",
+            out_path=out,
+            force=False,
+            fetch_fn=partial_fetch,
+        )
+    assert not out.exists()
+
+
+def test_empty_symbol_allowed_via_allowlist(backfill_mod, tmp_path):
+    def partial_fetch(symbols, start, end):
+        full = _stub_fetch(["XLK"], start, end)
+        full["DXYZ"] = pd.DataFrame(
+            columns=["date", "open", "high", "low", "close", "volume"]
+        )
+        return full
+
+    out = tmp_path / "thematic.parquet"
+    backfill_mod.backfill(
+        symbols=["XLK", "DXYZ"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=False,
+        fetch_fn=partial_fetch,
+        allow_empty=["DXYZ"],
+        min_coverage=0.0,
+    )
+    assert out.exists()
+    df = pd.read_parquet(out)
+    assert set(df["symbol"].unique()) == {"XLK"}

--- a/tests/research/test_backfill_thematic_universe.py
+++ b/tests/research/test_backfill_thematic_universe.py
@@ -18,7 +18,6 @@ import pandas as pd
 import pyarrow.parquet as pq
 import pytest
 
-
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = ROOT / "scripts" / "backfill_thematic_universe.py"
 
@@ -233,8 +232,9 @@ def test_dry_run_does_not_write(backfill_mod, tmp_path):
 
 def test_load_symbols_from_yaml(backfill_mod):
     """`load_symbols_from_yaml(path)` returns the flat ticker list from YAML."""
-    import yaml as _yaml
     from io import StringIO
+
+    import yaml as _yaml
 
     sample = """\
 version: 1

--- a/tests/research/test_thematic_registry.py
+++ b/tests/research/test_thematic_registry.py
@@ -1,0 +1,159 @@
+"""Stable-ID registry invariants (per DESIGN §5.4 + [D-015]).
+
+Ticker and sector registries are append-only parquets that assign integer
+IDs the FIRST time a symbol or sector_name is observed. Once an ID is
+assigned, it is NEVER reused or remapped — even if the symbol is removed
+from `config/thematic_universe.yaml`, the registry row stays so model
+embeddings keep referring to the same ID.
+
+Invariants tested here:
+  1. ``get_or_assign_ticker_id("XLK")`` called twice returns the same int.
+  2. After assigning ids 1..5 to {A,B,C,D,E}, removing A and adding F
+     leaves ids 1..5 untouched and gives F id=6 (next-available).
+  3. Sector registry obeys the same invariants on `sector_name`.
+  4. Registry parquet round-trips identically.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from rainier.research.breadth import registry as reg
+
+
+def test_first_assignment_returns_int(tmp_path: Path):
+    out = tmp_path / "ticker_registry.parquet"
+    tid = reg.get_or_assign_ticker_id("XLK", asof=date(2026, 5, 22), registry_path=out)
+    assert isinstance(tid, int)
+    assert tid >= 1
+
+
+def test_idempotent_same_symbol_same_id(tmp_path: Path):
+    out = tmp_path / "ticker_registry.parquet"
+    first = reg.get_or_assign_ticker_id("XLK", asof=date(2026, 5, 22), registry_path=out)
+    second = reg.get_or_assign_ticker_id("XLK", asof=date(2026, 5, 23), registry_path=out)
+    assert first == second, "second call must return the same id (stable-ID invariant)"
+
+
+def test_distinct_symbols_get_distinct_ids(tmp_path: Path):
+    out = tmp_path / "ticker_registry.parquet"
+    ids = {
+        sym: reg.get_or_assign_ticker_id(sym, asof=date(2026, 5, 22), registry_path=out)
+        for sym in ("AAA", "BBB", "CCC", "DDD", "EEE")
+    }
+    assert len(set(ids.values())) == 5
+    # First-seen ordering preserved → ids assigned in call order starting at 1.
+    assert ids == {"AAA": 1, "BBB": 2, "CCC": 3, "DDD": 4, "EEE": 5}
+
+
+def test_removed_symbol_keeps_id_new_symbol_gets_next(tmp_path: Path):
+    """Operator removes A from the YAML; A's registry row must NOT be deleted.
+    A new symbol F joining later gets id=6, not id=1 (no reuse).
+    """
+    out = tmp_path / "ticker_registry.parquet"
+    for sym in ("AAA", "BBB", "CCC", "DDD", "EEE"):
+        reg.get_or_assign_ticker_id(sym, asof=date(2026, 5, 22), registry_path=out)
+
+    # Simulate next backfill: only B..E + new F (A removed from YAML).
+    aid_before = reg.get_or_assign_ticker_id("AAA", asof=date(2026, 5, 22), registry_path=out)
+    fid = reg.get_or_assign_ticker_id("FFF", asof=date(2026, 5, 23), registry_path=out)
+
+    # AAA's row still present, same id.
+    assert aid_before == 1
+    # FFF gets next-available id, never recycled.
+    assert fid == 6
+
+
+def test_registry_round_trips_to_parquet(tmp_path: Path):
+    out = tmp_path / "ticker_registry.parquet"
+    reg.get_or_assign_ticker_id("XLK", asof=date(2026, 5, 22), registry_path=out)
+    reg.get_or_assign_ticker_id("XLF", asof=date(2026, 5, 23), registry_path=out)
+
+    assert out.exists()
+    df = pd.read_parquet(out)
+    assert set(df.columns) >= {"ticker_id", "symbol", "first_seen"}
+    assert df["symbol"].is_unique
+    # ints are int16-storable (within [-32768, 32767]); registry uses int16 per design.
+    assert df["ticker_id"].max() < 32768
+
+
+def test_load_registry_helper(tmp_path: Path):
+    """`load_ticker_registry` returns the current mapping as a dict."""
+    out = tmp_path / "ticker_registry.parquet"
+    reg.get_or_assign_ticker_id("XLK", asof=date(2026, 5, 22), registry_path=out)
+    reg.get_or_assign_ticker_id("XLF", asof=date(2026, 5, 22), registry_path=out)
+
+    mapping = reg.load_ticker_registry(out)
+    assert mapping == {"XLK": 1, "XLF": 2}
+
+
+def test_empty_registry_yields_empty_mapping(tmp_path: Path):
+    out = tmp_path / "missing.parquet"
+    assert reg.load_ticker_registry(out) == {}
+
+
+# ---------------------------------------------------------------------------
+# Sector registry — same invariants
+# ---------------------------------------------------------------------------
+
+
+def test_sector_registry_idempotent_and_appends(tmp_path: Path):
+    out = tmp_path / "sector_registry.parquet"
+    sids = {
+        s: reg.get_or_assign_sector_id(s, asof=date(2026, 5, 22), registry_path=out)
+        for s in ("energy", "technology", "healthcare")
+    }
+    assert sids == {"energy": 1, "technology": 2, "healthcare": 3}
+
+    # Re-assignment is stable.
+    again = reg.get_or_assign_sector_id("technology", asof=date(2026, 6, 1), registry_path=out)
+    assert again == 2
+
+
+def test_sector_remove_then_add_keeps_old_ids(tmp_path: Path):
+    out = tmp_path / "sector_registry.parquet"
+    for s in ("energy", "technology", "healthcare"):
+        reg.get_or_assign_sector_id(s, asof=date(2026, 5, 22), registry_path=out)
+    # Simulate sector rename: "thematic" is brand-new → gets id=4.
+    new_id = reg.get_or_assign_sector_id("thematic", asof=date(2026, 6, 1), registry_path=out)
+    assert new_id == 4
+
+
+def test_seed_registries_helper_handles_all_universe(tmp_path: Path):
+    """`seed_registries_from_universe` registers every (sector → tickers) pair.
+
+    Idempotent: second call adds nothing new.
+    """
+    universe = {
+        "energy": ["XLE", "XOP"],
+        "technology": ["XLK", "SMH"],
+    }
+    ticker_out = tmp_path / "ticker_registry.parquet"
+    sector_out = tmp_path / "sector_registry.parquet"
+
+    reg.seed_registries_from_universe(
+        universe,
+        asof=date(2026, 5, 22),
+        ticker_registry_path=ticker_out,
+        sector_registry_path=sector_out,
+    )
+    t1 = reg.load_ticker_registry(ticker_out)
+    s1 = reg.load_sector_registry(sector_out)
+    assert set(t1.keys()) == {"XLE", "XOP", "XLK", "SMH"}
+    assert set(s1.keys()) == {"energy", "technology"}
+
+    # Second call with identical universe → no new rows, no id changes.
+    reg.seed_registries_from_universe(
+        universe,
+        asof=date(2026, 5, 23),
+        ticker_registry_path=ticker_out,
+        sector_registry_path=sector_out,
+    )
+    t2 = reg.load_ticker_registry(ticker_out)
+    s2 = reg.load_sector_registry(sector_out)
+    assert t1 == t2
+    assert s1 == s2

--- a/tests/research/test_thematic_registry.py
+++ b/tests/research/test_thematic_registry.py
@@ -20,7 +20,6 @@ from datetime import date
 from pathlib import Path
 
 import pandas as pd
-import pytest
 
 from rainier.research.breadth import registry as reg
 

--- a/tests/research/test_thematic_universe_log.py
+++ b/tests/research/test_thematic_universe_log.py
@@ -1,0 +1,165 @@
+"""Append-only audit of `thematic_universe.yaml` SHA changes (Layer C).
+
+Per DESIGN §5.3 + [D-011], the universe-state log is required so historical
+centile ranks remain reproducible after operator YAML edits.
+
+Behavior contract:
+  - First call: seeds the parquet with one row capturing today's YAML SHA.
+  - Second call (YAML unchanged): NO new row appended.
+  - Third call (YAML mutated → new SHA): new row appended; old row preserved.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+from rainier.research.breadth import universe_loader as ul
+
+
+SAMPLE_YAML_V1 = """\
+version: 1
+schema: thematic_universe.v1
+asof_seeded: 2026-05-22
+universe:
+  technology:
+    - XLK
+    - SMH
+  energy:
+    - XLE
+    - XOP
+"""
+
+SAMPLE_YAML_V2 = """\
+version: 1
+schema: thematic_universe.v1
+asof_seeded: 2026-05-22
+universe:
+  technology:
+    - XLK
+    - SMH
+    - SOXX
+  energy:
+    - XLE
+    - XOP
+"""
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.write_text(content)
+
+
+def test_snapshot_universe_first_call_seeds_row(tmp_path: Path):
+    yaml_path = tmp_path / "thematic_universe.yaml"
+    log_path = tmp_path / "thematic_universe_log.parquet"
+    _write_yaml(yaml_path, SAMPLE_YAML_V1)
+
+    appended = ul.snapshot_universe(
+        yaml_path=yaml_path,
+        log_path=log_path,
+        effective_from=date(2026, 5, 22),
+        note="seed",
+    )
+    assert appended is True
+    assert log_path.exists()
+
+    df = pd.read_parquet(log_path)
+    assert len(df) == 1
+    row = df.iloc[0]
+    assert row["effective_from"] == date(2026, 5, 22)
+    assert isinstance(row["yaml_sha"], str)
+    assert len(row["yaml_sha"]) == 40  # SHA-1 hex
+    assert row["universe_size"] == 4
+    assert sorted(list(row["tickers"])) == ["SMH", "XLE", "XLK", "XOP"]
+
+
+def test_snapshot_universe_no_change_is_noop(tmp_path: Path):
+    """Same YAML → same SHA → no new row appended."""
+    yaml_path = tmp_path / "thematic_universe.yaml"
+    log_path = tmp_path / "thematic_universe_log.parquet"
+    _write_yaml(yaml_path, SAMPLE_YAML_V1)
+
+    ul.snapshot_universe(
+        yaml_path=yaml_path,
+        log_path=log_path,
+        effective_from=date(2026, 5, 22),
+    )
+    appended_second = ul.snapshot_universe(
+        yaml_path=yaml_path,
+        log_path=log_path,
+        effective_from=date(2026, 5, 23),  # later date, same content
+    )
+    assert appended_second is False
+    df = pd.read_parquet(log_path)
+    assert len(df) == 1  # still just the seed row
+
+
+def test_snapshot_universe_yaml_edit_appends_new_row(tmp_path: Path):
+    """YAML content changes → SHA changes → new row appended.
+
+    Old row preserved (append-only).
+    """
+    yaml_path = tmp_path / "thematic_universe.yaml"
+    log_path = tmp_path / "thematic_universe_log.parquet"
+    _write_yaml(yaml_path, SAMPLE_YAML_V1)
+    ul.snapshot_universe(
+        yaml_path=yaml_path,
+        log_path=log_path,
+        effective_from=date(2026, 5, 22),
+        note="seed",
+    )
+
+    # Operator edits the YAML (adds SOXX).
+    _write_yaml(yaml_path, SAMPLE_YAML_V2)
+    appended = ul.snapshot_universe(
+        yaml_path=yaml_path,
+        log_path=log_path,
+        effective_from=date(2026, 6, 1),
+        note="added SOXX",
+    )
+    assert appended is True
+
+    df = pd.read_parquet(log_path).sort_values("effective_from").reset_index(drop=True)
+    assert len(df) == 2
+    # Old row untouched.
+    assert df.iloc[0]["universe_size"] == 4
+    assert df.iloc[0]["note"] == "seed"
+    # New row reflects mutation.
+    assert df.iloc[1]["universe_size"] == 5
+    assert df.iloc[1]["note"] == "added SOXX"
+    assert df.iloc[0]["yaml_sha"] != df.iloc[1]["yaml_sha"]
+
+
+def test_load_universe_returns_sectors_and_tickers_and_sha(tmp_path: Path):
+    yaml_path = tmp_path / "thematic_universe.yaml"
+    _write_yaml(yaml_path, SAMPLE_YAML_V1)
+
+    spec = ul.load_universe(yaml_path)
+    assert spec.sectors == {
+        "technology": ["XLK", "SMH"],
+        "energy": ["XLE", "XOP"],
+    }
+    assert sorted(spec.all_tickers) == ["SMH", "XLE", "XLK", "XOP"]
+    assert isinstance(spec.yaml_sha, str)
+    assert len(spec.yaml_sha) == 40
+
+
+def test_load_universe_sha_deterministic(tmp_path: Path):
+    yaml_path = tmp_path / "thematic_universe.yaml"
+    _write_yaml(yaml_path, SAMPLE_YAML_V1)
+    sha1 = ul.load_universe(yaml_path).yaml_sha
+    sha2 = ul.load_universe(yaml_path).yaml_sha
+    assert sha1 == sha2
+
+
+def test_load_universe_sha_changes_with_content(tmp_path: Path):
+    yaml_path = tmp_path / "thematic_universe.yaml"
+    _write_yaml(yaml_path, SAMPLE_YAML_V1)
+    sha_v1 = ul.load_universe(yaml_path).yaml_sha
+
+    _write_yaml(yaml_path, SAMPLE_YAML_V2)
+    sha_v2 = ul.load_universe(yaml_path).yaml_sha
+
+    assert sha_v1 != sha_v2

--- a/tests/research/test_thematic_universe_log.py
+++ b/tests/research/test_thematic_universe_log.py
@@ -18,7 +18,6 @@ import pandas as pd
 
 from rainier.research.breadth import universe_loader as ul
 
-
 SAMPLE_YAML_V1 = """\
 version: 1
 schema: thematic_universe.v1

--- a/tests/research/test_thematic_universe_yaml.py
+++ b/tests/research/test_thematic_universe_yaml.py
@@ -1,0 +1,108 @@
+"""Schema validation for config/thematic_universe.yaml.
+
+The universe YAML is operator-edited; the backfill + ranking pipeline keys
+off it. The shape is load-bearing: bad shape → silent miscompute. Tests pin
+the contract so an accidental indent or stray "BATS:" prefix fails CI loudly.
+
+Design ref: docs/DESIGN-thematic-ranks-dashboard.md §4 ([D-001]).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+UNIVERSE_PATH = ROOT / "config" / "thematic_universe.yaml"
+
+# YFinance accepts plain symbols only — no `BATS:`, `NYSE:`, `NASDAQ:` prefixes.
+EXCHANGE_PREFIX_RE = re.compile(r"^[A-Z]+:")
+# YFinance ETF symbol shape: 1-5 alphanumerics, optionally one dot (e.g., BRK.B).
+SYMBOL_RE = re.compile(r"^[A-Z][A-Z0-9.]{0,5}$")
+
+
+@pytest.fixture
+def universe() -> dict:
+    with UNIVERSE_PATH.open("r") as fh:
+        return yaml.safe_load(fh)
+
+
+def test_universe_file_exists():
+    assert UNIVERSE_PATH.exists(), f"missing universe yaml at {UNIVERSE_PATH}"
+
+
+def test_top_level_shape(universe):
+    """Required keys: version, schema, asof_seeded, universe."""
+    assert universe.get("version") == 1
+    assert universe.get("schema") == "thematic_universe.v1"
+    assert "asof_seeded" in universe
+    assert "universe" in universe
+    assert isinstance(universe["universe"], dict)
+
+
+def test_universe_has_94_tickers(universe):
+    """Phase A seed per DESIGN §4 = 94 tickers spread across sector buckets."""
+    all_tickers: list[str] = []
+    for sector, tickers in universe["universe"].items():
+        all_tickers.extend(tickers)
+    assert len(all_tickers) == 94, (
+        f"expected 94 tickers in seed universe, got {len(all_tickers)}"
+    )
+
+
+def test_no_duplicate_tickers_across_sectors(universe):
+    """A ticker MUST live in exactly one sector bucket.
+
+    Duplicates would inflate the universe size for ranking (centile
+    denominator) without adding a real symbol — silent miscompute.
+    """
+    seen: dict[str, str] = {}
+    for sector, tickers in universe["universe"].items():
+        for t in tickers:
+            assert t not in seen, (
+                f"duplicate ticker {t!r}: in both {seen[t]!r} and {sector!r}"
+            )
+            seen[t] = sector
+
+
+def test_all_tickers_uppercase_no_prefix(universe):
+    """No `BATS:` / `NYSE:` / lowercase. yfinance is symbol-only."""
+    for sector, tickers in universe["universe"].items():
+        for t in tickers:
+            assert isinstance(t, str), f"non-string ticker in {sector}: {t!r}"
+            assert t == t.upper(), f"ticker not uppercase: {t!r}"
+            assert not EXCHANGE_PREFIX_RE.match(t), (
+                f"ticker has exchange prefix (strip it): {t!r}"
+            )
+            assert SYMBOL_RE.match(t), (
+                f"ticker doesn't match yfinance symbol shape: {t!r}"
+            )
+
+
+def test_no_empty_sector_buckets(universe):
+    """A sector key with an empty list is editor noise; drop the key instead."""
+    for sector, tickers in universe["universe"].items():
+        assert isinstance(tickers, list), f"sector {sector!r} not a list"
+        assert len(tickers) > 0, f"sector {sector!r} has zero tickers"
+
+
+def test_seed_includes_anchor_tickers(universe):
+    """Sanity: a few well-known SPDRs and themes from DESIGN §4 must be in the
+    seed (catches accidental deletes during YAML hand-edits).
+    """
+    all_tickers: set[str] = set()
+    for sector, tickers in universe["universe"].items():
+        all_tickers.update(tickers)
+
+    anchors = {
+        # Sector SPDRs
+        "XLK", "XLF", "XLE", "XLV", "XLI", "XLY", "XLP", "XLU", "XLB",
+        "XLRE", "XLC",
+        # Themes called out in DESIGN §4
+        "SMH", "XBI", "KRE", "ARKK", "DXYZ",
+    }
+    missing = anchors - all_tickers
+    assert not missing, f"seed missing anchor tickers from DESIGN §4: {sorted(missing)}"


### PR DESCRIPTION
## Summary
Phase A of the Industry/Thematic ranks dashboard feature (`docs/DESIGN-thematic-ranks-dashboard.md`). Lands the data substrate ONLY — compute layer + dashboard + cron ship in stacked Phase B (`thematic-ranks-dashboard-d245`).

- `config/thematic_universe.yaml` — 94 sector/theme ETF seed universe; operator-editable (per [D-001]).
- `scripts/backfill_thematic_universe.py` — parameterized yfinance fetcher with atomic-write, `--force` dated cohort, deterministic on stub fixtures. Mirrors `backfill_macro_context.py` patterns.
- `src/rainier/research/breadth/` — `universe_loader` (YAML+SHA), `registry` (append-only `ticker_id`/`sector_id` per [D-015]).
- `data_availability.yaml` extension: 94 `thematic_universe.*` OHLCV ledger entries with `observability_timestamp_rule: end_of_trading_day` + `revision_immutability: true`. `adjusted_close` intentionally NOT stored (look-ahead-leaky, per parent design's [D-014] discipline).
- New CLI: `uv run rainier thematic backfill` + `thematic snapshot-universe`. Compute/render/run-daily ship in Phase B.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 2)
- Zero P0/P1 across both runs — no reviewer fix commits added on top of worker's TDD trio.

## Deferred [P2] (intentional — documented for Phase B)
- `universe_loader.py:175` — A→B→A revert: append-on-revert vs match-any-historical-SHA. Worker's tdd-refactor chose match-any-historical (simpler); Phase B's asof-read implementation will revisit.
- `scripts/backfill_thematic_universe.py:297` — per-symbol row-count tier vs anchor-calendar exactness. Thematic universe has no natural single anchor (every member is a sector/theme ETF), so simpler tier was used; revisit if Phase B compute needs stricter calendar gate.

## Test plan
- [ ] CI green
- [ ] Operator: `uv run rainier thematic backfill --dry-run` lists 94 tickers without network
- [ ] Operator: `uv run rainier thematic snapshot-universe` writes first Layer C row
- [ ] Stacked on #78 (vix) — Phase B PR will be stacked on this one

---

Stacked on #78 (`worker/vix-sector-backfill-d05f`). When #78 squash-merges, this branch rebases onto new main; PR `--base` stays `main`.