### PR TITLE
feat(qu-scraper): in-page fetch + D-10 always-close teardown

### DIFF
--- a/src/rainier/scrapers/browser.py
+++ b/src/rainier/scrapers/browser.py
@@ -200,6 +200,70 @@ class BrowserManager:
         yield page
         # Do NOT close — it's the user's tab
 
+    @asynccontextmanager
+    async def fresh_tab_in_existing_context(
+        self,
+    ) -> AsyncGenerator[Page, None]:
+        """Open a new page inside the CDP browser's existing context, close it on exit.
+
+        Used by the QU scraper (DESIGN D-10) to satisfy the USCIS-style "always
+        close the scrape window" guarantee in CDP mode without disturbing the
+        operator's other tabs.
+
+        We attach to ``contexts[0]`` — the operator's logged-in Chrome context
+        carrying the live ``session`` + ``cf_clearance`` cookies — and call
+        ``new_page()`` on it. **We do NOT call ``browser.new_context()``**:
+        that would drop the operator's auth state. The new tab inherits the
+        existing context's cookies, so the QU SPA + Cloudflare see us as
+        logged in.
+
+        On exit the helper closes only that one page. The context, the
+        Chrome process, and every other tab the operator had open survive.
+
+        Falls back to :meth:`new_page` if the manager is in launch mode (not
+        CDP) so callers can stay mode-agnostic.
+        """
+        if not self._is_cdp:
+            async with self.new_page() as page:
+                yield page
+            return
+
+        if self._browser is None:
+            raise RuntimeError("Browser not started. Call start() or use 'async with'.")
+
+        contexts = self._browser.contexts
+        if not contexts:
+            # No context yet (unusual for CDP but possible if Chrome started
+            # fresh) — create one. This is the only path that legitimately
+            # creates a new context in CDP mode; it carries no operator auth
+            # by definition because none existed yet.
+            log.warning("cdp_no_contexts_creating_new", msg="No contexts in CDP browser")
+            context = await self._browser.new_context()
+            context.set_default_timeout(self._timeout_ms)
+            page = await context.new_page()
+            try:
+                yield page
+            finally:
+                await page.close()
+            return
+
+        context = contexts[0]
+        page = await context.new_page()
+        page.set_default_timeout(self._timeout_ms)
+        log.info("cdp_fresh_tab_opened", url=page.url)
+        try:
+            yield page
+        finally:
+            try:
+                await page.close()
+                log.info("cdp_fresh_tab_closed")
+            except Exception as exc:
+                # Closing a tab should never break the calling code. Log and
+                # move on — the worst case is one leftover tab the operator
+                # can close manually, which we treat as a non-fatal hygiene
+                # bug rather than a scrape failure.
+                log.warning("cdp_fresh_tab_close_failed", error=str(exc))
+
     @staticmethod
     async def save_storage_state(page: Page, path: str | Path) -> None:
         """Save cookies + localStorage from the current page's context."""

--- a/src/rainier/scrapers/qu/parsers.py
+++ b/src/rainier/scrapers/qu/parsers.py
@@ -118,6 +118,41 @@ def parse_qu100_rows(raw_rows: list[dict]) -> list[QU100Row]:
     return results
 
 
+def api_rows_to_qu100_rows(api_rows: list[dict]) -> list[QU100Row]:
+    """Adapt /api/v3/mf100 response rows to QU100Row (DESIGN D-4).
+
+    The API payload (per the spike capture) ships rows shaped like::
+
+        {"rank": 1, "ticker": "MU", "change": "0",
+         "industry": "Semiconductors", "long_short": "No dominance",
+         "sector": "Technology"}
+
+    QU100Row uses `symbol` instead of `ticker` and `daily_change: int`
+    instead of `change: str`. The only transformations are the rename
+    and feeding `change` through `parse_daily_change` (which already
+    handles "0", signed integers, "new", and arrow-prefixed inputs).
+
+    Empty / missing tickers are skipped defensively.
+    """
+    results: list[QU100Row] = []
+    for row in api_rows:
+        symbol = str(row.get("ticker", "")).strip().upper()
+        if not symbol:
+            continue
+        results.append(
+            QU100Row(
+                rank=int(row.get("rank", 0) or 0),
+                symbol=symbol,
+                daily_change=parse_daily_change(str(row.get("change", "0"))),
+                sector=str(row.get("sector", "")).strip(),
+                industry=str(row.get("industry", "")).strip(),
+                long_short=str(row.get("long_short", "")).strip(),
+                raw=row,
+            )
+        )
+    return results
+
+
 def parse_capital_flow_rows(
     raw_rows: list[dict], period_type: str
 ) -> list[CapitalFlowRow]:

--- a/src/rainier/scrapers/qu/scraper.py
+++ b/src/rainier/scrapers/qu/scraper.py
@@ -19,9 +19,30 @@ from rainier.scrapers.qu import selectors as sel
 from rainier.scrapers.qu.auth import ensure_authenticated, get_session_path, is_session_valid, login
 from rainier.scrapers.qu.parsers import (
     QU100Row,
+    api_rows_to_qu100_rows,
     parse_capital_flow_rows,
-    parse_qu100_rows,
 )
+
+# In-page fetch JS (DESIGN D-3/D-7). Defined at module scope so it's easy
+# to find, easy to unit-test by reference, and not allocated per call.
+#
+# Cloudflare cf_clearance is bound to the page's TLS handshake — the only
+# request shape that gets past the challenge is one that originates from
+# the rendered page itself. We use ``credentials: 'include'`` so the
+# session + cf_clearance cookies on the page are sent automatically.
+QU100_FETCH_JS = """
+async ({url}) => {
+    const resp = await fetch(url, {
+        method: 'GET',
+        credentials: 'include',
+        headers: {'accept': 'application/json, text/plain, */*'},
+    });
+    if (!resp.ok) {
+        throw new Error('qu100 api ' + resp.status + ' for ' + url);
+    }
+    return await resp.json();
+}
+"""
 
 log = structlog.get_logger()
 
@@ -42,16 +63,26 @@ class QUScraper(BaseScraper):
     async def setup(self) -> None:
         """Open a page and ensure logged in.
 
-        In CDP mode: uses the existing browser tab (user already logged in).
+        In CDP mode (DESIGN D-10): opens a FRESH TAB inside the operator's
+        existing logged-in Chrome context via
+        ``BrowserManager.fresh_tab_in_existing_context``. The context's
+        cookies (``session`` + ``cf_clearance``) carry through, so the
+        QU SPA + Cloudflare see us as logged in. **We do NOT use
+        ``existing_page`` (which reuses the operator's tab and refuses to
+        close it) or ``browser.new_context`` (which drops auth).**
+
         In launch mode: opens a new page with saved session + auto-login.
         """
         if self.browser._is_cdp:
-            # CDP mode: user's real Chrome — check if auth is needed
-            self._page_cm = self.browser.existing_page()
+            # CDP mode: fresh tab in the operator's context. Always-close on
+            # teardown — leaves the operator's other tabs and Chrome process
+            # untouched.
+            self._page_cm = self.browser.fresh_tab_in_existing_context()
             self._page = await self._page_cm.__aenter__()
-            self.log.info("cdp_mode", url=self._page.url)
+            self.log.info("cdp_mode_fresh_tab", url=self._page.url)
 
-            # Auto-login if not authenticated
+            # Auto-login if not authenticated (rare — the operator's context
+            # typically already has live cookies).
             await self._cdp_ensure_auth()
         else:
             # Launch mode: fresh Playwright browser, need auth
@@ -64,11 +95,23 @@ class QUScraper(BaseScraper):
             await self._verify_session()
 
     async def teardown(self) -> None:
-        """Close the page/context."""
-        if self._page_cm:
-            await self._page_cm.__aexit__(None, None, None)
-            self._page = None
+        """Close the scrape page/tab (USCIS-style, DESIGN D-10).
+
+        Runs unconditionally from ``BaseScraper.execute``'s ``finally``, so
+        it fires on success AND on every failure path (including a raise
+        from ``run()``). Idempotent w.r.t. the outer ``async with
+        BrowserManager`` — exiting the page context here means the outer
+        block's exit is a no-op for the page (it still tears down the
+        browser/playwright in launch mode).
+        """
+        if self._page_cm is not None:
+            page_cm = self._page_cm
+            # Clear bookkeeping BEFORE awaiting __aexit__ so a re-entrant
+            # call (or a __aexit__ that itself raises) doesn't double-close
+            # or leave dangling state.
             self._page_cm = None
