### PR TITLE
fix(qu): derive API date from America/New_York not UTC

### DIFF
--- a/src/rainier/scrapers/qu/scraper.py
+++ b/src/rainier/scrapers/qu/scraper.py
@@ -6,6 +6,7 @@ import asyncio
 import random
 from datetime import date as date_type
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 import structlog
 from sqlalchemy import func, select
@@ -45,6 +46,23 @@ async ({url}) => {
 """
 
 log = structlog.get_logger()
+
+# QU is a US-equity product; the API's ``date=`` query param keys off the
+# NYSE/NASDAQ calendar day. Manual operator runs at 19:00 PT (= 02:00 UTC
+# next day) would otherwise request "tomorrow's" non-existent data. We
+# hard-code America/New_York because QU is single-market — promote to a
+# config knob only if a non-US market ever materializes.
+MARKET_TZ = ZoneInfo("America/New_York")
+
+
+def market_date(timestamp: datetime) -> date_type:
+    """Return the US-market calendar date for a (UTC-or-other-tz) timestamp.
+
+    ``timestamp`` must be timezone-aware; ``astimezone`` raises on naive
+    inputs in Python 3.12+. The scraper always passes
+    ``datetime.now(timezone.utc)``, so naive inputs are not expected.
+    """
+    return timestamp.astimezone(MARKET_TZ).date()
 
 
 class QUScraper(BaseScraper):
@@ -336,16 +354,21 @@ class QUScraper(BaseScraper):
             await goto_with_retry(page, self._qu_config.url)
 
         # The API takes ``date`` as a query param (DESIGN D-9). We use the
-        # caller-supplied target_date if any, otherwise the run's captured_at.
+        # caller-supplied target_date if any, otherwise derive the US-market
+        # calendar day from captured_at. ``captured_at`` itself is UTC and
+        # stays UTC (it's the DB snapshot timestamp); only the *date*
+        # going into the API query is shifted to America/New_York so
+        # manual late-PT runs hit the correct trading day. See
+        # docs/TASK-PLAN-qu-captured-at-tz-drift-44e3.md.
         if target_date:
             try:
                 data_date = date_type.fromisoformat(target_date)
             except ValueError:
                 self.log.warning("invalid_target_date_fallback",
                                  target_date=target_date)
-                data_date = captured_at.date()
+                data_date = market_date(captured_at)
         else:
-            data_date = captured_at.date()
+            data_date = market_date(captured_at)
         self.log.info("qu100_data_date", date=str(data_date))
 
         # One fetch per ranking. ``top=true|false`` per the SPA contract.

--- a/tests/test_scrapers/test_market_date.py
+++ b/tests/test_scrapers/test_market_date.py
@@ -1,0 +1,50 @@
+"""Tests for the market-tz date helper in ``rainier.scrapers.qu.scraper``.
+
+Regression coverage for the UTC drift bug surfaced by codex iter 2 review
+of PR #84: ``_scrape_qu100`` was deriving the API's ``date=`` query param
+from ``captured_at.date()`` (UTC). At 19:00 PT (= 02:00 UTC next day) a
+manual operator run requested the wrong trading day. The fix is to
+derive the market date via ``America/New_York`` conversion.
+
+See ``docs/TASK-PLAN-qu-captured-at-tz-drift-44e3.md`` §4 for acceptance.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from rainier.scrapers.qu.scraper import market_date
+
+
+def test_market_date_late_pt_returns_same_day():
+    """Late evening PT (next-day UTC) maps to the US-market calendar day.
+
+    2026-05-22T02:30:00Z = 22:30 ET on 2026-05-21 = market day 2026-05-21.
+    Before the fix, ``timestamp.date()`` returned 2026-05-22, which made the
+    scraper request tomorrow's (non-existent) trading data.
+    """
+    ts = datetime(2026, 5, 22, 2, 30, tzinfo=timezone.utc)
+    assert market_date(ts) == date(2026, 5, 21)
+
+
+def test_market_date_morning_pt_returns_today():
+    """Daytime UTC during US market hours stays on the same calendar day.
+
+    2026-05-22T15:00:00Z = 11:00 ET on 2026-05-22 = market day 2026-05-22.
+    Sanity check that the helper is not flipping the date for in-market
+    timestamps.
+    """
+    ts = datetime(2026, 5, 22, 15, 0, tzinfo=timezone.utc)
+    assert market_date(ts) == date(2026, 5, 22)
+
+
+def test_market_date_dst_boundary():
+    """DST spring-forward boundary still resolves correctly.
+
+    On 2026-03-08, America/New_York jumps from EST (UTC-5) to EDT (UTC-4)
+    at 02:00 local time. 2026-03-08T07:00:00Z is 02:00 EST -> 03:00 EDT
+    on 2026-03-08 either way — the date should be 2026-03-08 regardless
+    of which side of the transition zoneinfo lands on.
+    """
+    ts = datetime(2026, 3, 8, 7, 0, tzinfo=timezone.utc)
+    assert market_date(ts) == date(2026, 3, 8)

--- a/tests/test_scrapers/test_scraper_in_page_fetch.py
+++ b/tests/test_scrapers/test_scraper_in_page_fetch.py
@@ -142,6 +142,51 @@ class TestQu100FetchReplaysAgainstMock:
         # No errors recorded on the happy path.
         assert result.errors == []
 
+    async def test_api_date_uses_market_tz_for_late_utc_captured_at(self):
+        """Regression for the UTC drift surfaced by codex iter 2 on PR #84.
+
+        When ``captured_at`` is in the next UTC day but the operator's
+        intent is "today's US market data" (e.g., a 19:00 PT manual run),
+        the API ``date=`` query param must derive from the America/New_York
+        calendar date, not from ``captured_at.date()``.
+
+        captured_at = 2026-05-22T02:30:00Z (= 22:30 ET on 2026-05-21).
+        Expected: ``date=2026-05-21`` in both fetched URLs.
+        """
+        top_payload = _load_fixture("qu_api_mf100_top.json")
+        bottom_payload = _load_fixture("qu_api_mf100_bottom.json")
+
+        page = _make_mock_page()
+        page.evaluate = AsyncMock(side_effect=[top_payload, bottom_payload])
+
+        scraper = _make_scraper()
+        scraper._page = page
+        scraper._persist_qu100 = MagicMock(return_value=100)  # type: ignore[assignment]
+
+        from rainier.scrapers.base import ScrapeResult
+        # Late-PT timestamp — 22:30 ET on 2026-05-21, but UTC date is
+        # 2026-05-22. Pre-fix this would request date=2026-05-22 and break.
+        captured_at = datetime(2026, 5, 22, 2, 30, tzinfo=timezone.utc)
+        result = ScrapeResult(scraper_name="qu", started_at=captured_at)
+
+        with patch("rainier.scrapers.qu.scraper.goto_with_retry", new_callable=AsyncMock):
+            # No target_date — exercises the captured_at-derived branch.
+            await scraper._scrape_qu100("morning", captured_at, result)
+
+        assert page.evaluate.await_count == 2
+        urls = []
+        for call in page.evaluate.await_args_list:
+            # The fetch URL is passed in the evaluate args dict: {"url": "..."}
+            blob = json.dumps(list(call.args) + list(call.kwargs.values()))
+            urls.append(blob)
+        for blob in urls:
+            assert "date=2026-05-21" in blob, (
+                f"market-tz date expected in fetch URL but got: {blob}"
+            )
+            assert "date=2026-05-22" not in blob, (
+                f"UTC date leaked into fetch URL: {blob}"
+            )
+
     async def test_no_date_picker_click(self):
         """D-9: the API takes `date` as a query param. The scraper must NOT
         click the date picker."""


### PR DESCRIPTION
## Summary

P2 regression fix introduced by PR #84. `_scrape_qu100` derived the `/api/v3/mf100?date=` query param from `captured_at.date()` (UTC). Late-PT manual scrapes (after 19:00 PT = next-day UTC) requested the wrong trading day. QU's API rejects non-trading dates, so this surfaced as either wrong-day data persisted or an API "Data not available" error.

- New `MARKET_TZ = ZoneInfo("America/New_York")` + `market_date(timestamp) -> date` helper in `src/rainier/scrapers/qu/scraper.py`.
- Two `captured_at.date()` call sites in `_scrape_qu100` swap to `market_date(captured_at)`.
- `captured_at` itself stays UTC (DB `TIMESTAMPTZ` column unchanged). Only the API date derivation is timezone-converted.
- No other UTC usage touched (per task plan §6 scope guardrail).

Parent design: `docs/DESIGN-qu-scraper-in-page-fetch.md` §3 (post-PR-#84 follow-ups).
Task plan: `docs/TASK-PLAN-qu-captured-at-tz-drift-44e3.md`.

## Review

- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 2)

0 P0/P1 findings across both reviewers. One P3 observation noted by `/review` and intentionally out-of-scope per task plan §6: `_persist_qu100` still has an unreachable UTC-date fallback at `effective_date = data_date or captured_at.date()` — left for a future direct-caller scenario that doesn't currently exist; invariant pinned in code comments.

## Test plan

- [ ] CI green (Lint + Test + Build)
- [ ] Optional: re-verify locally with a fixed `datetime.now(timezone.utc)` mocked to 02:30 UTC → confirm the API URL contains `date=YYYY-MM-DD` for the *previous* calendar day

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Fleet coord 585203b8