### PR TITLE
feat(breadth): thematic ranks compute + dashboard + daily cron (Phase B)

### DIFF
--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -49,3 +49,15 @@ jobs:
     command: "scripts/ensure-chrome.sh && uv run rainier scrape qu --session close --cdp http://127.0.0.1:9222"
     log: "data/qu-scrape.log"
     enabled: true
+
+  # Thematic Ranks dashboard — DESIGN-thematic-ranks-dashboard.md §7 [D-004].
+  # Runs 15min after NYSE close (16:30 ET / 13:30 PT) on weekdays. Idempotent
+  # `run-daily` short-circuits if today's Layer A row is already present, so
+  # cron retries are safe.
+  - name: thematic-ranks-daily
+    description: "Compute thematic ranks (Layer A+B) + render dashboard"
+    schedule: "30 13 * * 1-5"   # 13:30 PST = 16:30 ET, Mon-Fri
+    command: "uv run rainier thematic run-daily"
+    log: "data/thematic-ranks.log"
+    discord_on_failure: true
+    enabled: true

--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -54,10 +54,20 @@ jobs:
   # Runs 15min after NYSE close (16:30 ET / 13:30 PT) on weekdays. Idempotent
   # `run-daily` short-circuits if today's Layer A row is already present, so
   # cron retries are safe.
+  #
+  # DISABLED until a daily OHLCV refresh job lands (codex iter-7 [P1]).
+  # `run-daily` needs `data/cache/thematic_universe.parquet` to be current
+  # for today's asof. The Phase A `backfill_thematic_universe.py` is a
+  # one-shot bulk fetch (no `--resume`/--update mode) and is revision-
+  # immutable (`--force` writes a sibling cohort, not in-place). Until the
+  # backfill script grows a daily-refresh mode (deferred follow-up), enabling
+  # this cron would hit the stale-OHLCV guard and fail every weekday.
+  # Operator flips `enabled: true` once daily OHLCV refresh is wired up;
+  # `run-daily` itself remains operator-runnable via the CLI for ad-hoc use.
   - name: thematic-ranks-daily
     description: "Compute thematic ranks (Layer A+B) + render dashboard"
     schedule: "30 13 * * 1-5"   # 13:30 PST = 16:30 ET, Mon-Fri
     command: "uv run rainier thematic run-daily"
     log: "data/thematic-ranks.log"
     discord_on_failure: true
-    enabled: true
+    enabled: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ ignore = ["E501", "E741", "N806"]
 
 [project.optional-dependencies]
 dashboard = ["streamlit>=1.30,<2"]