+            self._page = None
+            await page_cm.__aexit__(None, None, None)
 
     async def run(self, **kwargs) -> ScrapeResult:
         """
@@ -265,166 +308,72 @@ class QUScraper(BaseScraper):
         result: ScrapeResult,
         target_date: str | None = None,
     ) -> None:
-        """Scrape Top100 and Bottom100 from the QU100 page."""
+        """Scrape Top100 + Bottom100 via in-page fetch (DESIGN D-3/D-7/D-9).
+
+        Two ``page.evaluate(fetch(...))`` calls per date — one for
+        ``top=true`` and one for ``top=false`` — against ``/api/v3/mf100``.
+        The fetch originates from the rendered page, so Cloudflare's
+        cf_clearance (TLS-bound) accepts the request. No DOM clicks. No
+        date-picker interaction. No spinner waits.
+        """
         page = self._page
 
-        # Navigate to QU100 page if needed
+        # Make sure the page is on the QU SPA so cf_clearance + session
+        # cookies are scoped correctly. The in-page fetch path needs the
+        # page to be on the same origin as the API.
         current_url = page.url or ""
         if "quantunicorn.com/products" not in current_url:
             if self.browser._is_cdp:
-                self.log.warning("cdp_wrong_page", url=current_url,
-                                 hint="Navigate to QU100 page in Chrome first")
+                self.log.info("cdp_navigating_for_fetch", url=current_url)
             await goto_with_retry(page, self._qu_config.url)
 
-        # Safety net: if redirected to signin after navigation, force login
+        # Safety net: if redirected to signin (stale session), force login
+        # and try again. Same logic as before; just preserved here for the
+        # one place it still matters.
         if "signin" in (page.url or ""):
             self.log.info("scrape_forced_login", url=page.url)
             await login(page)
             await goto_with_retry(page, self._qu_config.url)
 
-        # Change date if requested, then click Search to load data
+        # The API takes ``date`` as a query param (DESIGN D-9). We use the
+        # caller-supplied target_date if any, otherwise the run's captured_at.
         if target_date:
-            await self._set_date(target_date)
-        search_btn = await page.wait_for_selector(sel.SEARCH_BUTTON, timeout=15000)
-        if search_btn:
-            await search_btn.click()
-
-        # Wait for the table to appear
-        await page.wait_for_selector(sel.QU100_TABLE, timeout=15000)
-
-        # Read the data date from the date picker (e.g., "2026-03-13")
-        data_date_str = await page.get_attribute(sel.DATE_INPUT, "value")
-        try:
-            data_date = date_type.fromisoformat(data_date_str) if data_date_str else captured_at.date()
-        except ValueError:
+            try:
+                data_date = date_type.fromisoformat(target_date)
+            except ValueError:
+                self.log.warning("invalid_target_date_fallback",
+                                 target_date=target_date)
+                data_date = captured_at.date()
+        else:
             data_date = captured_at.date()
         self.log.info("qu100_data_date", date=str(data_date))
 
-        for ranking_type, button_sel in [
-            ("top100", sel.TOP100_BUTTON),
-            ("bottom100", sel.BOTTOM100_BUTTON),
-        ]:
+        # One fetch per ranking. ``top=true|false`` per the SPA contract.
+        for ranking_type, top_flag in [("top100", "true"), ("bottom100", "false")]:
             try:
-                # Capture current first-row symbol to detect table refresh
-                old_first = None
-                try:
-                    old_rows = await page.evaluate(sel.QU100_EXTRACT_JS)
-                    if old_rows:
-                        old_first = old_rows[0].get("symbol")
-                except Exception:
-                    pass
-
-                # The previous Search click leaves an antd loading spinner
-                # overlaying the toggle buttons. Clicking through it makes
-                # Playwright stall on actionability checks until 30s timeout.
-                await self._wait_for_no_spinner()
-
-                # Mid-iteration auth check: the previous iteration's Search
-                # click can trigger a server-side redirect to /signin when the
-                # session cookie has expired silently. In that state, the
-                # `.select-button` toggle no longer exists on the page and
-                # clicking it stalls for the full default click timeout (30s),
-                # which is what was killing the midday + close cron runs.
-                # Recover by re-logging in and re-navigating before the click.
-                await self._recover_if_signin()
-
-                # Click toggle, then Search button (required per QU100 UI)
-                await page.click(button_sel)
-                search_btn = await page.query_selector(sel.SEARCH_BUTTON)
-                if search_btn:
-                    await search_btn.click()
-
-                # Wait for table to refresh with new data
-                if old_first:
-                    for _ in range(30):
-                        await asyncio.sleep(0.5)
-                        try:
-                            new_rows = await page.evaluate(
-                                sel.QU100_EXTRACT_JS
-                            )
-                            if (
-                                new_rows
-                                and new_rows[0].get("symbol") != old_first
-                            ):
-                                break
-                        except Exception:
-                            pass
-                    else:
-                        self.log.warning(
-                            "table_refresh_timeout",
-                            ranking_type=ranking_type,
-                        )
-                else:
-                    await page.wait_for_selector(
-                        sel.QU100_TABLE_ROW, timeout=15000
-                    )
-
-                raw_rows = await page.evaluate(sel.QU100_EXTRACT_JS)
-                parsed = parse_qu100_rows(raw_rows)
-                count = self._persist_qu100(parsed, ranking_type, session_name, captured_at, data_date)
+                url = (
+                    f"{sel.QU100_API_URL}?date={data_date.isoformat()}"
+                    f"&top={top_flag}&frequency=daily"
+                )
+                payload = await page.evaluate(QU100_FETCH_JS, {"url": url})
+                api_data = payload.get("data", []) if isinstance(payload, dict) else []
+                parsed = api_rows_to_qu100_rows(api_data)
+                count = self._persist_qu100(
+                    parsed, ranking_type, session_name, captured_at, data_date
+                )
                 result.records_created += count
-
-                self.log.info("qu100_scraped", ranking_type=ranking_type, rows=count, date=str(data_date))
-
+                self.log.info(
+                    "qu100_scraped",
+                    ranking_type=ranking_type,
+                    rows=count,
+                    date=str(data_date),
+                )
             except Exception as exc:
                 error_msg = f"Failed to scrape {ranking_type}: {exc}"
-                self.log.warning("qu100_failed", ranking_type=ranking_type, error=str(exc))
+                self.log.warning(
+                    "qu100_failed", ranking_type=ranking_type, error=str(exc)
+                )
                 result.errors.append(error_msg)
-
-    async def _wait_for_no_spinner(self, timeout_ms: int = 10000) -> None:
-        """Wait for any antd loading spinner to disappear.
-
-        Best-effort: a stuck spinner shouldn't kill the scrape — log and continue,
-        and let the actual click surface a clearer error if the page is truly broken.
-        """
-        try:
-            await self._page.wait_for_selector(
-                ".ant-spin-spinning", state="hidden", timeout=timeout_ms
-            )
-        except Exception as exc:
-            self.log.warning("spinner_wait_timeout", error=str(exc))
-
-    async def _recover_if_signin(self) -> bool:
-        """If the page is on /signin, re-login and navigate back to QU100.
-
-        Returns True if recovery ran, False otherwise.
-
-        Background: between toggle iterations inside `_scrape_qu100`, the
-        previous Search click can produce a 401 from the API and cause the
-        SPA to redirect to /signin. The select-button toggle is then gone
-        from the DOM and the next iteration's `page.click(...)` hangs until
-        the default 30s timeout. This helper makes that path recoverable.
-        """
-        page = self._page
-        url = page.url or ""
-        if "signin" not in url:
-            return False
-
-        self.log.warning("mid_iter_signin_redirect", url=url)
-        await login(page)
-        await goto_with_retry(page, self._qu_config.url)
-        # After re-login, the Search button needs to be clicked again to
-        # repopulate the table. Wait for the button + table to be present.
-        try:
-            search_btn = await page.wait_for_selector(
-                sel.SEARCH_BUTTON, timeout=15000
-            )
-            if search_btn:
-                await search_btn.click()
-            await page.wait_for_selector(sel.QU100_TABLE, timeout=15000)
-        except Exception as exc:
-            self.log.warning("mid_iter_recover_failed", error=str(exc))
-        self.log.info("mid_iter_recovered")
-        return True
-
-    async def _set_date(self, date_str: str) -> None:
-        """Change the date picker to the given date and trigger search."""
-        page = self._page
-        date_input = page.locator(sel.DATE_INPUT)
-        await date_input.click(click_count=3)
-        await date_input.fill(date_str)
-        await page.keyboard.press("Enter")
-        self.log.info("date_changed", date=date_str)
 
     def _persist_qu100(
         self,

--- a/src/rainier/scrapers/qu/selectors.py
+++ b/src/rainier/scrapers/qu/selectors.py
@@ -22,65 +22,36 @@ LOGGED_IN_INDICATOR = None
 # Main container
 QU100_CONTAINER = ".qu100"
 
-# Ant Design table
+# Ant Design table — still referenced by the CDP auth probe (the table
+# appearing proves we are logged in and the SPA is alive).
 QU100_TABLE = ".ant-table"
 QU100_TABLE_ROW = ".ant-table-tbody tr.ant-table-row"
-
-# Top100/Bottom100 toggle — use text selectors (stable across DOM changes)
-TOP100_BUTTON = ".select-button span:text-is('前100')"
-BOTTOM100_BUTTON = ".select-button span:text-is('后100')"
 
 # Daily/Weekly toggle
 DAILY_BUTTON = ".select-button span:text-is('日线')"
 WEEKLY_BUTTON = ".select-button span:text-is('周线')"
 
-# Date picker (Ant Design)
+# Date picker (Ant Design) — kept for CDP auth probe; the in-page-fetch
+# path (DESIGN D-9) does NOT click this; it passes the date as a query
+# param.
 DATE_INPUT = ".ant-picker-input input"
 DATE_DISPLAY = ".ant-picker-input input"  # value attribute has the date
 
-# Search/Query button (查 询) — MUST click after any toggle or date change
+# Search/Query button (查 询) — kept for CDP auth flow + detail page.
+# The QU100 fetch path no longer needs it (DESIGN D-3).
 SEARCH_BUTTON = "button.ant-btn-default.button"
-
-# Global search input within the table
-TABLE_SEARCH_INPUT = ".table-input input.ant-input"
 
 # Last updated text
 UPDATE_TIME = ".update-time"
 
-# JavaScript to extract rows from the QU100 Ant Design table.
-# The table has 6 columns: Rank, Ticker, Daily Change, Sector, Industry, Long/Short
-# - Ticker is inside <div class="purple">SYMBOL</div>
-# - Daily change: <span class="green">▲</span><span>92</span> or "0" or "New"
-QU100_EXTRACT_JS = """
-() => {
-    const rows = document.querySelectorAll('.ant-table-tbody tr.ant-table-row');
-    return Array.from(rows).map(row => {
-        const cells = row.querySelectorAll('td.ant-table-cell');
-        // Daily change: get the raw text (includes ▲/▼ and number)
-        const changeCell = cells[2];
-        let dailyChange = '0';
-        if (changeCell) {
-            const spans = changeCell.querySelectorAll('span');
-            if (spans.length >= 2) {
-                // Has arrow span + number span
-                const arrow = spans[0]?.textContent?.trim() || '';
-                const num = spans[1]?.textContent?.trim() || '0';
-                dailyChange = arrow + num;
-            } else {
-                dailyChange = changeCell.textContent?.trim() || '0';
-            }
-        }
-        return {
-            rank: cells[0]?.textContent?.trim() || '',
-            symbol: cells[1]?.textContent?.trim() || '',
-            daily_change: dailyChange,
-            sector: cells[3]?.textContent?.trim() || '',
-            industry: cells[4]?.textContent?.trim() || '',
-            long_short: cells[5]?.textContent?.trim() || '',
-        };
-    });
-}
-"""
+# ---------------------------------------------------------------------------
+# QU100 in-page-fetch endpoint (DESIGN D-7)
+# ---------------------------------------------------------------------------
+# The SPA fetches /api/v3/mf100 with three query params: date (YYYY-MM-DD),
+# top (true|false), frequency (daily). Cloudflare cf_clearance is bound to
+# the page's TLS handshake, so the request MUST originate from inside the
+# rendered page (page.evaluate(fetch(...))). See SPIKE-qu-json-api.md.
+QU100_API_URL = "/api/v3/mf100"
 
 # ---------------------------------------------------------------------------
 # Detail page (QU Stock Capital Flow) — TODO: needs separate HTML inspection

--- a/tests/fixtures/qu_api_mf100_bottom.json
+++ b/tests/fixtures/qu_api_mf100_bottom.json
@@ -1,0 +1,804 @@
+{
+  "data": [
+    {
+      "change": "1604",
+      "industry": "ETF",
+      "long_short": "No dominance",
+      "rank": 1,
+      "sector": "Financial Services",
+      "ticker": "SPY"
+    },
+    {
+      "change": "0",
+      "industry": "ETF",
+      "long_short": "Short in",
+      "rank": 2,
+      "sector": "Financial Services",
+      "ticker": "IWM"
+    },
+    {
+      "change": "1146",
+      "industry": "Communication Equipment",
+      "long_short": "Long out",
+      "rank": 3,
+      "sector": "Technology",
+      "ticker": "VSAT"
+    },
+    {
+      "change": "1369",
+      "industry": "Autos",
+      "long_short": "Long out",
+      "rank": 4,
+      "sector": "Consumer Cyclical",
+      "ticker": "MOD"
+    },
+    {
+      "change": "1567",
+      "industry": "Semiconductors",
+      "long_short": "No dominance",
+      "rank": 5,
+      "sector": "Technology",
+      "ticker": "AMD"
+    },
+    {
+      "change": "1588",
+      "industry": "Software - Infrastructure",
+      "long_short": "Long out",
+      "rank": 6,
+      "sector": "Technology",
+      "ticker": "PLTR"
+    },
+    {
+      "change": "10",
+      "industry": "Financial data & stock exchanges",
+      "long_short": "Long out",
+      "rank": 7,
+      "sector": "Financial Services",
+      "ticker": "COIN"
+    },
+    {
+      "change": "1175",
+      "industry": "Semiconductors",
+      "long_short": "Long out",
+      "rank": 8,
+      "sector": "Technology",
+      "ticker": "SWKS"
+    },
+    {
+      "change": "1580",
+      "industry": "Solar",
+      "long_short": "Long out",
+      "rank": 9,
+      "sector": "Technology",
+      "ticker": "FSLR"
+    },
+    {
+      "change": "1551",
+      "industry": "Capital Markets",
+      "long_short": "Long out",
+      "rank": 10,
+      "sector": "Financial Services",
+      "ticker": "IREN"
+    },
+    {
+      "change": "1183",
+      "industry": "Semiconductors",
+      "long_short": "No dominance",
+      "rank": 11,
+      "sector": "Technology",
+      "ticker": "ON"
+    },
+    {
+      "change": "843",
+      "industry": "Biotechnology",
+      "long_short": "Long out",
+      "rank": 12,
+      "sector": "Healthcare",
+      "ticker": "RVMD"
+    },
+    {
+      "change": "-6",
+      "industry": "Semiconductors",
+      "long_short": "Long out",
+      "rank": 13,
+      "sector": "Technology",
+      "ticker": "WOLF"
+    },
+    {
+      "change": "1576",
+      "industry": "Asset Management",
+      "long_short": "Short in",
+      "rank": 14,
+      "sector": "Financial Services",
+      "ticker": "BX"
+    },
+    {
+      "change": "9",
+      "industry": "ETF",
+      "long_short": "Short in",
+      "rank": 15,
+      "sector": "Financial Services",
+      "ticker": "EWY"
+    },
+    {
+      "change": "1281",
+      "industry": "Capital Markets",
+      "long_short": "Short in",
+      "rank": 16,
+      "sector": "Financial Services",
+      "ticker": "HUT"
+    },
+    {
+      "change": "1253",
+      "industry": "Metals & Mining",
+      "long_short": "Short in",
+      "rank": 17,
+      "sector": "Basic Materials",
+      "ticker": "AG"
+    },
+    {
+      "change": "99",
+      "industry": "",
+      "long_short": "Short in",
+      "rank": 18,
+      "sector": "",
+      "ticker": "FIX"
+    },
+    {
+      "change": "47",
+      "industry": "ETF",
+      "long_short": "Long out",
+      "rank": 19,
+      "sector": "Financial Services",
+      "ticker": "NVDL"
+    },
+    {
+      "change": "17",
+      "industry": "Information Technology Services",
+      "long_short": "Long out",
+      "rank": 20,
+      "sector": "Technology",
+      "ticker": "GDX"
+    },
+    {
+      "change": "1091",
+      "industry": "Metals & Mining",
+      "long_short": "Short in",
+      "rank": 21,
+      "sector": "Basic Materials",
+      "ticker": "WPM"
+    },
+    {
+      "change": "81",
+      "industry": "Application Software",
+      "long_short": "Long out",
+      "rank": 22,
+      "sector": "Technology",
+      "ticker": "BTDR"
+    },
+    {
+      "change": "1578",
+      "industry": "Internet Content & Information",
+      "long_short": "No dominance",
+      "rank": 23,
+      "sector": "Technology",
+      "ticker": "GOOGL"
+    },
+    {
+      "change": "1376",
+      "industry": "Aerospace & Defense",
+      "long_short": "No dominance",
+      "rank": 24,
+      "sector": "Industrials",
+      "ticker": "LMT"
+    },
+    {
+      "change": "1402",
+      "industry": "Metals & Mining",
+      "long_short": "No dominance",
+      "rank": 25,
+      "sector": "ETF",
+      "ticker": "AGQ"
+    },
+    {
+      "change": "1034",
+      "industry": "",
+      "long_short": "Long out",
+      "rank": 26,
+      "sector": "",
+      "ticker": "PPTA"
+    },
+    {
+      "change": "1524",
+      "industry": "Entertainment",
+      "long_short": "No dominance",
+      "rank": 27,
+      "sector": "Consumer Cyclical",
+      "ticker": "NFLX"
+    },
+    {
+      "change": "-7",
+      "industry": "Application Software",
+      "long_short": "No dominance",
+      "rank": 28,
+      "sector": "Technology",
+      "ticker": "CRM"
+    },
+    {
+      "change": "1203",
+      "industry": "ETF",
+      "long_short": "Long out",
+      "rank": 29,
+      "sector": "Financial Services",
+      "ticker": "DIA"
+    },
+    {
+      "change": "1489",
+      "industry": "Semiconductors",
+      "long_short": "Long out",
+      "rank": 30,
+      "sector": "Technology",
+      "ticker": "NXPI"
+    },
+    {
+      "change": "1468",
+      "industry": "ETF",
+      "long_short": "No dominance",
+      "rank": 31,
+      "sector": "Financial Services",
+      "ticker": "TLT"
+    },
+    {
+      "change": "162",
+      "industry": "Metals & Mining",
+      "long_short": "Short in",
+      "rank": 32,
+      "sector": "Basic Materials",
+      "ticker": "VALE"
+    },
+    {
+      "change": "37",
+      "industry": "Asset Management",
+      "long_short": "Short in",
+      "rank": 33,
+      "sector": "Financial Services",
+      "ticker": "APO"
+    },
+    {
+      "rank": 34,
+      "ticker": "SB034",
+      "change": "-10",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 35,
+      "ticker": "SB035",
+      "change": "1604",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 36,
+      "ticker": "SB036",
+      "change": "100",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 37,
+      "ticker": "SB037",
+      "change": "5",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 38,
+      "ticker": "SB038",
+      "change": "new",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 39,
+      "ticker": "SB039",
+      "change": "-3",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 40,
+      "ticker": "SB040",
+      "change": "12",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 41,
+      "ticker": "SB041",
+      "change": "0",
+      "industry": "Autos",
+      "sector": "Industrials",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 42,
+      "ticker": "SB042",
+      "change": "-1497",
+      "industry": "Media",
+      "sector": "Utilities",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 43,
+      "ticker": "SB043",
+      "change": "-10",
+      "industry": "Aerospace",
+      "sector": "Real Estate",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 44,
+      "ticker": "SB044",
+      "change": "1604",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 45,
+      "ticker": "SB045",
+      "change": "100",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 46,
+      "ticker": "SB046",
+      "change": "5",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 47,
+      "ticker": "SB047",
+      "change": "new",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 48,
+      "ticker": "SB048",
+      "change": "-3",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 49,
+      "ticker": "SB049",
+      "change": "12",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 50,
+      "ticker": "SB050",
+      "change": "0",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 51,
+      "ticker": "SB051",
+      "change": "-1497",
+      "industry": "Autos",
+      "sector": "Industrials",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 52,
+      "ticker": "SB052",
+      "change": "-10",
+      "industry": "Media",
+      "sector": "Utilities",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 53,
+      "ticker": "SB053",
+      "change": "1604",
+      "industry": "Aerospace",
+      "sector": "Real Estate",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 54,
+      "ticker": "SB054",
+      "change": "100",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 55,
+      "ticker": "SB055",
+      "change": "5",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 56,
+      "ticker": "SB056",
+      "change": "new",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 57,
+      "ticker": "SB057",
+      "change": "-3",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 58,
+      "ticker": "SB058",
+      "change": "12",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 59,
+      "ticker": "SB059",
+      "change": "0",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 60,
+      "ticker": "SB060",
+      "change": "-1497",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 61,
+      "ticker": "SB061",
+      "change": "-10",
+      "industry": "Autos",
+      "sector": "Industrials",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 62,
+      "ticker": "SB062",
+      "change": "1604",
+      "industry": "Media",
+      "sector": "Utilities",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 63,
+      "ticker": "SB063",
+      "change": "100",
+      "industry": "Aerospace",
+      "sector": "Real Estate",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 64,
+      "ticker": "SB064",
+      "change": "5",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 65,
+      "ticker": "SB065",
+      "change": "new",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 66,
+      "ticker": "SB066",
+      "change": "-3",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 67,
+      "ticker": "SB067",
+      "change": "12",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 68,
+      "ticker": "SB068",
+      "change": "0",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 69,
+      "ticker": "SB069",
+      "change": "-1497",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 70,
+      "ticker": "SB070",
+      "change": "-10",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 71,
+      "ticker": "SB071",
+      "change": "1604",
+      "industry": "Autos",
+      "sector": "Industrials",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 72,
+      "ticker": "SB072",
+      "change": "100",
+      "industry": "Media",
+      "sector": "Utilities",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 73,
+      "ticker": "SB073",
+      "change": "5",
+      "industry": "Aerospace",
+      "sector": "Real Estate",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 74,
+      "ticker": "SB074",
+      "change": "new",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 75,
+      "ticker": "SB075",
+      "change": "-3",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 76,
+      "ticker": "SB076",
+      "change": "12",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 77,
+      "ticker": "SB077",
+      "change": "0",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 78,
+      "ticker": "SB078",
+      "change": "-1497",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 79,
+      "ticker": "SB079",
+      "change": "-10",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 80,
+      "ticker": "SB080",
+      "change": "1604",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 81,
+      "ticker": "SB081",
+      "change": "100",
+      "industry": "Autos",
+      "sector": "Industrials",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 82,
+      "ticker": "SB082",
+      "change": "5",
+      "industry": "Media",
+      "sector": "Utilities",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 83,
+      "ticker": "SB083",
+      "change": "new",
+      "industry": "Aerospace",
+      "sector": "Real Estate",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 84,
+      "ticker": "SB084",
+      "change": "-3",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 85,
+      "ticker": "SB085",
+      "change": "12",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 86,
+      "ticker": "SB086",
+      "change": "0",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 87,
+      "ticker": "SB087",
+      "change": "-1497",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 88,
+      "ticker": "SB088",
+      "change": "-10",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 89,
+      "ticker": "SB089",
+      "change": "1604",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 90,
+      "ticker": "SB090",
+      "change": "100",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 91,
+      "ticker": "SB091",
+      "change": "5",
+      "industry": "Autos",
+      "sector": "Industrials",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 92,
+      "ticker": "SB092",
+      "change": "new",
+      "industry": "Media",
+      "sector": "Utilities",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 93,
+      "ticker": "SB093",
+      "change": "-3",
+      "industry": "Aerospace",
+      "sector": "Real Estate",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 94,
+      "ticker": "SB094",
+      "change": "12",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 95,
+      "ticker": "SB095",
+      "change": "0",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 96,
+      "ticker": "SB096",
+      "change": "-1497",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 97,
+      "ticker": "SB097",
+      "change": "-10",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 98,
+      "ticker": "SB098",
+      "change": "1604",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 99,
+      "ticker": "SB099",
+      "change": "100",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 100,
+      "ticker": "SB100",
+      "change": "5",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    }
+  ]
+}

--- a/tests/fixtures/qu_api_mf100_top.json
+++ b/tests/fixtures/qu_api_mf100_top.json
@@ -1,0 +1,804 @@
+{
+  "data": [
+    {
+      "change": "0",
+      "industry": "Semiconductors",
+      "long_short": "No dominance",
+      "rank": 1,
+      "sector": "Technology",
+      "ticker": "MU"
+    },
+    {
+      "change": "-3",
+      "industry": "Autos",
+      "long_short": "No dominance",
+      "rank": 2,
+      "sector": "Consumer Cyclical",
+      "ticker": "TSLA"
+    },
+    {
+      "change": "-14",
+      "industry": "Computer Hardware",
+      "long_short": "No dominance",
+      "rank": 3,
+      "sector": "Technology",
+      "ticker": "AAPL"
+    },
+    {
+      "change": "-17",
+      "industry": "Communication Equipment",
+      "long_short": "Long in",
+      "rank": 4,
+      "sector": "Technology",
+      "ticker": "ASTS"
+    },
+    {
+      "change": "-2",
+      "industry": "Information Technology Services",
+      "long_short": "Long in",
+      "rank": 5,
+      "sector": "Technology",
+      "ticker": "IBM"
+    },
+    {
+      "change": "-24",
+      "industry": "Computer SYstems",
+      "long_short": "No dominance",
+      "rank": 6,
+      "sector": "Technology",
+      "ticker": "DELL"
+    },
+    {
+      "change": "-21",
+      "industry": "Aerospace & Defense",
+      "long_short": "Long in",
+      "rank": 7,
+      "sector": "Industrials",
+      "ticker": "RKLB"
+    },
+    {
+      "change": "-36",
+      "industry": "Application Software",
+      "long_short": "Long in",
+      "rank": 8,
+      "sector": "Technology",
+      "ticker": "MSFT"
+    },
+    {
+      "change": "-1497",
+      "industry": "Application Software",
+      "long_short": "Short out",
+      "rank": 9,
+      "sector": "Technology",
+      "ticker": "ADBE"
+    },
+    {
+      "change": "8",
+      "industry": "",
+      "long_short": "No dominance",
+      "rank": 10,
+      "sector": "",
+      "ticker": "SNDK"
+    },
+    {
+      "change": "-23",
+      "industry": "Semiconductors",
+      "long_short": "No dominance",
+      "rank": 11,
+      "sector": "Technology",
+      "ticker": "QCOM"
+    },
+    {
+      "change": "9",
+      "industry": "Semiconductors",
+      "long_short": "No dominance",
+      "rank": 12,
+      "sector": "Technology",
+      "ticker": "ARM"
+    },
+    {
+      "change": "-1599",
+      "industry": "Semiconductors",
+      "long_short": "No dominance",
+      "rank": 13,
+      "sector": "Technology",
+      "ticker": "NVDA"
+    },
+    {
+      "change": "5",
+      "industry": "Semiconductors",
+      "long_short": "No dominance",
+      "rank": 14,
+      "sector": "Technology",
+      "ticker": "INTC"
+    },
+    {
+      "change": "-1",
+      "industry": "Electronic Components",
+      "long_short": "No dominance",
+      "rank": 15,
+      "sector": "Technology",
+      "ticker": "BE"
+    },
+    {
+      "change": "-13",
+      "industry": "ETF",
+      "long_short": "No dominance",
+      "rank": 16,
+      "sector": "Financial Services",
+      "ticker": "SOXL"
+    },
+    {
+      "change": "13",
+      "industry": "ETF",
+      "long_short": "No dominance",
+      "rank": 17,
+      "sector": "Financial Services",
+      "ticker": "QQQ"
+    },
+    {
+      "change": "-2",
+      "industry": "Computer Systems",
+      "long_short": "Long in",
+      "rank": 18,
+      "sector": "Technology",
+      "ticker": "IONQ"
+    },
+    {
+      "change": "-45",
+      "industry": "",
+      "long_short": "Long in",
+      "rank": 19,
+      "sector": "",
+      "ticker": "NOK"
+    },
+    {
+      "change": "9",
+      "industry": "Retail - Apparel & Specialty",
+      "long_short": "No dominance",
+      "rank": 20,
+      "sector": "Consumer Cyclical",
+      "ticker": "AMZN"
+    },
+    {
+      "change": "6",
+      "industry": "Retail - Apparel & Specialty",
+      "long_short": "No dominance",
+      "rank": 21,
+      "sector": "Consumer Cyclical",
+      "ticker": "CRWD"
+    },
+    {
+      "change": "-9",
+      "industry": "Semiconductors",
+      "long_short": "Long in",
+      "rank": 22,
+      "sector": "Technology",
+      "ticker": "ALAB"
+    },
+    {
+      "change": "-16",
+      "industry": "Semiconductors",
+      "long_short": "No dominance",
+      "rank": 23,
+      "sector": "Technology",
+      "ticker": "MRVL"
+    },
+    {
+      "change": "-48",
+      "industry": "",
+      "long_short": "Long in",
+      "rank": 24,
+      "sector": "",
+      "ticker": "CRDO"
+    },
+    {
+      "change": "-72",
+      "industry": "Application Software",
+      "long_short": "Long in",
+      "rank": 25,
+      "sector": "Technology",
+      "ticker": "TTWO"
+    },
+    {
+      "change": "-83",
+      "industry": "Communication Equipment",
+      "long_short": "Long in",
+      "rank": 26,
+      "sector": "Technology",
+      "ticker": "CSCO"
+    },
+    {
+      "change": "-1571",
+      "industry": "ETF",
+      "long_short": "Long in",
+      "rank": 27,
+      "sector": "Financials",
+      "ticker": "IBIT"
+    },
+    {
+      "change": "-68",
+      "industry": "ETF",
+      "long_short": "Short out",
+      "rank": 28,
+      "sector": "Technology",
+      "ticker": "IGV"
+    },
+    {
+      "change": "-9",
+      "industry": "Semiconductors",
+      "long_short": "No dominance",
+      "rank": 29,
+      "sector": "Technology",
+      "ticker": "AVGO"
+    },
+    {
+      "change": "-164",
+      "industry": "Semiconductors",
+      "long_short": "Long in",
+      "rank": 30,
+      "sector": "Technology",
+      "ticker": "SIMO"
+    },
+    {
+      "change": "-36",
+      "industry": "Application Software",
+      "long_short": "Long in",
+      "rank": 31,
+      "sector": "Technology",
+      "ticker": "NOW"
+    },
+    {
+      "change": "-11",
+      "industry": "Capital Markets",
+      "long_short": "No dominance",
+      "rank": 32,
+      "sector": "Financial Services",
+      "ticker": "GS"
+    },
+    {
+      "change": "19",
+      "industry": "Drug Manufacturers",
+      "long_short": "No dominance",
+      "rank": 33,
+      "sector": "Healthcare",
+      "ticker": "LLY"
+    },
+    {
+      "rank": 34,
+      "ticker": "ST034",
+      "change": "0",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 35,
+      "ticker": "ST035",
+      "change": "-1497",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 36,
+      "ticker": "ST036",
+      "change": "-10",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 37,
+      "ticker": "ST037",
+      "change": "1604",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 38,
+      "ticker": "ST038",
+      "change": "100",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 39,
+      "ticker": "ST039",
+      "change": "5",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 40,
+      "ticker": "ST040",
+      "change": "new",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 41,
+      "ticker": "ST041",
+      "change": "-3",
+      "industry": "Autos",
+      "sector": "Industrials",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 42,
+      "ticker": "ST042",
+      "change": "12",
+      "industry": "Media",
+      "sector": "Utilities",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 43,
+      "ticker": "ST043",
+      "change": "0",
+      "industry": "Aerospace",
+      "sector": "Real Estate",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 44,
+      "ticker": "ST044",
+      "change": "-1497",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 45,
+      "ticker": "ST045",
+      "change": "-10",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 46,
+      "ticker": "ST046",
+      "change": "1604",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 47,
+      "ticker": "ST047",
+      "change": "100",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 48,
+      "ticker": "ST048",
+      "change": "5",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 49,
+      "ticker": "ST049",
+      "change": "new",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 50,
+      "ticker": "ST050",
+      "change": "-3",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 51,
+      "ticker": "ST051",
+      "change": "12",
+      "industry": "Autos",
+      "sector": "Industrials",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 52,
+      "ticker": "ST052",
+      "change": "0",
+      "industry": "Media",
+      "sector": "Utilities",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 53,
+      "ticker": "ST053",
+      "change": "-1497",
+      "industry": "Aerospace",
+      "sector": "Real Estate",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 54,
+      "ticker": "ST054",
+      "change": "-10",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 55,
+      "ticker": "ST055",
+      "change": "1604",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 56,
+      "ticker": "ST056",
+      "change": "100",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 57,
+      "ticker": "ST057",
+      "change": "5",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 58,
+      "ticker": "ST058",
+      "change": "new",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 59,
+      "ticker": "ST059",
+      "change": "-3",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 60,
+      "ticker": "ST060",
+      "change": "12",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 61,
+      "ticker": "ST061",
+      "change": "0",
+      "industry": "Autos",
+      "sector": "Industrials",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 62,
+      "ticker": "ST062",
+      "change": "-1497",
+      "industry": "Media",
+      "sector": "Utilities",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 63,
+      "ticker": "ST063",
+      "change": "-10",
+      "industry": "Aerospace",
+      "sector": "Real Estate",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 64,
+      "ticker": "ST064",
+      "change": "1604",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 65,
+      "ticker": "ST065",
+      "change": "100",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 66,
+      "ticker": "ST066",
+      "change": "5",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 67,
+      "ticker": "ST067",
+      "change": "new",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 68,
+      "ticker": "ST068",
+      "change": "-3",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 69,
+      "ticker": "ST069",
+      "change": "12",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 70,
+      "ticker": "ST070",
+      "change": "0",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 71,
+      "ticker": "ST071",
+      "change": "-1497",
+      "industry": "Autos",
+      "sector": "Industrials",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 72,
+      "ticker": "ST072",
+      "change": "-10",
+      "industry": "Media",
+      "sector": "Utilities",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 73,
+      "ticker": "ST073",
+      "change": "1604",
+      "industry": "Aerospace",
+      "sector": "Real Estate",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 74,
+      "ticker": "ST074",
+      "change": "100",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 75,
+      "ticker": "ST075",
+      "change": "5",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 76,
+      "ticker": "ST076",
+      "change": "new",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 77,
+      "ticker": "ST077",
+      "change": "-3",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 78,
+      "ticker": "ST078",
+      "change": "12",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 79,
+      "ticker": "ST079",
+      "change": "0",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 80,
+      "ticker": "ST080",
+      "change": "-1497",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 81,
+      "ticker": "ST081",
+      "change": "-10",
+      "industry": "Autos",
+      "sector": "Industrials",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 82,
+      "ticker": "ST082",
+      "change": "1604",
+      "industry": "Media",
+      "sector": "Utilities",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 83,
+      "ticker": "ST083",
+      "change": "100",
+      "industry": "Aerospace",
+      "sector": "Real Estate",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 84,
+      "ticker": "ST084",
+      "change": "5",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 85,
+      "ticker": "ST085",
+      "change": "new",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 86,
+      "ticker": "ST086",
+      "change": "-3",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 87,
+      "ticker": "ST087",
+      "change": "12",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 88,
+      "ticker": "ST088",
+      "change": "0",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 89,
+      "ticker": "ST089",
+      "change": "-1497",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 90,
+      "ticker": "ST090",
+      "change": "-10",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 91,
+      "ticker": "ST091",
+      "change": "1604",
+      "industry": "Autos",
+      "sector": "Industrials",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 92,
+      "ticker": "ST092",
+      "change": "100",
+      "industry": "Media",
+      "sector": "Utilities",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 93,
+      "ticker": "ST093",
+      "change": "5",
+      "industry": "Aerospace",
+      "sector": "Real Estate",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 94,
+      "ticker": "ST094",
+      "change": "new",
+      "industry": "Electric Utilities",
+      "sector": "Basic Materials",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 95,
+      "ticker": "ST095",
+      "change": "-3",
+      "industry": "REIT",
+      "sector": "Technology",
+      "long_short": "Long in"
+    },
+    {
+      "rank": 96,
+      "ticker": "ST096",
+      "change": "12",
+      "industry": "Mining",
+      "sector": "Healthcare",
+      "long_short": "Short in"
+    },
+    {
+      "rank": 97,
+      "ticker": "ST097",
+      "change": "0",
+      "industry": "Semiconductors",
+      "sector": "Financial Services",
+      "long_short": "Short out"
+    },
+    {
+      "rank": 98,
+      "ticker": "ST098",
+      "change": "-1497",
+      "industry": "Software",
+      "sector": "Energy",
+      "long_short": "Long out"
+    },
+    {
+      "rank": 99,
+      "ticker": "ST099",
+      "change": "-10",
+      "industry": "Banks",
+      "sector": "Consumer Cyclical",
+      "long_short": "No dominance"
+    },
+    {
+      "rank": 100,
+      "ticker": "ST100",
+      "change": "1604",
+      "industry": "Oil & Gas",
+      "sector": "Communication Services",
+      "long_short": "Long in"
+    }
+  ]
+}

--- a/tests/test_scrapers/test_cdp_auth.py
+++ b/tests/test_scrapers/test_cdp_auth.py
@@ -76,7 +76,8 @@ class TestSetupCDP:
 
     @pytest.mark.asyncio
     async def test_cdp_setup_happy_path(self):
-        """CDP mode: existing_page works, _cdp_ensure_auth is called."""
+        """CDP mode (DESIGN D-10): fresh_tab_in_existing_context works,
+        _cdp_ensure_auth is called."""
         page, _ = _make_mock_page()
         # Table already visible → early return from _cdp_ensure_auth
         page.query_selector = AsyncMock(return_value=AsyncMock())
@@ -86,7 +87,7 @@ class TestSetupCDP:
         mock_cm = AsyncMock()
         mock_cm.__aenter__ = AsyncMock(return_value=page)
         mock_cm.__aexit__ = AsyncMock(return_value=False)
-        mock_browser.existing_page = MagicMock(return_value=mock_cm)
+        mock_browser.fresh_tab_in_existing_context = MagicMock(return_value=mock_cm)
 
         scraper = _make_scraper(mock_browser)
 
@@ -99,10 +100,12 @@ class TestSetupCDP:
             await scraper.setup()
 
         assert scraper._page is page
+        mock_browser.fresh_tab_in_existing_context.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_cdp_setup_chrome_not_open(self):
-        """CDP mode: existing_page() raises when Chrome isn't reachable."""
+        """CDP mode: fresh_tab_in_existing_context() raises when Chrome isn't
+        reachable."""
         mock_browser = MagicMock()
         mock_browser._is_cdp = True
         mock_cm = AsyncMock()
@@ -110,7 +113,7 @@ class TestSetupCDP:
             side_effect=ConnectionError("Cannot connect to Chrome on CDP")
         )
         mock_cm.__aexit__ = AsyncMock(return_value=False)
-        mock_browser.existing_page = MagicMock(return_value=mock_cm)
+        mock_browser.fresh_tab_in_existing_context = MagicMock(return_value=mock_cm)
 
         scraper = _make_scraper(mock_browser)
 
@@ -537,254 +540,18 @@ class TestScrapeQU100PostLogin:
 
         mock_login.assert_called_once()
 
-    @pytest.mark.asyncio
-    async def test_signin_redirect_between_toggle_iterations_recovers(self):
-        """The Search click inside the top100 iteration can trigger a server-side
-        redirect to /signin (session expired silently). The next iteration's
-        toggle click must NOT fire blind — the scraper must detect the signin
-        URL, re-login, navigate back, and only then click the bottom100 toggle.
-
-        This is the production failure mode that kills 50% of cron runs:
-        - top100 Search → server 401 → page redirects to /signin
-        - `.select-button span:text-is('后100')` no longer exists on the page
-        - default 30s click timeout fires, scraper returns records_created=0
-        """
-        page, page_url = _make_mock_page(
-            url="https://www.quantunicorn.com/products#qu100"
-        )
-
-        # Track every page.click call so we can correlate URL vs. toggle clicks.
-        click_targets: list[str] = []
-
-        async def fake_click(selector, *args, **kwargs):
-            click_targets.append(selector)
-
-        page.click = AsyncMock(side_effect=fake_click)
-
-        # The Search button is obtained via wait_for_selector/query_selector
-        # and `.click()` is called on the handle (NOT page.click). The toggle
-        # iteration's Search click is what triggers the silent signin redirect.
-        search_btn = AsyncMock()
-        search_click_count = {"n": 0}
-
-        async def fake_search_click(*args, **kwargs):
-            search_click_count["n"] += 1
-            # The SECOND search click is the one inside the top100 toggle
-            # iteration (first was the initial table load). Simulate the
-            # server-side redirect to /signin happening then.
-            if search_click_count["n"] == 2:
-                page_url["value"] = (
-                    "https://www.quantunicorn.com/signin?next=%2Fproducts%23qu100"
-                )
-
-        search_btn.click = AsyncMock(side_effect=fake_search_click)
-
-        # wait_for_selector returns the search button for SEARCH_BUTTON and a
-        # generic mock for everything else.
-        async def fake_wait_for_selector(selector, *args, **kwargs):
-            if selector == sel.SEARCH_BUTTON:
-                return search_btn
-            return AsyncMock()
-
-        page.wait_for_selector = AsyncMock(side_effect=fake_wait_for_selector)
-        # query_selector for SEARCH_BUTTON (inside the toggle loop) returns
-        # the same handle.
-        page.query_selector = AsyncMock(return_value=search_btn)
-        page.get_attribute = AsyncMock(return_value="2026-04-09")
-
-        # Make `evaluate` return a different first symbol on each call so the
-        # "table refresh" polling loop exits quickly instead of running its
-        # full 15s timeout (this is purely to keep the unit test fast).
-        eval_counter = {"n": 0}
-
-        async def fake_evaluate(*args, **kwargs):
-            eval_counter["n"] += 1
-            return [
-                {"rank": "1", "symbol": f"SYM{eval_counter['n']}",
-                 "daily_change": "▲5", "sector": "Tech",
-                 "industry": "Semi", "long_short": "多"}
-            ]
-
-        page.evaluate = AsyncMock(side_effect=fake_evaluate)
-
-        scraper = _make_scraper()
-        scraper._page = page
-
-        async def fake_goto(p, url):
-            # After re-login + navigate, URL settles on products again.
-            page_url["value"] = url
-
-        login_calls = {"n": 0}
-
-        async def fake_login(p):
-            # Login also returns us to the products URL.
-            login_calls["n"] += 1
-            page_url["value"] = "https://www.quantunicorn.com/products#qu100"
-
-        from datetime import datetime, timezone
-
-        from rainier.scrapers.base import ScrapeResult
-        result = ScrapeResult(scraper_name="qu", started_at=datetime.now(timezone.utc))
-
-        with (
-            patch("rainier.scrapers.qu.scraper.goto_with_retry",
-                  new_callable=AsyncMock, side_effect=fake_goto),
-            patch("rainier.scrapers.qu.scraper.login",
-                  new_callable=AsyncMock, side_effect=fake_login),
-            patch.object(scraper, "_persist_qu100", return_value=1),
-            # Stub the spinner wait so the test runs instantly.
-            patch.object(scraper, "_wait_for_no_spinner",
-                         new_callable=AsyncMock),
-        ):
-            await scraper._scrape_qu100(
-                "afternoon", datetime.now(timezone.utc), result
-            )
-
-        # Recovery happened: login was called at least once mid-scrape.
-        assert login_calls["n"] >= 1, (
-            "Scraper must re-login when session redirects mid-iteration; "
-            f"got login_calls={login_calls['n']}"
-        )
-
-        # Both toggle clicks were dispatched (no silent skip on bottom100).
-        assert sel.TOP100_BUTTON in click_targets
-        assert sel.BOTTOM100_BUTTON in click_targets
-
-        # And critically: the bottom100 toggle came AFTER top100 in dispatch
-        # order — the scraper didn't bail out after the signin redirect.
-        # Recovery returned control to the loop and let it continue.
-        assert click_targets.index(sel.TOP100_BUTTON) < click_targets.index(
-            sel.BOTTOM100_BUTTON
-        ), f"toggle order broken: {click_targets}"
-
-        # And the recorded error list on the result must NOT contain a
-        # bottom100 click failure — the recovery should have prevented it.
-        assert not any("bottom100" in e for e in result.errors), (
-            f"bottom100 should not fail after recovery; errors={result.errors}"
-        )
-
-    @pytest.mark.asyncio
-    async def test_search_button_uses_wait_for_selector(self):
-        """_scrape_qu100 uses wait_for_selector for Search button (PR #47 fix)."""
-        page, page_url = _make_mock_page(
-            url="https://www.quantunicorn.com/products#qu100"
-        )
-
-        search_btn = AsyncMock()
-        wait_selectors = []
-
-        async def fake_wait(selector, timeout=None):
-            wait_selectors.append(selector)
-            if selector == sel.SEARCH_BUTTON:
-                return search_btn
-            return AsyncMock()
-
-        page.wait_for_selector = AsyncMock(side_effect=fake_wait)
-        page.get_attribute = AsyncMock(return_value="2026-04-09")
-        page.evaluate = AsyncMock(return_value=[
-            {"rank": "1", "symbol": "NVDA", "daily_change": "▲5",
-             "sector": "Tech", "industry": "Semi", "long_short": "多"}
-        ])
-
-        scraper = _make_scraper()
-        scraper._page = page
-
-        from datetime import datetime, timezone
-
-        from rainier.scrapers.base import ScrapeResult
-        result = ScrapeResult(scraper_name="qu", started_at=datetime.now(timezone.utc))
-
-        with (
-            patch("rainier.scrapers.qu.scraper.goto_with_retry", new_callable=AsyncMock),
-            patch("rainier.scrapers.qu.scraper.login", new_callable=AsyncMock),
-            patch.object(scraper, "_persist_qu100", return_value=1),
-        ):
-            await scraper._scrape_qu100("afternoon", datetime.now(timezone.utc), result)
-
-        # Search button was found via wait_for_selector, not query_selector
-        assert sel.SEARCH_BUTTON in wait_selectors
-        search_btn.click.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# _wait_for_no_spinner() tests
-# ---------------------------------------------------------------------------
-
-
-class TestWaitForNoSpinner:
-    """Tests for the antd loading-spinner wait that guards toggle clicks."""
-
-    @pytest.mark.asyncio
-    async def test_waits_for_spinner_hidden(self):
-        """Calls wait_for_selector with the antd spinner selector and state='hidden'."""
-        page, _ = _make_mock_page()
-        scraper = _make_scraper()
-        scraper._page = page
-
-        await scraper._wait_for_no_spinner(timeout_ms=5000)
-
-        page.wait_for_selector.assert_awaited_once_with(
-            ".ant-spin-spinning", state="hidden", timeout=5000
-        )
-
-    @pytest.mark.asyncio
-    async def test_swallows_timeout(self):
-        """A stuck spinner must not raise — we log and continue."""
-        page, _ = _make_mock_page()
-        page.wait_for_selector = AsyncMock(side_effect=TimeoutError("spinner stuck"))
-        scraper = _make_scraper()
-        scraper._page = page
-
-        # Must not raise — the actual click will surface a clearer error if needed
-        await scraper._wait_for_no_spinner(timeout_ms=100)
-
-    @pytest.mark.asyncio
-    async def test_invoked_before_toggle_click(self):
-        """_scrape_qu100 calls _wait_for_no_spinner before each toggle click."""
-        page, _ = _make_mock_page(url="https://www.quantunicorn.com/products#qu100")
-
-        # Order trace: every page.click and every _wait_for_no_spinner call
-        events: list[str] = []
-
-        async def trace_click(target):
-            events.append(f"click:{target}")
-
-        page.click = AsyncMock(side_effect=trace_click)
-        page.wait_for_selector = AsyncMock(return_value=AsyncMock())
-        page.query_selector = AsyncMock(return_value=None)
-        page.get_attribute = AsyncMock(return_value="2026-04-09")
-        page.evaluate = AsyncMock(return_value=[
-            {"rank": "1", "symbol": "NVDA", "daily_change": "▲5",
-             "sector": "Tech", "industry": "Semi", "long_short": "多"}
-        ])
-
-        scraper = _make_scraper()
-        scraper._page = page
-
-        async def trace_spinner_wait(timeout_ms=10000):
-            events.append("spinner_wait")
-
-        from datetime import datetime, timezone
-
-        from rainier.scrapers.base import ScrapeResult
-
-        result = ScrapeResult(scraper_name="qu", started_at=datetime.now(timezone.utc))
-
-        with (
-            patch("rainier.scrapers.qu.scraper.goto_with_retry", new_callable=AsyncMock),
-            patch("rainier.scrapers.qu.scraper.login", new_callable=AsyncMock),
-            patch.object(scraper, "_persist_qu100", return_value=1),
-            patch.object(scraper, "_wait_for_no_spinner", side_effect=trace_spinner_wait),
-        ):
-            await scraper._scrape_qu100("afternoon", datetime.now(timezone.utc), result)
-
-        # Both toggle clicks must be preceded by a spinner wait
-        toggle_clicks = [
-            (i, e) for i, e in enumerate(events)
-            if e in (f"click:{sel.TOP100_BUTTON}", f"click:{sel.BOTTOM100_BUTTON}")
-        ]
-        assert len(toggle_clicks) == 2, f"Expected 2 toggle clicks, got {events}"
-        for idx, _ in toggle_clicks:
-            assert events[idx - 1] == "spinner_wait", (
-                f"Expected spinner_wait before toggle click at index {idx}, got {events}"
-            )
+# NOTE: Tests for DOM-path internals have been removed as part of the
+# in-page-fetch migration (DESIGN-qu-scraper-in-page-fetch / TASK-PLAN §3):
+#
+#   - test_signin_redirect_between_toggle_iterations_recovers
+#   - test_search_button_uses_wait_for_selector
+#   - class TestWaitForNoSpinner (3 tests)
+#
+# The behaviors they covered (mid-iteration toggle/Search-click recovery,
+# spinner waits) no longer exist: the scrape is a single
+# page.evaluate(fetch) per ranking and Cloudflare/auth failures surface as
+# fetch errors caught by the per-iteration ``except`` in ``_scrape_qu100``.
+#
+# The pre-scrape signin-redirect path is still covered by
+# ``test_signin_redirect_during_scrape`` above. The in-page-fetch happy
+# path is covered by ``tests/test_scrapers/test_scraper_in_page_fetch.py``.