+# RL — gymnasium env for ThematicTradingEnv. Lazy-imported only when the env
+# is constructed; not required for compute / dashboard / cron paths.
+rl = ["gymnasium>=0.29"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3420,3 +3420,418 @@ def thematic_snapshot_universe(
 from rainier.research.cli import register as _register_llm_research  # noqa: E402
 
 _register_llm_research(cli)
+
+
+# ---------------------------------------------------------------------------
+# thematic — Phase B: compute, backfill-labels, render, run-daily
+# ---------------------------------------------------------------------------
+#
+# These build on Phase A's thematic_universe.parquet + ticker/sector
+# registries + universe log to produce:
+#   - Layer A features  -> data/cache/thematic_features_daily.parquet
+#   - Layer B labels    -> data/cache/thematic_labels_daily.parquet
+#   - Dashboard HTML    -> docs/thematic-ranks-<YYYY-MM-DD>.html
+#
+# Design ref: docs/DESIGN-thematic-ranks-dashboard.md §6 / §7.
+
+
+def _load_universe_for_compute(yaml_path: Path):
+    """Return ``(sector_map, ticker_registry, sector_registry, yaml_sha,
+    all_symbols)`` from the YAML at ``yaml_path``.
+
+    Registries are loaded if their parquets exist, else seeded from the YAML
+    so first-run compute always succeeds even before the operator has run
+    `thematic backfill` (which usually seeds them).
+    """
+    from rainier.research.breadth import universe_loader as _ul
+
+    spec = _ul.load_universe(yaml_path)
+    sector_map: dict[str, str] = {}
+    for sec, syms in spec.sectors.items():
+        for s in syms:
+            sector_map[s] = sec
+    return spec, sector_map
+
+
+@thematic.command("compute")
+@click.option("--asof", required=True, help="Compute date (YYYY-MM-DD).")
+@click.option(
+    "--ohlcv",
+    "ohlcv_path",
+    type=click.Path(exists=True),
+    default="data/cache/thematic_universe.parquet",
+    show_default=True,
+    help="Path to thematic_universe.parquet (Phase A OHLCV cache).",
+)
+@click.option(
+    "--yaml",
+    "yaml_path",
+    type=click.Path(exists=True),
+    default="config/thematic_universe.yaml",
+    show_default=True,
+)
+@click.option(
+    "--out",
+    "out_path",
+    type=click.Path(),
+    default="data/cache/thematic_features_daily.parquet",
+    show_default=True,
+)
+@click.option(
+    "--ticker-registry",
+    type=click.Path(),
+    default="data/cache/ticker_registry.parquet",
+    show_default=True,
+)
+@click.option(
+    "--sector-registry",
+    type=click.Path(),
+    default="data/cache/sector_registry.parquet",
+    show_default=True,
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Recompute even if asof_date already present in the output.",
+)
+def thematic_compute(
+    asof: str,
+    ohlcv_path: str,
+    yaml_path: str,
+    out_path: str,
+    ticker_registry: str,
+    sector_registry: str,
+    force: bool,
+) -> None:
+    """Compute Layer A features for one ``asof`` and insert into the parquet.
+
+    Idempotent: re-running for the same asof_date is a no-op unless ``--force``.
+    """
+    from datetime import date as _date
+
+    from rainier.research.breadth import registry as _reg
+    from rainier.research.breadth.ranks import compute_thematic_features
+
+    asof_dt = _date.fromisoformat(asof)
+    spec, sector_map = _load_universe_for_compute(Path(yaml_path))
+
+    # Seed registries from the YAML if they don't exist yet.
+    ticker_registry_path = Path(ticker_registry)
+    sector_registry_path = Path(sector_registry)
+    _reg.seed_registries_from_universe(
+        spec.sectors,
+        asof=asof_dt,
+        ticker_registry_path=ticker_registry_path,
+        sector_registry_path=sector_registry_path,
+    )
+    ticker_reg_map = _reg.load_ticker_registry(ticker_registry_path)
+    sector_reg_map = _reg.load_sector_registry(sector_registry_path)
+
+    out_p = Path(out_path)
+    # Idempotency check.
+    if out_p.exists() and not force:
+        existing = pd.read_parquet(out_p)
+        if "asof_date" in existing.columns:
+            existing_dates = pd.to_datetime(existing["asof_date"]).dt.date
+            if (existing_dates == asof_dt).any():
+                click.echo(f"no-op: asof={asof_dt} already in {out_p}")
+                return
+
+    panel = pd.read_parquet(ohlcv_path)
+    if "date" in panel.columns:
+        panel["date"] = pd.to_datetime(panel["date"]).dt.date
+
+    # Pull previous asof's row (if any) so deltas + streak chain correctly.
+    prev_features = None
+    if out_p.exists():
+        existing = pd.read_parquet(out_p)
+        if not existing.empty and "asof_date" in existing.columns:
+            existing["asof_date"] = pd.to_datetime(existing["asof_date"]).dt.date
+            prior = existing.loc[existing["asof_date"] < asof_dt]
+            if not prior.empty:
+                latest = prior["asof_date"].max()
+                prev_features = prior.loc[prior["asof_date"] == latest]
+
+    out_df = compute_thematic_features(
+        panel=panel,
+        asof=asof_dt,
+        sector_map=sector_map,
+        ticker_registry=ticker_reg_map,
+        sector_registry=sector_reg_map,
+        universe_yaml_sha=spec.yaml_sha,
+        prev_features=prev_features,
+    )
+    if out_df.empty:
+        click.echo(f"no rows computed for asof={asof_dt}; aborting write")
+        return
+
+    _append_features(out_df, out_p, asof_dt, force=force)
+    click.echo(f"wrote {len(out_df)} rows -> {out_p}")
+
+
+def _append_features(new_df: pd.DataFrame, path: Path, asof: date, force: bool) -> None:
+    """Append new_df to the parquet at path, replacing any existing rows for
+    the same asof_date if ``force``. Atomic write via tmp + os.replace.
+    """
+    import os
+
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        existing = pd.read_parquet(path)
+        if not existing.empty and "asof_date" in existing.columns:
+            existing["asof_date"] = pd.to_datetime(existing["asof_date"]).dt.date
+            if force:
+                existing = existing.loc[existing["asof_date"] != asof]
+        combined = pd.concat([existing, new_df], ignore_index=True)
+    else:
+        combined = new_df
+
+    combined = combined.sort_values(["symbol", "asof_date"]).reset_index(drop=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    combined.to_parquet(tmp, index=False)
+    os.replace(tmp, path)
+
+
+@thematic.command("backfill-labels")
+@click.option(
+    "--ohlcv",
+    "ohlcv_path",
+    type=click.Path(exists=True),
+    default="data/cache/thematic_universe.parquet",
+    show_default=True,
+)
+@click.option(
+    "--out",
+    "out_path",
+    type=click.Path(),
+    default="data/cache/thematic_labels_daily.parquet",
+    show_default=True,
+)
+def thematic_backfill_labels(ohlcv_path: str, out_path: str) -> None:
+    """Compute Layer B forward-return labels for every (asof_date, symbol)."""
+    import os
+
+    from rainier.research.breadth.ranks import compute_forward_labels
+
+    panel = pd.read_parquet(ohlcv_path)
+    if "date" in panel.columns:
+        panel["date"] = pd.to_datetime(panel["date"]).dt.date
+    out_df = compute_forward_labels(panel=panel)
+
+    out_p = Path(out_path)
+    out_p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_p.with_suffix(out_p.suffix + ".tmp")
+    out_df.to_parquet(tmp, index=False)
+    os.replace(tmp, out_p)
+    click.echo(f"wrote {len(out_df)} label rows -> {out_p}")
+
+
+@thematic.command("render")
+@click.option("--asof", required=True, help="Date to render (YYYY-MM-DD).")
+@click.option(
+    "--features",
+    "features_path",
+    type=click.Path(exists=True),
+    default="data/cache/thematic_features_daily.parquet",
+    show_default=True,
+)
+@click.option(
+    "--yaml",
+    "yaml_path",
+    type=click.Path(exists=True),
+    default="config/thematic_universe.yaml",
+    show_default=True,
+)
+@click.option(
+    "--out",
+    "out_path",
+    type=click.Path(),
+    default=None,
+    help="HTML path. Default: docs/thematic-ranks-<asof>.html.",
+)
+def thematic_render(
+    asof: str, features_path: str, yaml_path: str, out_path: str | None
+) -> None:
+    """Render the thematic ranks dashboard for ``asof`` to a self-contained HTML."""
+    from datetime import date as _date
+
+    from rainier.viz.thematic_dashboard import render_dashboard
+
+    asof_dt = _date.fromisoformat(asof)
+    features = pd.read_parquet(features_path)
+    if "asof_date" in features.columns:
+        features["asof_date"] = pd.to_datetime(features["asof_date"]).dt.date
+    sub = features.loc[features["asof_date"] == asof_dt]
+    if sub.empty:
+        raise click.ClickException(
+            f"no features for asof={asof_dt} in {features_path}; "
+            f"run `rainier thematic compute --asof {asof_dt}` first."
+        )
+
+    # Join sector_name from the YAML universe.
+    spec, sector_map = _load_universe_for_compute(Path(yaml_path))
+    sub = sub.copy()
+    sub["sector_name"] = sub["symbol"].map(sector_map).fillna("unknown")
+
+    target = Path(out_path) if out_path else Path(f"docs/thematic-ranks-{asof_dt}.html")
+    written = render_dashboard(sub, out_path=target, asof=asof_dt)
+    click.echo(f"wrote dashboard -> {written}")
+
+
+@thematic.command("run-daily")
+@click.option(
+    "--asof",
+    default=None,
+    help="Date to run for (YYYY-MM-DD). Default: today.",
+)
+@click.option(
+    "--ohlcv",
+    "ohlcv_path",
+    type=click.Path(exists=True),
+    default="data/cache/thematic_universe.parquet",
+    show_default=True,
+)
+@click.option(
+    "--yaml",
+    "yaml_path",
+    type=click.Path(exists=True),
+    default="config/thematic_universe.yaml",
+    show_default=True,
+)
+@click.option(
+    "--features-out",
+    type=click.Path(),
+    default="data/cache/thematic_features_daily.parquet",
+    show_default=True,
+)
+@click.option(
+    "--labels-out",
+    type=click.Path(),
+    default="data/cache/thematic_labels_daily.parquet",
+    show_default=True,
+)
+@click.option(
+    "--ticker-registry",
+    type=click.Path(),
+    default="data/cache/ticker_registry.parquet",
+    show_default=True,
+)
+@click.option(
+    "--sector-registry",
+    type=click.Path(),
+    default="data/cache/sector_registry.parquet",
+    show_default=True,
+)
+@click.option(
+    "--html-out",
+    type=click.Path(),
+    default=None,
+    help="HTML path. Default: docs/thematic-ranks-<asof>.html.",
+)
+def thematic_run_daily(
+    asof: str | None,
+    ohlcv_path: str,
+    yaml_path: str,
+    features_out: str,
+    labels_out: str,
+    ticker_registry: str,
+    sector_registry: str,
+    html_out: str | None,
+) -> None:
+    """One-shot daily flow: compute Layer A + Layer B + render dashboard.
+
+    Idempotent: if today's Layer A row already exists, the compute step is
+    a no-op. Label backfill always runs (it's cheap and the freshest rows
+    drift forward as new days arrive).
+    """
+    from datetime import date as _date
+
+    from rainier.research.breadth import registry as _reg
+    from rainier.research.breadth.ranks import (
+        compute_forward_labels,
+        compute_thematic_features,
+    )
+    from rainier.viz.thematic_dashboard import render_dashboard
+
+    asof_dt = _date.fromisoformat(asof) if asof else _date.today()
+    spec, sector_map = _load_universe_for_compute(Path(yaml_path))
+
+    # Seed registries.
+    ticker_registry_path = Path(ticker_registry)
+    sector_registry_path = Path(sector_registry)
+    _reg.seed_registries_from_universe(
+        spec.sectors,
+        asof=asof_dt,
+        ticker_registry_path=ticker_registry_path,
+        sector_registry_path=sector_registry_path,
+    )
+    ticker_reg_map = _reg.load_ticker_registry(ticker_registry_path)
+    sector_reg_map = _reg.load_sector_registry(sector_registry_path)
+
+    panel = pd.read_parquet(ohlcv_path)
+    if "date" in panel.columns:
+        panel["date"] = pd.to_datetime(panel["date"]).dt.date
+
+    # Layer A: idempotent compute.
+    features_path = Path(features_out)
+    skip_compute = False
+    if features_path.exists():
+        existing = pd.read_parquet(features_path)
+        if not existing.empty and "asof_date" in existing.columns:
+            existing["asof_date"] = pd.to_datetime(existing["asof_date"]).dt.date
+            if (existing["asof_date"] == asof_dt).any():
+                click.echo(f"layer A: no-op (asof={asof_dt} already present)")
+                skip_compute = True
+
+    if not skip_compute:
+        prev_features = None
+        if features_path.exists():
+            existing = pd.read_parquet(features_path)
+            if not existing.empty and "asof_date" in existing.columns:
+                existing["asof_date"] = pd.to_datetime(existing["asof_date"]).dt.date
+                prior = existing.loc[existing["asof_date"] < asof_dt]
+                if not prior.empty:
+                    latest = prior["asof_date"].max()
+                    prev_features = prior.loc[prior["asof_date"] == latest]
+
+        out_df = compute_thematic_features(
+            panel=panel,
+            asof=asof_dt,
+            sector_map=sector_map,
+            ticker_registry=ticker_reg_map,
+            sector_registry=sector_reg_map,
+            universe_yaml_sha=spec.yaml_sha,
+            prev_features=prev_features,
+        )
+        if out_df.empty:
+            click.echo(f"layer A: no rows for asof={asof_dt}; skipping")
+        else:
+            _append_features(out_df, features_path, asof_dt, force=False)
+            click.echo(f"layer A: wrote {len(out_df)} rows -> {features_path}")
+
+    # Layer B: always recompute (cheap + freshness drifts forward).
+    import os
+
+    labels_path = Path(labels_out)
+    labels_path.parent.mkdir(parents=True, exist_ok=True)
+    label_df = compute_forward_labels(panel=panel)
+    tmp = labels_path.with_suffix(labels_path.suffix + ".tmp")
+    label_df.to_parquet(tmp, index=False)
+    os.replace(tmp, labels_path)
+    click.echo(f"layer B: wrote {len(label_df)} rows -> {labels_path}")
+
+    # Render dashboard.
+    features = pd.read_parquet(features_path)
+    if "asof_date" in features.columns:
+        features["asof_date"] = pd.to_datetime(features["asof_date"]).dt.date
+    sub = features.loc[features["asof_date"] == asof_dt]
+    if sub.empty:
+        click.echo(f"render: no features for asof={asof_dt}; skipping HTML")
+        return
+    sub = sub.copy()
+    sub["sector_name"] = sub["symbol"].map(sector_map).fillna("unknown")
+    target = Path(html_out) if html_out else Path(f"docs/thematic-ranks-{asof_dt}.html")
+    written = render_dashboard(sub, out_path=target, asof=asof_dt)
+    click.echo(f"render: wrote dashboard -> {written}")

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3778,14 +3778,24 @@ def thematic_run_daily(
     # incrementally first." We don't auto-fetch (yfinance side effect inside
     # a cron run is too magical). Instead surface clearly with the exact
     # next-step command per the operator's surface-don't-silo discipline.
+    #
+    # The Phase A backfill script is revision-immutable: pointing it at an
+    # existing `--out` raises FileExistsError, and `--force` writes a
+    # timestamped sibling cohort (it deliberately never overwrites). The
+    # recovery flow is therefore three steps: backfill --force to a sibling,
+    # then atomically swap the new cohort into the cache path.
     if not panel.empty and "date" in panel.columns:
         panel_max = panel["date"].max()
         if panel_max < asof_dt:
             raise click.ClickException(
                 f"OHLCV cache stale: max(date)={panel_max} < asof={asof_dt}. "
-                f"Run `uv run python scripts/backfill_thematic_universe.py "
-                f"--start {panel_max} --end {asof_dt} --out {ohlcv_path}` to "
-                f"refresh, then retry `rainier thematic run-daily`."
+                f"Refresh with:\n"
+                f"  1. uv run python scripts/backfill_thematic_universe.py "
+                f"--start 2024-10-01 --end {asof_dt} --force\n"
+                f"  2. mv $(ls -t {Path(ohlcv_path).parent}/"
+                f"{Path(ohlcv_path).stem}_*{Path(ohlcv_path).suffix} | head -1) "
+                f"{ohlcv_path}\n"
+                f"  3. uv run rainier thematic run-daily  # retry"
             )
 
     # Layer A: idempotent compute.

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3774,6 +3774,20 @@ def thematic_run_daily(
     if "date" in panel.columns:
         panel["date"] = pd.to_datetime(panel["date"]).dt.date
 
+    # Stale-OHLCV guard. Per DESIGN §7: "If OHLCV is stale, backfill
+    # incrementally first." We don't auto-fetch (yfinance side effect inside
+    # a cron run is too magical). Instead surface clearly with the exact
+    # next-step command per the operator's surface-don't-silo discipline.
+    if not panel.empty and "date" in panel.columns:
+        panel_max = panel["date"].max()
+        if panel_max < asof_dt:
+            raise click.ClickException(
+                f"OHLCV cache stale: max(date)={panel_max} < asof={asof_dt}. "
+                f"Run `uv run python scripts/backfill_thematic_universe.py "
+                f"--start {panel_max} --end {asof_dt} --out {ohlcv_path}` to "
+                f"refresh, then retry `rainier thematic run-daily`."
+            )
+
     # Layer A: idempotent compute.
     features_path = Path(features_out)
     skip_compute = False
@@ -3822,7 +3836,15 @@ def thematic_run_daily(
     os.replace(tmp, labels_path)
     click.echo(f"layer B: wrote {len(label_df)} rows -> {labels_path}")
 
-    # Render dashboard.
+    # Render dashboard. Guard against a missing features parquet (would only
+    # happen if the OHLCV panel had zero rows AND no prior features had ever
+    # been written — surface a useful diagnostic instead of FileNotFoundError).
+    if not features_path.exists():
+        click.echo(
+            f"render: features parquet missing at {features_path}; nothing "
+            f"to render. Confirm OHLCV cache contains rows for asof={asof_dt}."
+        )
+        return
     features = pd.read_parquet(features_path)
     if "asof_date" in features.columns:
         features["asof_date"] = pd.to_datetime(features["asof_date"]).dt.date

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3798,6 +3798,41 @@ def thematic_run_daily(
                 f"  3. uv run rainier thematic run-daily  # retry"
             )
 
+        # Partial-coverage guard. Ranks are cross-sectional: if a partial
+        # backfill leaves the panel without an asof close for most of the
+        # YAML universe, `compute_thematic_features` silently drops missing
+        # symbols and ranks over a shrunken universe. Surface the gap so the
+        # operator runs a full re-backfill rather than rendering a misleading
+        # dashboard (codex iter-6 [P1] + memory feedback_surface_dont_silo).
+        expected_syms = {
+            sym for syms in spec.sectors.values() for sym in syms
+        }
+        asof_rows = panel.loc[panel["date"] == asof_dt]
+        present = set(asof_rows["symbol"].dropna().unique()) if not asof_rows.empty else set()
+        missing = expected_syms - present
+        # Threshold: warn when >10% missing; fail when >25% missing. 10%
+        # absorbs typical NYSE-holiday + late-listing noise without false
+        # alarms; >25% indicates a botched backfill that should not silently
+        # ship a dashboard.
+        if expected_syms:
+            missing_frac = len(missing) / len(expected_syms)
+            if missing_frac > 0.25:
+                example = sorted(missing)[:8]
+                raise click.ClickException(
+                    f"OHLCV cache has partial coverage on asof={asof_dt}: "
+                    f"{len(missing)}/{len(expected_syms)} YAML symbols missing "
+                    f"({missing_frac:.0%}). Examples: {example}. "
+                    f"Re-run the backfill --force flow above before computing."
+                )
+            if missing_frac > 0.10:
+                example = sorted(missing)[:8]
+                click.echo(
+                    f"warning: {len(missing)}/{len(expected_syms)} YAML "
+                    f"symbols missing on asof={asof_dt} ({missing_frac:.0%}). "
+                    f"Examples: {example}. Proceeding; consider refreshing OHLCV.",
+                    err=True,
+                )
+
     # Layer A: idempotent compute.
     features_path = Path(features_out)
     skip_compute = False

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3436,8 +3436,10 @@ _register_llm_research(cli)
 
 
 def _load_universe_for_compute(yaml_path: Path):
-    """Return ``(sector_map, ticker_registry, sector_registry, yaml_sha,
-    all_symbols)`` from the YAML at ``yaml_path``.
+    """Return ``(spec, sector_map)`` for the YAML at ``yaml_path``.
+
+    ``spec`` is the parsed universe (with ``.sectors`` dict + ``.yaml_sha``);
+    ``sector_map`` is the flattened ``symbol -> sector_name`` dict.
 
     Registries are loaded if their parquets exist, else seeded from the YAML
     so first-run compute always succeeds even before the operator has run
@@ -3451,6 +3453,63 @@ def _load_universe_for_compute(yaml_path: Path):
         for s in syms:
             sector_map[s] = sec
     return spec, sector_map
+
+
+def _check_ohlcv_freshness(
+    panel: pd.DataFrame,
+    asof_dt: date,
+    ohlcv_path: str,
+    spec,  # universe spec with .sectors dict
+) -> None:
+    """Raise click.ClickException if the OHLCV cache is stale or partial for
+    ``asof_dt``. Shared by `thematic compute` and `thematic run-daily` so
+    both paths surface the same diagnostic (codex iter-6/8 [P1]/[P2]).
+
+    Stale: panel.max(date) < asof_dt.
+    Partial: > 25% of YAML symbols missing on asof_dt (fail);
+             > 10% missing (warning to stderr).
+    """
+    if panel.empty or "date" not in panel.columns:
+        return
+
+    panel_max = panel["date"].max()
+    if panel_max < asof_dt:
+        raise click.ClickException(
+            f"OHLCV cache stale: max(date)={panel_max} < asof={asof_dt}. "
+            f"Refresh with:\n"
+            f"  1. uv run python scripts/backfill_thematic_universe.py "
+            f"--start 2024-10-01 --end {asof_dt} --force\n"
+            f"  2. mv $(ls -t {Path(ohlcv_path).parent}/"
+            f"{Path(ohlcv_path).stem}_*{Path(ohlcv_path).suffix} | head -1) "
+            f"{ohlcv_path}\n"
+            f"  3. uv run rainier thematic run-daily  # retry"
+        )
+
+    expected_syms = {sym for syms in spec.sectors.values() for sym in syms}
+    asof_rows = panel.loc[panel["date"] == asof_dt]
+    present = (
+        set(asof_rows["symbol"].dropna().unique()) if not asof_rows.empty else set()
+    )
+    missing = expected_syms - present
+    if not expected_syms:
+        return
+    missing_frac = len(missing) / len(expected_syms)
+    if missing_frac > 0.25:
+        example = sorted(missing)[:8]
+        raise click.ClickException(
+            f"OHLCV cache has partial coverage on asof={asof_dt}: "
+            f"{len(missing)}/{len(expected_syms)} YAML symbols missing "
+            f"({missing_frac:.0%}). Examples: {example}. "
+            f"Re-run the backfill --force flow above before computing."
+        )
+    if missing_frac > 0.10:
+        example = sorted(missing)[:8]
+        click.echo(
+            f"warning: {len(missing)}/{len(expected_syms)} YAML symbols "
+            f"missing on asof={asof_dt} ({missing_frac:.0%}). "
+            f"Examples: {example}. Proceeding; consider refreshing OHLCV.",
+            err=True,
+        )
 
 
 @thematic.command("compute")
@@ -3541,6 +3600,12 @@ def thematic_compute(
     panel = pd.read_parquet(ohlcv_path)
     if "date" in panel.columns:
         panel["date"] = pd.to_datetime(panel["date"]).dt.date
+
+    # Same stale/partial-coverage gate as run-daily (codex iter-8 [P2]):
+    # the direct compute path must not silently rank over a shrunken
+    # universe just because the operator invoked `thematic compute` instead
+    # of `thematic run-daily`.
+    _check_ohlcv_freshness(panel, asof_dt, ohlcv_path, spec)
 
     # Pull previous asof's row (if any) so deltas + streak chain correctly.
     prev_features = None
@@ -3774,64 +3839,11 @@ def thematic_run_daily(
     if "date" in panel.columns:
         panel["date"] = pd.to_datetime(panel["date"]).dt.date
 
-    # Stale-OHLCV guard. Per DESIGN §7: "If OHLCV is stale, backfill
-    # incrementally first." We don't auto-fetch (yfinance side effect inside
-    # a cron run is too magical). Instead surface clearly with the exact
-    # next-step command per the operator's surface-don't-silo discipline.
-    #
-    # The Phase A backfill script is revision-immutable: pointing it at an
-    # existing `--out` raises FileExistsError, and `--force` writes a
-    # timestamped sibling cohort (it deliberately never overwrites). The
-    # recovery flow is therefore three steps: backfill --force to a sibling,
-    # then atomically swap the new cohort into the cache path.
-    if not panel.empty and "date" in panel.columns:
-        panel_max = panel["date"].max()
-        if panel_max < asof_dt:
-            raise click.ClickException(
-                f"OHLCV cache stale: max(date)={panel_max} < asof={asof_dt}. "
-                f"Refresh with:\n"
-                f"  1. uv run python scripts/backfill_thematic_universe.py "
-                f"--start 2024-10-01 --end {asof_dt} --force\n"
-                f"  2. mv $(ls -t {Path(ohlcv_path).parent}/"
-                f"{Path(ohlcv_path).stem}_*{Path(ohlcv_path).suffix} | head -1) "
-                f"{ohlcv_path}\n"
-                f"  3. uv run rainier thematic run-daily  # retry"
-            )
-
-        # Partial-coverage guard. Ranks are cross-sectional: if a partial
-        # backfill leaves the panel without an asof close for most of the
-        # YAML universe, `compute_thematic_features` silently drops missing
-        # symbols and ranks over a shrunken universe. Surface the gap so the
-        # operator runs a full re-backfill rather than rendering a misleading
-        # dashboard (codex iter-6 [P1] + memory feedback_surface_dont_silo).
-        expected_syms = {
-            sym for syms in spec.sectors.values() for sym in syms
-        }
-        asof_rows = panel.loc[panel["date"] == asof_dt]
-        present = set(asof_rows["symbol"].dropna().unique()) if not asof_rows.empty else set()
-        missing = expected_syms - present
-        # Threshold: warn when >10% missing; fail when >25% missing. 10%
-        # absorbs typical NYSE-holiday + late-listing noise without false
-        # alarms; >25% indicates a botched backfill that should not silently
-        # ship a dashboard.
-        if expected_syms:
-            missing_frac = len(missing) / len(expected_syms)
-            if missing_frac > 0.25:
-                example = sorted(missing)[:8]
-                raise click.ClickException(
-                    f"OHLCV cache has partial coverage on asof={asof_dt}: "
-                    f"{len(missing)}/{len(expected_syms)} YAML symbols missing "
-                    f"({missing_frac:.0%}). Examples: {example}. "
-                    f"Re-run the backfill --force flow above before computing."
-                )
-            if missing_frac > 0.10:
-                example = sorted(missing)[:8]
-                click.echo(
-                    f"warning: {len(missing)}/{len(expected_syms)} YAML "
-                    f"symbols missing on asof={asof_dt} ({missing_frac:.0%}). "
-                    f"Examples: {example}. Proceeding; consider refreshing OHLCV.",
-                    err=True,
-                )
+    # Stale-OHLCV / partial-coverage guard. Per DESIGN §7: "If OHLCV is
+    # stale, backfill incrementally first." We don't auto-fetch (yfinance
+    # side effect inside a cron run is too magical) — instead surface clearly
+    # with the exact next-step command per `feedback_surface_dont_silo`.
+    _check_ohlcv_freshness(panel, asof_dt, ohlcv_path, spec)
 
     # Layer A: idempotent compute.
     features_path = Path(features_out)

--- a/src/rainier/research/breadth/__init__.py
+++ b/src/rainier/research/breadth/__init__.py
@@ -1,16 +1,30 @@
 """Breadth / thematic-ranks support package.
 
-Phase A (this PR) ships the data substrate: universe loader, ticker /
-sector registries, universe-state log writer.
+Phase A ships the data substrate: universe loader, ticker / sector
+registries, universe-state log writer.
 
-Phase B (`thematic-ranks-dashboard-d245`) adds `ranks.py`, `loaders.py`,
-`ml_builders.py`, and the dashboard renderer on top.
+Phase B (this PR) adds Layer A point-in-time features + Layer B forward-
+return labels in `ranks.py`, the read-side loaders in `loaders.py`, and
+the ML/RL panel builders in `ml_builders.py`. The dashboard renderer
+lives at `rainier.viz.thematic_dashboard`.
 
 Design ref: docs/DESIGN-thematic-ranks-dashboard.md
 """
 
 from __future__ import annotations
 
-from rainier.research.breadth import registry, universe_loader
+from rainier.research.breadth import (
+    loaders,
+    ml_builders,
+    ranks,
+    registry,
+    universe_loader,
+)
 
-__all__ = ["registry", "universe_loader"]
+__all__ = [
+    "loaders",
+    "ml_builders",
+    "ranks",
+    "registry",
+    "universe_loader",
+]

--- a/src/rainier/research/breadth/loaders.py
+++ b/src/rainier/research/breadth/loaders.py
@@ -169,18 +169,31 @@ def _most_restrictive_label(label_cols: list[str]) -> str | None:
 
     Heuristic: among requested labels, prefer ``fwd_30d_ret`` (the most-
     restrictive in the §5.2 schema). If not requested, scan for any
-    ``fwd_<N>d_ret`` and return the largest N.
+    ``fwd_<N>d_ret`` / ``fwd_<N>d_excess_ret`` / ``fwd_<N>d_max_drawdown`` /
+    ``fwd_<N>d_max_runup`` column and return the one with the largest N.
+
+    Why every fwd_* family is considered (codex iter-3 [P2]): callers may
+    request only excess-return or drawdown/runup labels (no plain `_d_ret`).
+    Previously this function returned None for those callers, so
+    ``drop_incomplete_labels=True`` silently kept trailing NaN rows. Now
+    every fwd_<N>d_* family is a valid completeness gate.
     """
     if "fwd_30d_ret" in label_cols:
         return "fwd_30d_ret"
     candidates: list[tuple[int, str]] = []
     for c in label_cols:
-        if c.startswith("fwd_") and c.endswith("d_ret"):
-            try:
-                n = int(c.removeprefix("fwd_").removesuffix("d_ret"))
-                candidates.append((n, c))
-            except ValueError:
-                continue
+        if not c.startswith("fwd_"):
+            continue
+        # Strip the fwd_ prefix and parse the leading "<N>d" segment.
+        rest = c.removeprefix("fwd_")
+        if "d" not in rest:
+            continue
+        n_str, _sep, _tail = rest.partition("d")
+        try:
+            n = int(n_str)
+        except ValueError:
+            continue
+        candidates.append((n, c))
     if not candidates:
         return None
     return max(candidates, key=lambda x: x[0])[1]

--- a/src/rainier/research/breadth/loaders.py
+++ b/src/rainier/research/breadth/loaders.py
@@ -1,0 +1,186 @@
+"""Read-only loaders for Layer A features + Layer A/B supervised joins.
+
+Pure functions of `(date_range, paths)` -> `pd.DataFrame`. Identical inputs
+return identical outputs (deterministic sort + filter).
+
+Design ref:
+    docs/DESIGN-thematic-ranks-dashboard.md §5.6 ([D-016] long-format base +
+    builder-function API).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+
+import pandas as pd
+
+DEFAULT_FEATURES_PATH = Path("data/cache/thematic_features_daily.parquet")
+DEFAULT_LABELS_PATH = Path("data/cache/thematic_labels_daily.parquet")
+
+
+# ---------------------------------------------------------------------------
+# Coercion helper
+# ---------------------------------------------------------------------------
+
+
+def _coerce_date(value: str | date | datetime | pd.Timestamp) -> date:
+    if isinstance(value, datetime) or isinstance(value, pd.Timestamp):
+        return pd.to_datetime(value).date()
+    if isinstance(value, date):
+        return value
+    return pd.to_datetime(value).date()
+
+
+# ---------------------------------------------------------------------------
+# Layer A reader — long format
+# ---------------------------------------------------------------------------
+
+
+def load_thematic_features(
+    start: str | date,
+    end: str | date,
+    path: str | Path | None = None,
+) -> pd.DataFrame:
+    """Load Layer A features filtered to ``start <= asof_date <= end``.
+
+    Returns a DataFrame sorted by ``(symbol, asof_date)`` ascending so that
+    byte-identical inputs return byte-identical outputs.
+    """
+    p = Path(path) if path is not None else DEFAULT_FEATURES_PATH
+    if not p.exists():
+        raise FileNotFoundError(p)
+
+    df = pd.read_parquet(p)
+    start_d = _coerce_date(start)
+    end_d = _coerce_date(end)
+    df["asof_date"] = pd.to_datetime(df["asof_date"]).dt.date
+    df = df.loc[(df["asof_date"] >= start_d) & (df["asof_date"] <= end_d)]
+    df = df.sort_values(["symbol", "asof_date"]).reset_index(drop=True)
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Wide panel — MultiIndex (asof_date, symbol) x features
+# ---------------------------------------------------------------------------
+
+
+def load_thematic_panel(
+    features: list[str],
+    start: str | date,
+    end: str | date,
+    path: str | Path | None = None,
+) -> pd.DataFrame:
+    """Return a wide panel indexed by ``(asof_date, symbol)`` with the
+    requested feature columns in the order supplied.
+
+    Shape: ``(n_dates * n_tickers, n_features)`` rows; downstream code can
+    convert to torch.Tensor via ``df.values.reshape(n_dates, n_tickers, n_feat)``.
+
+    Parameters
+    ----------
+    features:
+        List of feature column names. Order is preserved in the output columns.
+    start, end:
+        Inclusive date filter.
+    path:
+        Override for the Layer A parquet location.
+    """
+    long = load_thematic_features(start=start, end=end, path=path)
+    # Validate requested columns exist.
+    missing = [c for c in features if c not in long.columns]
+    if missing:
+        raise ValueError(f"requested features not in Layer A: {missing}")
+
+    panel = long.set_index(["asof_date", "symbol"])[features]
+    panel = panel.sort_index()
+    return panel
+
+
+# ---------------------------------------------------------------------------
+# Supervised — Layer A + B join
+# ---------------------------------------------------------------------------
+
+
+def load_supervised(
+    feature_cols: list[str],
+    label_cols: list[str],
+    start: str | date,
+    end: str | date,
+    features_path: str | Path | None = None,
+    labels_path: str | Path | None = None,
+    drop_incomplete_labels: bool = True,
+) -> pd.DataFrame:
+    """Join Layer A features with Layer B labels for supervised ML.
+
+    Parameters
+    ----------
+    feature_cols, label_cols:
+        Column lists from Layer A / Layer B respectively. Order is preserved
+        in the output: ``[asof_date, symbol, *feature_cols, *label_cols]``.
+    start, end:
+        Inclusive ``asof_date`` filter.
+    features_path, labels_path:
+        Cache-path overrides.
+    drop_incomplete_labels:
+        When True (default), rows lacking a complete set of labels (any NaN
+        in the most-restrictive label, ``fwd_30d_ret``) are filtered out.
+        When False, the join keeps incomplete rows so callers can inspect.
+    """
+    f = Path(features_path) if features_path is not None else DEFAULT_FEATURES_PATH
+    l = Path(labels_path) if labels_path is not None else DEFAULT_LABELS_PATH
+    if not f.exists():
+        raise FileNotFoundError(f)
+    if not l.exists():
+        raise FileNotFoundError(l)
+
+    start_d = _coerce_date(start)
+    end_d = _coerce_date(end)
+
+    features = pd.read_parquet(f)
+    labels = pd.read_parquet(l)
+    features["asof_date"] = pd.to_datetime(features["asof_date"]).dt.date
+    labels["asof_date"] = pd.to_datetime(labels["asof_date"]).dt.date
+
+    # Project to requested cols + identity
+    feat_proj = features.loc[
+        (features["asof_date"] >= start_d) & (features["asof_date"] <= end_d),
+        ["asof_date", "symbol", *feature_cols],
+    ]
+    label_proj = labels.loc[
+        (labels["asof_date"] >= start_d) & (labels["asof_date"] <= end_d),
+        ["asof_date", "symbol", *label_cols],
+    ]
+
+    joined = feat_proj.merge(label_proj, on=["asof_date", "symbol"], how="inner")
+    if drop_incomplete_labels:
+        # Most-restrictive label: prefer fwd_30d_ret if requested, else the
+        # longest-horizon column among label_cols (largest N in fwd_Nd_ret).
+        gate_col = _most_restrictive_label(label_cols)
+        if gate_col and gate_col in joined.columns:
+            joined = joined.loc[joined[gate_col].notna()].reset_index(drop=True)
+
+    joined = joined.sort_values(["symbol", "asof_date"]).reset_index(drop=True)
+    return joined
+
+
+def _most_restrictive_label(label_cols: list[str]) -> str | None:
+    """Pick the label column with the longest forward horizon.
+
+    Heuristic: among requested labels, prefer ``fwd_30d_ret`` (the most-
+    restrictive in the §5.2 schema). If not requested, scan for any
+    ``fwd_<N>d_ret`` and return the largest N.
+    """
+    if "fwd_30d_ret" in label_cols:
+        return "fwd_30d_ret"
+    candidates: list[tuple[int, str]] = []
+    for c in label_cols:
+        if c.startswith("fwd_") and c.endswith("d_ret"):
+            try:
+                n = int(c.removeprefix("fwd_").removesuffix("d_ret"))
+                candidates.append((n, c))
+            except ValueError:
+                continue
+    if not candidates:
+        return None
+    return max(candidates, key=lambda x: x[0])[1]

--- a/src/rainier/research/breadth/ml_builders.py
+++ b/src/rainier/research/breadth/ml_builders.py
@@ -91,14 +91,23 @@ class ThematicTradingEnv:
 
         if action_space != "long_short_topk":
             raise ValueError(f"unknown action_space: {action_space}")
+        # `_after_cost` reward variants are reserved for a future cost-model
+        # injection. Accepting them today and silently stripping the suffix
+        # would alias them to the pre-cost label and hide that no cost is
+        # applied (codex iter-3 / iter-5 [P2]). Reject explicitly until the
+        # cost-adjusted labels land.
         if reward not in (
             "fwd_5d_excess_ret",
             "fwd_10d_excess_ret",
             "fwd_20d_excess_ret",
-            "fwd_5d_excess_ret_after_cost",
-            "fwd_10d_excess_ret_after_cost",
-            "fwd_20d_excess_ret_after_cost",
         ):
+            if reward.endswith("_after_cost"):
+                raise NotImplementedError(
+                    f"reward={reward!r} is reserved for cost-adjusted "
+                    f"labels which are not yet implemented. Use the "
+                    f"pre-cost variant (e.g. 'fwd_5d_excess_ret') or "
+                    f"inject a cost model in a follow-up PR."
+                )
             raise ValueError(f"unknown reward: {reward}")
 
         self.features = features.copy()
@@ -129,8 +138,10 @@ class ThematicTradingEnv:
         if self._step_idx >= len(self._dates):
             return self._observation(), 0.0, True, False, {}
         cur_date = self._dates[self._step_idx]
-        # Lookup excess returns on the labels frame for cur_date.
-        reward_col = self.reward.removesuffix("_after_cost")
+        # Lookup excess returns on the labels frame for cur_date. The
+        # constructor rejects `_after_cost` reward variants until cost-
+        # adjusted labels exist, so `self.reward` is always a real column.
+        reward_col = self.reward
         sub = self.labels.loc[self.labels["asof_date"] == cur_date]
         if not sub.empty and reward_col in sub.columns:
             # Align action to symbol order.

--- a/src/rainier/research/breadth/ml_builders.py
+++ b/src/rainier/research/breadth/ml_builders.py
@@ -1,0 +1,158 @@
+"""ML/RL panel builders + gym-style trading environment.
+
+Lazy gymnasium import — the gymnasium dep is loaded ONLY inside this module
+when ``ThematicTradingEnv`` is constructed. Importing this module itself does
+NOT require gymnasium; only the env class does.
+
+Design ref:
+    docs/DESIGN-thematic-ranks-dashboard.md §5.6 ([D-016]).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Wide panel builder (3D tensor-friendly)
+# ---------------------------------------------------------------------------
+
+
+def build_panel_tensor(
+    panel: pd.DataFrame,
+) -> tuple[np.ndarray, list, list, list]:
+    """Convert a wide-format panel (from ``load_thematic_panel``) into a
+    numpy 3D tensor of shape ``(n_dates, n_tickers, n_features)`` plus the
+    axis labels.
+
+    Returns
+    -------
+    arr:
+        ``np.ndarray`` of shape ``(n_dates, n_tickers, n_features)``.
+    dates, tickers, features:
+        Axis labels in the same order as the tensor dimensions.
+    """
+    if panel.empty:
+        return np.empty((0, 0, 0), dtype=np.float32), [], [], []
+
+    dates = sorted({d for d, _ in panel.index})
+    tickers = sorted({t for _, t in panel.index})
+    features = list(panel.columns)
+
+    arr = np.full(
+        (len(dates), len(tickers), len(features)), np.nan, dtype=np.float32
+    )
+    for i, d in enumerate(dates):
+        if d not in panel.index.get_level_values(0):
+            continue
+        sub = panel.loc[d]
+        for j, t in enumerate(tickers):
+            if t in sub.index:
+                arr[i, j, :] = sub.loc[t].values
+    return arr, dates, tickers, features
+
+
+# ---------------------------------------------------------------------------
+# Gym-style env (lazy gymnasium import)
+# ---------------------------------------------------------------------------
+
+
+class ThematicTradingEnv:
+    """A minimal gym-style env over the thematic panel.
+
+    Out of scope for this PR: actual training loop or RL agent (the env is the
+    deliverable; training is consumer responsibility).
+
+    Action space: ``long_short_topk`` — at each step the agent receives a
+    feature vector and produces a length-``n_tickers`` vector of {-1, 0, +1}
+    indicating short / hold / long. Reward = portfolio's realized
+    ``fwd_<reward_horizon>_excess_ret`` over the next ``reward_horizon`` days.
+    """
+
+    def __init__(
+        self,
+        features: pd.DataFrame,
+        labels: pd.DataFrame,
+        reward: str = "fwd_5d_excess_ret",
+        action_space: str = "long_short_topk",
+        k: int = 10,
+    ):
+        # Lazy gymnasium import — only enforced if the operator opts in.
+        # The env still works without gymnasium (the API is gym-shaped);
+        # consumers that want a strict gym.Env should subclass and inject.
+        try:
+            import gymnasium  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "ThematicTradingEnv requires the `gymnasium` package. "
+                "Install via: uv pip install gymnasium  (or "
+                "pip install '.[rl]')"
+            ) from exc
+
+        if action_space != "long_short_topk":
+            raise ValueError(f"unknown action_space: {action_space}")
+        if reward not in (
+            "fwd_5d_excess_ret",
+            "fwd_10d_excess_ret",
+            "fwd_20d_excess_ret",
+            "fwd_5d_excess_ret_after_cost",
+            "fwd_10d_excess_ret_after_cost",
+            "fwd_20d_excess_ret_after_cost",
+        ):
+            raise ValueError(f"unknown reward: {reward}")
+
+        self.features = features.copy()
+        self.labels = labels.copy()
+        self.reward = reward
+        self.action_space_kind = action_space
+        self.k = int(k)
+        self._step_idx = 0
+        self._dates = sorted(features.index.get_level_values(0).unique())
+
+    def reset(self) -> tuple[np.ndarray, dict]:
+        self._step_idx = 0
+        return self._observation(), {}
+
+    def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, bool, dict]:
+        """Execute one step.
+
+        Parameters
+        ----------
+        action:
+            Length-n_tickers vector of {-1, 0, +1}.
+
+        Returns
+        -------
+        observation, reward, terminated, truncated, info
+        """
+        # Reward = sum over tickers of action_i * fwd_excess_ret_i
+        if self._step_idx >= len(self._dates):
+            return self._observation(), 0.0, True, False, {}
+        cur_date = self._dates[self._step_idx]
+        # Lookup excess returns on the labels frame for cur_date.
+        reward_col = self.reward.removesuffix("_after_cost")
+        sub = self.labels.loc[self.labels["asof_date"] == cur_date]
+        if not sub.empty and reward_col in sub.columns:
+            # Align action to symbol order.
+            sub_sorted = sub.sort_values("symbol").reset_index(drop=True)
+            rets = sub_sorted[reward_col].fillna(0.0).to_numpy(dtype=np.float32)
+            if action.shape[0] != rets.shape[0]:
+                # Pad / truncate to match.
+                if action.shape[0] < rets.shape[0]:
+                    pad = np.zeros(rets.shape[0] - action.shape[0], dtype=action.dtype)
+                    action = np.concatenate([action, pad])
+                else:
+                    action = action[: rets.shape[0]]
+            r = float(np.dot(action, rets))
+        else:
+            r = 0.0
+        self._step_idx += 1
+        terminated = self._step_idx >= len(self._dates)
+        return self._observation(), r, terminated, False, {"date": str(cur_date)}
+
+    def _observation(self) -> np.ndarray:
+        if self._step_idx >= len(self._dates):
+            return np.zeros(0, dtype=np.float32)
+        cur_date = self._dates[self._step_idx]
+        sub = self.features.loc[cur_date]
+        return sub.values.astype(np.float32).flatten()

--- a/src/rainier/research/breadth/ranks.py
+++ b/src/rainier/research/breadth/ranks.py
@@ -309,7 +309,15 @@ def compute_thematic_features(
         prev_rank = prev_rank_by_sym.get(sym)
         prev_streak = prev_streak_by_sym.get(sym, 0)
 
-        if pd.notna(rank_v) and prev_rank is not None:
+        # rank_delta_1d: treat the int8 -1 sentinel from prior_features as
+        # "missing rank, neutral delta" — otherwise the first day a ticker
+        # becomes rankable would record a spurious `rank_v + 1` jump (codex
+        # iter-3 [P2]).
+        if (
+            pd.notna(rank_v)
+            and prev_rank is not None
+            and int(prev_rank) >= 0
+        ):
             rd1 = int(rank_v) - int(prev_rank)
         else:
             rd1 = 0

--- a/src/rainier/research/breadth/ranks.py
+++ b/src/rainier/research/breadth/ranks.py
@@ -1,0 +1,575 @@
+"""Compute Layer A point-in-time features + Layer B forward-return labels.
+
+Layer A: provably look-ahead-clean per-(asof_date, symbol) row of stationary
+features. Layer B: per-(asof_date, symbol) row of T+N forward returns. Both
+deterministic on byte-identical input.
+
+Design ref:
+    docs/DESIGN-thematic-ranks-dashboard.md §5.1 (Layer A schema),
+                                            §5.2 (Layer B schema),
+                                            §3   (REL/R/Rank arithmetic),
+                                            [D-002] windows {5,10,20},
+                                            [D-003] rank = round(mean(r_5,r_10,r_20)),
+                                            [D-008] centile scaling 0-99,
+                                            [D-013] vol-norm fixed N=20,
+                                            [D-014] top15_streak threshold rank>=85.
+
+ASCII flow (Layer A, single asof_date T):
+
+    panel(symbol, date, close, ...)
+            |
+            v
+    for each window N in {5,10,20}:
+        REL_N(s, T) = close(s, T) / close(s, T - N_trading_days) - 1
+            |
+            v
+        rank within universe (scipy rankdata method='average')
+            |
+            v
+        R_N = round((rank - 1) / (n - 1) * 99)  in [0, 99]
+            |
+            v
+    Rank = round(mean(R_5, R_10, R_20))
+            |
+            v
+    rank_delta_1d, rank_delta_5d, top15_streak  (from prev_features)
+            |
+            v
+    DataFrame[(symbol, asof_date), schema-stable columns]
+
+ASCII flow (Layer B):
+
+    panel(symbol, date, close, ...)
+            |
+            v
+    for each asof_date T:
+        fwd_Nd_ret(s, T) = close(s, T+N) / close(s, T) - 1
+            |
+            v
+        fwd_5d_excess_ret(s, T) = fwd_5d_ret(s, T) - mean(fwd_5d_ret(*, T))
+            |
+            v
+        rolling max(close[T:T+10]) -> runup
+        rolling min(close[T:T+10]) -> drawdown
+            |
+            v
+    label_complete_through = max asof_date with all fwd_30d defined
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Mapping
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+# Windows per [D-002]
+_REL_WINDOWS: tuple[int, ...] = (5, 10, 20)
+_VOL_WINDOW: int = 20  # [D-013] fixed N=20 vol denominator
+_PERSISTENCE_THRESHOLD: int = 85  # [D-014] top 15%
+_RANK_DELTA_5D_LOOKBACK: int = 5
+
+_FORWARD_RETURN_HORIZONS: tuple[int, ...] = (3, 5, 10, 20, 30)  # [D-012]
+_FORWARD_EXCESS_HORIZONS: tuple[int, ...] = (5, 10, 20)
+_DRAWDOWN_RUNUP_WINDOW: int = 10
+
+# Sentinel for "no rank computable" (e.g. ticker with <20d history). Stored as
+# int8 because the Rank composite column is int8; a NaN would force float64.
+_RANK_SENTINEL_MISSING: int = -1
+
+# ---------------------------------------------------------------------------
+# Layer A — point-in-time features
+# ---------------------------------------------------------------------------
+
+
+def _centile_rank(values: pd.Series) -> pd.Series:
+    """Map values to centiles 0..99 via scipy.stats.rankdata(method='average').
+
+    NaNs propagate (return NaN). Per [D-008]:
+        centile = round((rank - 1) / (n - 1) * 99)
+    where n = number of NON-NaN values in the series.
+    """
+    out = pd.Series(index=values.index, dtype="float64")
+    notna = values.notna()
+    sub = values[notna]
+    n = len(sub)
+    if n == 0:
+        out[:] = np.nan
+        return out
+    if n == 1:
+        # Single observation gets the top centile by convention (mid-range
+        # would also be defensible but produces a single-value series of
+        # NaN under the (n-1) denominator — pick 99 to avoid div-by-zero).
+        out.loc[notna] = 99.0
+        out.loc[~notna] = np.nan
+        return out
+    ranks = stats.rankdata(sub.values, method="average")
+    centiles = np.round((ranks - 1.0) / (n - 1.0) * 99.0)
+    out.loc[notna] = centiles
+    out.loc[~notna] = np.nan
+    return out
+
+
+def _ordinal_for(d: date, all_trading_days: list[date]) -> int:
+    """Return the 0-indexed ordinal of d within sorted all_trading_days.
+
+    Used for transformer positional encoding. Falls back to -1 if d not found.
+    """
+    try:
+        return all_trading_days.index(d)
+    except ValueError:
+        return -1
+
+
+def _trading_day_ordinal(d: date) -> int:
+    """Epoch-anchored integer ordinal (counts every calendar day, not just
+    trading days). We use calendar days to keep the function pure — no
+    NYSE-calendar dep needed — and the transformer only requires monotonicity.
+    """
+    epoch = date(1970, 1, 1)
+    return (d - epoch).days
+
+
+def compute_thematic_features(
+    panel: pd.DataFrame,
+    asof: date,
+    sector_map: Mapping[str, str],
+    ticker_registry: Mapping[str, int],
+    sector_registry: Mapping[str, int],
+    universe_yaml_sha: str,
+    prev_features: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """Compute Layer A features for one ``asof_date``.
+
+    Parameters
+    ----------
+    panel:
+        Long-format OHLCV (columns ``symbol``, ``date``, ``open``, ``high``,
+        ``low``, ``close``, ``volume``). At minimum must contain rows for
+        ``asof`` and (asof - 20 trading days) per symbol.
+    asof:
+        The T date being computed.
+    sector_map:
+        ``symbol -> sector_name``. Used for ``rank_minus_sector_mean``.
+    ticker_registry:
+        ``symbol -> ticker_id``. Stable per [D-015].
+    sector_registry:
+        ``sector_name -> sector_id``. Stable per [D-015].
+    universe_yaml_sha:
+        SHA-1 of the YAML universe in effect at ``asof``. Propagated to the
+        ``universe_yaml_sha`` column (audit + cache-key).
+    prev_features:
+        Optional output of a previous ``compute_thematic_features`` call (for
+        the most recent prior trading day). Required only for ``rank_delta_*``
+        and ``top15_streak`` — first-call use is permitted; deltas + streak
+        default to 0 in that case.
+
+    Returns
+    -------
+    pd.DataFrame with §5.1 schema, one row per symbol in the universe at
+    ``asof``.
+    """
+    if panel.empty:
+        return _empty_features_frame()
+
+    # Slice to data <= asof (defensive — never look forward).
+    cols_needed = {"symbol", "date", "close"}
+    missing = cols_needed - set(panel.columns)
+    if missing:
+        raise ValueError(f"panel missing columns: {sorted(missing)}")
+
+    panel = panel.loc[panel["date"] <= asof].copy()
+    if panel.empty:
+        return _empty_features_frame()
+
+    # All trading days seen across the input (per-symbol may differ but the
+    # universe trading calendar is the union).
+    all_days = sorted(panel["date"].unique())
+    if asof not in panel["date"].values:
+        # asof is not a trading day per the panel; return empty.
+        return _empty_features_frame()
+    asof_idx = all_days.index(asof)
+
+    # Pivot to wide close: index=date, columns=symbol.
+    wide_close = (
+        panel.pivot_table(index="date", columns="symbol", values="close", aggfunc="last")
+        .sort_index()
+    )
+
+    # Symbols present in the asof row (drop symbols without a close on asof).
+    asof_close = wide_close.loc[asof].dropna()
+    symbols_asof = asof_close.index.tolist()
+
+    # ---- Raw returns and REL_N ----
+    rows: list[dict] = []
+    rel_values: dict[int, pd.Series] = {}  # window -> series indexed by symbol
+    for window in _REL_WINDOWS:
+        prior_idx = asof_idx - window
+        if prior_idx < 0:
+            # Not enough history to compute this window — all-NaN series.
+            rel_values[window] = pd.Series(np.nan, index=symbols_asof)
+            continue
+        prior_day = all_days[prior_idx]
+        prior_row = wide_close.loc[prior_day]
+        # Per-symbol REL_N: NaN if prior is NaN (insufficient history).
+        rel = asof_close / prior_row - 1.0
+        rel_values[window] = rel.reindex(symbols_asof)
+
+    # ---- ret_1d ----
+    if asof_idx >= 1:
+        ret_1d_row = asof_close / wide_close.loc[all_days[asof_idx - 1]] - 1.0
+    else:
+        ret_1d_row = pd.Series(np.nan, index=symbols_asof)
+    ret_1d_row = ret_1d_row.reindex(symbols_asof)
+
+    # ---- Realized vol over fixed 20-day window (std of daily log returns) ----
+    # Per [D-013] — fixed N=20 vol denominator for all relvol_N.
+    if asof_idx >= _VOL_WINDOW:
+        # Use simple returns (close/close.shift - 1) over the window.
+        window_close = wide_close.iloc[asof_idx - _VOL_WINDOW : asof_idx + 1]
+        rets = window_close.pct_change().iloc[1:]
+        vol_20 = rets.std(ddof=0)  # population std, deterministic
+    else:
+        vol_20 = pd.Series(np.nan, index=symbols_asof)
+    vol_20 = vol_20.reindex(symbols_asof)
+
+    # ---- YTD return ----
+    asof_year = asof.year
+    # Find last trading day of prior year present in the panel.
+    prior_year_days = [d for d in all_days if d.year < asof_year]
+    if prior_year_days:
+        last_prior_year = prior_year_days[-1]
+        ytd_base = wide_close.loc[last_prior_year]
+    else:
+        # If no prior-year data in panel, use the first available day for each
+        # symbol (best-effort; dashboard context only).
+        ytd_base = wide_close.iloc[0]
+    ret_ytd_row = (asof_close / ytd_base - 1.0).reindex(symbols_asof)
+
+    # ---- Centile ranks R_N within universe ----
+    r_values: dict[int, pd.Series] = {}
+    for window in _REL_WINDOWS:
+        r_values[window] = _centile_rank(rel_values[window])
+
+    # ---- Composite Rank = round(mean(R_5, R_10, R_20)) per [D-003] ----
+    # NaN propagates: if any R_N is NaN, Rank is NaN.
+    rank_df = pd.DataFrame(
+        {f"r_{w}": r_values[w] for w in _REL_WINDOWS},
+        index=symbols_asof,
+    )
+    rank_mean = rank_df.mean(axis=1, skipna=False)
+    rank_composite = rank_mean.round()
+
+    # ---- Sector mean and rank_minus_sector_mean ----
+    sector_means = {}
+    for sec_name in sorted({sector_map.get(s, "_unknown") for s in symbols_asof}):
+        sec_syms = [s for s in symbols_asof if sector_map.get(s, "_unknown") == sec_name]
+        sec_ranks = rank_composite.loc[sec_syms]
+        # NaN-skip mean for the sector reference.
+        sector_means[sec_name] = sec_ranks.mean(skipna=True)
+
+    # ---- prev_features lookup for rank_delta_1d / top15_streak ----
+    # rank_delta_1d uses previous asof_date's rank; if prev_features is the
+    # output of the immediately-prior asof, we use that.
+    prev_rank_by_sym: dict[str, float] = {}
+    prev_streak_by_sym: dict[str, int] = {}
+    if prev_features is not None and not prev_features.empty:
+        for row in prev_features.itertuples(index=False):
+            prev_rank_by_sym[row.symbol] = float(row.rank)
+            prev_streak_by_sym[row.symbol] = int(row.top15_streak)
+
+    # ---- rank_delta_5d: snap from this same asof's panel + 5d-prior compute ----
+    # We do NOT recompute 5d-prior here (caller may want to chain). For Phase B
+    # API simplicity: rank_delta_5d defaults to 0 unless prev_features carries
+    # a rank-5d-prior column — out of scope. Set to 0 sentinel for the row.
+    # Long-term improvement: cache the most-recent 5 prev_features.
+    rank_delta_5d = 0
+
+    universe_size = len(symbols_asof)
+    computed_at = pd.Timestamp(datetime.now(timezone.utc))
+
+    for sym in symbols_asof:
+        sec = sector_map.get(sym, "_unknown")
+        ticker_id = ticker_registry.get(sym, 0)
+        sector_id = sector_registry.get(sec, 0)
+        r5 = r_values[5].get(sym, np.nan)
+        r10 = r_values[10].get(sym, np.nan)
+        r20 = r_values[20].get(sym, np.nan)
+        rank_v = rank_composite.get(sym, np.nan)
+        prev_rank = prev_rank_by_sym.get(sym)
+        prev_streak = prev_streak_by_sym.get(sym, 0)
+
+        if pd.notna(rank_v) and prev_rank is not None:
+            rd1 = int(rank_v) - int(prev_rank)
+        else:
+            rd1 = 0
+
+        # Persistence streak: increments on rank>=85, resets to 0 otherwise.
+        if pd.notna(rank_v) and rank_v >= _PERSISTENCE_THRESHOLD:
+            streak = prev_streak + 1
+        else:
+            streak = 0
+
+        sec_mean = sector_means.get(sec, np.nan)
+        if pd.notna(rank_v) and pd.notna(sec_mean):
+            rms = float(rank_v) - float(sec_mean)
+        else:
+            rms = 0.0
+
+        # Relvol N: rel_N / vol_20 (vol_20 in raw returns space). Defensive
+        # zero-vol guard: if vol_20 == 0 we get inf; clamp to NaN.
+        def _relvol(rel: float, v: float) -> float:
+            if pd.isna(rel) or pd.isna(v) or v == 0:
+                return float("nan")
+            return rel / v
+
+        rel5 = rel_values[5].get(sym, np.nan)
+        rel10 = rel_values[10].get(sym, np.nan)
+        rel20 = rel_values[20].get(sym, np.nan)
+        v20 = vol_20.get(sym, np.nan)
+
+        # Convert NaN ranks to sentinel for int8 storage.
+        def _r_int8(x: float) -> int:
+            if pd.isna(x):
+                return _RANK_SENTINEL_MISSING
+            return int(x)
+
+        rows.append(
+            {
+                "asof_date": asof,
+                "trading_day_ordinal": np.int32(_trading_day_ordinal(asof)),
+                "symbol": sym,
+                "ticker_id": np.int16(ticker_id),
+                "sector_id": np.int8(sector_id),
+                "close": float(asof_close[sym]),
+                "ret_1d": np.float32(ret_1d_row.get(sym, np.nan)),
+                "rel_5": np.float32(rel5 if pd.notna(rel5) else np.nan),
+                "rel_10": np.float32(rel10 if pd.notna(rel10) else np.nan),
+                "rel_20": np.float32(rel20 if pd.notna(rel20) else np.nan),
+                "ret_ytd": np.float32(ret_ytd_row.get(sym, np.nan)),
+                "relvol_5": np.float32(_relvol(rel5, v20)),
+                "relvol_10": np.float32(_relvol(rel10, v20)),
+                "relvol_20": np.float32(_relvol(rel20, v20)),
+                "r_5": np.int8(_r_int8(r5)),
+                "r_10": np.int8(_r_int8(r10)),
+                "r_20": np.int8(_r_int8(r20)),
+                "rank": np.int8(_r_int8(rank_v)),
+                "rank_delta_1d": np.int8(rd1),
+                "rank_delta_5d": np.int8(rank_delta_5d),
+                "top15_streak": np.int16(streak),
+                "rank_minus_sector_mean": np.float32(rms),
+                "universe_size": np.int16(universe_size),
+                "universe_yaml_sha": universe_yaml_sha,
+                "computed_at": computed_at,
+            }
+        )
+
+    df = pd.DataFrame(rows)
+    # Stable sort key: (symbol, asof_date)
+    df = df.sort_values(["symbol", "asof_date"]).reset_index(drop=True)
+    # Enforce dtypes (DataFrame ctor may upcast on mixed-NaN handling).
+    df = _enforce_features_dtypes(df)
+    return df
+
+
+def _empty_features_frame() -> pd.DataFrame:
+    """Return an empty DataFrame with the Layer A schema."""
+    cols = {
+        "asof_date": pd.Series(dtype="object"),
+        "trading_day_ordinal": pd.Series(dtype="int32"),
+        "symbol": pd.Series(dtype="object"),
+        "ticker_id": pd.Series(dtype="int16"),
+        "sector_id": pd.Series(dtype="int8"),
+        "close": pd.Series(dtype="float64"),
+        "ret_1d": pd.Series(dtype="float32"),
+        "rel_5": pd.Series(dtype="float32"),
+        "rel_10": pd.Series(dtype="float32"),
+        "rel_20": pd.Series(dtype="float32"),
+        "ret_ytd": pd.Series(dtype="float32"),
+        "relvol_5": pd.Series(dtype="float32"),
+        "relvol_10": pd.Series(dtype="float32"),
+        "relvol_20": pd.Series(dtype="float32"),
+        "r_5": pd.Series(dtype="int8"),
+        "r_10": pd.Series(dtype="int8"),
+        "r_20": pd.Series(dtype="int8"),
+        "rank": pd.Series(dtype="int8"),
+        "rank_delta_1d": pd.Series(dtype="int8"),
+        "rank_delta_5d": pd.Series(dtype="int8"),
+        "top15_streak": pd.Series(dtype="int16"),
+        "rank_minus_sector_mean": pd.Series(dtype="float32"),
+        "universe_size": pd.Series(dtype="int16"),
+        "universe_yaml_sha": pd.Series(dtype="object"),
+        "computed_at": pd.Series(dtype="datetime64[ns, UTC]"),
+    }
+    return pd.DataFrame(cols)
+
+
+def _enforce_features_dtypes(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return df
+    casts = {
+        "trading_day_ordinal": "int32",
+        "ticker_id": "int16",
+        "sector_id": "int8",
+        "close": "float64",
+        "ret_1d": "float32",
+        "rel_5": "float32",
+        "rel_10": "float32",
+        "rel_20": "float32",
+        "ret_ytd": "float32",
+        "relvol_5": "float32",
+        "relvol_10": "float32",
+        "relvol_20": "float32",
+        "r_5": "int8",
+        "r_10": "int8",
+        "r_20": "int8",
+        "rank": "int8",
+        "rank_delta_1d": "int8",
+        "rank_delta_5d": "int8",
+        "top15_streak": "int16",
+        "rank_minus_sector_mean": "float32",
+        "universe_size": "int16",
+    }
+    for col, dt in casts.items():
+        if col in df.columns:
+            df[col] = df[col].astype(dt)
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Layer B — forward-return labels
+# ---------------------------------------------------------------------------
+
+
+def compute_forward_labels(panel: pd.DataFrame) -> pd.DataFrame:
+    """Compute Layer B forward-return labels for every (asof_date, symbol)
+    pair in ``panel``.
+
+    The freshest computable row is `panel_end - max_horizon` (where
+    max_horizon = 30 trading days). Rows beyond that have NaN forward returns.
+
+    Returns one DataFrame with the §5.2 schema.
+    """
+    if panel.empty:
+        return _empty_labels_frame()
+
+    panel = panel.copy()
+    panel["date"] = pd.to_datetime(panel["date"]).dt.date
+
+    # Wide close pivot
+    wide = (
+        panel.pivot_table(index="date", columns="symbol", values="close", aggfunc="last")
+        .sort_index()
+    )
+    all_days = sorted(wide.index.tolist())
+    n_days = len(all_days)
+
+    # Determine label_complete_through: last asof_idx such that
+    # asof_idx + max_horizon < n_days.
+    max_h = max(_FORWARD_RETURN_HORIZONS)
+    if n_days <= max_h:
+        label_complete_through = all_days[0] if all_days else None
+    else:
+        label_complete_through = all_days[n_days - max_h - 1]
+
+    rows: list[dict] = []
+    symbols = list(wide.columns)
+
+    # Pre-compute forward returns matrices
+    # fwd_ret[N][asof_idx, sym] = close(T+N) / close(T) - 1, NaN if out-of-range
+    fwd_ret: dict[int, pd.DataFrame] = {}
+    for N in _FORWARD_RETURN_HORIZONS:
+        shifted = wide.shift(-N)
+        fwd_ret[N] = shifted / wide - 1.0
+
+    # Excess returns vs universe mean per horizon
+    fwd_excess: dict[int, pd.DataFrame] = {}
+    for N in _FORWARD_EXCESS_HORIZONS:
+        # axis=1 mean across symbols at each date.
+        universe_mean = fwd_ret[N].mean(axis=1, skipna=True)
+        fwd_excess[N] = fwd_ret[N].sub(universe_mean, axis=0)
+
+    # Drawdown + runup within the 10-day window:
+    #   fwd_10d_max_drawdown(T) = min over k in [1..10] of close(T+k)/close(T) - 1
+    #                              but only if negative — represented as positive
+    #                              magnitude (0 if no drawdown).
+    #   fwd_10d_max_runup(T)    = max over k in [1..10] of close(T+k)/close(T) - 1
+    #                              (0 if no runup).
+    drawdown = pd.DataFrame(np.nan, index=wide.index, columns=wide.columns)
+    runup = pd.DataFrame(np.nan, index=wide.index, columns=wide.columns)
+    W = _DRAWDOWN_RUNUP_WINDOW
+    for i in range(n_days - W):
+        slice_ = wide.iloc[i : i + W + 1]
+        base = slice_.iloc[0]
+        # Pct vs base for each day in [1..W]
+        rel = slice_.iloc[1:].div(base, axis=1) - 1.0
+        # max drawdown = absolute value of most-negative; clipped to >=0
+        dd = (-rel.min(axis=0)).clip(lower=0)
+        ru = rel.max(axis=0).clip(lower=0)
+        drawdown.iloc[i] = dd
+        runup.iloc[i] = ru
+
+    for asof_dt in all_days:
+        for sym in symbols:
+            close_t = wide.at[asof_dt, sym]
+            if pd.isna(close_t):
+                # Symbol not present on this asof — skip.
+                continue
+            row = {
+                "asof_date": asof_dt,
+                "symbol": sym,
+                "label_complete_through": label_complete_through,
+            }
+            for N in _FORWARD_RETURN_HORIZONS:
+                row[f"fwd_{N}d_ret"] = np.float32(fwd_ret[N].at[asof_dt, sym])
+            for N in _FORWARD_EXCESS_HORIZONS:
+                row[f"fwd_{N}d_excess_ret"] = np.float32(fwd_excess[N].at[asof_dt, sym])
+            row["fwd_10d_max_drawdown"] = np.float32(drawdown.at[asof_dt, sym])
+            row["fwd_10d_max_runup"] = np.float32(runup.at[asof_dt, sym])
+            rows.append(row)
+
+    df = pd.DataFrame(rows)
+    df = df.sort_values(["symbol", "asof_date"]).reset_index(drop=True)
+    return _enforce_labels_dtypes(df)
+
+
+def _empty_labels_frame() -> pd.DataFrame:
+    cols = {
+        "asof_date": pd.Series(dtype="object"),
+        "symbol": pd.Series(dtype="object"),
+        "fwd_3d_ret": pd.Series(dtype="float32"),
+        "fwd_5d_ret": pd.Series(dtype="float32"),
+        "fwd_10d_ret": pd.Series(dtype="float32"),
+        "fwd_20d_ret": pd.Series(dtype="float32"),
+        "fwd_30d_ret": pd.Series(dtype="float32"),
+        "fwd_5d_excess_ret": pd.Series(dtype="float32"),
+        "fwd_10d_excess_ret": pd.Series(dtype="float32"),
+        "fwd_20d_excess_ret": pd.Series(dtype="float32"),
+        "fwd_10d_max_drawdown": pd.Series(dtype="float32"),
+        "fwd_10d_max_runup": pd.Series(dtype="float32"),
+        "label_complete_through": pd.Series(dtype="object"),
+    }
+    return pd.DataFrame(cols)
+
+
+def _enforce_labels_dtypes(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return df
+    float32_cols = (
+        "fwd_3d_ret",
+        "fwd_5d_ret",
+        "fwd_10d_ret",
+        "fwd_20d_ret",
+        "fwd_30d_ret",
+        "fwd_5d_excess_ret",
+        "fwd_10d_excess_ret",
+        "fwd_20d_excess_ret",
+        "fwd_10d_max_drawdown",
+        "fwd_10d_max_runup",
+    )
+    for c in float32_cols:
+        if c in df.columns:
+            df[c] = df[c].astype("float32")
+    return df

--- a/src/rainier/research/breadth/ranks.py
+++ b/src/rainier/research/breadth/ranks.py
@@ -228,10 +228,14 @@ def compute_thematic_features(
         # fill_method=None: do NOT forward-fill internal NaNs before pct_change.
         # The default 'pad' behaviour silently turns gap days into 0% returns,
         # under-estimating vol_20 for sparse thematic ETFs (codex iter-6 [P2]).
-        # NaN returns propagate to std() which is what we want.
+        # skipna=False: codex iter-9 [P2] — pandas std() skips NaN by default,
+        # so a sparse symbol with even one missing close in the window would
+        # still emit a finite vol from a shrunken sample. Propagating NaN
+        # here forces the symbol's relvol_* to NaN, which is the safe
+        # behaviour for an incomplete window.
         window_close = wide_close.iloc[asof_idx - _VOL_WINDOW : asof_idx + 1]
         rets = window_close.pct_change(fill_method=None).iloc[1:]
-        vol_20 = rets.std(ddof=0)  # population std, deterministic
+        vol_20 = rets.std(ddof=0, skipna=False)  # population std, deterministic
     else:
         vol_20 = pd.Series(np.nan, index=symbols_asof)
     vol_20 = vol_20.reindex(symbols_asof)
@@ -543,9 +547,16 @@ def compute_forward_labels(panel: pd.DataFrame) -> pd.DataFrame:
         base = slice_.iloc[0]
         # Pct vs base for each day in [1..W]
         rel = slice_.iloc[1:].div(base, axis=1) - 1.0
+        # codex iter-9 [P2]: pandas min()/max() skip NaN by default, so a
+        # symbol with even one missing close inside the window would emit a
+        # drawdown/runup computed from a partial path. Mark symbols missing
+        # any forward close in [T+1..T+10] as NaN.
+        complete = rel.notna().all(axis=0)
         # max drawdown = absolute value of most-negative; clipped to >=0
         dd = (-rel.min(axis=0)).clip(lower=0)
         ru = rel.max(axis=0).clip(lower=0)
+        dd = dd.where(complete, np.nan)
+        ru = ru.where(complete, np.nan)
         drawdown.iloc[i] = dd
         runup.iloc[i] = ru
 

--- a/src/rainier/research/breadth/ranks.py
+++ b/src/rainier/research/breadth/ranks.py
@@ -190,6 +190,14 @@ def compute_thematic_features(
     # Symbols present in the asof row (drop symbols without a close on asof).
     asof_close = wide_close.loc[asof].dropna()
     symbols_asof = asof_close.index.tolist()
+    # Restrict to the active YAML universe so a cached panel that retains
+    # removed tickers does NOT pollute cross-sectional ranks or universe_size
+    # (codex iter-7 [P2]). When sector_map is empty (defensive), keep all
+    # symbols — the explicit YAML cohort is the source of truth.
+    if sector_map:
+        active = set(sector_map.keys())
+        symbols_asof = [s for s in symbols_asof if s in active]
+        asof_close = asof_close.loc[symbols_asof]
 
     # ---- Raw returns and REL_N ----
     rows: list[dict] = []

--- a/src/rainier/research/breadth/ranks.py
+++ b/src/rainier/research/breadth/ranks.py
@@ -112,17 +112,6 @@ def _centile_rank(values: pd.Series) -> pd.Series:
     return out
 
 
-def _ordinal_for(d: date, all_trading_days: list[date]) -> int:
-    """Return the 0-indexed ordinal of d within sorted all_trading_days.
-
-    Used for transformer positional encoding. Falls back to -1 if d not found.
-    """
-    try:
-        return all_trading_days.index(d)
-    except ValueError:
-        return -1
-
-
 def _trading_day_ordinal(d: date) -> int:
     """Epoch-anchored integer ordinal (counts every calendar day, not just
     trading days). We use calendar days to keep the function pure — no
@@ -280,12 +269,31 @@ def compute_thematic_features(
             prev_rank_by_sym[row.symbol] = float(row.rank)
             prev_streak_by_sym[row.symbol] = int(row.top15_streak)
 
-    # ---- rank_delta_5d: snap from this same asof's panel + 5d-prior compute ----
-    # We do NOT recompute 5d-prior here (caller may want to chain). For Phase B
-    # API simplicity: rank_delta_5d defaults to 0 unless prev_features carries
-    # a rank-5d-prior column — out of scope. Set to 0 sentinel for the row.
-    # Long-term improvement: cache the most-recent 5 prev_features.
-    rank_delta_5d = 0
+    # ---- rank_delta_5d: compute the composite rank 5 trading days ago and diff ----
+    # This is a single-shot recomputation against the same panel (no prev_features
+    # chain required). Cheap (one extra cross-sectional rankdata pass) and stays
+    # deterministic on the same input.
+    rank_5d_ago: pd.Series
+    prior_5_idx = asof_idx - _RANK_DELTA_5D_LOOKBACK
+    if prior_5_idx >= 0:
+        prior_5_day = all_days[prior_5_idx]
+        prior_5_close = wide_close.loc[prior_5_day]
+        # Recompute REL_N at prior_5 using the same windows; this gives us the
+        # historical rank at that day under the *current* universe membership
+        # (correct for rank_delta_5d under the [D-015] stable-id discipline).
+        prior_r: dict[int, pd.Series] = {}
+        for window in _REL_WINDOWS:
+            pp_idx = prior_5_idx - window
+            if pp_idx < 0:
+                prior_r[window] = pd.Series(np.nan, index=symbols_asof)
+                continue
+            pp_day = all_days[pp_idx]
+            rel_pp = prior_5_close / wide_close.loc[pp_day] - 1.0
+            prior_r[window] = _centile_rank(rel_pp.reindex(symbols_asof))
+        prior_rank_df = pd.DataFrame(prior_r, index=symbols_asof)
+        rank_5d_ago = prior_rank_df.mean(axis=1, skipna=False).round()
+    else:
+        rank_5d_ago = pd.Series(np.nan, index=symbols_asof)
 
     universe_size = len(symbols_asof)
     computed_at = pd.Timestamp(datetime.now(timezone.utc))
@@ -305,6 +313,12 @@ def compute_thematic_features(
             rd1 = int(rank_v) - int(prev_rank)
         else:
             rd1 = 0
+
+        rank_5d = rank_5d_ago.get(sym, np.nan)
+        if pd.notna(rank_v) and pd.notna(rank_5d):
+            rd5 = int(rank_v) - int(rank_5d)
+        else:
+            rd5 = 0
 
         # Persistence streak: increments on rank>=85, resets to 0 otherwise.
         if pd.notna(rank_v) and rank_v >= _PERSISTENCE_THRESHOLD:
@@ -357,7 +371,7 @@ def compute_thematic_features(
                 "r_20": np.int8(_r_int8(r20)),
                 "rank": np.int8(_r_int8(rank_v)),
                 "rank_delta_1d": np.int8(rd1),
-                "rank_delta_5d": np.int8(rank_delta_5d),
+                "rank_delta_5d": np.int8(rd5),
                 "top15_streak": np.int16(streak),
                 "rank_minus_sector_mean": np.float32(rms),
                 "universe_size": np.int16(universe_size),

--- a/src/rainier/research/breadth/ranks.py
+++ b/src/rainier/research/breadth/ranks.py
@@ -217,8 +217,12 @@ def compute_thematic_features(
     # Per [D-013] — fixed N=20 vol denominator for all relvol_N.
     if asof_idx >= _VOL_WINDOW:
         # Use simple returns (close/close.shift - 1) over the window.
+        # fill_method=None: do NOT forward-fill internal NaNs before pct_change.
+        # The default 'pad' behaviour silently turns gap days into 0% returns,
+        # under-estimating vol_20 for sparse thematic ETFs (codex iter-6 [P2]).
+        # NaN returns propagate to std() which is what we want.
         window_close = wide_close.iloc[asof_idx - _VOL_WINDOW : asof_idx + 1]
-        rets = window_close.pct_change().iloc[1:]
+        rets = window_close.pct_change(fill_method=None).iloc[1:]
         vol_20 = rets.std(ddof=0)  # population std, deterministic
     else:
         vol_20 = pd.Series(np.nan, index=symbols_asof)
@@ -489,10 +493,14 @@ def compute_forward_labels(panel: pd.DataFrame) -> pd.DataFrame:
     n_days = len(all_days)
 
     # Determine label_complete_through: last asof_idx such that
-    # asof_idx + max_horizon < n_days.
+    # asof_idx + max_horizon < n_days. When the panel is shorter than the
+    # longest forward horizon, NO row has a complete fwd_30d_ret — represent
+    # that as None rather than `all_days[0]`, otherwise downstream consumers
+    # that filter on this metadata would treat incomplete rows as trainable
+    # (codex iter-6 [P2]).
     max_h = max(_FORWARD_RETURN_HORIZONS)
     if n_days <= max_h:
-        label_complete_through = all_days[0] if all_days else None
+        label_complete_through = None
     else:
         label_complete_through = all_days[n_days - max_h - 1]
 

--- a/src/rainier/research/data_availability.yaml
+++ b/src/rainier/research/data_availability.yaml
@@ -1,1297 +1,5953 @@
-# Data-availability ledger — look-ahead control surface for the LLM-backtest
-# L3 evaluator. Every (symbol, field) pair the evaluator can read must be
-# registered here with an observability timestamp rule + revision-immutability
-# claim per DESIGN-qu100-llm-backtest.md [D-014].
-#
-# Schema:
-#   schema_version: integer; bump on any breaking shape change.
-#   entries: list of per-(dataset, symbol) records:
-#     dataset: string identifier for the cache (e.g., macro_context).
-#     symbol: normalized ticker (no ^-prefix; matches the parquet column).
-#     fields: list of fields the L3 evaluator may read AS-OF the
-#       observability_timestamp_rule. The parquet may contain additional
-#       columns (notably `adjusted_close`) that are NOT in this list — those
-#       are back-adjusted for future splits/dividends and CANNOT be used in
-#       look-ahead-controlled backtests. Code consuming the ledger MUST
-#       restrict reads to fields[]. Per codex iter-6.
-#     observability_timestamp_rule: one of:
-#       - end_of_trading_day  (T close fully observable at market-close T)
-#     revision_immutability: bool. true means the cache writer never
-#       UPDATE/DELETEs a historical row in place; --force cuts a new cohort
-#       file alongside the prior one.
-#     source: data provider (yfinance for macro_context Phase 0).
-#     yfinance_version_at_backfill: minimum yfinance version that the
-#       backfill script was developed/tested against. Per-row provenance is
-#       additionally recorded in the parquet's `yfinance_version` column.
-#     notes: free-form per-entry context (gaps, half-days, listing dates).
-#
-# Adding/removing a symbol from scripts/backfill_macro_context.py SYMBOLS
-# requires a matching update here in the same commit. The
-# tests/test_data_availability_yaml.py schema test enforces lockstep.
-
 schema_version: 1
-
 entries:
-  # ------------------------------------------------------------------
-  # Volatility / risk regime (4)
-  # ------------------------------------------------------------------
-  - dataset: macro_context
-    symbol: VIX
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: >
-      CBOE VIX index. yfinance wire ticker `^VIX`; normalized to `VIX` in the
-      stored `symbol` column. Volume is 0 for indices.
+- dataset: macro_context
+  symbol: VIX
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: 'CBOE VIX index. yfinance wire ticker `^VIX`; normalized to `VIX` in the
+    stored `symbol` column. Volume is 0 for indices.
 
-  - dataset: macro_context
-    symbol: VIX9D
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: >
-      9-day volatility; short end of VIX term structure. Wire `^VIX9D`.
-      Occasional missing dates (early-close half-days); gaps left absent.
+    '
+- dataset: macro_context
+  symbol: VIX9D
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: '9-day volatility; short end of VIX term structure. Wire `^VIX9D`. Occasional
+    missing dates (early-close half-days); gaps left absent.
 
-  - dataset: macro_context
-    symbol: VIX3M
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: >
-      3-month volatility; long end of VIX term structure. Wire `^VIX3M`.
+    '
+- dataset: macro_context
+  symbol: VIX3M
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: '3-month volatility; long end of VIX term structure. Wire `^VIX3M`.
 
-  - dataset: macro_context
-    symbol: UVXY
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: >
-      Leveraged VIX short-term futures ETF; regime-shift detector.
+    '
+- dataset: macro_context
+  symbol: UVXY
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: 'Leveraged VIX short-term futures ETF; regime-shift detector.
 
-  # ------------------------------------------------------------------
-  # Benchmarks / size buckets (4)
-  # ------------------------------------------------------------------
-  - dataset: macro_context
-    symbol: SPY
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Large-cap broad-market benchmark.
+    '
+- dataset: macro_context
+  symbol: SPY
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Large-cap broad-market benchmark.
+- dataset: macro_context
+  symbol: QQQ
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Nasdaq-100 large-cap growth benchmark.
+- dataset: macro_context
+  symbol: DIA
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Dow Jones 30 blue-chip benchmark.
+- dataset: macro_context
+  symbol: IWM
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Russell 2000 small-cap benchmark.
+- dataset: macro_context
+  symbol: XLK
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Technology SPDR.
+- dataset: macro_context
+  symbol: XLF
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Financials SPDR.
+- dataset: macro_context
+  symbol: XLE
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Energy SPDR.
+- dataset: macro_context
+  symbol: XLV
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Health Care SPDR.
+- dataset: macro_context
+  symbol: XLI
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Industrials SPDR.
+- dataset: macro_context
+  symbol: XLY
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Consumer Discretionary SPDR.
+- dataset: macro_context
+  symbol: XLP
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Consumer Staples SPDR.
+- dataset: macro_context
+  symbol: XLU
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Utilities SPDR.
+- dataset: macro_context
+  symbol: XLB
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Materials SPDR.
+- dataset: macro_context
+  symbol: XLRE
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Real Estate SPDR.
+- dataset: macro_context
+  symbol: XLC
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Communication Services SPDR.
+- dataset: macro_context
+  symbol: SMH
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: VanEck Semiconductor; operator-flagged very important for current trend.
+- dataset: macro_context
+  symbol: XBI
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: SPDR S&P Biotech; operator-flagged top priority.
+- dataset: macro_context
+  symbol: KRE
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: SPDR Regional Banking; stress proxy.
+- dataset: macro_context
+  symbol: EEM
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: iShares MSCI Emerging Markets (broad EM).
+- dataset: macro_context
+  symbol: FXI
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: iShares China Large-Cap.
+- dataset: macro_context
+  symbol: KWEB
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: KraneShares CSI China Internet.
+- dataset: macro_context
+  symbol: USO
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: United States Oil Fund (crude oil).
+- dataset: macro_context
+  symbol: GDX
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: VanEck Gold Miners.
+- dataset: macro_context
+  symbol: SLV
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: iShares Silver Trust.
+- dataset: macro_context
+  symbol: TLT
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: iShares 20+ Year Treasury (long duration).
+- dataset: macro_context
+  symbol: HYG
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: iShares iBoxx HY Corporate Bond (credit spread proxy).
+- dataset: macro_context
+  symbol: IEF
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: iShares 7-10 Year Treasury (mid-curve duration).
+- dataset: macro_context
+  symbol: TIP
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: iShares TIPS (inflation-protected; with IEF gives real-yield regime).
+- dataset: macro_context
+  symbol: UUP
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Invesco US Dollar Index Fund (dollar-strength regime).
+- dataset: macro_context
+  symbol: IBIT
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: "iShares Bitcoin Trust (spot BTC). Listed 2024-01-11; data may start mid-window\
+    \ for very early backfill dates \u2014 acceptance criterion allows per-symbol\
+    \ gaps for newer listings.\n"
+- dataset: macro_context
+  symbol: IREN
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: Iris Energy (single-stock; bitcoin-mining proxy).
+- dataset: macro_context
+  symbol: ARKK
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: ARK Innovation (speculative-growth / risk-on).
+- dataset: qu100_history
+  symbol: null
+  fields:
+  - data_date
+  - ranking_type
+  - symbol
+  - rank
+  - sector
+  - industry
+  - long_short
+  observability_timestamp_rule: qu_session_close
+  revision_immutability: true
+  source: quantunicorn
+  notes: 'money_flow_snapshots filtered to ranking_type=''top100''. Daily refresh
+    at QU close session; older rows never UPDATE/DELETE. Survivorship gate (CLI: `llm-research
+    survivorship-check`) validates this property.
 
-  - dataset: macro_context
-    symbol: QQQ
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Nasdaq-100 large-cap growth benchmark.
+    '
+- dataset: qu100_ohlcv
+  symbol: null
+  fields:
+  - date
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  notes: 'Per-symbol daily candles for each QU100 member, cached under data/cache/stocks/<SYMBOL>.parquet.
+    yfinance back-adjustment risk for splits/dividends is handled by the loader (adjusted_close
+    excluded from the look-ahead ledger; raw OHLC is point-in-time).
 
-  - dataset: macro_context
-    symbol: DIA
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Dow Jones 30 blue-chip benchmark.
+    '
+- dataset: chart_image
+  symbol: null
+  fields:
+  - ticker
+  - date
+  - sha256
+  - chart_render_version
+  observability_timestamp_rule: derived_from_t_minus_1_close
+  revision_immutability: true
+  source: chart_export
+  notes: "Deterministic chart PNG per (ticker, date). Same inputs \u2192 byte-identical\
+    \ output (D-025 contract). Cache key includes chart_render_version SHA so bumping\
+    \ the renderer invalidates downstream LLM cache hits.\n"
+- dataset: signals_pinbar
+  symbol: null
+  fields:
+  - ticker
+  - date
+  - direction
+  - body_ratio
+  - wick_ratio
+  - confidence
+  observability_timestamp_rule: derived_from_t_minus_1_close
+  revision_immutability: true
+  source: rainier.analysis.pinbar
+  notes: Pinbar detector output for the T-1 daily bar.
+- dataset: signals_sr
+  symbol: null
+  fields:
+  - ticker
+  - date
+  - level
+  - touches
+  - sr_type
+  - source_tf
+  observability_timestamp_rule: derived_from_t_minus_1_close
+  revision_immutability: true
+  source: rainier.analysis.sr_horizontal
+  notes: Support/resistance levels computed from history up to T-1 close.
+- dataset: signals_pivots
+  symbol: null
+  fields:
+  - ticker
+  - date
+  - kind
+  - index
+  - price
+  observability_timestamp_rule: derived_from_t_minus_1_close
+  revision_immutability: true
+  source: rainier.analysis.pivots
+  notes: Swing-pivot output (high/low/HH/LH/HL/LL).
+- dataset: signals_bias
+  symbol: null
+  fields:
+  - ticker
+  - date
+  - bias
+  observability_timestamp_rule: derived_from_t_minus_1_close
+  revision_immutability: true
+  source: rainier.analysis.bias
+  notes: Up/down/neutral bias derived from S/R + pivots.
+- dataset: money_flow_net
+  symbol: null
+  fields:
+  - ticker
+  - date
+  - net_flow_5d
+  observability_timestamp_rule: pending_sibling_task
+  revision_immutability: true
+  source: quantunicorn
+  pending: true
+  notes: 'Per-ticker net institutional inflow/outflow over last 5d. Daily QU rank
+    is already persisted (qu100_history); the per-ticker detail awaits a separate
+    backfill task. Field is registered as pending so the L3 evaluator rejects look-ups
+    until the backfill lands. See D-024.
 
-  - dataset: macro_context
-    symbol: IWM
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Russell 2000 small-cap benchmark.
-
-  # ------------------------------------------------------------------
-  # Sector SPDR ETFs (11)
-  # ------------------------------------------------------------------
-  - dataset: macro_context
-    symbol: XLK
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Technology SPDR.
-
-  - dataset: macro_context
-    symbol: XLF
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Financials SPDR.
-
-  - dataset: macro_context
-    symbol: XLE
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Energy SPDR.
-
-  - dataset: macro_context
-    symbol: XLV
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Health Care SPDR.
-
-  - dataset: macro_context
-    symbol: XLI
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Industrials SPDR.
-
-  - dataset: macro_context
-    symbol: XLY
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Consumer Discretionary SPDR.
-
-  - dataset: macro_context
-    symbol: XLP
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Consumer Staples SPDR.
-
-  - dataset: macro_context
-    symbol: XLU
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Utilities SPDR.
-
-  - dataset: macro_context
-    symbol: XLB
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Materials SPDR.
-
-  - dataset: macro_context
-    symbol: XLRE
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Real Estate SPDR.
-
-  - dataset: macro_context
-    symbol: XLC
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Communication Services SPDR.
-
-  # ------------------------------------------------------------------
-  # Theme / sub-sector (3) — operator-flagged priority for trending
-  # ------------------------------------------------------------------
-  - dataset: macro_context
-    symbol: SMH
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: VanEck Semiconductor; operator-flagged very important for current trend.
-
-  - dataset: macro_context
-    symbol: XBI
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: SPDR S&P Biotech; operator-flagged top priority.
-
-  - dataset: macro_context
-    symbol: KRE
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: SPDR Regional Banking; stress proxy.
-
-  # ------------------------------------------------------------------
-  # International (3)
-  # ------------------------------------------------------------------
-  - dataset: macro_context
-    symbol: EEM
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: iShares MSCI Emerging Markets (broad EM).
-
-  - dataset: macro_context
-    symbol: FXI
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: iShares China Large-Cap.
-
-  - dataset: macro_context
-    symbol: KWEB
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: KraneShares CSI China Internet.
-
-  # ------------------------------------------------------------------
-  # Commodities / hard assets (3)
-  # ------------------------------------------------------------------
-  - dataset: macro_context
-    symbol: USO
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: United States Oil Fund (crude oil).
-
-  - dataset: macro_context
-    symbol: GDX
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: VanEck Gold Miners.
-
-  - dataset: macro_context
-    symbol: SLV
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: iShares Silver Trust.
-
-  # ------------------------------------------------------------------
-  # Fixed income / rates (4)
-  # ------------------------------------------------------------------
-  - dataset: macro_context
-    symbol: TLT
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: iShares 20+ Year Treasury (long duration).
-
-  - dataset: macro_context
-    symbol: HYG
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: iShares iBoxx HY Corporate Bond (credit spread proxy).
-
-  - dataset: macro_context
-    symbol: IEF
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: iShares 7-10 Year Treasury (mid-curve duration).
-
-  - dataset: macro_context
-    symbol: TIP
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: iShares TIPS (inflation-protected; with IEF gives real-yield regime).
-
-  # ------------------------------------------------------------------
-  # Currency (1)
-  # ------------------------------------------------------------------
-  - dataset: macro_context
-    symbol: UUP
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Invesco US Dollar Index Fund (dollar-strength regime).
-
-  # ------------------------------------------------------------------
-  # Crypto / digital assets (2)
-  # ------------------------------------------------------------------
-  - dataset: macro_context
-    symbol: IBIT
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: >
-      iShares Bitcoin Trust (spot BTC). Listed 2024-01-11; data may start
-      mid-window for very early backfill dates — acceptance criterion allows
-      per-symbol gaps for newer listings.
-
-  - dataset: macro_context
-    symbol: IREN
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: Iris Energy (single-stock; bitcoin-mining proxy).
-
-  # ------------------------------------------------------------------
-  # Innovation / risk appetite (1)
-  # ------------------------------------------------------------------
-  - dataset: macro_context
-    symbol: ARKK
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: ARK Innovation (speculative-growth / risk-on).
-
-  # ------------------------------------------------------------------
-  # Slice 0 — QU100 historical universe (D-001, D-016)
-  # ------------------------------------------------------------------
-  # qu100_history rotates the universe daily; every (data_date, symbol) row
-  # is the QU rank for that ticker on that scrape session. Insert-only
-  # writes preserve delisted tickers per D-009 / D-016. The symbol column
-  # is null at the ledger level because the dataset is per-day, not
-  # per-ticker; survivorship-check / L3 evaluator query by data_date.
-  - dataset: qu100_history
-    symbol: null
-    fields: [data_date, ranking_type, symbol, rank, sector, industry, long_short]
-    observability_timestamp_rule: qu_session_close
-    revision_immutability: true
-    source: quantunicorn
-    notes: >
-      money_flow_snapshots filtered to ranking_type='top100'. Daily refresh
-      at QU close session; older rows never UPDATE/DELETE. Survivorship
-      gate (CLI: `llm-research survivorship-check`) validates this property.
-
-  # ------------------------------------------------------------------
-  # Slice 0 — Per-ticker daily OHLCV (D-004)
-  # ------------------------------------------------------------------
-  - dataset: qu100_ohlcv
-    symbol: null
-    fields: [date, open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    notes: >
-      Per-symbol daily candles for each QU100 member, cached under
-      data/cache/stocks/<SYMBOL>.parquet. yfinance back-adjustment risk for
-      splits/dividends is handled by the loader (adjusted_close excluded
-      from the look-ahead ledger; raw OHLC is point-in-time).
-
-  # ------------------------------------------------------------------
-  # Slice 0 — Chart image fingerprint (D-004, D-025)
-  # ------------------------------------------------------------------
-  - dataset: chart_image
-    symbol: null
-    fields: [ticker, date, sha256, chart_render_version]
-    observability_timestamp_rule: derived_from_t_minus_1_close
-    revision_immutability: true
-    source: chart_export
-    notes: >
-      Deterministic chart PNG per (ticker, date). Same inputs → byte-identical
-      output (D-025 contract). Cache key includes chart_render_version SHA so
-      bumping the renderer invalidates downstream LLM cache hits.
-
-  # ------------------------------------------------------------------
-  # Slice 0 — Per-symbol price-action signals (D-004)
-  # ------------------------------------------------------------------
-  # The signals/* outputs are computed as a pure function of OHLCV up to
-  # and including T-1 close. The ledger registers each signal family so the
-  # L3 evaluator can grep-match EvidencePack fields against the registry.
-  - dataset: signals_pinbar
-    symbol: null
-    fields: [ticker, date, direction, body_ratio, wick_ratio, confidence]
-    observability_timestamp_rule: derived_from_t_minus_1_close
-    revision_immutability: true
-    source: rainier.analysis.pinbar
-    notes: Pinbar detector output for the T-1 daily bar.
-
-  - dataset: signals_sr
-    symbol: null
-    fields: [ticker, date, level, touches, sr_type, source_tf]
-    observability_timestamp_rule: derived_from_t_minus_1_close
-    revision_immutability: true
-    source: rainier.analysis.sr_horizontal
-    notes: Support/resistance levels computed from history up to T-1 close.
-
-  - dataset: signals_pivots
-    symbol: null
-    fields: [ticker, date, kind, index, price]
-    observability_timestamp_rule: derived_from_t_minus_1_close
-    revision_immutability: true
-    source: rainier.analysis.pivots
-    notes: Swing-pivot output (high/low/HH/LH/HL/LL).
-
-  - dataset: signals_bias
-    symbol: null
-    fields: [ticker, date, bias]
-    observability_timestamp_rule: derived_from_t_minus_1_close
-    revision_immutability: true
-    source: rainier.analysis.bias
-    notes: Up/down/neutral bias derived from S/R + pivots.
-
-  # ------------------------------------------------------------------
-  # Slice 0 — QU per-ticker money-flow (D-024 deferred to backfill)
-  # ------------------------------------------------------------------
-  - dataset: money_flow_net
-    symbol: null
-    fields: [ticker, date, net_flow_5d]
-    observability_timestamp_rule: pending_sibling_task
-    revision_immutability: true
-    source: quantunicorn
-    pending: true
-    notes: >
-      Per-ticker net institutional inflow/outflow over last 5d. Daily QU rank
-      is already persisted (qu100_history); the per-ticker detail awaits a
-      separate backfill task. Field is registered as pending so the L3
-      evaluator rejects look-ups until the backfill lands. See D-024.
-
-  # ==================================================================
-  # thematic_universe dataset — operator-owned universe loaded from
-  # config/thematic_universe.yaml. Per DESIGN-thematic-ranks-dashboard.md
-  # §5.5: registers OHLCV observability for the ~94-ticker sector/theme
-  # ETF universe ranked by the dashboard (Phase B will compute Layer A
-  # features and add the thematic_features_daily + thematic_labels_daily
-  # blocks). adjusted_close intentionally NOT in fields[] — yfinance
-  # back-adjusts and the cache does not store it (see §5.0).
-  # ==================================================================
-  # ------------------------------------------------------------------
-  # communication_service (4)
-  # ------------------------------------------------------------------
-  - dataset: thematic_universe
-    symbol: XLC
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: communication_service
-  - dataset: thematic_universe
-    symbol: IYZ
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: communication_service
-  - dataset: thematic_universe
-    symbol: SOCL
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: communication_service
-  - dataset: thematic_universe
-    symbol: HERO
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: communication_service
-  # ------------------------------------------------------------------
-  # consumer_discretionary (6)
-  # ------------------------------------------------------------------
-  - dataset: thematic_universe
-    symbol: XLY
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: consumer_discretionary
-  - dataset: thematic_universe
-    symbol: ITB
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: consumer_discretionary
-  - dataset: thematic_universe
-    symbol: XHB
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: consumer_discretionary
-  - dataset: thematic_universe
-    symbol: IBUY
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: consumer_discretionary
-  - dataset: thematic_universe
-    symbol: ONLN
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: consumer_discretionary
-  - dataset: thematic_universe
-    symbol: PEJ
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: consumer_discretionary
-  # ------------------------------------------------------------------
-  # consumer_staples (2)
-  # ------------------------------------------------------------------
-  - dataset: thematic_universe
-    symbol: XLP
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: consumer_staples
-  - dataset: thematic_universe
-    symbol: XRT
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: consumer_staples
-  # ------------------------------------------------------------------
-  # energy (9)
-  # ------------------------------------------------------------------
-  - dataset: thematic_universe
-    symbol: XLE
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: energy
-  - dataset: thematic_universe
-    symbol: GUNR
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: energy
-  - dataset: thematic_universe
-    symbol: FCG
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: energy
-  - dataset: thematic_universe
-    symbol: XOP
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: energy
-  - dataset: thematic_universe
-    symbol: ICLN
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: energy
-  - dataset: thematic_universe
-    symbol: QCLN
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: energy
-  - dataset: thematic_universe
-    symbol: OIH
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: energy
-  - dataset: thematic_universe
-    symbol: TAN
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: energy
-  - dataset: thematic_universe
-    symbol: NLR
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: energy
-  # ------------------------------------------------------------------
-  # finance (7)
-  # ------------------------------------------------------------------
-  - dataset: thematic_universe
-    symbol: XLF
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: finance
-  - dataset: thematic_universe
-    symbol: VFH
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: finance
-  - dataset: thematic_universe
-    symbol: KRE
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: finance
-  - dataset: thematic_universe
-    symbol: KBE
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: finance
-  - dataset: thematic_universe
-    symbol: IAI
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: finance
-  - dataset: thematic_universe
-    symbol: KIE
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: finance
-  - dataset: thematic_universe
-    symbol: IPAY
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: finance
-  # ------------------------------------------------------------------
-  # healthcare (8)
-  # ------------------------------------------------------------------
-  - dataset: thematic_universe
-    symbol: XLV
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: healthcare
-  - dataset: thematic_universe
-    symbol: IBB
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: healthcare
-  - dataset: thematic_universe
-    symbol: XBI
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: healthcare
-  - dataset: thematic_universe
-    symbol: IHI
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: healthcare
-  - dataset: thematic_universe
-    symbol: IHF
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: healthcare
-  - dataset: thematic_universe
-    symbol: XHE
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: healthcare
-  - dataset: thematic_universe
-    symbol: XPH
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: healthcare
-  - dataset: thematic_universe
-    symbol: MJ
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: healthcare
-  # ------------------------------------------------------------------
-  # industrials (10)
-  # ------------------------------------------------------------------
-  - dataset: thematic_universe
-    symbol: XLI
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: industrials
-  - dataset: thematic_universe
-    symbol: ITA
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: industrials
-  - dataset: thematic_universe
-    symbol: ROKT
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: industrials
-  - dataset: thematic_universe
-    symbol: UFO
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: industrials
-  - dataset: thematic_universe
-    symbol: SHLD
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: industrials
-  - dataset: thematic_universe
-    symbol: BOTZ
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: industrials
-  - dataset: thematic_universe
-    symbol: IYT
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: industrials
-  - dataset: thematic_universe
-    symbol: JETS
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: industrials
-  - dataset: thematic_universe
-    symbol: SNSR
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: industrials
-  - dataset: thematic_universe
-    symbol: DRIV
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: industrials
-  # ------------------------------------------------------------------
-  # materials (9)
-  # ------------------------------------------------------------------
-  - dataset: thematic_universe
-    symbol: XLB
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: materials
-  - dataset: thematic_universe
-    symbol: GDX
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: materials
-  - dataset: thematic_universe
-    symbol: SIL
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: materials
-  - dataset: thematic_universe
-    symbol: COPX
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: materials
-  - dataset: thematic_universe
-    symbol: XME
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: materials
-  - dataset: thematic_universe
-    symbol: LIT
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: materials
-  - dataset: thematic_universe
-    symbol: IYM
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: materials
-  - dataset: thematic_universe
-    symbol: URA
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: materials
-  - dataset: thematic_universe
-    symbol: REMX
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: materials
-  # ------------------------------------------------------------------
-  # real_estate (5)
-  # ------------------------------------------------------------------
-  - dataset: thematic_universe
-    symbol: XLRE
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: real_estate
-  - dataset: thematic_universe
-    symbol: VNQ
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: real_estate
-  - dataset: thematic_universe
-    symbol: VNQI
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: real_estate
-  - dataset: thematic_universe
-    symbol: REET
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: real_estate
-  - dataset: thematic_universe
-    symbol: REM
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: real_estate
-  # ------------------------------------------------------------------
-  # technology (19)
-  # ------------------------------------------------------------------
-  - dataset: thematic_universe
-    symbol: XLK
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: CHAT
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: AIQ
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: IXN
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: QTEC
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: QTUM
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: VGT
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: SOXX
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: SMH
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: DRAM
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: IGV
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: FDN
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: KWEB
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: CIBR
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: HACK
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: SKYY
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: METV
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: FINX
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  - dataset: thematic_universe
-    symbol: XT
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: technology
-  # ------------------------------------------------------------------
-  # utilities (4)
-  # ------------------------------------------------------------------
-  - dataset: thematic_universe
-    symbol: XLU
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: utilities
-  - dataset: thematic_universe
-    symbol: IGF
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: utilities
-  - dataset: thematic_universe
-    symbol: PAVE
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: utilities
-  - dataset: thematic_universe
-    symbol: GRID
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: utilities
-  # ------------------------------------------------------------------
-  # thematic (11)
-  # ------------------------------------------------------------------
-  - dataset: thematic_universe
-    symbol: MEME
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: thematic
-  - dataset: thematic_universe
-    symbol: DXYZ
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: thematic
-  - dataset: thematic_universe
-    symbol: BLOK
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: thematic
-  - dataset: thematic_universe
-    symbol: IPO
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: thematic
-  - dataset: thematic_universe
-    symbol: MOAT
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: thematic
-  - dataset: thematic_universe
-    symbol: MOO
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: thematic
-  - dataset: thematic_universe
-    symbol: ARKK
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: thematic
-  - dataset: thematic_universe
-    symbol: ARKW
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: thematic
-  - dataset: thematic_universe
-    symbol: ARKF
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: thematic
-  - dataset: thematic_universe
-    symbol: ARKX
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: thematic
-  - dataset: thematic_universe
-    symbol: ARKQ
-    fields: [open, high, low, close, volume]
-    observability_timestamp_rule: end_of_trading_day
-    revision_immutability: true
-    source: yfinance
-    yfinance_version_at_backfill: "1.2.0"
-    sector: thematic
+    '
+- dataset: thematic_universe
+  symbol: XLC
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: communication_service
+- dataset: thematic_universe
+  symbol: IYZ
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: communication_service
+- dataset: thematic_universe
+  symbol: SOCL
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: communication_service
+- dataset: thematic_universe
+  symbol: HERO
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: communication_service
+- dataset: thematic_universe
+  symbol: XLY
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: consumer_discretionary
+- dataset: thematic_universe
+  symbol: ITB
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: consumer_discretionary
+- dataset: thematic_universe
+  symbol: XHB
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: consumer_discretionary
+- dataset: thematic_universe
+  symbol: IBUY
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: consumer_discretionary
+- dataset: thematic_universe
+  symbol: ONLN
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: consumer_discretionary
+- dataset: thematic_universe
+  symbol: PEJ
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: consumer_discretionary
+- dataset: thematic_universe
+  symbol: XLP
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: consumer_staples
+- dataset: thematic_universe
+  symbol: XRT
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: consumer_staples
+- dataset: thematic_universe
+  symbol: XLE
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: energy
+- dataset: thematic_universe
+  symbol: GUNR
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: energy
+- dataset: thematic_universe
+  symbol: FCG
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: energy
+- dataset: thematic_universe
+  symbol: XOP
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: energy
+- dataset: thematic_universe
+  symbol: ICLN
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: energy
+- dataset: thematic_universe
+  symbol: QCLN
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: energy
+- dataset: thematic_universe
+  symbol: OIH
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: energy
+- dataset: thematic_universe
+  symbol: TAN
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: energy
+- dataset: thematic_universe
+  symbol: NLR
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: energy
+- dataset: thematic_universe
+  symbol: XLF
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: finance
+- dataset: thematic_universe
+  symbol: VFH
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: finance
+- dataset: thematic_universe
+  symbol: KRE
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: finance
+- dataset: thematic_universe
+  symbol: KBE
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: finance
+- dataset: thematic_universe
+  symbol: IAI
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: finance
+- dataset: thematic_universe
+  symbol: KIE
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: finance
+- dataset: thematic_universe
+  symbol: IPAY
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: finance
+- dataset: thematic_universe
+  symbol: XLV
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: healthcare
+- dataset: thematic_universe
+  symbol: IBB
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: healthcare
+- dataset: thematic_universe
+  symbol: XBI
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: healthcare
+- dataset: thematic_universe
+  symbol: IHI
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: healthcare
+- dataset: thematic_universe
+  symbol: IHF
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: healthcare
+- dataset: thematic_universe
+  symbol: XHE
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: healthcare
+- dataset: thematic_universe
+  symbol: XPH
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: healthcare
+- dataset: thematic_universe
+  symbol: MJ
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: healthcare
+- dataset: thematic_universe
+  symbol: XLI
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: industrials
+- dataset: thematic_universe
+  symbol: ITA
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: industrials
+- dataset: thematic_universe
+  symbol: ROKT
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: industrials
+- dataset: thematic_universe
+  symbol: UFO
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: industrials
+- dataset: thematic_universe
+  symbol: SHLD
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: industrials
+- dataset: thematic_universe
+  symbol: BOTZ
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: industrials
+- dataset: thematic_universe
+  symbol: IYT
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: industrials
+- dataset: thematic_universe
+  symbol: JETS
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: industrials
+- dataset: thematic_universe
+  symbol: SNSR
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: industrials
+- dataset: thematic_universe
+  symbol: DRIV
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: industrials
+- dataset: thematic_universe
+  symbol: XLB
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: materials
+- dataset: thematic_universe
+  symbol: GDX
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: materials
+- dataset: thematic_universe
+  symbol: SIL
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: materials
+- dataset: thematic_universe
+  symbol: COPX
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: materials
+- dataset: thematic_universe
+  symbol: XME
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: materials
+- dataset: thematic_universe
+  symbol: LIT
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: materials
+- dataset: thematic_universe
+  symbol: IYM
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: materials
+- dataset: thematic_universe
+  symbol: URA
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: materials
+- dataset: thematic_universe
+  symbol: REMX
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: materials
+- dataset: thematic_universe
+  symbol: XLRE
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: real_estate
+- dataset: thematic_universe
+  symbol: VNQ
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: real_estate
+- dataset: thematic_universe
+  symbol: VNQI
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: real_estate
+- dataset: thematic_universe
+  symbol: REET
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: real_estate
+- dataset: thematic_universe
+  symbol: REM
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: real_estate
+- dataset: thematic_universe
+  symbol: XLK
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: CHAT
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: AIQ
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: IXN
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: QTEC
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: QTUM
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: VGT
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: SOXX
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: SMH
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: DRAM
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: IGV
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: FDN
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: KWEB
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: CIBR
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: HACK
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: SKYY
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: METV
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: FINX
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: XT
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: technology
+- dataset: thematic_universe
+  symbol: XLU
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: utilities
+- dataset: thematic_universe
+  symbol: IGF
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: utilities
+- dataset: thematic_universe
+  symbol: PAVE
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: utilities
+- dataset: thematic_universe
+  symbol: GRID
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: utilities
+- dataset: thematic_universe
+  symbol: MEME
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: thematic
+- dataset: thematic_universe
+  symbol: DXYZ
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: thematic
+- dataset: thematic_universe
+  symbol: BLOK
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: thematic
+- dataset: thematic_universe
+  symbol: IPO
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: thematic
+- dataset: thematic_universe
+  symbol: MOAT
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: thematic
+- dataset: thematic_universe
+  symbol: MOO
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: thematic
+- dataset: thematic_universe
+  symbol: ARKK
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: thematic
+- dataset: thematic_universe
+  symbol: ARKW
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: thematic
+- dataset: thematic_universe
+  symbol: ARKF
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: thematic
+- dataset: thematic_universe
+  symbol: ARKX
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: thematic
+- dataset: thematic_universe
+  symbol: ARKQ
+  fields:
+  - open
+  - high
+  - low
+  - close
+  - volume
+  observability_timestamp_rule: end_of_trading_day
+  revision_immutability: true
+  source: yfinance
+  yfinance_version_at_backfill: 1.2.0
+  sector: thematic
+- dataset: thematic_features_daily
+  symbol: XLC
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: communication_service
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IYZ
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: communication_service
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: SOCL
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: communication_service
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: HERO
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: communication_service
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XLY
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_discretionary
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: ITB
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_discretionary
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XHB
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_discretionary
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IBUY
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_discretionary
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: ONLN
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_discretionary
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: PEJ
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_discretionary
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XLP
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_staples
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XRT
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_staples
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XLE
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: GUNR
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: FCG
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XOP
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: ICLN
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: QCLN
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: OIH
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: TAN
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: NLR
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XLF
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: VFH
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: KRE
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: KBE
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IAI
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: KIE
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IPAY
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XLV
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IBB
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XBI
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IHI
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IHF
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XHE
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XPH
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: MJ
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XLI
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: ITA
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: ROKT
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: UFO
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: SHLD
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: BOTZ
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IYT
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: JETS
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: SNSR
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: DRIV
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XLB
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: GDX
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: SIL
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: COPX
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XME
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: LIT
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IYM
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: URA
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: REMX
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XLRE
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: real_estate
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: VNQ
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: real_estate
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: VNQI
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: real_estate
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: REET
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: real_estate
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: REM
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: real_estate
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XLK
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: CHAT
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: AIQ
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IXN
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: QTEC
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: QTUM
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: VGT
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: SOXX
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: SMH
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: DRAM
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IGV
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: FDN
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: KWEB
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: CIBR
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: HACK
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: SKYY
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: METV
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: FINX
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XT
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: XLU
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: utilities
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IGF
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: utilities
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: PAVE
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: utilities
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: GRID
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: utilities
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: MEME
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: DXYZ
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: BLOK
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: IPO
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: MOAT
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: MOO
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: ARKK
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: ARKW
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: ARKF
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: ARKX
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_features_daily
+  symbol: ARKQ
+  fields:
+  - rel_5
+  - rel_10
+  - rel_20
+  - ret_1d
+  - ret_ytd
+  - relvol_5
+  - relvol_10
+  - relvol_20
+  - r_5
+  - r_10
+  - r_20
+  - rank
+  - rank_delta_1d
+  - rank_delta_5d
+  - top15_streak
+  - rank_minus_sector_mean
+  observability_timestamp_rule: derived_from_eod
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+  compute_input_hash_inputs:
+  - thematic_universe.parquet
+  - thematic_universe_log.yaml_sha
+  - rainier_breadth_ranks_version
+- dataset: thematic_labels_daily
+  symbol: XLC
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: communication_service
+- dataset: thematic_labels_daily
+  symbol: IYZ
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: communication_service
+- dataset: thematic_labels_daily
+  symbol: SOCL
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: communication_service
+- dataset: thematic_labels_daily
+  symbol: HERO
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: communication_service
+- dataset: thematic_labels_daily
+  symbol: XLY
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_discretionary
+- dataset: thematic_labels_daily
+  symbol: ITB
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_discretionary
+- dataset: thematic_labels_daily
+  symbol: XHB
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_discretionary
+- dataset: thematic_labels_daily
+  symbol: IBUY
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_discretionary
+- dataset: thematic_labels_daily
+  symbol: ONLN
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_discretionary
+- dataset: thematic_labels_daily
+  symbol: PEJ
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_discretionary
+- dataset: thematic_labels_daily
+  symbol: XLP
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_staples
+- dataset: thematic_labels_daily
+  symbol: XRT
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: consumer_staples
+- dataset: thematic_labels_daily
+  symbol: XLE
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+- dataset: thematic_labels_daily
+  symbol: GUNR
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+- dataset: thematic_labels_daily
+  symbol: FCG
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+- dataset: thematic_labels_daily
+  symbol: XOP
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+- dataset: thematic_labels_daily
+  symbol: ICLN
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+- dataset: thematic_labels_daily
+  symbol: QCLN
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+- dataset: thematic_labels_daily
+  symbol: OIH
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+- dataset: thematic_labels_daily
+  symbol: TAN
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+- dataset: thematic_labels_daily
+  symbol: NLR
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: energy
+- dataset: thematic_labels_daily
+  symbol: XLF
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+- dataset: thematic_labels_daily
+  symbol: VFH
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+- dataset: thematic_labels_daily
+  symbol: KRE
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+- dataset: thematic_labels_daily
+  symbol: KBE
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+- dataset: thematic_labels_daily
+  symbol: IAI
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+- dataset: thematic_labels_daily
+  symbol: KIE
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+- dataset: thematic_labels_daily
+  symbol: IPAY
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: finance
+- dataset: thematic_labels_daily
+  symbol: XLV
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+- dataset: thematic_labels_daily
+  symbol: IBB
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+- dataset: thematic_labels_daily
+  symbol: XBI
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+- dataset: thematic_labels_daily
+  symbol: IHI
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+- dataset: thematic_labels_daily
+  symbol: IHF
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+- dataset: thematic_labels_daily
+  symbol: XHE
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+- dataset: thematic_labels_daily
+  symbol: XPH
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+- dataset: thematic_labels_daily
+  symbol: MJ
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: healthcare
+- dataset: thematic_labels_daily
+  symbol: XLI
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+- dataset: thematic_labels_daily
+  symbol: ITA
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+- dataset: thematic_labels_daily
+  symbol: ROKT
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+- dataset: thematic_labels_daily
+  symbol: UFO
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+- dataset: thematic_labels_daily
+  symbol: SHLD
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+- dataset: thematic_labels_daily
+  symbol: BOTZ
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+- dataset: thematic_labels_daily
+  symbol: IYT
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+- dataset: thematic_labels_daily
+  symbol: JETS
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+- dataset: thematic_labels_daily
+  symbol: SNSR
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+- dataset: thematic_labels_daily
+  symbol: DRIV
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: industrials
+- dataset: thematic_labels_daily
+  symbol: XLB
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+- dataset: thematic_labels_daily
+  symbol: GDX
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+- dataset: thematic_labels_daily
+  symbol: SIL
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+- dataset: thematic_labels_daily
+  symbol: COPX
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+- dataset: thematic_labels_daily
+  symbol: XME
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+- dataset: thematic_labels_daily
+  symbol: LIT
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+- dataset: thematic_labels_daily
+  symbol: IYM
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+- dataset: thematic_labels_daily
+  symbol: URA
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+- dataset: thematic_labels_daily
+  symbol: REMX
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: materials
+- dataset: thematic_labels_daily
+  symbol: XLRE
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: real_estate
+- dataset: thematic_labels_daily
+  symbol: VNQ
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: real_estate
+- dataset: thematic_labels_daily
+  symbol: VNQI
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: real_estate
+- dataset: thematic_labels_daily
+  symbol: REET
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: real_estate
+- dataset: thematic_labels_daily
+  symbol: REM
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: real_estate
+- dataset: thematic_labels_daily
+  symbol: XLK
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: CHAT
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: AIQ
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: IXN
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: QTEC
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: QTUM
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: VGT
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: SOXX
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: SMH
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: DRAM
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: IGV
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: FDN
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: KWEB
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: CIBR
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: HACK
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: SKYY
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: METV
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: FINX
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: XT
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: technology
+- dataset: thematic_labels_daily
+  symbol: XLU
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: utilities
+- dataset: thematic_labels_daily
+  symbol: IGF
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: utilities
+- dataset: thematic_labels_daily
+  symbol: PAVE
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: utilities
+- dataset: thematic_labels_daily
+  symbol: GRID
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: utilities
+- dataset: thematic_labels_daily
+  symbol: MEME
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+- dataset: thematic_labels_daily
+  symbol: DXYZ
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+- dataset: thematic_labels_daily
+  symbol: BLOK
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+- dataset: thematic_labels_daily
+  symbol: IPO
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+- dataset: thematic_labels_daily
+  symbol: MOAT
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+- dataset: thematic_labels_daily
+  symbol: MOO
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+- dataset: thematic_labels_daily
+  symbol: ARKK
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+- dataset: thematic_labels_daily
+  symbol: ARKW
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+- dataset: thematic_labels_daily
+  symbol: ARKF
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+- dataset: thematic_labels_daily
+  symbol: ARKX
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic
+- dataset: thematic_labels_daily
+  symbol: ARKQ
+  fields:
+  - fwd_3d_ret
+  - fwd_5d_ret
+  - fwd_10d_ret
+  - fwd_20d_ret
+  - fwd_30d_ret
+  - fwd_5d_excess_ret
+  - fwd_10d_excess_ret
+  - fwd_20d_excess_ret
+  - fwd_10d_max_drawdown
+  - fwd_10d_max_runup
+  observability_timestamp_rule: t_plus_n_close
+  revision_immutability: true
+  source: computed_locally
+  sector: thematic

--- a/src/rainier/research/data_availability_loader.py
+++ b/src/rainier/research/data_availability_loader.py
@@ -37,6 +37,13 @@ VALID_OBSERVABILITY_RULES: frozenset[str] = frozenset(
         # Available immediately on the day it's computed (signals derived from
         # T-1 close inputs; output is T-1-close itself).
         "derived_from_t_minus_1_close",
+        # Computed locally from end-of-day inputs (e.g. thematic features).
+        # Output is observable at T-close + compute latency.
+        "derived_from_eod",
+        # Forward-looking label: observable T+n trading days after the as-of
+        # date (e.g. thematic_labels_daily ret_fwd_5d only knows its value at
+        # T+5). The L3 evaluator must NOT serve these for as-of <= T+n-1.
+        "t_plus_n_close",
         # Pending an external dependency (sibling task). Treated as "unobservable
         # by default" — the L3 evaluator rejects look-ups against pending fields.
         "pending_sibling_task",

--- a/src/rainier/viz/thematic_dashboard.py
+++ b/src/rainier/viz/thematic_dashboard.py
@@ -80,10 +80,29 @@ _SORT_JS = """
 function sortTable(idx) {
   const table = document.getElementById('ranks');
   const tbody = table.tBodies[0];
-  const rows = Array.from(tbody.rows).filter(r => !r.classList.contains('sector-header'));
   const dir = table.dataset.sortDir === 'asc' ? 'desc' : 'asc';
   table.dataset.sortDir = dir;
-  rows.sort((a, b) => {
+
+  // Walk tbody rows once, partitioning into sector groups. Each group is
+  // {header: <tr.sector-header or null>, data: [<tr>, ...]}. We preserve
+  // group order from the rendered DOM and only re-sort the data rows
+  // within each group — keeps headers stuck to their rows on every click.
+  const groups = [];
+  let current = null;
+  Array.from(tbody.rows).forEach(r => {
+    if (r.classList.contains('sector-header')) {
+      current = { header: r, data: [] };
+      groups.push(current);
+    } else {
+      if (current === null) {
+        current = { header: null, data: [] };
+        groups.push(current);
+      }
+      current.data.push(r);
+    }
+  });
+
+  const cmp = (a, b) => {
     const va = a.cells[idx].dataset.sort || a.cells[idx].textContent;
     const vb = b.cells[idx].dataset.sort || b.cells[idx].textContent;
     const na = parseFloat(va);
@@ -92,8 +111,13 @@ function sortTable(idx) {
       return dir === 'asc' ? na - nb : nb - na;
     }
     return dir === 'asc' ? va.localeCompare(vb) : vb.localeCompare(va);
+  };
+
+  // Re-append in group order: header then sorted data rows.
+  groups.forEach(g => {
+    if (g.header) tbody.appendChild(g.header);
+    g.data.sort(cmp).forEach(r => tbody.appendChild(r));
   });
-  rows.forEach(r => tbody.appendChild(r));
 }
 """
 

--- a/src/rainier/viz/thematic_dashboard.py
+++ b/src/rainier/viz/thematic_dashboard.py
@@ -1,0 +1,246 @@
+"""Self-contained HTML dashboard for thematic ranks.
+
+Renders a sortable table grouped by sector with color-scaled R cells.
+Byte-identical render on byte-identical input (no timestamps, no UUIDs,
+no library-version strings embedded in the output).
+
+Design ref:
+    docs/DESIGN-thematic-ranks-dashboard.md §6 (architecture) + [D-009] (no
+    publish hook in v0 — render-only).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from html import escape
+from pathlib import Path
+
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Color scale — sequential green-to-red over [0, 99]
+# ---------------------------------------------------------------------------
+
+
+def _rank_color(rank: int) -> str:
+    """Map rank centile (0..99) to a hex color via a fixed gradient.
+
+    99 (top) -> green (#1b9e3a); 50 -> yellow (#dccd2c); 0 (bottom) -> red (#c92a2a).
+    Deterministic on identical input (no random / library calls).
+    Negative ranks (sentinel for missing data) → neutral gray.
+    """
+    if rank < 0:
+        return "#cccccc"
+    rank = max(0, min(99, int(rank)))
+    # Two-stop linear interp: 0 -> red; 50 -> yellow; 99 -> green.
+    if rank <= 50:
+        # red (201, 42, 42) -> yellow (220, 205, 44)
+        t = rank / 50.0
+        r = int(201 + (220 - 201) * t)
+        g = int(42 + (205 - 42) * t)
+        b = int(42 + (44 - 42) * t)
+    else:
+        # yellow (220, 205, 44) -> green (27, 158, 58)
+        t = (rank - 50) / 49.0
+        r = int(220 + (27 - 220) * t)
+        g = int(205 + (158 - 205) * t)
+        b = int(44 + (58 - 44) * t)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+
+_CSS = """
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui,
+       Roboto, "Helvetica Neue", Arial, sans-serif;
+       margin: 24px; color: #1f2933; background: #f7fafc; }
+h1 { font-size: 1.5rem; margin: 0 0 8px; }
+.subtitle { color: #52606d; margin: 0 0 24px; font-size: 0.9rem; }
+table { border-collapse: collapse; background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+        border-radius: 6px; overflow: hidden; }
+th, td { padding: 6px 12px; text-align: right; font-size: 0.85rem;
+         border-bottom: 1px solid #e4e7eb; }
+th { background: #f0f4f8; cursor: pointer; user-select: none;
+     text-align: right; font-weight: 600; }
+th:first-child, td:first-child { text-align: left; }
+th:nth-child(2), td:nth-child(2) { text-align: left; font-weight: 500; }
+.rank-cell { font-weight: 600; color: #fff; min-width: 28px;
+             text-align: center; padding: 6px 10px; }
+.sector-header td { background: #e4e7eb; font-weight: 700;
+                    padding: 8px 12px; text-align: left;
+                    text-transform: capitalize; font-size: 0.95rem; }
+.numeric { font-variant-numeric: tabular-nums; }
+"""
+
+
+_SORT_JS = """
+function sortTable(idx) {
+  const table = document.getElementById('ranks');
+  const tbody = table.tBodies[0];
+  const rows = Array.from(tbody.rows).filter(r => !r.classList.contains('sector-header'));
+  const dir = table.dataset.sortDir === 'asc' ? 'desc' : 'asc';
+  table.dataset.sortDir = dir;
+  rows.sort((a, b) => {
+    const va = a.cells[idx].dataset.sort || a.cells[idx].textContent;
+    const vb = b.cells[idx].dataset.sort || b.cells[idx].textContent;
+    const na = parseFloat(va);
+    const nb = parseFloat(vb);
+    if (!isNaN(na) && !isNaN(nb)) {
+      return dir === 'asc' ? na - nb : nb - na;
+    }
+    return dir === 'asc' ? va.localeCompare(vb) : vb.localeCompare(va);
+  });
+  rows.forEach(r => tbody.appendChild(r));
+}
+"""
+
+
+_COLUMN_SPECS = [
+    ("symbol", "Ticker", "text"),
+    ("sector_name", "Sector", "text"),
+    ("close", "Close", "float"),
+    ("ret_1d", "1d %", "pct"),
+    ("rel_5", "5d %", "pct"),
+    ("rel_10", "10d %", "pct"),
+    ("rel_20", "20d %", "pct"),
+    ("ret_ytd", "YTD %", "pct"),
+    ("r_5", "R5", "rank"),
+    ("r_10", "R10", "rank"),
+    ("r_20", "R20", "rank"),
+    ("rank", "Rank", "rank"),
+    ("top15_streak", "Streak", "int"),
+]
+
+
+def _format_cell(value, kind: str) -> tuple[str, str]:
+    """Return ``(display_text, sort_key)`` for the given value + type."""
+    if pd.isna(value):
+        return ("—", "")
+    if kind == "text":
+        return (str(value), str(value))
+    if kind == "float":
+        return (f"{value:.2f}", f"{value:.6f}")
+    if kind == "pct":
+        return (f"{value * 100:.2f}%", f"{value:.6f}")
+    if kind == "rank":
+        v = int(value)
+        if v < 0:
+            return ("—", "-1")
+        return (str(v), str(v))
+    if kind == "int":
+        return (str(int(value)), str(int(value)))
+    return (str(value), str(value))
+
+
+def render_dashboard(
+    features: pd.DataFrame,
+    out_path: str | Path,
+    asof: date,
+) -> Path:
+    """Render the thematic-ranks dashboard for a single ``asof_date``.
+
+    Parameters
+    ----------
+    features:
+        Long-format Layer A DataFrame. MUST include ``sector_name`` (the
+        renderer groups rows by sector for display). If absent, callers
+        should join sector_name onto the features before calling.
+    out_path:
+        Destination HTML file. Parent directory created if missing.
+    asof:
+        Display-only date for the header. Does not filter the input — the
+        caller projects ``features`` to the desired snapshot.
+    """
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    if features.empty:
+        out.write_text(_render_empty(asof))
+        return out
+
+    if "sector_name" not in features.columns:
+        # Defensive default: every ticker in 'unknown' sector.
+        features = features.copy()
+        features["sector_name"] = "unknown"
+
+    # Deterministic ordering: by (sector_name, -rank, symbol) for the initial
+    # table layout. Sort key is fully deterministic on the input DataFrame.
+    df = features.copy()
+    df = df.sort_values(
+        by=["sector_name", "rank", "symbol"],
+        ascending=[True, False, True],
+    ).reset_index(drop=True)
+
+    # Build HTML.
+    parts: list[str] = []
+    parts.append("<!DOCTYPE html>")
+    parts.append('<html lang="en"><head><meta charset="utf-8">')
+    parts.append(f"<title>Thematic Ranks — {asof.isoformat()}</title>")
+    parts.append(f"<style>{_CSS}</style>")
+    parts.append("</head><body>")
+    parts.append(f"<h1>Thematic Ranks — {asof.isoformat()}</h1>")
+    parts.append(
+        f'<p class="subtitle">Universe size: {len(df)} tickers; ranks computed '
+        f"vs cross-sectional universe. Click column headers to sort.</p>"
+    )
+    parts.append('<table id="ranks" data-sort-dir="asc">')
+
+    # Header row
+    parts.append("<thead><tr>")
+    for i, (_col, label, _kind) in enumerate(_COLUMN_SPECS):
+        parts.append(f'<th onclick="sortTable({i})">{escape(label)}</th>')
+    parts.append("</tr></thead><tbody>")
+
+    # Body: grouped by sector with a separator row per group.
+    for sector_name, sec_group in df.groupby("sector_name", sort=True):
+        parts.append(
+            f'<tr class="sector-header"><td colspan="{len(_COLUMN_SPECS)}">'
+            f"{escape(str(sector_name))}</td></tr>"
+        )
+        for _, row in sec_group.iterrows():
+            parts.append("<tr>")
+            for col, _label, kind in _COLUMN_SPECS:
+                if col not in row.index:
+                    parts.append("<td>—</td>")
+                    continue
+                text, sort_key = _format_cell(row[col], kind)
+                if kind == "rank":
+                    rank_val = int(row[col]) if pd.notna(row[col]) else -1
+                    color = _rank_color(rank_val)
+                    parts.append(
+                        f'<td class="rank-cell" data-sort="{escape(sort_key)}" '
+                        f'style="background:{color}">{escape(text)}</td>'
+                    )
+                elif kind in ("float", "pct", "int"):
+                    parts.append(
+                        f'<td class="numeric" data-sort="{escape(sort_key)}">'
+                        f"{escape(text)}</td>"
+                    )
+                else:
+                    parts.append(
+                        f'<td data-sort="{escape(sort_key)}">{escape(text)}</td>'
+                    )
+            parts.append("</tr>")
+
+    parts.append("</tbody></table>")
+    parts.append(f"<script>{_SORT_JS}</script>")
+    parts.append("</body></html>")
+
+    out.write_text("\n".join(parts), encoding="utf-8")
+    return out
+
+
+def _render_empty(asof: date) -> str:
+    return (
+        "<!DOCTYPE html>\n"
+        "<html><head><meta charset='utf-8'>"
+        f"<title>Thematic Ranks — {asof.isoformat()}</title>"
+        f"<style>{_CSS}</style>"
+        "</head><body>"
+        f"<h1>Thematic Ranks — {asof.isoformat()}</h1>"
+        "<p>No data for this asof_date.</p>"
+        "</body></html>"
+    )

--- a/tests/research/test_thematic_dashboard.py
+++ b/tests/research/test_thematic_dashboard.py
@@ -1,0 +1,151 @@
+"""Dashboard render tests — byte-identical on byte-identical input.
+
+Design ref: docs/DESIGN-thematic-ranks-dashboard.md §6 + [D-009].
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import date
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from rainier.viz.thematic_dashboard import render_dashboard
+
+
+def _build_features_df() -> pd.DataFrame:
+    """Build a deterministic features DataFrame for one asof_date."""
+    sectors = ["tech", "tech", "healthcare", "healthcare", "energy"]
+    symbols = ["AAA", "BBB", "CCC", "DDD", "EEE"]
+    sector_ids = [1, 1, 2, 2, 3]
+    ranks = [90, 70, 50, 30, 10]
+    rows = []
+    for i, sym in enumerate(symbols):
+        rows.append(
+            {
+                "asof_date": date(2024, 11, 8),
+                "trading_day_ordinal": np.int32(100),
+                "symbol": sym,
+                "ticker_id": np.int16(i + 1),
+                "sector_id": np.int8(sector_ids[i]),
+                "sector_name": sectors[i],
+                "close": np.float64(100.0 + i),
+                "ret_1d": np.float32(0.01),
+                "rel_5": np.float32(0.02),
+                "rel_10": np.float32(0.03),
+                "rel_20": np.float32(0.04),
+                "ret_ytd": np.float32(0.10),
+                "relvol_5": np.float32(0.5),
+                "relvol_10": np.float32(0.5),
+                "relvol_20": np.float32(0.5),
+                "r_5": np.int8(ranks[i]),
+                "r_10": np.int8(ranks[i]),
+                "r_20": np.int8(ranks[i]),
+                "rank": np.int8(ranks[i]),
+                "rank_delta_1d": np.int8(0),
+                "rank_delta_5d": np.int8(0),
+                "top15_streak": np.int16(0),
+                "rank_minus_sector_mean": np.float32(0.0),
+                "universe_size": np.int16(5),
+                "universe_yaml_sha": "abc123",
+                "computed_at": pd.Timestamp("2024-11-08T16:30:00Z"),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def features_df() -> pd.DataFrame:
+    return _build_features_df()
+
+
+# ---------------------------------------------------------------------------
+# Render produces an HTML file
+# ---------------------------------------------------------------------------
+
+
+def test_render_writes_html_file(features_df, tmp_path: Path):
+    out = tmp_path / "thematic-ranks-2024-11-08.html"
+    render_dashboard(features_df, out_path=out, asof=date(2024, 11, 8))
+    assert out.exists()
+    content = out.read_text()
+    assert content.startswith("<!DOCTYPE html") or content.lstrip().startswith("<!DOCTYPE")
+    assert "</html>" in content
+
+
+def test_render_contains_all_tickers(features_df, tmp_path: Path):
+    out = tmp_path / "dashboard.html"
+    render_dashboard(features_df, out_path=out, asof=date(2024, 11, 8))
+    html = out.read_text()
+    for sym in ("AAA", "BBB", "CCC", "DDD", "EEE"):
+        assert sym in html, f"ticker {sym} missing from HTML"
+
+
+def test_render_contains_sector_labels(features_df, tmp_path: Path):
+    out = tmp_path / "dashboard.html"
+    render_dashboard(features_df, out_path=out, asof=date(2024, 11, 8))
+    html = out.read_text()
+    for sector in ("tech", "healthcare", "energy"):
+        assert sector in html, f"sector {sector} missing from HTML"
+
+
+def test_render_contains_rank_values(features_df, tmp_path: Path):
+    out = tmp_path / "dashboard.html"
+    render_dashboard(features_df, out_path=out, asof=date(2024, 11, 8))
+    html = out.read_text()
+    # Rank values should appear (90, 70, 50, 30, 10).
+    for r in (90, 70, 50, 30, 10):
+        assert str(r) in html, f"rank value {r} missing from HTML"
+
+
+# ---------------------------------------------------------------------------
+# Byte-identical determinism
+# ---------------------------------------------------------------------------
+
+
+def test_render_byte_identical_on_identical_input(features_df, tmp_path: Path):
+    """Same DataFrame input → byte-identical HTML output."""
+    out_a = tmp_path / "a.html"
+    out_b = tmp_path / "b.html"
+    render_dashboard(features_df.copy(), out_path=out_a, asof=date(2024, 11, 8))
+    render_dashboard(features_df.copy(), out_path=out_b, asof=date(2024, 11, 8))
+
+    bytes_a = out_a.read_bytes()
+    bytes_b = out_b.read_bytes()
+    assert hashlib.sha256(bytes_a).hexdigest() == hashlib.sha256(bytes_b).hexdigest(), (
+        "dashboard HTML not byte-identical on identical input"
+    )
+
+
+def test_render_self_contained_no_external_assets(features_df, tmp_path: Path):
+    """No <script src=...>, no <link href=...> — fully self-contained.
+
+    Operators preview locally with `open <path>` — the HTML must work without
+    network and without companion files (per DESIGN-thematic dashboard §6 spec).
+    """
+    out = tmp_path / "dashboard.html"
+    render_dashboard(features_df, out_path=out, asof=date(2024, 11, 8))
+    html = out.read_text()
+    # Allow embedded <style> and inline CSS; reject external <link href=
+    # pointing at remote resources or local stylesheet files.
+    import re
+
+    external_links = re.findall(
+        r'<link[^>]*rel=["\']stylesheet["\'][^>]*href=["\']([^"\']+)["\']',
+        html,
+        re.IGNORECASE,
+    )
+    for href in external_links:
+        # Allow data: URIs.
+        assert href.startswith("data:"), (
+            f"external stylesheet found: {href!r}"
+        )
+    # External script src=... is also forbidden.
+    external_scripts = re.findall(
+        r'<script[^>]*src=["\']([^"\']+)["\']', html, re.IGNORECASE
+    )
+    for src in external_scripts:
+        assert src.startswith("data:"), f"external script found: {src!r}"

--- a/tests/research/test_thematic_dashboard.py
+++ b/tests/research/test_thematic_dashboard.py
@@ -120,6 +120,27 @@ def test_render_byte_identical_on_identical_input(features_df, tmp_path: Path):
     )
 
 
+def test_render_sort_js_groups_by_sector(features_df, tmp_path: Path):
+    """Regression — codex iter-2 [P2]: the per-column sort JS must preserve
+    sector grouping. The earlier implementation filtered headers out of the
+    row list and appended only data rows, leaving headers detached at the
+    top of the tbody after any sort click. The new sort walks tbody once,
+    partitions into per-sector groups, re-appends header then sorted data
+    inside each group.
+    """
+    out = tmp_path / "dashboard.html"
+    render_dashboard(features_df, out_path=out, asof=date(2024, 11, 8))
+    html = out.read_text()
+    # Group-aware sort: must build a `groups` array AND re-append header
+    # then data rows inside the forEach. Stale impl had no `groups` var.
+    assert "const groups = []" in html, "sort JS missing per-sector grouping"
+    assert "g.header" in html, "sort JS missing header re-append"
+    # Belt-and-braces: the old filter-then-append shape must not be present.
+    assert "rows.forEach(r => tbody.appendChild(r));" not in html, (
+        "old filter-then-append sort shape detected — sector headers will detach"
+    )
+
+
 def test_render_self_contained_no_external_assets(features_df, tmp_path: Path):
     """No <script src=...>, no <link href=...> — fully self-contained.
 

--- a/tests/research/test_thematic_labels.py
+++ b/tests/research/test_thematic_labels.py
@@ -228,6 +228,44 @@ def test_max_runup_positive_for_steady_riser():
 # ---------------------------------------------------------------------------
 
 
+def test_drawdown_runup_nan_for_incomplete_forward_window():
+    """Regression — codex iter-9 [P2]: if a symbol has a missing close
+    anywhere in the T+1..T+10 window, fwd_10d_max_drawdown / fwd_10d_max_runup
+    must be NaN rather than computed from the partial path. Otherwise
+    consumers treat partial labels as complete.
+    """
+    # Build a 60d panel for SPARSE with a gap mid-window.
+    base = _build_panel_constant_returns(
+        symbols=["UP"], n_days=60, daily_returns={"UP": 0.01}
+    )
+    sparse = _build_panel_constant_returns(
+        symbols=["SPARSE"], n_days=60, daily_returns={"SPARSE": 0.002}
+    )
+    # Punch a hole at the 25th trading day for SPARSE.
+    gap_day = sorted(sparse["date"].unique())[25]
+    sparse = sparse.loc[~((sparse["symbol"] == "SPARSE") & (sparse["date"] == gap_day))]
+    panel = pd.concat([base, sparse], ignore_index=True)
+
+    out = compute_forward_labels(panel=panel)
+    # An asof T whose [T+1..T+10] window covers gap_day should have NaN dd/ru.
+    # gap_day is at idx 25; affected asofs are 15..24 (inclusive).
+    affected_asofs = sorted(panel["date"].unique())[15:25]
+    for asof_dt in affected_asofs:
+        sparse_row = out.loc[
+            (out["symbol"] == "SPARSE") & (out["asof_date"] == asof_dt)
+        ]
+        if sparse_row.empty:
+            continue
+        dd = sparse_row.iloc[0]["fwd_10d_max_drawdown"]
+        ru = sparse_row.iloc[0]["fwd_10d_max_runup"]
+        assert pd.isna(dd), (
+            f"SPARSE asof={asof_dt}: dd should be NaN (gap in window) but got {dd}"
+        )
+        assert pd.isna(ru), (
+            f"SPARSE asof={asof_dt}: ru should be NaN (gap in window) but got {ru}"
+        )
+
+
 def test_label_complete_through_is_none_for_short_panel():
     """Regression — codex iter-6 [P2]: when the panel is shorter than the
     longest forward horizon (30 trading days), NO row has a complete

--- a/tests/research/test_thematic_labels.py
+++ b/tests/research/test_thematic_labels.py
@@ -228,6 +228,22 @@ def test_max_runup_positive_for_steady_riser():
 # ---------------------------------------------------------------------------
 
 
+def test_label_complete_through_is_none_for_short_panel():
+    """Regression — codex iter-6 [P2]: when the panel is shorter than the
+    longest forward horizon (30 trading days), NO row has a complete
+    fwd_30d_ret. ``label_complete_through`` must be None, not the first
+    asof_date (which would mislead consumers filtering on completeness).
+    """
+    panel = _build_panel_constant_returns(
+        symbols=["AAA"], n_days=10, daily_returns={"AAA": 0.01}
+    )
+    out = compute_forward_labels(panel=panel)
+    assert (out["label_complete_through"].isna()).all(), (
+        "label_complete_through must be None when panel < max_horizon; "
+        f"got unique values {out['label_complete_through'].unique()}"
+    )
+
+
 def test_label_dtypes(panel_5x60):
     out = compute_forward_labels(panel=panel_5x60)
     for col in (

--- a/tests/research/test_thematic_labels.py
+++ b/tests/research/test_thematic_labels.py
@@ -1,0 +1,245 @@
+"""Golden-fixture tests for Layer B forward-return labels.
+
+Critical safety test: assert no T+1 leak — a row at asof_date=T cannot
+reference any data after T in Layer A. Layer B has the fwd_* columns and
+explicitly declares t_plus_n_close observability per [D-011] + DESIGN §5.5.
+
+Design ref: docs/DESIGN-thematic-ranks-dashboard.md §5.2 ([D-011] / [D-012]).
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from rainier.research.breadth.ranks import compute_forward_labels
+
+
+def _build_panel_constant_returns(
+    symbols: list[str],
+    n_days: int,
+    daily_returns: dict[str, float],
+    start: date = date(2024, 10, 1),
+) -> pd.DataFrame:
+    """Build a long-format OHLCV panel where each ticker compounds at a fixed
+    daily return.
+    """
+    dates = []
+    d = start
+    while len(dates) < n_days:
+        if d.weekday() < 5:
+            dates.append(d)
+        d = d + timedelta(days=1)
+
+    rows = []
+    for sym in symbols:
+        r = daily_returns[sym]
+        close = 100.0
+        for i, day in enumerate(dates):
+            if i > 0:
+                close = close * (1.0 + r)
+            rows.append(
+                {
+                    "symbol": sym,
+                    "date": day,
+                    "open": close,
+                    "high": close,
+                    "low": close,
+                    "close": close,
+                    "volume": 1_000_000,
+                }
+            )
+    return pd.DataFrame(rows).sort_values(["symbol", "date"]).reset_index(drop=True)
+
+
+@pytest.fixture
+def panel_5x60() -> pd.DataFrame:
+    """5 tickers x 60 trading days with mixed return profiles."""
+    daily_returns = {
+        "AAA": 0.01,
+        "BBB": 0.005,
+        "CCC": 0.0,
+        "DDD": -0.005,
+        "EEE": -0.01,
+    }
+    return _build_panel_constant_returns(
+        symbols=["AAA", "BBB", "CCC", "DDD", "EEE"],
+        n_days=60,
+        daily_returns=daily_returns,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+REQUIRED_LABEL_COLS = {
+    "asof_date",
+    "symbol",
+    "fwd_3d_ret",
+    "fwd_5d_ret",
+    "fwd_10d_ret",
+    "fwd_20d_ret",
+    "fwd_30d_ret",
+    "fwd_5d_excess_ret",
+    "fwd_10d_excess_ret",
+    "fwd_20d_excess_ret",
+    "fwd_10d_max_drawdown",
+    "fwd_10d_max_runup",
+    "label_complete_through",
+}
+
+
+def test_label_schema(panel_5x60):
+    out = compute_forward_labels(panel=panel_5x60)
+    assert REQUIRED_LABEL_COLS.issubset(out.columns), (
+        f"missing label columns: {REQUIRED_LABEL_COLS - set(out.columns)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Forward-return arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_fwd_5d_ret_matches_simple_compounding(panel_5x60):
+    """For AAA growing 1%/day: fwd_5d_ret(asof=T) = (1.01)^5 - 1 = ~0.05101."""
+    out = compute_forward_labels(panel=panel_5x60)
+    aaa = out.loc[out["symbol"] == "AAA"]
+    # Pick an asof_date well inside the panel
+    asof_dates = sorted(aaa["asof_date"].tolist())
+    mid = asof_dates[20]  # day 20 of 60
+    row = aaa.loc[aaa["asof_date"] == mid].iloc[0]
+    expected = (1.01) ** 5 - 1
+    assert abs(row["fwd_5d_ret"] - expected) < 1e-4, (
+        f"fwd_5d_ret for AAA on day 20: got {row['fwd_5d_ret']} vs {expected}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Look-ahead safety — no T+1 leak in Layer A side
+# ---------------------------------------------------------------------------
+
+
+def test_label_complete_through_excludes_recent_rows(panel_5x60):
+    """label_complete_through must be at most panel_end - 30 trading days."""
+    out = compute_forward_labels(panel=panel_5x60)
+    # Find the max asof_date with a non-NaN fwd_30d_ret.
+    full = out.dropna(subset=["fwd_30d_ret"])
+    max_asof = full["asof_date"].max()
+    panel_end = panel_5x60["date"].max()
+    # There must be at least ~30 trading days between max_asof and panel_end.
+    gap_days = (panel_end - max_asof).days
+    # 30 trading days ≈ 42 calendar days. Allow for >= 30 calendar days at least.
+    assert gap_days >= 30, (
+        f"fwd_30d_ret has rows too close to panel end: gap={gap_days}d"
+    )
+
+    # label_complete_through column must reflect this.
+    assert (out["label_complete_through"] == max_asof).all(), (
+        f"label_complete_through inconsistent: unique values "
+        f"{out['label_complete_through'].unique()}"
+    )
+
+
+def test_fwd_columns_nan_for_incomplete_rows(panel_5x60):
+    """The last 30 trading days of the panel must have NaN fwd_30d_ret."""
+    out = compute_forward_labels(panel=panel_5x60)
+    # Last asof_date in the panel
+    panel_end = panel_5x60["date"].max()
+    # Rows in the last ~30 trading days should have NaN fwd_30d_ret
+    near_end = out[out["asof_date"] >= panel_end - timedelta(days=10)]
+    assert near_end["fwd_30d_ret"].isna().all(), (
+        "fwd_30d_ret should be NaN within 30 trading days of panel end"
+    )
+
+
+def test_no_future_dates_in_label_assembly(panel_5x60):
+    """Subtle safety: the row at asof=T uses close(T+N) — but the asof_date
+    itself is T. No row's asof_date should exceed panel_end.
+    """
+    out = compute_forward_labels(panel=panel_5x60)
+    panel_end = panel_5x60["date"].max()
+    assert out["asof_date"].max() <= panel_end, (
+        "label compute leaked asof_date beyond panel end"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Excess returns (universe-mean)
+# ---------------------------------------------------------------------------
+
+
+def test_fwd_5d_excess_ret_relative_to_universe_mean(panel_5x60):
+    """fwd_5d_excess_ret(t,d) = fwd_5d_ret(t,d) - mean_over_universe(fwd_5d_ret(*,d))."""
+    out = compute_forward_labels(panel=panel_5x60)
+    # Pick a complete asof_date
+    full = out.dropna(subset=["fwd_5d_ret", "fwd_5d_excess_ret"])
+    sample_asof = full["asof_date"].iloc[10]
+    same_day = out.loc[
+        (out["asof_date"] == sample_asof) & out["fwd_5d_ret"].notna()
+    ]
+    universe_mean = same_day["fwd_5d_ret"].mean()
+    for _, row in same_day.iterrows():
+        expected = row["fwd_5d_ret"] - universe_mean
+        assert abs(row["fwd_5d_excess_ret"] - expected) < 1e-5, (
+            f"{row['symbol']} excess mismatch: "
+            f"{row['fwd_5d_excess_ret']} vs {expected}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Drawdown / runup in the 10-day window
+# ---------------------------------------------------------------------------
+
+
+def test_max_drawdown_zero_for_steady_riser():
+    """A ticker that rises every day has zero drawdown over the 10d window."""
+    panel = _build_panel_constant_returns(
+        symbols=["UP"], n_days=60, daily_returns={"UP": 0.01}
+    )
+    out = compute_forward_labels(panel=panel)
+    full = out.dropna(subset=["fwd_10d_max_drawdown"])
+    # Steady riser → max drawdown should be 0 or very close to 0.
+    assert (full["fwd_10d_max_drawdown"] <= 1e-6).all(), (
+        f"steady riser has drawdown > 0: "
+        f"{full['fwd_10d_max_drawdown'].describe()}"
+    )
+
+
+def test_max_runup_positive_for_steady_riser():
+    """A ticker that rises every day has positive runup over the 10d window."""
+    panel = _build_panel_constant_returns(
+        symbols=["UP"], n_days=60, daily_returns={"UP": 0.01}
+    )
+    out = compute_forward_labels(panel=panel)
+    full = out.dropna(subset=["fwd_10d_max_runup"])
+    assert (full["fwd_10d_max_runup"] > 0).all(), (
+        "steady riser must show positive runup"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dtype contract
+# ---------------------------------------------------------------------------
+
+
+def test_label_dtypes(panel_5x60):
+    out = compute_forward_labels(panel=panel_5x60)
+    for col in (
+        "fwd_3d_ret",
+        "fwd_5d_ret",
+        "fwd_10d_ret",
+        "fwd_20d_ret",
+        "fwd_30d_ret",
+        "fwd_5d_excess_ret",
+        "fwd_10d_excess_ret",
+        "fwd_20d_excess_ret",
+        "fwd_10d_max_drawdown",
+        "fwd_10d_max_runup",
+    ):
+        assert out[col].dtype == np.float32, f"{col} dtype: {out[col].dtype}"

--- a/tests/research/test_thematic_loaders.py
+++ b/tests/research/test_thematic_loaders.py
@@ -1,0 +1,281 @@
+"""Loader tests — long-format read, wide-panel pivot, supervised join.
+
+Design ref: docs/DESIGN-thematic-ranks-dashboard.md §5.6 ([D-016]).
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from rainier.research.breadth.loaders import (
+    load_supervised,
+    load_thematic_features,
+    load_thematic_panel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders — synthesize Layer A and Layer B parquets
+# ---------------------------------------------------------------------------
+
+
+def _make_features_df(symbols: list[str], dates: list[date]) -> pd.DataFrame:
+    rows = []
+    for s_idx, sym in enumerate(symbols):
+        for d_idx, dt in enumerate(dates):
+            rows.append(
+                {
+                    "asof_date": dt,
+                    "trading_day_ordinal": np.int32(d_idx),
+                    "symbol": sym,
+                    "ticker_id": np.int16(s_idx + 1),
+                    "sector_id": np.int8(1),
+                    "close": np.float64(100.0 + s_idx + d_idx),
+                    "ret_1d": np.float32(0.01),
+                    "rel_5": np.float32(0.02 + s_idx * 0.01),
+                    "rel_10": np.float32(0.03 + s_idx * 0.01),
+                    "rel_20": np.float32(0.04 + s_idx * 0.01),
+                    "ret_ytd": np.float32(0.1),
+                    "relvol_5": np.float32(0.5),
+                    "relvol_10": np.float32(0.5),
+                    "relvol_20": np.float32(0.5),
+                    "r_5": np.int8(20 + s_idx * 15),
+                    "r_10": np.int8(20 + s_idx * 15),
+                    "r_20": np.int8(20 + s_idx * 15),
+                    "rank": np.int8(20 + s_idx * 15),
+                    "rank_delta_1d": np.int8(0),
+                    "rank_delta_5d": np.int8(0),
+                    "top15_streak": np.int16(0),
+                    "rank_minus_sector_mean": np.float32(0.0),
+                    "universe_size": np.int16(len(symbols)),
+                    "universe_yaml_sha": "abc123",
+                    "computed_at": pd.Timestamp("2024-11-08T16:30:00Z"),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _make_labels_df(symbols: list[str], dates: list[date]) -> pd.DataFrame:
+    rows = []
+    # Last 30 trading days of dates are incomplete (NaN fwd_30d_ret).
+    cutoff_idx = max(0, len(dates) - 30)
+    label_complete_through = dates[cutoff_idx - 1] if cutoff_idx > 0 else dates[0]
+    for s_idx, sym in enumerate(symbols):
+        for d_idx, dt in enumerate(dates):
+            incomplete = d_idx >= cutoff_idx
+            rows.append(
+                {
+                    "asof_date": dt,
+                    "symbol": sym,
+                    "fwd_3d_ret": np.float32(
+                        np.nan if d_idx >= len(dates) - 3 else 0.02
+                    ),
+                    "fwd_5d_ret": np.float32(
+                        np.nan if d_idx >= len(dates) - 5 else 0.03
+                    ),
+                    "fwd_10d_ret": np.float32(
+                        np.nan if d_idx >= len(dates) - 10 else 0.04
+                    ),
+                    "fwd_20d_ret": np.float32(
+                        np.nan if d_idx >= len(dates) - 20 else 0.05
+                    ),
+                    "fwd_30d_ret": np.float32(np.nan if incomplete else 0.06),
+                    "fwd_5d_excess_ret": np.float32(
+                        np.nan if d_idx >= len(dates) - 5 else 0.01
+                    ),
+                    "fwd_10d_excess_ret": np.float32(
+                        np.nan if d_idx >= len(dates) - 10 else 0.01
+                    ),
+                    "fwd_20d_excess_ret": np.float32(
+                        np.nan if d_idx >= len(dates) - 20 else 0.01
+                    ),
+                    "fwd_10d_max_drawdown": np.float32(
+                        np.nan if d_idx >= len(dates) - 10 else 0.0
+                    ),
+                    "fwd_10d_max_runup": np.float32(
+                        np.nan if d_idx >= len(dates) - 10 else 0.05
+                    ),
+                    "label_complete_through": label_complete_through,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def tmp_cache(tmp_path: Path) -> dict[str, Path]:
+    """Write Layer A and Layer B parquets to a temp dir."""
+    symbols = ["AAA", "BBB", "CCC"]
+    dates = []
+    d = date(2024, 10, 1)
+    while len(dates) < 60:
+        if d.weekday() < 5:
+            dates.append(d)
+        d = d + timedelta(days=1)
+
+    feats = _make_features_df(symbols, dates)
+    labels = _make_labels_df(symbols, dates)
+
+    feats_path = tmp_path / "thematic_features_daily.parquet"
+    labels_path = tmp_path / "thematic_labels_daily.parquet"
+
+    feats.to_parquet(feats_path)
+    labels.to_parquet(labels_path)
+    return {"features": feats_path, "labels": labels_path}
+
+
+# ---------------------------------------------------------------------------
+# load_thematic_features
+# ---------------------------------------------------------------------------
+
+
+def test_load_features_returns_dataframe(tmp_cache):
+    df = load_thematic_features(
+        start=date(2024, 10, 1),
+        end=date(2024, 12, 31),
+        path=tmp_cache["features"],
+    )
+    assert isinstance(df, pd.DataFrame)
+    assert "asof_date" in df.columns
+    assert "symbol" in df.columns
+    assert len(df) > 0
+
+
+def test_load_features_date_filter(tmp_cache):
+    df = load_thematic_features(
+        start=date(2024, 10, 1),
+        end=date(2024, 10, 10),
+        path=tmp_cache["features"],
+    )
+    assert df["asof_date"].max() <= date(2024, 10, 10)
+    assert df["asof_date"].min() >= date(2024, 10, 1)
+
+
+def test_load_features_deterministic_sort(tmp_cache):
+    df = load_thematic_features(
+        start=date(2024, 10, 1),
+        end=date(2024, 12, 31),
+        path=tmp_cache["features"],
+    )
+    # Stable sort key: (symbol, asof_date) ascending
+    for sym in df["symbol"].unique():
+        sub = df.loc[df["symbol"] == sym, "asof_date"].tolist()
+        assert sub == sorted(sub)
+
+
+# ---------------------------------------------------------------------------
+# load_thematic_panel — wide pivot
+# ---------------------------------------------------------------------------
+
+
+def test_load_panel_returns_wide_shape(tmp_cache):
+    """Panel is a wide DataFrame indexed by (asof_date, symbol)."""
+    panel = load_thematic_panel(
+        features=["r_5", "r_10", "rank"],
+        start=date(2024, 10, 1),
+        end=date(2024, 12, 31),
+        path=tmp_cache["features"],
+    )
+    # Could be MultiIndex columns or DataFrame with feature columns.
+    # Spec: shape (n_dates, n_tickers, n_features). For a flat DataFrame,
+    # we expect MultiIndex (asof_date, symbol) as rows and feature cols.
+    assert "r_5" in panel.columns or any(
+        "r_5" in str(c) for c in panel.columns
+    )
+    # n_unique asof_dates = 60; n_unique symbols = 3
+    n_dates = panel.index.get_level_values(0).nunique()
+    n_syms = panel.index.get_level_values(1).nunique()
+    assert n_dates > 0 and n_syms == 3
+
+
+def test_load_panel_preserves_feature_ordering(tmp_cache):
+    """The features list determines column order in the panel output."""
+    panel = load_thematic_panel(
+        features=["r_5", "rank", "r_10"],
+        start=date(2024, 10, 1),
+        end=date(2024, 12, 31),
+        path=tmp_cache["features"],
+    )
+    assert list(panel.columns) == ["r_5", "rank", "r_10"]
+
+
+# ---------------------------------------------------------------------------
+# load_supervised — A + B join
+# ---------------------------------------------------------------------------
+
+
+def test_load_supervised_joins_features_and_labels(tmp_cache):
+    """load_supervised returns rows present in BOTH features and labels."""
+    df = load_supervised(
+        feature_cols=["r_5", "rank"],
+        label_cols=["fwd_5d_ret", "fwd_30d_ret"],
+        start=date(2024, 10, 1),
+        end=date(2024, 12, 31),
+        features_path=tmp_cache["features"],
+        labels_path=tmp_cache["labels"],
+    )
+    for col in ("asof_date", "symbol", "r_5", "rank", "fwd_5d_ret", "fwd_30d_ret"):
+        assert col in df.columns, f"missing column: {col}"
+
+
+def test_load_supervised_drop_incomplete_labels(tmp_cache):
+    """drop_incomplete_labels=True excludes rows where fwd_30d_ret is NaN."""
+    df = load_supervised(
+        feature_cols=["r_5"],
+        label_cols=["fwd_5d_ret", "fwd_30d_ret"],
+        start=date(2024, 10, 1),
+        end=date(2024, 12, 31),
+        features_path=tmp_cache["features"],
+        labels_path=tmp_cache["labels"],
+        drop_incomplete_labels=True,
+    )
+    # No NaN in fwd_30d_ret after filtering.
+    assert not df["fwd_30d_ret"].isna().any(), (
+        "drop_incomplete_labels=True should remove NaN fwd_30d_ret rows"
+    )
+
+
+def test_load_supervised_keeps_incomplete_when_flag_false(tmp_cache):
+    """drop_incomplete_labels=False keeps NaN rows for inspection."""
+    df = load_supervised(
+        feature_cols=["r_5"],
+        label_cols=["fwd_30d_ret"],
+        start=date(2024, 10, 1),
+        end=date(2024, 12, 31),
+        features_path=tmp_cache["features"],
+        labels_path=tmp_cache["labels"],
+        drop_incomplete_labels=False,
+    )
+    # Should have some NaN fwd_30d_ret rows (the last ~30 trading days).
+    assert df["fwd_30d_ret"].isna().any(), (
+        "drop_incomplete_labels=False should keep NaN rows"
+    )
+
+
+def test_load_supervised_deterministic(tmp_cache):
+    """Identical calls yield identical DataFrames."""
+    df_a = load_supervised(
+        feature_cols=["r_5", "rank"],
+        label_cols=["fwd_5d_ret"],
+        start=date(2024, 10, 1),
+        end=date(2024, 12, 31),
+        features_path=tmp_cache["features"],
+        labels_path=tmp_cache["labels"],
+        drop_incomplete_labels=True,
+    )
+    df_b = load_supervised(
+        feature_cols=["r_5", "rank"],
+        label_cols=["fwd_5d_ret"],
+        start=date(2024, 10, 1),
+        end=date(2024, 12, 31),
+        features_path=tmp_cache["features"],
+        labels_path=tmp_cache["labels"],
+        drop_incomplete_labels=True,
+    )
+    pd.testing.assert_frame_equal(df_a, df_b)

--- a/tests/research/test_thematic_loaders.py
+++ b/tests/research/test_thematic_loaders.py
@@ -255,6 +255,45 @@ def test_load_supervised_keeps_incomplete_when_flag_false(tmp_cache):
     )
 
 
+def test_load_supervised_drop_incomplete_excess_only_label(tmp_cache):
+    """Regression — codex iter-3 [P2]: when caller requests only excess-ret
+    or drawdown/runup labels (no plain ``fwd_Nd_ret``), the completeness
+    gate must still kick in. Previously _most_restrictive_label returned
+    None and trailing NaN rows leaked into the supervised set.
+    """
+    df = load_supervised(
+        feature_cols=["r_5"],
+        label_cols=["fwd_5d_excess_ret"],
+        start=date(2024, 10, 1),
+        end=date(2024, 12, 31),
+        features_path=tmp_cache["features"],
+        labels_path=tmp_cache["labels"],
+        drop_incomplete_labels=True,
+    )
+    assert not df["fwd_5d_excess_ret"].isna().any(), (
+        "excess-only label with drop_incomplete_labels=True must filter NaN rows"
+    )
+
+
+def test_load_supervised_drop_incomplete_drawdown_only_label(tmp_cache):
+    """Regression — codex iter-3 [P2]: drawdown/runup-only labels also gate.
+    These columns use the suffix ``_max_drawdown`` / ``_max_runup`` rather
+    than ``_ret``.
+    """
+    df = load_supervised(
+        feature_cols=["r_5"],
+        label_cols=["fwd_10d_max_drawdown"],
+        start=date(2024, 10, 1),
+        end=date(2024, 12, 31),
+        features_path=tmp_cache["features"],
+        labels_path=tmp_cache["labels"],
+        drop_incomplete_labels=True,
+    )
+    assert not df["fwd_10d_max_drawdown"].isna().any(), (
+        "drawdown-only label with drop_incomplete_labels=True must filter NaN rows"
+    )
+
+
 def test_load_supervised_deterministic(tmp_cache):
     """Identical calls yield identical DataFrames."""
     df_a = load_supervised(

--- a/tests/research/test_thematic_loaders.py
+++ b/tests/research/test_thematic_loaders.py
@@ -10,8 +10,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import pyarrow as pa
-import pyarrow.parquet as pq
 import pytest
 
 from rainier.research.breadth.loaders import (
@@ -19,7 +17,6 @@ from rainier.research.breadth.loaders import (
     load_thematic_features,
     load_thematic_panel,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixture builders — synthesize Layer A and Layer B parquets

--- a/tests/research/test_thematic_ml_builders.py
+++ b/tests/research/test_thematic_ml_builders.py
@@ -1,0 +1,150 @@
+"""Tests for ml_builders — focused regression coverage.
+
+Phase B shipped ``build_panel_tensor`` + ``ThematicTradingEnv`` largely as
+consumer-deliverables (training loop is downstream-owned). These tests cover
+the constructor rejection paths that came out of codex review.
+
+Design ref: docs/DESIGN-thematic-ranks-dashboard.md §5.6 ([D-016]).
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+import pytest
+
+from rainier.research.breadth.ml_builders import ThematicTradingEnv
+
+
+def _stub_features_panel() -> pd.DataFrame:
+    """Minimal wide panel — MultiIndex(date, symbol), feature columns."""
+    dates = [date(2024, 10, 1), date(2024, 10, 2)]
+    syms = ["AAA", "BBB"]
+    rows = []
+    for d in dates:
+        for s in syms:
+            rows.append({"asof_date": d, "symbol": s, "rank": 50})
+    df = pd.DataFrame(rows).set_index(["asof_date", "symbol"])
+    return df
+
+
+def _stub_labels_frame() -> pd.DataFrame:
+    dates = [date(2024, 10, 1), date(2024, 10, 2)]
+    syms = ["AAA", "BBB"]
+    rows = []
+    for d in dates:
+        for s in syms:
+            rows.append(
+                {
+                    "asof_date": d,
+                    "symbol": s,
+                    "fwd_5d_excess_ret": 0.01,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def test_env_rejects_unknown_reward():
+    """Unknown reward names raise ValueError."""
+    pytest.importorskip("gymnasium")
+    with pytest.raises(ValueError, match="unknown reward"):
+        ThematicTradingEnv(
+            features=_stub_features_panel(),
+            labels=_stub_labels_frame(),
+            reward="nonsense_reward",
+        )
+
+
+def test_env_rejects_after_cost_reward_until_implemented():
+    """Regression — codex iter-3 / iter-5 [P2]: previously the constructor
+    accepted ``fwd_5d_excess_ret_after_cost`` and silently stripped the
+    suffix in step(), so the after-cost reward equalled the pre-cost
+    reward (no cost ever applied). The env must reject these names with
+    a NotImplementedError that names the follow-up requirement.
+    """
+    pytest.importorskip("gymnasium")
+    for variant in (
+        "fwd_5d_excess_ret_after_cost",
+        "fwd_10d_excess_ret_after_cost",
+        "fwd_20d_excess_ret_after_cost",
+    ):
+        with pytest.raises(NotImplementedError, match="cost-adjusted"):
+            ThematicTradingEnv(
+                features=_stub_features_panel(),
+                labels=_stub_labels_frame(),
+                reward=variant,
+            )
+
+
+def test_env_accepts_excess_ret_rewards():
+    """Constructor accepts the supported excess-return reward names."""
+    pytest.importorskip("gymnasium")
+    for variant in (
+        "fwd_5d_excess_ret",
+        "fwd_10d_excess_ret",
+        "fwd_20d_excess_ret",
+    ):
+        env = ThematicTradingEnv(
+            features=_stub_features_panel(),
+            labels=_stub_labels_frame(),
+            reward=variant,
+        )
+        assert env.reward == variant
+
+
+def test_env_rejects_unknown_action_space():
+    """Action spaces other than 'long_short_topk' raise."""
+    pytest.importorskip("gymnasium")
+    with pytest.raises(ValueError, match="unknown action_space"):
+        ThematicTradingEnv(
+            features=_stub_features_panel(),
+            labels=_stub_labels_frame(),
+            action_space="continuous_weights",
+        )
+
+
+# ---------------------------------------------------------------------------
+# build_panel_tensor — basic axis correctness
+# ---------------------------------------------------------------------------
+
+
+def test_build_panel_tensor_shape_and_axes():
+    """``build_panel_tensor`` returns a (dates, tickers, features) tensor
+    with sorted axes for byte-deterministic downstream consumption.
+    """
+    from rainier.research.breadth.ml_builders import build_panel_tensor
+
+    dates = [date(2024, 10, 1) + timedelta(days=i) for i in range(3)]
+    syms = ["BBB", "AAA"]  # intentionally unsorted input
+    rows = []
+    for d in dates:
+        for s in syms:
+            rows.append(
+                {
+                    "asof_date": d,
+                    "symbol": s,
+                    "rank": float(50),
+                    "r_5": float(20),
+                }
+            )
+    panel = pd.DataFrame(rows).set_index(["asof_date", "symbol"])[["rank", "r_5"]]
+
+    arr, ax_dates, ax_tickers, ax_features = build_panel_tensor(panel)
+    assert arr.shape == (3, 2, 2)
+    # Axes are sorted for determinism.
+    assert ax_tickers == ["AAA", "BBB"]
+    assert ax_dates == sorted(dates)
+    assert ax_features == ["rank", "r_5"]
+
+
+def test_build_panel_tensor_empty_input():
+    """Empty panel returns an empty tensor + empty axes (no crash)."""
+    from rainier.research.breadth.ml_builders import build_panel_tensor
+
+    panel = pd.DataFrame(
+        {"asof_date": [], "symbol": [], "rank": []}
+    ).set_index(["asof_date", "symbol"])
+    arr, ax_dates, ax_tickers, ax_features = build_panel_tensor(panel)
+    assert arr.shape == (0, 0, 0)
+    assert ax_dates == [] and ax_tickers == [] and ax_features == []

--- a/tests/research/test_thematic_ranks.py
+++ b/tests/research/test_thematic_ranks.py
@@ -413,6 +413,79 @@ def test_top15_streak_increments_and_resets(
 # ---------------------------------------------------------------------------
 
 
+def test_vol_window_no_pad_on_internal_gaps(
+    sector_map, ticker_registry, sector_registry
+):
+    """Regression — codex iter-6 [P2]: pct_change with default `fill_method='pad'`
+    silently turns missing internal close days into 0% returns, under-
+    estimating vol_20 for sparse symbols. With fill_method=None, gap days
+    propagate NaN through std() — the returned vol/relvol is NaN instead
+    of an artificially-low value.
+    """
+    # Build a base 5-ticker panel + one extra ticker SPARSE with a gap mid-window.
+    symbols = ["AAA", "BBB", "CCC", "DDD", "EEE"]
+    daily_returns = {
+        "AAA": [0.01] * 29,
+        "BBB": [0.005] * 29,
+        "CCC": [0.0] * 29,
+        "DDD": [-0.005] * 29,
+        "EEE": [-0.01] * 29,
+    }
+    panel = _build_panel(symbols, 30, daily_returns)
+
+    # Add SPARSE with a hole on a specific mid-window date so the wide pivot
+    # has an internal NaN for SPARSE on that day.
+    sparse_rows = []
+    sparse_close = 100.0
+    days_seen = panel["date"].drop_duplicates().sort_values().tolist()
+    gap_day = days_seen[10]  # mid-window
+    for i, day in enumerate(days_seen):
+        if i > 0:
+            sparse_close *= 1.002
+        if day == gap_day:
+            continue  # leave a hole — wide pivot will have NaN for SPARSE here
+        sparse_rows.append(
+            {
+                "symbol": "SPARSE",
+                "date": day,
+                "open": sparse_close,
+                "high": sparse_close,
+                "low": sparse_close,
+                "close": sparse_close,
+                "volume": 1_000_000,
+            }
+        )
+    panel = pd.concat([panel, pd.DataFrame(sparse_rows)], ignore_index=True)
+
+    smap = dict(sector_map)
+    smap["SPARSE"] = "tech"
+    treg = dict(ticker_registry)
+    treg["SPARSE"] = 6
+
+    out = compute_thematic_features(
+        panel=panel,
+        asof=date(2024, 11, 8),
+        sector_map=smap,
+        ticker_registry=treg,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+    )
+    sparse_row = out.loc[out["symbol"] == "SPARSE"]
+    if sparse_row.empty:
+        # SPARSE got dropped because it had no close on asof. The fixture
+        # placement should keep SPARSE present on asof — but if not, the
+        # test is moot.
+        pytest.skip("SPARSE not present on asof; gap placement skipped row")
+    # With fill_method=None, the internal-gap return is NaN -> vol_20 is NaN
+    # -> relvol_* are NaN (the safe behaviour). Without the fix, vol_20 would
+    # be artificially low (zero-return injected) and relvol would be finite.
+    relvol_5 = sparse_row.iloc[0]["relvol_5"]
+    assert pd.isna(relvol_5), (
+        f"vol window must NOT pad over internal gaps; relvol_5 should be NaN "
+        f"for SPARSE but got {relvol_5}"
+    )
+
+
 def test_rank_delta_1d_treats_sentinel_prev_rank_as_missing(
     panel_5x30, sector_map, ticker_registry, sector_registry
 ):

--- a/tests/research/test_thematic_ranks.py
+++ b/tests/research/test_thematic_ranks.py
@@ -10,14 +10,12 @@ Design ref: docs/DESIGN-thematic-ranks-dashboard.md §5.1 ([D-002] / [D-003] /
 from __future__ import annotations
 
 from datetime import date, timedelta
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pytest
 
 from rainier.research.breadth.ranks import compute_thematic_features
-
 
 # ---------------------------------------------------------------------------
 # Fixture builder
@@ -82,7 +80,6 @@ def _universe_log_seed(yaml_sha: str) -> pd.DataFrame:
 @pytest.fixture
 def panel_5x30() -> pd.DataFrame:
     """Crafted 5-ticker x 30-day panel."""
-    rng = np.random.default_rng(42)
     symbols = ["AAA", "BBB", "CCC", "DDD", "EEE"]
     # Per-ticker return profile to anchor expected ranks
     daily_returns = {

--- a/tests/research/test_thematic_ranks.py
+++ b/tests/research/test_thematic_ranks.py
@@ -1,0 +1,449 @@
+"""Golden-fixture deterministic tests for Layer A compute (thematic ranks).
+
+The fixture: 5 tickers x 30 trading days of synthetic OHLCV with crafted
+return profiles so we can hand-compute REL_N, R_N, and Rank to the last bit.
+
+Design ref: docs/DESIGN-thematic-ranks-dashboard.md §5.1 ([D-002] / [D-003] /
+[D-008] / [D-013] / [D-014]).
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from rainier.research.breadth.ranks import compute_thematic_features
+
+
+# ---------------------------------------------------------------------------
+# Fixture builder
+# ---------------------------------------------------------------------------
+
+
+def _build_panel(
+    symbols: list[str],
+    n_days: int,
+    daily_returns: dict[str, list[float]],
+    start: date = date(2024, 10, 1),
+) -> pd.DataFrame:
+    """Build a deterministic long-format OHLCV panel.
+
+    Each ticker's close price compounds from 100.0 by the daily_returns list.
+    open/high/low track close (toy values; ranking code ignores them).
+    """
+    dates = []
+    d = start
+    while len(dates) < n_days:
+        # weekday only (skip Sat=5, Sun=6)
+        if d.weekday() < 5:
+            dates.append(d)
+        d = d + timedelta(days=1)
+
+    rows = []
+    for sym in symbols:
+        rets = daily_returns[sym]
+        close = 100.0
+        for i, day in enumerate(dates):
+            if i > 0:
+                close = close * (1.0 + rets[i - 1])
+            rows.append(
+                {
+                    "symbol": sym,
+                    "date": day,
+                    "open": close,
+                    "high": close,
+                    "low": close,
+                    "close": close,
+                    "volume": 1_000_000,
+                }
+            )
+    return pd.DataFrame(rows).sort_values(["symbol", "date"]).reset_index(drop=True)
+
+
+def _universe_log_seed(yaml_sha: str) -> pd.DataFrame:
+    """Return a one-row Layer C log as the input would arrive at compute time."""
+    return pd.DataFrame(
+        [
+            {
+                "effective_from": date(2024, 10, 1),
+                "yaml_sha": yaml_sha,
+                "universe_size": 5,
+                "tickers": ["AAA", "BBB", "CCC", "DDD", "EEE"],
+                "note": "test seed",
+            }
+        ]
+    )
+
+
+@pytest.fixture
+def panel_5x30() -> pd.DataFrame:
+    """Crafted 5-ticker x 30-day panel."""
+    rng = np.random.default_rng(42)
+    symbols = ["AAA", "BBB", "CCC", "DDD", "EEE"]
+    # Per-ticker return profile to anchor expected ranks
+    daily_returns = {
+        "AAA": [0.01] * 29,  # steady leader
+        "BBB": [0.005] * 29,  # steady mild
+        "CCC": [0.0] * 29,  # flat
+        "DDD": [-0.005] * 29,  # steady decliner
+        "EEE": [-0.01] * 29,  # steady laggard
+    }
+    return _build_panel(symbols, 30, daily_returns)
+
+
+@pytest.fixture
+def sector_map() -> dict[str, str]:
+    return {
+        "AAA": "tech",
+        "BBB": "tech",
+        "CCC": "healthcare",
+        "DDD": "healthcare",
+        "EEE": "energy",
+    }
+
+
+@pytest.fixture
+def ticker_registry() -> dict[str, int]:
+    return {"AAA": 1, "BBB": 2, "CCC": 3, "DDD": 4, "EEE": 5}
+
+
+@pytest.fixture
+def sector_registry() -> dict[str, int]:
+    return {"tech": 1, "healthcare": 2, "energy": 3}
+
+
+# ---------------------------------------------------------------------------
+# Schema invariants
+# ---------------------------------------------------------------------------
+
+
+REQUIRED_COLS = {
+    "asof_date",
+    "trading_day_ordinal",
+    "symbol",
+    "ticker_id",
+    "sector_id",
+    "close",
+    "ret_1d",
+    "rel_5",
+    "rel_10",
+    "rel_20",
+    "ret_ytd",
+    "relvol_5",
+    "relvol_10",
+    "relvol_20",
+    "r_5",
+    "r_10",
+    "r_20",
+    "rank",
+    "rank_delta_1d",
+    "rank_delta_5d",
+    "top15_streak",
+    "rank_minus_sector_mean",
+    "universe_size",
+    "universe_yaml_sha",
+    "computed_at",
+}
+
+
+def test_features_returns_required_schema(
+    panel_5x30, sector_map, ticker_registry, sector_registry
+):
+    """compute_thematic_features returns a DataFrame with the §5.1 schema."""
+    out = compute_thematic_features(
+        panel=panel_5x30,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map,
+        ticker_registry=ticker_registry,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+    )
+    assert REQUIRED_COLS.issubset(out.columns), (
+        f"missing columns: {REQUIRED_COLS - set(out.columns)}"
+    )
+
+
+def test_features_dtypes_match_design(
+    panel_5x30, sector_map, ticker_registry, sector_registry
+):
+    """float32 for stationary numerical features; close stays float64."""
+    out = compute_thematic_features(
+        panel=panel_5x30,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map,
+        ticker_registry=ticker_registry,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+    )
+    # close: float64 (per [D-016])
+    assert out["close"].dtype == np.float64
+    # stationary returns: float32
+    for col in ("rel_5", "rel_10", "rel_20", "relvol_5", "relvol_10", "relvol_20"):
+        assert out[col].dtype == np.float32, f"{col} dtype: {out[col].dtype}"
+    # ranks: int8 (0-99 fits)
+    for col in ("r_5", "r_10", "r_20", "rank", "rank_delta_1d", "rank_delta_5d"):
+        assert out[col].dtype == np.int8, f"{col} dtype: {out[col].dtype}"
+    # top15_streak: int16
+    assert out["top15_streak"].dtype == np.int16
+
+
+# ---------------------------------------------------------------------------
+# Rank composite arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_rank_composite_is_round_mean(
+    panel_5x30, sector_map, ticker_registry, sector_registry
+):
+    """rank = round(mean(r_5, r_10, r_20)) per [D-003]."""
+    out = compute_thematic_features(
+        panel=panel_5x30,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map,
+        ticker_registry=ticker_registry,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+    )
+    for row in out.itertuples(index=False):
+        expected = int(round((row.r_5 + row.r_10 + row.r_20) / 3))
+        assert row.rank == expected, (
+            f"{row.symbol}: rank={row.rank} vs round(mean)={expected}"
+        )
+
+
+def test_centile_scaling_min_max(
+    panel_5x30, sector_map, ticker_registry, sector_registry
+):
+    """Highest REL → centile 99; lowest → centile 0 in a 5-ticker universe.
+
+    With our crafted monotone returns (AAA top, EEE bottom), AAA must rank 99
+    and EEE must rank 0 across all windows.
+    """
+    out = compute_thematic_features(
+        panel=panel_5x30,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map,
+        ticker_registry=ticker_registry,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+    )
+    aaa = out.loc[out["symbol"] == "AAA"].iloc[0]
+    eee = out.loc[out["symbol"] == "EEE"].iloc[0]
+    for col in ("r_5", "r_10", "r_20"):
+        assert aaa[col] == 99, f"AAA {col} should be 99, got {aaa[col]}"
+        assert eee[col] == 0, f"EEE {col} should be 0, got {eee[col]}"
+
+
+# ---------------------------------------------------------------------------
+# Tie handling — method='average'
+# ---------------------------------------------------------------------------
+
+
+def test_centile_scaling_handles_ties_with_average_method(
+    sector_map, ticker_registry, sector_registry
+):
+    """With 3 tickers tied at the same REL_5, all three should share the same
+    rank (the average of their ordinal positions). Per [D-008].
+    """
+    # AAA flat; BBB flat; CCC flat; DDD up; EEE down. Three-way tie at flat.
+    symbols = ["AAA", "BBB", "CCC", "DDD", "EEE"]
+    daily_returns = {
+        "AAA": [0.0] * 29,
+        "BBB": [0.0] * 29,
+        "CCC": [0.0] * 29,
+        "DDD": [0.01] * 29,
+        "EEE": [-0.01] * 29,
+    }
+    panel = _build_panel(symbols, 30, daily_returns)
+
+    out = compute_thematic_features(
+        panel=panel,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map,
+        ticker_registry=ticker_registry,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+    )
+    # The three flat tickers should share the same r_5 (the average ordinal).
+    flat_ranks = out.loc[out["symbol"].isin(["AAA", "BBB", "CCC"]), "r_5"].tolist()
+    assert len(set(flat_ranks)) == 1, f"ties not handled: {flat_ranks}"
+
+
+# ---------------------------------------------------------------------------
+# Determinism (byte-identical compute)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_is_byte_deterministic(
+    panel_5x30, sector_map, ticker_registry, sector_registry
+):
+    """Two identical compute calls produce identical DataFrames modulo
+    computed_at (which is process-time)."""
+    out_a = compute_thematic_features(
+        panel=panel_5x30,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map,
+        ticker_registry=ticker_registry,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+    )
+    out_b = compute_thematic_features(
+        panel=panel_5x30,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map,
+        ticker_registry=ticker_registry,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+    )
+    # Drop computed_at then compare the rest.
+    a = out_a.drop(columns=["computed_at"]).reset_index(drop=True)
+    b = out_b.drop(columns=["computed_at"]).reset_index(drop=True)
+    pd.testing.assert_frame_equal(a, b)
+
+
+# ---------------------------------------------------------------------------
+# Insufficient history — NaN, excluded from Rank composite
+# ---------------------------------------------------------------------------
+
+
+def test_insufficient_history_yields_excluded_from_rank(
+    sector_map, ticker_registry, sector_registry
+):
+    """A ticker with fewer than 20 days of history must have NaN rel_20 and
+    must be excluded from the Rank composite for that day (Rank still computed
+    from r_5 + r_10 only is NOT acceptable — DESIGN §5.1 + TASK-PLAN §6 say
+    excluded, i.e. rank is NaN/missing → represented as sentinel).
+    """
+    # Build full 30d for 4 tickers + only 15d for FFF (insufficient for rel_20)
+    symbols = ["AAA", "BBB", "CCC", "DDD"]
+    daily_returns = {
+        "AAA": [0.01] * 29,
+        "BBB": [0.005] * 29,
+        "CCC": [0.0] * 29,
+        "DDD": [-0.01] * 29,
+    }
+    panel_full = _build_panel(symbols, 30, daily_returns)
+
+    # Now append FFF with only 15 days (starting after day 14 of the same
+    # trading-day window).
+    short_panel = _build_panel(["FFF"], 30, {"FFF": [0.002] * 29})
+    # Keep only the last 15 trading days for FFF.
+    short_panel = short_panel.tail(15).reset_index(drop=True)
+
+    panel = pd.concat([panel_full, short_panel], ignore_index=True)
+    panel = panel.sort_values(["symbol", "date"]).reset_index(drop=True)
+
+    sector_map_with_fff = dict(sector_map)
+    sector_map_with_fff["FFF"] = "tech"
+    ticker_registry_with_fff = dict(ticker_registry)
+    ticker_registry_with_fff["FFF"] = 6
+
+    out = compute_thematic_features(
+        panel=panel,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map_with_fff,
+        ticker_registry=ticker_registry_with_fff,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+    )
+    fff = out.loc[out["symbol"] == "FFF"]
+    if not fff.empty:
+        row = fff.iloc[0]
+        # rel_20 is undefined for FFF (only 15 days); must be NaN.
+        assert pd.isna(row["rel_20"]) or row["rel_20"] == 0, (
+            f"FFF should have NaN rel_20; got {row['rel_20']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# top15_streak persistence column
+# ---------------------------------------------------------------------------
+
+
+def test_top15_streak_increments_and_resets(
+    sector_map, ticker_registry, sector_registry
+):
+    """Streak counts consecutive days with rank >= 85 and resets to 0 on the
+    first day below threshold. Per [D-014].
+    """
+    # Use a multi-asof_date series: AAA dominates for 5 days then collapses.
+    # We compute features for one asof_date at a time; the streak must come
+    # from prior features (pass via prev_features parameter).
+    symbols = ["AAA", "BBB", "CCC", "DDD", "EEE"]
+    daily_returns = {
+        "AAA": [0.05] * 29,  # dominant
+        "BBB": [0.0] * 29,
+        "CCC": [0.0] * 29,
+        "DDD": [0.0] * 29,
+        "EEE": [0.0] * 29,
+    }
+    panel = _build_panel(symbols, 30, daily_returns)
+
+    # Compute features at sequential asof_dates and check that streak grows.
+    prev = None
+    streaks = []
+    asof_dates = sorted(panel["date"].unique())[5:10]  # 5 sequential days
+    for asof in asof_dates:
+        out = compute_thematic_features(
+            panel=panel,
+            asof=asof,
+            sector_map=sector_map,
+            ticker_registry=ticker_registry,
+            sector_registry=sector_registry,
+            universe_yaml_sha="abc123",
+            prev_features=prev,
+        )
+        aaa_row = out.loc[out["symbol"] == "AAA"].iloc[0]
+        if aaa_row["rank"] >= 85:
+            streaks.append(int(aaa_row["top15_streak"]))
+        prev = out
+
+    # Streaks must be monotone non-decreasing across days where AAA stays top.
+    assert streaks == sorted(streaks), f"streaks not monotone: {streaks}"
+    # And the last streak must be at least len(streaks).
+    if streaks:
+        assert streaks[-1] >= len(streaks), (
+            f"streak {streaks[-1]} too low for {len(streaks)} consecutive days"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Provenance + audit fields
+# ---------------------------------------------------------------------------
+
+
+def test_universe_size_recorded(
+    panel_5x30, sector_map, ticker_registry, sector_registry
+):
+    """universe_size column matches the actual universe at asof_date."""
+    out = compute_thematic_features(
+        panel=panel_5x30,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map,
+        ticker_registry=ticker_registry,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+    )
+    assert (out["universe_size"] == 5).all(), (
+        f"universe_size should be 5, got unique: {out['universe_size'].unique()}"
+    )
+
+
+def test_universe_yaml_sha_propagated(
+    panel_5x30, sector_map, ticker_registry, sector_registry
+):
+    """universe_yaml_sha column carries the SHA passed in."""
+    sha = "deadbeef" * 5
+    out = compute_thematic_features(
+        panel=panel_5x30,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map,
+        ticker_registry=ticker_registry,
+        sector_registry=sector_registry,
+        universe_yaml_sha=sha,
+    )
+    assert (out["universe_yaml_sha"] == sha).all()

--- a/tests/research/test_thematic_ranks.py
+++ b/tests/research/test_thematic_ranks.py
@@ -413,6 +413,44 @@ def test_top15_streak_increments_and_resets(
 # ---------------------------------------------------------------------------
 
 
+def test_rank_delta_1d_treats_sentinel_prev_rank_as_missing(
+    panel_5x30, sector_map, ticker_registry, sector_registry
+):
+    """Regression — codex iter-3 [P2]: when a ticker previously had
+    rank=-1 (insufficient-history sentinel) and now becomes rankable, the
+    rank_delta_1d must be 0 (missing/neutral), not ``current - (-1)``.
+
+    Without the fix, the first day a previously-unrankable ticker enters
+    the rank gives it a spurious +1 momentum feature.
+    """
+    out_t = compute_thematic_features(
+        panel=panel_5x30,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map,
+        ticker_registry=ticker_registry,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+    )
+    # Manually craft a prev_features row where AAA's previous rank is the
+    # -1 sentinel (simulating a ticker that just became rankable today).
+    prev = out_t.copy()
+    prev.loc[prev["symbol"] == "AAA", "rank"] = np.int8(-1)
+
+    out_t1 = compute_thematic_features(
+        panel=panel_5x30,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map,
+        ticker_registry=ticker_registry,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+        prev_features=prev,
+    )
+    aaa_delta = int(out_t1.loc[out_t1["symbol"] == "AAA", "rank_delta_1d"].iloc[0])
+    assert aaa_delta == 0, (
+        f"rank_delta_1d should be 0 when prev_rank is -1 sentinel; got {aaa_delta}"
+    )
+
+
 def test_universe_size_recorded(
     panel_5x30, sector_map, ticker_registry, sector_registry
 ):

--- a/tests/research/test_thematic_ranks.py
+++ b/tests/research/test_thematic_ranks.py
@@ -413,6 +413,48 @@ def test_top15_streak_increments_and_resets(
 # ---------------------------------------------------------------------------
 
 
+def test_compute_excludes_symbols_not_in_yaml_sector_map(
+    sector_map, ticker_registry, sector_registry
+):
+    """Regression — codex iter-7 [P2]: cached panel may contain tickers no
+    longer in the active YAML universe (e.g. one removed in a YAML edit).
+    Cross-sectional ranks must be computed only over the active universe,
+    not every symbol still in the parquet.
+    """
+    symbols = ["AAA", "BBB", "CCC", "DDD", "EEE"]
+    daily_returns = {
+        "AAA": [0.01] * 29,
+        "BBB": [0.005] * 29,
+        "CCC": [0.0] * 29,
+        "DDD": [-0.005] * 29,
+        "EEE": [-0.01] * 29,
+    }
+    panel = _build_panel(symbols, 30, daily_returns)
+
+    # Add a STALE symbol that's still in the OHLCV cache but NOT in sector_map
+    # (simulating a YAML removal). It must be excluded from ranks/universe.
+    stale = _build_panel(["STALE"], 30, {"STALE": [0.02] * 29})
+    panel = pd.concat([panel, stale], ignore_index=True)
+
+    # sector_map does NOT include STALE — i.e. operator removed it from YAML.
+    out = compute_thematic_features(
+        panel=panel,
+        asof=date(2024, 11, 8),
+        sector_map=sector_map,  # 5-ticker universe
+        ticker_registry=ticker_registry,
+        sector_registry=sector_registry,
+        universe_yaml_sha="abc123",
+    )
+    out_syms = set(out["symbol"].tolist())
+    assert "STALE" not in out_syms, (
+        "removed-from-YAML symbol must not appear in features output"
+    )
+    assert (out["universe_size"] == 5).all(), (
+        f"universe_size must reflect active YAML universe (5), not cached "
+        f"panel symbol count; got: {out['universe_size'].unique()}"
+    )
+
+
 def test_vol_window_no_pad_on_internal_gaps(
     sector_map, ticker_registry, sector_registry
 ):

--- a/tests/research/test_thematic_run_daily.py
+++ b/tests/research/test_thematic_run_daily.py
@@ -280,3 +280,54 @@ def test_thematic_run_daily_is_idempotent(fake_cache):
     assert rows_1 == rows_2, (
         f"non-idempotent: row count grew {rows_1} -> {rows_2}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Stale-OHLCV diagnostic — surface-don't-silo (review iter-1 / codex iter-1)
+# ---------------------------------------------------------------------------
+
+
+def test_run_daily_stale_ohlcv_surfaces_diagnostic(fake_cache):
+    """When the OHLCV cache's max date is before --asof, run-daily must fail
+    fast with a diagnostic that names the next-step backfill command rather
+    than silently producing an empty Layer A and missing render.
+
+    Per DESIGN-thematic-ranks-dashboard.md §7 + memory feedback_surface_dont_silo.
+    """
+    from rainier.cli import cli
+
+    runner = CliRunner()
+    # fake_cache panel ends at the synthesized last weekday in the 60-day
+    # window; asof set well past that.
+    asof_stale = date(2030, 1, 2)
+    result = runner.invoke(
+        cli,
+        [
+            "thematic",
+            "run-daily",
+            "--asof",
+            asof_stale.isoformat(),
+            "--ohlcv",
+            str(fake_cache["panel"]),
+            "--yaml",
+            str(fake_cache["yaml"]),
+            "--features-out",
+            str(fake_cache["features_out"]),
+            "--labels-out",
+            str(fake_cache["labels_out"]),
+            "--ticker-registry",
+            str(fake_cache["ticker_registry"]),
+            "--sector-registry",
+            str(fake_cache["sector_registry"]),
+            "--html-out",
+            str(fake_cache["html_out"]),
+        ],
+    )
+    # ClickException returns exit_code=1 with a clean diagnostic.
+    assert result.exit_code != 0, "stale OHLCV should fail fast"
+    assert "stale" in result.output.lower(), (
+        f"diagnostic should mention 'stale'; got: {result.output!r}"
+    )
+    assert "backfill_thematic_universe" in result.output, (
+        f"diagnostic should name the next-step backfill command; got: {result.output!r}"
+    )

--- a/tests/research/test_thematic_run_daily.py
+++ b/tests/research/test_thematic_run_daily.py
@@ -8,11 +8,9 @@ Design ref: docs/DESIGN-thematic-ranks-dashboard.md §7 ([D-004]).
 
 from __future__ import annotations
 
-import os
 from datetime import date, timedelta
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 import pytest
 from click.testing import CliRunner

--- a/tests/research/test_thematic_run_daily.py
+++ b/tests/research/test_thematic_run_daily.py
@@ -1,0 +1,284 @@
+"""End-to-end CLI smoke test for `rainier thematic run-daily`.
+
+Drives the full path: stub OHLCV → compute Layer A → compute Layer B → render HTML.
+Re-running with same inputs must short-circuit (idempotent).
+
+Design ref: docs/DESIGN-thematic-ranks-dashboard.md §7 ([D-004]).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+
+
+def _build_ohlcv_panel(symbols: list[str], n_days: int) -> pd.DataFrame:
+    """Synth OHLCV panel matching the schema produced by backfill_thematic_universe."""
+    dates = []
+    d = date(2024, 10, 1)
+    while len(dates) < n_days:
+        if d.weekday() < 5:
+            dates.append(d)
+        d = d + timedelta(days=1)
+
+    rows = []
+    for s_idx, sym in enumerate(symbols):
+        close = 100.0
+        for i, day in enumerate(dates):
+            if i > 0:
+                close = close * (1.0 + 0.005 * (s_idx - 2))  # spread of returns
+            rows.append(
+                {
+                    "symbol": sym,
+                    "date": day,
+                    "open": close,
+                    "high": close * 1.005,
+                    "low": close * 0.995,
+                    "close": close,
+                    "volume": 1_000_000,
+                    "fetched_at": pd.Timestamp("2024-11-08T16:30:00Z"),
+                    "yfinance_version": "1.2.0",
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def fake_cache(tmp_path: Path) -> dict[str, Path]:
+    """Stage thematic_universe.parquet, registries, and a YAML universe.
+
+    Returns a dict of paths that the run-daily CLI consumes.
+    """
+    symbols = ["AAA", "BBB", "CCC", "DDD", "EEE"]
+    panel = _build_ohlcv_panel(symbols, n_days=60)
+
+    cache_dir = tmp_path / "data" / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+
+    panel_path = cache_dir / "thematic_universe.parquet"
+    panel.to_parquet(panel_path)
+
+    # Minimal universe YAML grouping tickers by single sector.
+    yaml_path = tmp_path / "thematic_universe.yaml"
+    yaml_path.write_text(
+        "version: 1\n"
+        "schema: thematic_universe.v1\n"
+        "asof_seeded: 2024-10-01\n"
+        "universe:\n"
+        "  test_sector:\n"
+        "    - AAA\n"
+        "    - BBB\n"
+        "    - CCC\n"
+        "    - DDD\n"
+        "    - EEE\n"
+    )
+
+    return {
+        "panel": panel_path,
+        "yaml": yaml_path,
+        "features_out": cache_dir / "thematic_features_daily.parquet",
+        "labels_out": cache_dir / "thematic_labels_daily.parquet",
+        "log_out": cache_dir / "thematic_universe_log.parquet",
+        "ticker_registry": cache_dir / "ticker_registry.parquet",
+        "sector_registry": cache_dir / "sector_registry.parquet",
+        "html_out": docs_dir / "thematic-ranks-latest.html",
+        "docs_dir": docs_dir,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_thematic_compute_writes_features_parquet(fake_cache):
+    """`thematic compute --asof <date>` populates thematic_features_daily.parquet."""
+    from rainier.cli import cli
+
+    runner = CliRunner()
+    asof = date(2024, 11, 8)
+    result = runner.invoke(
+        cli,
+        [
+            "thematic",
+            "compute",
+            "--asof",
+            asof.isoformat(),
+            "--ohlcv",
+            str(fake_cache["panel"]),
+            "--yaml",
+            str(fake_cache["yaml"]),
+            "--out",
+            str(fake_cache["features_out"]),
+            "--ticker-registry",
+            str(fake_cache["ticker_registry"]),
+            "--sector-registry",
+            str(fake_cache["sector_registry"]),
+        ],
+    )
+    assert result.exit_code == 0, (
+        f"compute failed: exit={result.exit_code} output={result.output}"
+    )
+    assert fake_cache["features_out"].exists()
+    df = pd.read_parquet(fake_cache["features_out"])
+    assert len(df) == 5  # 5 tickers, one asof_date
+    assert (df["asof_date"] == asof).all()
+
+
+def test_thematic_backfill_labels_writes_labels_parquet(fake_cache):
+    """`thematic backfill-labels` populates thematic_labels_daily.parquet."""
+    from rainier.cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "thematic",
+            "backfill-labels",
+            "--ohlcv",
+            str(fake_cache["panel"]),
+            "--out",
+            str(fake_cache["labels_out"]),
+        ],
+    )
+    assert result.exit_code == 0, (
+        f"backfill-labels failed: exit={result.exit_code} output={result.output}"
+    )
+    assert fake_cache["labels_out"].exists()
+
+
+def test_thematic_render_writes_html(fake_cache):
+    """`thematic render` writes a self-contained HTML file."""
+    from rainier.cli import cli
+
+    runner = CliRunner()
+    # First need a features parquet
+    runner.invoke(
+        cli,
+        [
+            "thematic",
+            "compute",
+            "--asof",
+            "2024-11-08",
+            "--ohlcv",
+            str(fake_cache["panel"]),
+            "--yaml",
+            str(fake_cache["yaml"]),
+            "--out",
+            str(fake_cache["features_out"]),
+            "--ticker-registry",
+            str(fake_cache["ticker_registry"]),
+            "--sector-registry",
+            str(fake_cache["sector_registry"]),
+        ],
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "thematic",
+            "render",
+            "--asof",
+            "2024-11-08",
+            "--features",
+            str(fake_cache["features_out"]),
+            "--yaml",
+            str(fake_cache["yaml"]),
+            "--out",
+            str(fake_cache["html_out"]),
+        ],
+    )
+    assert result.exit_code == 0, (
+        f"render failed: exit={result.exit_code} output={result.output}"
+    )
+    assert fake_cache["html_out"].exists()
+    html = fake_cache["html_out"].read_text()
+    assert "AAA" in html and "EEE" in html
+
+
+def test_thematic_run_daily_writes_all_artifacts(fake_cache):
+    """`thematic run-daily` writes features parquet + labels parquet + HTML."""
+    from rainier.cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "thematic",
+            "run-daily",
+            "--asof",
+            "2024-11-08",
+            "--ohlcv",
+            str(fake_cache["panel"]),
+            "--yaml",
+            str(fake_cache["yaml"]),
+            "--features-out",
+            str(fake_cache["features_out"]),
+            "--labels-out",
+            str(fake_cache["labels_out"]),
+            "--ticker-registry",
+            str(fake_cache["ticker_registry"]),
+            "--sector-registry",
+            str(fake_cache["sector_registry"]),
+            "--html-out",
+            str(fake_cache["html_out"]),
+        ],
+    )
+    assert result.exit_code == 0, (
+        f"run-daily failed: exit={result.exit_code} output={result.output}"
+    )
+    assert fake_cache["features_out"].exists()
+    assert fake_cache["labels_out"].exists()
+    assert fake_cache["html_out"].exists()
+
+
+def test_thematic_run_daily_is_idempotent(fake_cache):
+    """Re-running run-daily for same asof leaves parquets unchanged."""
+    from rainier.cli import cli
+
+    runner = CliRunner()
+    args = [
+        "thematic",
+        "run-daily",
+        "--asof",
+        "2024-11-08",
+        "--ohlcv",
+        str(fake_cache["panel"]),
+        "--yaml",
+        str(fake_cache["yaml"]),
+        "--features-out",
+        str(fake_cache["features_out"]),
+        "--labels-out",
+        str(fake_cache["labels_out"]),
+        "--ticker-registry",
+        str(fake_cache["ticker_registry"]),
+        "--sector-registry",
+        str(fake_cache["sector_registry"]),
+        "--html-out",
+        str(fake_cache["html_out"]),
+    ]
+    r1 = runner.invoke(cli, args)
+    assert r1.exit_code == 0
+
+    # Snapshot features parquet
+    df1 = pd.read_parquet(fake_cache["features_out"])
+    rows_1 = len(df1)
+
+    # Run again with same args.
+    r2 = runner.invoke(cli, args)
+    assert r2.exit_code == 0
+    df2 = pd.read_parquet(fake_cache["features_out"])
+    rows_2 = len(df2)
+
+    # Idempotent: same number of rows (no duplicate insert)
+    assert rows_1 == rows_2, (
+        f"non-idempotent: row count grew {rows_1} -> {rows_2}"
+    )

--- a/tests/research/test_thematic_run_daily.py
+++ b/tests/research/test_thematic_run_daily.py
@@ -343,6 +343,49 @@ def test_run_daily_stale_ohlcv_surfaces_diagnostic(fake_cache):
     )
 
 
+def test_thematic_compute_partial_universe_coverage_fails(fake_cache, tmp_path):
+    """Regression — codex iter-8 [P2]: the direct `thematic compute` path
+    must apply the same partial-coverage gate as `run-daily`, otherwise an
+    operator running compute directly with a partial cache would silently
+    produce shrunken ranks.
+    """
+    from rainier.cli import cli
+
+    panel = pd.read_parquet(fake_cache["panel"])
+    asof_dt = date(2024, 11, 8)
+    drop_mask = (panel["date"] == asof_dt) & panel["symbol"].isin(
+        ["AAA", "BBB", "CCC"]
+    )
+    partial = panel.loc[~drop_mask].reset_index(drop=True)
+    partial_path = tmp_path / "partial_universe.parquet"
+    partial.to_parquet(partial_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "thematic",
+            "compute",
+            "--asof",
+            asof_dt.isoformat(),
+            "--ohlcv",
+            str(partial_path),
+            "--yaml",
+            str(fake_cache["yaml"]),
+            "--out",
+            str(fake_cache["features_out"]),
+            "--ticker-registry",
+            str(fake_cache["ticker_registry"]),
+            "--sector-registry",
+            str(fake_cache["sector_registry"]),
+        ],
+    )
+    assert result.exit_code != 0, "direct compute must also fail on partial coverage"
+    assert "partial coverage" in result.output.lower(), (
+        f"diagnostic should mention partial coverage; got: {result.output!r}"
+    )
+
+
 def test_run_daily_partial_universe_coverage_fails(fake_cache, tmp_path):
     """Regression — codex iter-6 [P1]: ranks are cross-sectional, so if a
     partial backfill leaves the panel without close rows for >25% of the

--- a/tests/research/test_thematic_run_daily.py
+++ b/tests/research/test_thematic_run_daily.py
@@ -341,3 +341,52 @@ def test_run_daily_stale_ohlcv_surfaces_diagnostic(fake_cache):
     assert " mv " in result.output, (
         f"diagnostic must include cohort-swap mv step; got: {result.output!r}"
     )
+
+
+def test_run_daily_partial_universe_coverage_fails(fake_cache, tmp_path):
+    """Regression — codex iter-6 [P1]: ranks are cross-sectional, so if a
+    partial backfill leaves the panel without close rows for >25% of the
+    YAML universe on asof, run-daily must surface that gap rather than
+    silently rendering a shrunken dashboard.
+    """
+    from rainier.cli import cli
+
+    # Read the fake panel and drop 3 of 5 tickers on the chosen asof to
+    # simulate a partial yfinance run. 3/5 = 60% missing -> well above 25%.
+    panel = pd.read_parquet(fake_cache["panel"])
+    asof_dt = date(2024, 11, 8)
+    drop_mask = (panel["date"] == asof_dt) & panel["symbol"].isin(
+        ["AAA", "BBB", "CCC"]
+    )
+    partial = panel.loc[~drop_mask].reset_index(drop=True)
+    partial_path = tmp_path / "partial_universe.parquet"
+    partial.to_parquet(partial_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "thematic",
+            "run-daily",
+            "--asof",
+            asof_dt.isoformat(),
+            "--ohlcv",
+            str(partial_path),
+            "--yaml",
+            str(fake_cache["yaml"]),
+            "--features-out",
+            str(fake_cache["features_out"]),
+            "--labels-out",
+            str(fake_cache["labels_out"]),
+            "--ticker-registry",
+            str(fake_cache["ticker_registry"]),
+            "--sector-registry",
+            str(fake_cache["sector_registry"]),
+            "--html-out",
+            str(fake_cache["html_out"]),
+        ],
+    )
+    assert result.exit_code != 0, "partial-coverage backfill should fail fast"
+    assert "partial coverage" in result.output.lower(), (
+        f"diagnostic should mention partial coverage; got: {result.output!r}"
+    )

--- a/tests/research/test_thematic_run_daily.py
+++ b/tests/research/test_thematic_run_daily.py
@@ -331,3 +331,13 @@ def test_run_daily_stale_ohlcv_surfaces_diagnostic(fake_cache):
     assert "backfill_thematic_universe" in result.output, (
         f"diagnostic should name the next-step backfill command; got: {result.output!r}"
     )
+    # codex iter-3 [P1]: the recovery flow must account for backfill's
+    # revision-immutability (--force writes a sibling cohort, not in-place).
+    # Diagnostic must include the cohort-swap step (--force then mv).
+    assert "--force" in result.output, (
+        f"diagnostic must mention --force (sibling cohort flow); "
+        f"got: {result.output!r}"
+    )
+    assert " mv " in result.output, (
+        f"diagnostic must include cohort-swap mv step; got: {result.output!r}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -565,6 +565,15 @@ wheels = [
 ]
 
 [[package]]
+name = "farama-notifications"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/91/14397890dde30adc4bee6462158933806207bc5dd10d7b4d09d5c33845cf/farama_notifications-0.0.6.tar.gz", hash = "sha256:b19acac4bb41d76e59e03394b5dd165f4761c86fa327f56307a35cbee3b60158", size = 2517, upload-time = "2026-04-24T08:43:57.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/f0/21f81892e4ed10f4ec3ef2e7cf8635fb76e7c0907c55d0da66be50094760/farama_notifications-0.0.6-py3-none-any.whl", hash = "sha256:f84839188efa1ce5bb361c2a84881b2dc2c0d0d7fb661ff00421820170930935", size = 2897, upload-time = "2026-04-24T08:43:56.785Z" },
+]
+
+[[package]]
 name = "fastuuid"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -786,6 +795,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
     { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
+name = "gymnasium"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "farama-notifications" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/ff/14b6880d703dfaca204490979d3254ccd280c99550798993319902873658/gymnasium-1.3.0.tar.gz", hash = "sha256:6939e86e835d6b71b6ba6bfd360487420876deafc79bfb7bacba83a7c446bcf3", size = 830646, upload-time = "2026-04-22T13:47:14.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
 ]
 
 [[package]]
@@ -2242,6 +2267,9 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+rl = [
+    { name = "gymnasium" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2251,6 +2279,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "click", specifier = ">=8.1" },
     { name = "exchange-calendars", specifier = ">=4.13.2" },
+    { name = "gymnasium", marker = "extra == 'rl'", specifier = ">=0.29" },
     { name = "hmmlearn", specifier = ">=0.3.3" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "ib-insync", specifier = ">=0.9.86" },
@@ -2281,7 +2310,7 @@ requires-dist = [
     { name = "xgboost", specifier = ">=3.2.0" },
     { name = "yfinance", specifier = ">=1.2.0" },
 ]
-provides-extras = ["dashboard", "dev"]
+provides-extras = ["dashboard", "rl", "dev"]
 
 [[package]]
 name = "referencing"


### PR DESCRIPTION
## Summary
Phase B of the Industry/Thematic ranks dashboard feature (`docs/DESIGN-thematic-ranks-dashboard.md`). Lands the compute + dashboard + cron layers on top of Phase A (PR #80, the data substrate).

- `src/rainier/research/breadth/ranks.py` — `compute_thematic_features` (Layer A: REL_{5,10,20}, vol-normalized REL with fixed N=20 denominator per [D-013], centile ranks R_{5,10,20}, Rank composite, rank dynamics, `top15_streak` per [D-014], cross-sectional context) and `compute_forward_labels` (Layer B: fwd_{3,5,10,20,30}_ret + excess + drawdown/runup per [D-012]).
- `src/rainier/research/breadth/loaders.py` — `load_thematic_features`, `load_thematic_panel` (wide pivot), `load_supervised` with `drop_incomplete_labels`. Per DESIGN §5.6.
- `src/rainier/research/breadth/ml_builders.py` — `build_panel_tensor` + `ThematicTradingEnv` (gymnasium dep loaded lazily; `[project.optional-dependencies] rl`).
- `src/rainier/viz/thematic_dashboard.py` — self-contained sortable HTML (inline CSS+JS, no external links). Byte-identical render on byte-identical input.
- `src/rainier/cli.py` extended with `thematic compute / backfill-labels / render / run-daily` subcommands. `run-daily` is idempotent.
- `data_availability.yaml` extended with 94 `thematic_features_daily.*` + 94 `thematic_labels_daily.*` ledger entries per DESIGN §5.5. Layer B uses `observability_timestamp_rule: t_plus_n_close` (explicit look-ahead acknowledgment).
- `config/cron.yaml` adds `thematic-ranks-daily` at 30 13 * * 1-5 PT (matches existing QU entries' timezone convention).

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 10)
- 11 total commits on this PR: 3 TDD + 8 reviewer-iter fixes (P1: run-daily stale-OHLCV guard, partial-coverage guard, cron-gating until daily OHLCV refresh wired; P2: sort UX, cost-label gates, NaN propagation through vol/drawdown, OHLCV-freshness helper extraction).
- 13 regression tests added during review iterations.

## Deferred [P2]
- universe_loader.py A->B->A revert log gap (codex iter-5/7) — Phase A territory, deferred for follow-up.
- `compute_thematic_features` public-API date coercion (codex iter-10) — CLI normalizes; would be design improvement.
- `label_complete_through` could be derived from actual labels (codex iter-10) — design improvement.
- RL env reward alignment vs feature order (codex iter-8/10) — env is consumer-responsibility per DESIGN §9.

## Test plan
- [ ] CI green
- [ ] Operator: `uv run rainier thematic compute --asof <today>` writes today's row to `data/cache/thematic_features_daily.parquet` (requires Phase A backfill to have run first)
- [ ] Operator: `uv run rainier thematic render --asof <today>` writes self-contained dashboard HTML
- [ ] Operator: visually verify `docs/thematic-ranks-<YYYY-MM-DD>.html` after first cron run (sector grouping, sortable, color-scaled R cells)
- [ ] Stacked on #80 (Phase A) -> #78 (vix). When upstack squash-merges, this branch rebases onto new main; PR `--base` stays `main`.

---

Stacked: this PR -> #80 (Phase A) -> #78 (vix). When operator merges upstack, this branch rebases onto new main.