--- a/tests/test_scrapers/test_parsers.py
+++ b/tests/test_scrapers/test_parsers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from rainier.scrapers.qu.parsers import (
+    api_rows_to_qu100_rows,
     parse_capital_flow_rows,
     parse_daily_change,
     parse_qu100_rows,
@@ -158,6 +159,87 @@ class TestParseQU100Rows:
         assert result[2].daily_change == 0
         assert result[3].daily_change == 0  # "New" -> 0
         assert result[3].symbol == "CTRN"
+
+
+# ---------------------------------------------------------------------------
+# api_rows_to_qu100_rows (D-4 adapter for the in-page-fetch /api/v3/mf100 path)
+# ---------------------------------------------------------------------------
+
+
+class TestApiRowsToQU100Rows:
+    """Adapter that maps the /api/v3/mf100 response shape onto QU100Row.
+
+    API shape (per spike capture):
+        {"rank": 1, "ticker": "MU", "change": "0",
+         "industry": "Semiconductors", "long_short": "No dominance",
+         "sector": "Technology"}
+
+    The adapter renames `ticker -> symbol` and runs `change` through
+    `parse_daily_change` to land on `daily_change`. No other transformations.
+    """
+
+    def test_happy_path(self):
+        api = [
+            {
+                "rank": 1,
+                "ticker": "MU",
+                "change": "0",
+                "industry": "Semiconductors",
+                "long_short": "No dominance",
+                "sector": "Technology",
+            }
+        ]
+        rows = api_rows_to_qu100_rows(api)
+        assert len(rows) == 1
+        assert rows[0].rank == 1
+        assert rows[0].symbol == "MU"
+        assert rows[0].daily_change == 0
+        assert rows[0].sector == "Technology"
+        assert rows[0].industry == "Semiconductors"
+        assert rows[0].long_short == "No dominance"
+        # raw preserves the original API dict so downstream JSONB storage
+        # keeps the source-of-truth payload.
+        assert rows[0].raw is api[0]
+
+    def test_change_variants(self):
+        api = [
+            {"rank": 1, "ticker": "AAA", "change": "0",
+             "industry": "", "long_short": "", "sector": ""},
+            {"rank": 2, "ticker": "BBB", "change": "-3",
+             "industry": "", "long_short": "", "sector": ""},
+            {"rank": 3, "ticker": "CCC", "change": "1604",
+             "industry": "", "long_short": "", "sector": ""},
+            {"rank": 4, "ticker": "DDD", "change": "new",
+             "industry": "", "long_short": "", "sector": ""},
+            # change missing entirely — should not raise, falls through to 0
+            {"rank": 5, "ticker": "EEE",
+             "industry": "", "long_short": "", "sector": ""},
+        ]
+        rows = api_rows_to_qu100_rows(api)
+        assert [r.daily_change for r in rows] == [0, -3, 1604, 0, 0]
+
+    def test_field_rename_ticker_to_symbol(self):
+        # The API field is named `ticker`. The QU100Row field is `symbol`.
+        # The adapter must never leak `ticker` onto QU100Row.
+        api = [{"rank": 1, "ticker": "msft", "change": "0",
+                "industry": "", "long_short": "", "sector": ""}]
+        rows = api_rows_to_qu100_rows(api)
+        assert rows[0].symbol == "MSFT"  # uppercased per existing convention
+
+    def test_empty_data(self):
+        assert api_rows_to_qu100_rows([]) == []
+
+    def test_skips_empty_ticker(self):
+        # Defensive: an empty ticker shouldn't produce a junk row.
+        api = [
+            {"rank": 1, "ticker": "", "change": "0",
+             "industry": "", "long_short": "", "sector": ""},
+            {"rank": 2, "ticker": "AAPL", "change": "5",
+             "industry": "", "long_short": "", "sector": ""},
+        ]
+        rows = api_rows_to_qu100_rows(api)
+        assert len(rows) == 1
+        assert rows[0].symbol == "AAPL"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scrapers/test_scraper_in_page_fetch.py
+++ b/tests/test_scrapers/test_scraper_in_page_fetch.py
@@ -164,13 +164,21 @@ class TestQu100FetchReplaysAgainstMock:
                 "morning", captured_at, result, target_date="2026-05-22"
             )
 
-        # No interactions with the date input. _set_date should not be invoked.
+        # No interactions with the date input. _set_date is gone; nothing
+        # in the in-page-fetch path should locator()/fill() the date input.
         assert sel.DATE_INPUT not in str(page.locator.mock_calls)
-        # And no Search button clicks: the DOM scrape sequence is gone.
+        # And no Search-button clicks from _scrape_qu100: the DOM scrape
+        # sequence is gone (the previous toggle/search/old-DOM-extract loop).
         click_targets = [c.args[0] for c in page.click.await_args_list if c.args]
         assert sel.SEARCH_BUTTON not in click_targets
-        assert sel.TOP100_BUTTON not in click_targets
-        assert sel.BOTTOM100_BUTTON not in click_targets
+        # The DOM-only selectors (TOP100_BUTTON, BOTTOM100_BUTTON) were
+        # deleted from selectors.py — their absence is asserted by the
+        # selector-deletion checks at module import time. Here we just
+        # confirm no click() was made against the Chinese-text toggles or
+        # any ant-table row selector either.
+        assert not any(
+            "select-button" in t for t in click_targets if isinstance(t, str)
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scrapers/test_scraper_in_page_fetch.py
+++ b/tests/test_scrapers/test_scraper_in_page_fetch.py
@@ -1,0 +1,307 @@
+"""Tests for the QU100 in-page-fetch migration (DESIGN-qu-scraper-in-page-fetch).
+
+Covers:
+- D-3 / D-4 / D-7 / D-9: _scrape_qu100 calls /api/v3/mf100 via
+  page.evaluate(fetch(...)) and persists 200 rows (top + bottom) for one date.
+- D-10: USCIS-style teardown closes the scrape page/tab on success, on
+  run-time exception, and in CDP mode (where a fresh tab is opened in
+  contexts[0] and closed on teardown without touching the operator's other
+  tabs or the Chrome process).
+
+All Playwright interactions are mocked — no real browser.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+
+from rainier.scrapers.qu import selectors as sel
+from rainier.scrapers.qu.scraper import QUScraper
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text())
+
+
+def _make_mock_page(url: str = "https://www.quantunicorn.com/products#qu100") -> MagicMock:
+    page = AsyncMock()
+    page_url = {"value": url}
+    type(page).url = PropertyMock(side_effect=lambda: page_url["value"])
+    page.title = AsyncMock(return_value="QU100")
+    page.context = AsyncMock()
+    page.context.add_cookies = AsyncMock()
+    page.query_selector = AsyncMock(return_value=AsyncMock())
+    page.wait_for_selector = AsyncMock(return_value=AsyncMock())
+    page.wait_for_load_state = AsyncMock()
+    page.goto = AsyncMock(side_effect=lambda u, **kw: page_url.update(value=u))
+    return page
+
+
+def _make_scraper(mock_browser: MagicMock | None = None) -> QUScraper:
+    if mock_browser is None:
+        mock_browser = MagicMock()
+        mock_browser._is_cdp = False
+
+    with patch("rainier.scrapers.qu.scraper.get_settings") as mock_settings:
+        qu_config = MagicMock()
+        qu_config.url = "https://www.quantunicorn.com/products#qu100"
+        qu_config.login_url = "https://www.quantunicorn.com/signin"
+        qu_config.session_file = "./data/auth/qu_session.json"
+        qu_config.session_ttl_hours = 12
+        qu_config.timeout_ms = 30000
+        qu_config.backfill_delay_seconds = 2.0
+        mock_settings.return_value.scraping.quantunicorn = qu_config
+        scraper = QUScraper(mock_browser)
+    return scraper
+
+
+# ---------------------------------------------------------------------------
+# D-3 / D-4 / D-7 / D-9: in-page fetch replay
+# ---------------------------------------------------------------------------
+
+
+class TestQu100FetchReplaysAgainstMock:
+    """_scrape_qu100 makes two page.evaluate(fetch(...)) calls and persists
+    100 top + 100 bottom rows for one date.
+    """
+
+    async def test_persists_200_rows_for_one_date(self):
+        top_payload = _load_fixture("qu_api_mf100_top.json")
+        bottom_payload = _load_fixture("qu_api_mf100_bottom.json")
+
+        page = _make_mock_page()
+        # page.evaluate returns the API payload from the fixture. The scraper
+        # calls evaluate twice — once for top, once for bottom — in this order.
+        page.evaluate = AsyncMock(side_effect=[top_payload, bottom_payload])
+
+        scraper = _make_scraper()
+        scraper._page = page
+
+        # Capture persist calls instead of going to the DB.
+        persist_calls: list[dict] = []
+
+        def fake_persist(rows, ranking_type, session_name, captured_at, data_date=None):
+            persist_calls.append({
+                "rows": rows,
+                "ranking_type": ranking_type,
+                "session_name": session_name,
+                "captured_at": captured_at,
+                "data_date": data_date,
+            })
+            return len(rows)
+
+        scraper._persist_qu100 = fake_persist  # type: ignore[assignment]
+
+        from rainier.scrapers.base import ScrapeResult
+        captured_at = datetime(2026, 5, 22, 13, 0, tzinfo=timezone.utc)
+        result = ScrapeResult(scraper_name="qu", started_at=captured_at)
+
+        with patch("rainier.scrapers.qu.scraper.goto_with_retry", new_callable=AsyncMock):
+            await scraper._scrape_qu100(
+                "morning", captured_at, result, target_date="2026-05-22"
+            )
+
+        # Exactly two evaluate calls: top + bottom.
+        assert page.evaluate.await_count == 2
+
+        # Both calls hit the API URL constant (D-7) and carry the right
+        # `top` flag and the requested date as query params (D-9).
+        first_call = page.evaluate.await_args_list[0]
+        second_call = page.evaluate.await_args_list[1]
+        first_blob = json.dumps(list(first_call.args) + list(first_call.kwargs.values()))
+        second_blob = json.dumps(list(second_call.args) + list(second_call.kwargs.values()))
+        assert sel.QU100_API_URL in first_blob
+        assert sel.QU100_API_URL in second_blob
+        assert "2026-05-22" in first_blob
+        assert "2026-05-22" in second_blob
+        assert "top=true" in first_blob
+        assert "top=false" in second_blob
+
+        # 200 rows persisted: 100 top + 100 bottom.
+        assert len(persist_calls) == 2
+        assert persist_calls[0]["ranking_type"] == "top100"
+        assert persist_calls[1]["ranking_type"] == "bottom100"
+        assert len(persist_calls[0]["rows"]) == 100
+        assert len(persist_calls[1]["rows"]) == 100
+        # Field rename landed (ticker -> symbol via api_rows_to_qu100_rows).
+        assert persist_calls[0]["rows"][0].symbol == top_payload["data"][0]["ticker"]
+        # records_created accumulates both calls.
+        assert result.records_created == 200
+        # No errors recorded on the happy path.
+        assert result.errors == []
+
+    async def test_no_date_picker_click(self):
+        """D-9: the API takes `date` as a query param. The scraper must NOT
+        click the date picker."""
+        top_payload = _load_fixture("qu_api_mf100_top.json")
+        bottom_payload = _load_fixture("qu_api_mf100_bottom.json")
+
+        page = _make_mock_page()
+        page.evaluate = AsyncMock(side_effect=[top_payload, bottom_payload])
+
+        scraper = _make_scraper()
+        scraper._page = page
+        scraper._persist_qu100 = MagicMock(return_value=100)  # type: ignore[assignment]
+
+        from rainier.scrapers.base import ScrapeResult
+        captured_at = datetime(2026, 5, 22, 13, 0, tzinfo=timezone.utc)
+        result = ScrapeResult(scraper_name="qu", started_at=captured_at)
+
+        with patch("rainier.scrapers.qu.scraper.goto_with_retry", new_callable=AsyncMock):
+            await scraper._scrape_qu100(
+                "morning", captured_at, result, target_date="2026-05-22"
+            )
+
+        # No interactions with the date input. _set_date should not be invoked.
+        assert sel.DATE_INPUT not in str(page.locator.mock_calls)
+        # And no Search button clicks: the DOM scrape sequence is gone.
+        click_targets = [c.args[0] for c in page.click.await_args_list if c.args]
+        assert sel.SEARCH_BUTTON not in click_targets
+        assert sel.TOP100_BUTTON not in click_targets
+        assert sel.BOTTOM100_BUTTON not in click_targets
+
+
+# ---------------------------------------------------------------------------
+# D-10: USCIS-style teardown
+# ---------------------------------------------------------------------------
+
+
+class TestTeardownClosesPageOnSuccess:
+    """Launch mode: after a successful execute(), the page context manager
+    has been exited (page closed) and the scraper's bookkeeping is cleared."""
+
+    async def test_page_cm_exited_after_execute(self):
+        page = _make_mock_page()
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=page)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+        mock_browser = MagicMock()
+        mock_browser._is_cdp = False
+        mock_browser.new_page = MagicMock(return_value=mock_cm)
+
+        scraper = _make_scraper(mock_browser)
+
+        # Stub run() so the test is independent of the scrape logic.
+        scraper.run = AsyncMock(  # type: ignore[assignment]
+            return_value=__import__(
+                "rainier.scrapers.base", fromlist=["ScrapeResult"]
+            ).ScrapeResult(
+                scraper_name="qu", started_at=datetime.now(timezone.utc)
+            )
+        )
+
+        with (
+            patch("rainier.scrapers.qu.scraper.is_session_valid", return_value=False),
+            patch("rainier.scrapers.qu.scraper.get_session_path", return_value="/fake"),
+            patch("rainier.scrapers.qu.scraper.ensure_authenticated", new_callable=AsyncMock),
+            patch.object(QUScraper, "_verify_session", new_callable=AsyncMock),
+        ):
+            await scraper.execute()
+
+        mock_cm.__aexit__.assert_awaited_once()
+        assert scraper._page is None
+        assert scraper._page_cm is None
+
+
+class TestTeardownClosesPageOnRunException:
+    """If run() raises, teardown still closes the page (failure-path coverage)."""
+
+    async def test_page_cm_exited_when_run_raises(self):
+        page = _make_mock_page()
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=page)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+        mock_browser = MagicMock()
+        mock_browser._is_cdp = False
+        mock_browser.new_page = MagicMock(return_value=mock_cm)
+
+        scraper = _make_scraper(mock_browser)
+        scraper.run = AsyncMock(  # type: ignore[assignment]
+            side_effect=RuntimeError("boom")
+        )
+
+        with (
+            patch("rainier.scrapers.qu.scraper.is_session_valid", return_value=False),
+            patch("rainier.scrapers.qu.scraper.get_session_path", return_value="/fake"),
+            patch("rainier.scrapers.qu.scraper.ensure_authenticated", new_callable=AsyncMock),
+            patch.object(QUScraper, "_verify_session", new_callable=AsyncMock),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            await scraper.execute()
+
+        mock_cm.__aexit__.assert_awaited_once()
+        assert scraper._page is None
+        assert scraper._page_cm is None
+
+
+class TestTeardownCdpModeOpensAndClosesFreshTab:
+    """CDP mode: setup() opens a fresh tab inside contexts[0] (via
+    fresh_tab_in_existing_context, NOT existing_page or browser.new_context),
+    teardown() closes that tab, the Chrome process stays alive, and the
+    operator's other tabs are untouched."""
+
+    async def test_setup_uses_fresh_tab_helper_and_teardown_closes_only_that_tab(self):
+        page = _make_mock_page()
+
+        # The fresh-tab helper is an async context manager. Track __aenter__
+        # and __aexit__ separately so we can assert only the helper's page
+        # got closed, never context.close() or browser.close().
+        fresh_cm = AsyncMock()
+        fresh_cm.__aenter__ = AsyncMock(return_value=page)
+        fresh_cm.__aexit__ = AsyncMock(return_value=False)
+
+        mock_browser = MagicMock()
+        mock_browser._is_cdp = True
+        mock_browser.fresh_tab_in_existing_context = MagicMock(return_value=fresh_cm)
+        # If the scraper falls back to one of these, the test fails: those are
+        # the wrong APIs in CDP mode per D-10.
+        mock_browser.existing_page = MagicMock(
+            side_effect=AssertionError("D-10: must NOT use existing_page in CDP mode")
+        )
+        mock_browser.new_page = MagicMock(
+            side_effect=AssertionError("D-10: must NOT use new_page in CDP mode")
+        )
+
+        scraper = _make_scraper(mock_browser)
+        scraper.run = AsyncMock(  # type: ignore[assignment]
+            return_value=__import__(
+                "rainier.scrapers.base", fromlist=["ScrapeResult"]
+            ).ScrapeResult(
+                scraper_name="qu", started_at=datetime.now(timezone.utc)
+            )
+        )
+
+        with (
+            patch("rainier.scrapers.qu.scraper.get_session_path", return_value="/fake"),
+            patch("pathlib.Path.exists", return_value=False),
+            patch("rainier.scrapers.qu.scraper.login", new_callable=AsyncMock),
+            patch("rainier.scrapers.qu.scraper.goto_with_retry", new_callable=AsyncMock),
+        ):
+            await scraper.execute()
+
+        # The fresh-tab helper was the entry point.
+        mock_browser.fresh_tab_in_existing_context.assert_called_once()
+        fresh_cm.__aenter__.assert_awaited_once()
+        # And was exited exactly once on teardown — closing the scrape tab.
+        fresh_cm.__aexit__.assert_awaited_once()
+        # context.close / browser.close must NOT have been called (operator's
+        # context + Chrome process must survive).
+        assert not page.context.close.await_args_list  # type: ignore[attr-defined]
+        assert scraper._page is None
+        assert scraper._page_cm is None


### PR DESCRIPTION
## Summary

Migrate `_scrape_qu100` from DOM-clicking the antd QU100 table to `page.evaluate(fetch())` against the SPA's internal `/api/v3/mf100` endpoint. Keep Playwright as the transport (spike SPIKE-qu-json-api.md proved Cloudflare's `cf_clearance` is TLS-fingerprint-bound, so pure-httpx/curl_cffi are dead). Add USCIS-style explicit `page.close()` in `teardown()` for both launch and CDP modes (D-10 — fleet/operator lifecycle rule).

- Replace ~80 lines of DOM-scrape (toggle clicks + spinner waits + table-refresh detection + extract JS) with two `fetch()` calls per scrape (`top=true` then `top=false`).
- New helper `api_rows_to_qu100_rows()` in `parsers.py` does the field rename (API `ticker -> symbol`, `change -> daily_change` via existing `parse_daily_change`).
- New `BrowserManager.fresh_tab_in_existing_context()` for CDP-mode: opens a fresh tab in `contexts[0]` (preserves operator's auth), closes only that tab on teardown.
- ~9x per-toggle speedup expected (1.9-3.1s -> ~210ms warm).

Parent design: `docs/DESIGN-qu-scraper-in-page-fetch.md` (D-1 through D-10).
Spike: `docs/SPIKE-qu-json-api.md` (CONDITIONAL GO, 2026-05-24).

## Review

- /review: passed (claude rounds: 1)
- codex review: passed (codex rounds: 2)

No P0/P1 findings. All [P2]/[P3] deferred for follow-up tasks (see below).

## CDP smoke test (D-10 acceptance §10)

SKIPPED — `:9222` not reachable from the worker shell (Connection refused). Unit test `test_setup_uses_fresh_tab_helper_and_teardown_closes_only_that_tab` covers the D-10 contract programmatically. Operator-side re-run recipe in `cdp-smoke.md` (worktree artifact, not committed).

## Deferred follow-up findings

Filed for the operator to triage post-merge:

- [P2] `_scrape_qu100` no longer auto-recovers from mid-session 401/403 (codex iter 1)
- [P2] `captured_at.date()` is UTC; late-PT manual runs / holidays may request wrong date (codex iter 2)
- [P3] `parse_qu100_rows` + its tests are dead code in production (operator-approved per design D-4)
- [P3] `api_rows_to_qu100_rows` exported as public (task-plan judgment call)
- [P3] `fresh_tab_in_existing_context` "no contexts" branch is untested
- [P3] `payload.get("data", [])` is None-vulnerable (cosmetic harden)

## Test plan

- [ ] CI green
- [ ] Manual CDP smoke (operator runs once Chrome is on `:9222`; recipe in `cdp-smoke.md` artifact)
- [ ] Verify a daily scrape in production after merge — confirm 100 top + 100 bottom rows persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Fleet coord 585203b8