### PR TITLE
fix(qu): _verify_session API probe + CDP CF challenge wait (P1)

### DIFF
--- a/src/rainier/scrapers/qu/scraper.py
+++ b/src/rainier/scrapers/qu/scraper.py
@@ -199,30 +199,46 @@ class QUScraper(BaseScraper):
     # ------------------------------------------------------------------
 
     async def _verify_session(self) -> None:
-        """Navigate to QU100 and verify the session is live.
+        """Verify the saved session works against the QU API.
 
-        If the saved session is stale (server-side), force a fresh login.
+        Uses the same in-page-fetch transport the scrape itself uses
+        (DESIGN D-3/D-7). A 200 with valid JSON means the session +
+        cf_clearance are alive; a 401/403 triggers ``_fetch_qu_api``'s
+        one-shot reauth + retry; anything else propagates as a real
+        error.
+
+        The previous implementation waited for ``.ant-table`` to render
+        on ``/products#qu100``. Post-PR-#84 the scrape no longer clicks
+        Search, so the table never renders on bare nav — verification
+        timed out every cron run. Probing the API directly is the only
+        check that agrees with what the scrape actually does.
         """
         page = self._page
         await goto_with_retry(page, self._qu_config.url)
 
-        # Check if we got redirected to signin
+        # Pre-auth state — saved storage was empty or cookies wiped at
+        # the file level; force a login then return. The next caller
+        # (the scrape itself) will exercise the API path; no need to
+        # double-probe here.
         if "signin" in (page.url or ""):
             self.log.warning("session_stale_redirected", url=page.url)
             await login(page)
             await goto_with_retry(page, self._qu_config.url)
             return
 
-        # Check if QU100 table is visible (proves auth works)
+        # API probe. ``_fetch_qu_api`` handles 401/403 → reauth + retry
+        # (PR #86); we just propagate any RuntimeError it raises.
+        probe_date = market_date(datetime.now(timezone.utc)).isoformat()
+        probe_url = (
+            f"{sel.QU100_API_URL}?date={probe_date}"
+            "&top=true&frequency=daily"
+        )
         try:
-            await page.wait_for_selector(sel.QU100_TABLE, timeout=10000)
-            self.log.info("session_verified")
-        except Exception:
-            self.log.warning("session_stale_no_table", url=page.url)
-            await login(page)
-            await goto_with_retry(page, self._qu_config.url)
-            await page.wait_for_selector(sel.QU100_TABLE, timeout=15000)
-            self.log.info("session_verified_after_relogin")
+            await self._fetch_qu_api(page, probe_url)
+            self.log.info("session_verified_via_api")
+        except RuntimeError as exc:
+            self.log.error("session_verify_failed", error=str(exc))
+            raise
 
     # ------------------------------------------------------------------
     # CDP auto-auth
@@ -269,14 +285,37 @@ class QUScraper(BaseScraper):
             await login(page)
             await goto_with_retry(page, self._qu_config.url)
 
-        # Detect Cloudflare challenge page
+        # Detect Cloudflare JS challenge. Playwright (Chromium) executes
+        # the challenge JS automatically; we just need to wait for it to
+        # resolve and issue a fresh cf_clearance cookie. Most challenges
+        # clear in 5-10s. The old code bailed immediately and asked the
+        # operator for a --headed run, which broke every unattended cron.
         title = await page.title()
         if "just a moment" in title.lower():
-            raise RuntimeError(
-                "Cloudflare challenge detected — cf_clearance cookie expired. "
-                "Run `rainier scrape qu --session morning --headed` in a "
-                "terminal to pass the challenge manually, then retry."
-            )
+            self.log.info("cf_challenge_waiting", initial_title=title)
+            try:
+                # Wait for document.title to flip away from "Just a
+                # moment..." (case-insensitive). On success the SPA loads
+                # with title = "QuantUnicorn" (or similar). 25s is
+                # generous; Cloudflare's own SLA for the challenge is
+                # ~10s end-to-end.
+                await page.wait_for_function(
+                    """() => !document.title.toLowerCase().includes("just a moment")""",
+                    timeout=25000,
+                )
+                new_title = await page.title()
+                self.log.info("cf_challenge_cleared", new_title=new_title)
+            except Exception as exc:
+                # Challenge stuck > 25s — operator intervention needed.
+                # The operator already has Chrome on :9222 (CDP mode), so
+                # the simplest recovery is just to open QU there manually.
+                raise RuntimeError(
+                    "Cloudflare challenge stuck for >25s — cf_clearance "
+                    "cookie expired and JS challenge didn't auto-resolve. "
+                    f"Open {self._qu_config.url} in the CDP browser "
+                    "(currently on :9222) and manually clear any "
+                    "challenge, then retry."
+                ) from exc
 
         # Check if redirected to signin — cookies didn't work
         if "signin" in (page.url or ""):

--- a/tests/test_scrapers/test_cdp_auth.py
+++ b/tests/test_scrapers/test_cdp_auth.py
@@ -37,6 +37,9 @@ def _make_mock_page(url="https://www.quantunicorn.com/products#qu100", title="QU
     # wait_for_selector returns a mock element by default
     page.wait_for_selector = AsyncMock(return_value=AsyncMock())
     page.wait_for_load_state = AsyncMock()
+    # wait_for_function (CF challenge wait) — defaults to clean return so
+    # title==challenge tests don't accidentally hit the timeout branch.
+    page.wait_for_function = AsyncMock()
 
     def set_url(new_url, **kwargs):
         page_url["value"] = new_url
@@ -303,11 +306,22 @@ class TestCDPEnsureAuth:
         mock_login.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_cloudflare_challenge_raises(self):
-        """Cloudflare challenge page detected → raises RuntimeError."""
+    async def test_cloudflare_challenge_stuck_raises(self):
+        """Cloudflare 'Just a moment...' challenge that doesn't clear within
+        25s → RuntimeError pointing operator at the CDP browser.
+
+        Post-fix (TASK-PLAN-qu-verify-and-cf-recover-9f39 §3) the
+        immediate bail is replaced with a wait_for_function(25s). The
+        stuck path still raises, but with new wording ("stuck for >25s")
+        and a CDP-browser recovery hint, not the old "--headed" message.
+        """
         page, _ = _make_mock_page(
             url="https://www.quantunicorn.com/products#qu100",
             title="Just a moment..."
+        )
+        # Force the wait to fail so we exercise the raise path.
+        page.wait_for_function = AsyncMock(
+            side_effect=Exception("Timeout 25000ms exceeded")
         )
 
         scraper = _make_scraper()
@@ -319,7 +333,7 @@ class TestCDPEnsureAuth:
             patch("rainier.scrapers.qu.scraper.login", new_callable=AsyncMock),
             patch("pathlib.Path.exists", return_value=False),
         ):
-            with pytest.raises(RuntimeError, match="Cloudflare challenge"):
+            with pytest.raises(RuntimeError, match="stuck for >25s"):
                 await scraper._cdp_ensure_auth()
 
     @pytest.mark.asyncio

--- a/tests/test_scrapers/test_cdp_cf_recovery.py
+++ b/tests/test_scrapers/test_cdp_cf_recovery.py
@@ -1,0 +1,158 @@
+"""Unit tests for _cdp_ensure_auth Cloudflare-challenge wait/recover path.
+
+Per TASK-PLAN-qu-verify-and-cf-recover-9f39 §3, the immediate "raise
+RuntimeError on title == 'Just a moment...'" bail is replaced with a
+25-second wait_for_function on the document title. CF JS challenges
+typically resolve in 5-10s and Playwright's Chromium executes them
+automatically; we just have to wait, not bail.
+
+Test matrix:
+  1. CF title detected, then clears within budget → no raise.
+     wait_for_function called with timeout=25000.
+  2. CF title detected, wait_for_function times out (challenge stuck) →
+     raise RuntimeError with the new "stuck for >25s" message + QU URL.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+
+from rainier.scrapers.qu.scraper import QUScraper
+
+
+def _make_mock_page(
+    url: str = "https://www.quantunicorn.com/products#qu100",
+    titles: list[str] | None = None,
+):
+    """Mock Page where successive .title() calls return entries from `titles`.
+
+    On the (n+1)th call, the last value is repeated — so a list of
+    ["Just a moment...", "QuantUnicorn"] gives the CF page first and
+    every subsequent title check resolves cleanly.
+    """
+    page = AsyncMock()
+    page_url = {"value": url}
+    type(page).url = PropertyMock(side_effect=lambda: page_url["value"])
+
+    titles = titles or ["QU100"]
+    title_idx = {"n": 0}
+
+    async def fake_title():
+        idx = min(title_idx["n"], len(titles) - 1)
+        title_idx["n"] += 1
+        return titles[idx]
+
+    page.title = AsyncMock(side_effect=fake_title)
+    page.context = AsyncMock()
+    page.context.add_cookies = AsyncMock()
+    # Table query: return a truthy element so the post-CF path early-returns
+    # at "table already loaded".
+    page.query_selector = AsyncMock(return_value=AsyncMock())
+    page.wait_for_selector = AsyncMock(return_value=AsyncMock())
+    page.wait_for_load_state = AsyncMock()
+    page.wait_for_function = AsyncMock()
+    page.goto = AsyncMock(side_effect=lambda u, **kw: page_url.update(value=u))
+    return page, page_url
+
+
+def _make_scraper():
+    mock_browser = MagicMock()
+    mock_browser._is_cdp = True
+    with patch("rainier.scrapers.qu.scraper.get_settings") as mock_settings:
+        qu_config = MagicMock()
+        qu_config.url = "https://www.quantunicorn.com/products#qu100"
+        qu_config.login_url = "https://www.quantunicorn.com/signin"
+        qu_config.session_file = "./data/auth/qu_session.json"
+        qu_config.session_ttl_hours = 12
+        qu_config.timeout_ms = 30000
+        qu_config.backfill_delay_seconds = 2.0
+        mock_settings.return_value.scraping.quantunicorn = qu_config
+        return QUScraper(mock_browser)
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestCDPCFRecovery:
+    """_cdp_ensure_auth waits up to 25s for CF challenge to clear."""
+
+    @pytest.mark.asyncio
+    async def test_cdp_cf_challenge_clears_in_time(self):
+        """Title flips from 'Just a moment...' to 'QuantUnicorn' within 25s.
+
+        wait_for_function is called with timeout=25000; no raise.
+        """
+        # First title call (CF detect) → "Just a moment..."; subsequent
+        # calls (post-wait verification) → "QuantUnicorn".
+        page, _ = _make_mock_page(titles=["Just a moment...", "QuantUnicorn"])
+
+        scraper = _make_scraper()
+        scraper._page = page
+
+        with (
+            patch(
+                "rainier.scrapers.qu.scraper.get_session_path",
+                return_value="/fake",
+            ),
+            patch(
+                "rainier.scrapers.qu.scraper.goto_with_retry",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "rainier.scrapers.qu.scraper.login",
+                new_callable=AsyncMock,
+            ),
+            patch("pathlib.Path.exists", return_value=False),
+        ):
+            # No raise expected.
+            await scraper._cdp_ensure_auth()
+
+        # wait_for_function must be called for the CF title.
+        page.wait_for_function.assert_called_once()
+        call_kwargs = page.wait_for_function.call_args.kwargs
+        assert call_kwargs.get("timeout") == 25000
+        # The JS predicate must check that the title no longer contains
+        # "just a moment" (case-insensitive).
+        js_arg = page.wait_for_function.call_args.args[0]
+        assert "just a moment" in js_arg.lower()
+
+    @pytest.mark.asyncio
+    async def test_cdp_cf_challenge_stuck_raises_clearly(self):
+        """wait_for_function times out → RuntimeError mentioning
+        '>25s' and the QU URL so the operator knows how to recover.
+        """
+        page, _ = _make_mock_page(titles=["Just a moment..."])
+
+        # The wait raises (Playwright TimeoutError surfaces as a
+        # synchronous Exception subclass; we use a plain Exception here
+        # since the fix's except clause catches broadly).
+        page.wait_for_function = AsyncMock(
+            side_effect=Exception("Timeout 25000ms exceeded")
+        )
+
+        scraper = _make_scraper()
+        scraper._page = page
+
+        with (
+            patch(
+                "rainier.scrapers.qu.scraper.get_session_path",
+                return_value="/fake",
+            ),
+            patch(
+                "rainier.scrapers.qu.scraper.goto_with_retry",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "rainier.scrapers.qu.scraper.login",
+                new_callable=AsyncMock,
+            ),
+            patch("pathlib.Path.exists", return_value=False),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                await scraper._cdp_ensure_auth()
+
+        msg = str(exc_info.value)
+        assert "stuck for >25s" in msg
+        assert "quantunicorn.com/products" in msg

--- a/tests/test_scrapers/test_verify_session.py
+++ b/tests/test_scrapers/test_verify_session.py
@@ -1,0 +1,161 @@
+"""Unit tests for QUScraper._verify_session (API-probe replacement).
+
+After the fix in TASK-PLAN-qu-verify-and-cf-recover-9f39 §2,
+_verify_session no longer waits for the .ant-table DOM element (which
+only renders after click+Search on the QU SPA). Instead it probes the
+same /api/v3/mf100 endpoint the scrape itself uses, via the in-page
+fetch transport. _fetch_qu_api already encapsulates the 401/403
+reauth-and-retry path (PR #86), so verification just delegates.
+
+These tests pin the new behavior:
+  1. API probe returns 200 → no raise, session is good.
+  2. signin redirect on initial nav → force login + re-navigate.
+  3. _fetch_qu_api propagates RuntimeError (e.g. persistent 401/403
+     after reauth) → _verify_session re-raises so the caller sees it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+
+from rainier.scrapers.qu.scraper import QUScraper
+
+
+def _make_mock_page(url: str = "https://www.quantunicorn.com/products#qu100"):
+    """Mock Playwright Page that lets tests mutate `.url` mid-flow."""
+    page = AsyncMock()
+    page_url = {"value": url}
+    type(page).url = PropertyMock(side_effect=lambda: page_url["value"])
+    page.title = AsyncMock(return_value="QU100")
+    page.context = AsyncMock()
+    page.context.add_cookies = AsyncMock()
+    page.query_selector = AsyncMock(return_value=AsyncMock())
+    page.wait_for_selector = AsyncMock(return_value=AsyncMock())
+    page.wait_for_load_state = AsyncMock()
+    page.goto = AsyncMock(side_effect=lambda u, **kw: page_url.update(value=u))
+    return page, page_url
+
+
+def _make_scraper():
+    """QUScraper with mocked browser + settings; launch mode (not CDP)."""
+    mock_browser = MagicMock()
+    mock_browser._is_cdp = False
+    with patch("rainier.scrapers.qu.scraper.get_settings") as mock_settings:
+        qu_config = MagicMock()
+        qu_config.url = "https://www.quantunicorn.com/products#qu100"
+        qu_config.login_url = "https://www.quantunicorn.com/signin"
+        qu_config.session_file = "./data/auth/qu_session.json"
+        qu_config.session_ttl_hours = 12
+        qu_config.timeout_ms = 30000
+        qu_config.backfill_delay_seconds = 2.0
+        mock_settings.return_value.scraping.quantunicorn = qu_config
+        return QUScraper(mock_browser)
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestVerifySessionAPIProbe:
+    """_verify_session probes /api/v3/mf100 via _fetch_qu_api."""
+
+    @pytest.mark.asyncio
+    async def test_verify_session_api_200_returns(self):
+        """API probe succeeds (200, valid body) → no raise."""
+        page, _ = _make_mock_page()
+        scraper = _make_scraper()
+        scraper._page = page
+
+        # _fetch_qu_api returns the parsed JSON body (any non-raising value
+        # means session OK).
+        scraper._fetch_qu_api = AsyncMock(return_value={"data": []})
+
+        with patch(
+            "rainier.scrapers.qu.scraper.goto_with_retry",
+            new_callable=AsyncMock,
+        ) as mock_goto:
+            await scraper._verify_session()
+
+        # Probed the right endpoint. We don't pin the exact date (it's
+        # market_date(now)), but the URL must hit /api/v3/mf100 with
+        # top=true and frequency=daily.
+        scraper._fetch_qu_api.assert_called_once()
+        probe_url = scraper._fetch_qu_api.call_args.args[1]
+        assert "/api/v3/mf100" in probe_url
+        assert "top=true" in probe_url
+        assert "frequency=daily" in probe_url
+        # No DOM table wait should have happened.
+        page.wait_for_selector.assert_not_called()
+        # And we did navigate to the QU SPA at least once.
+        mock_goto.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_verify_session_signin_redirects_relogs(self):
+        """Initial nav lands on /signin → call login(), re-navigate, return.
+
+        Don't fall through to the API probe — the signin branch is the
+        pre-auth pathway (saved storage_state was empty/stale at the file
+        level, never even got cookies in the request).
+        """
+        page, page_url = _make_mock_page()
+
+        goto_calls = {"n": 0}
+
+        async def fake_goto(p, url):
+            goto_calls["n"] += 1
+            if goto_calls["n"] == 1:
+                page_url["value"] = (
+                    "https://www.quantunicorn.com/signin?next=/products"
+                )
+            else:
+                page_url["value"] = url
+
+        scraper = _make_scraper()
+        scraper._page = page
+        scraper._fetch_qu_api = AsyncMock(return_value={"data": []})
+
+        with (
+            patch(
+                "rainier.scrapers.qu.scraper.goto_with_retry",
+                new_callable=AsyncMock,
+                side_effect=fake_goto,
+            ),
+            patch(
+                "rainier.scrapers.qu.scraper.login",
+                new_callable=AsyncMock,
+            ) as mock_login,
+        ):
+            await scraper._verify_session()
+
+        mock_login.assert_called_once_with(page)
+        # After signin branch: do NOT fall through to API probe in this
+        # call. The next scraper interaction (the actual scrape) will
+        # exercise the API + 401/403 path if needed.
+        scraper._fetch_qu_api.assert_not_called()
+        # Goto was called twice: initial (→ signin) + post-login.
+        assert goto_calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_verify_session_api_401_propagates_after_reauth_fails(self):
+        """_fetch_qu_api already retries on 401/403 once; if it still
+        raises, _verify_session must propagate.
+
+        We don't simulate the reauth-and-retry path itself here —
+        test_qu_api_retry.py owns that. We just assert that a raise
+        from _fetch_qu_api bubbles out of _verify_session unchanged.
+        """
+        page, _ = _make_mock_page()
+        scraper = _make_scraper()
+        scraper._page = page
+
+        scraper._fetch_qu_api = AsyncMock(
+            side_effect=RuntimeError("qu api 401 after re-auth: ...")
+        )
+
+        with patch(
+            "rainier.scrapers.qu.scraper.goto_with_retry",
+            new_callable=AsyncMock,
+        ):
+            with pytest.raises(RuntimeError, match="qu api 401 after re-auth"):
+                await scraper._verify_session()


### PR DESCRIPTION
## Summary

**P1 production cron fix.** QU100 cron has been failing every session since 2026-05-22; live evidence from operator's morning + midday runs on 2026-05-25. Two distinct post-PR-#84 bugs:

**Bug A — `_verify_session` DOM dependency.** Waits for `.ant-table` on `/products#qu100`. The QU SPA only renders that table after click+Search; bare nav doesn't render it. Post-PR-#84 the scraper no longer clicks anything, so verification times out every login.

**Bug B — `_cdp_ensure_auth` CF challenge eager bail.** Checks `page.title()` for `"just a moment"` immediately after `goto` and bails with a manual `--headed` recovery message. But Cloudflare's JS challenge typically resolves in 5–10s and issues fresh cf_clearance — the code didn't wait.

## Fix A — verify_session via API probe

Replace the DOM `wait_for_selector(QU100_TABLE)` with an in-page-fetch probe of `/api/v3/mf100?date=<market_date(now)>&top=true&frequency=daily` via `_fetch_qu_api`. Reuses PR #86's 401/403 reauth + retry path. Uses `market_date` from PR #85. No new auth-failure code path.

## Fix B — CDP CF wait-for-clear

When `"just a moment"` title detected in CDP mode, wrap in:

```python
await page.wait_for_function(
    """() => !document.title.toLowerCase().includes("just a moment")""",
    timeout=25000,
)
```

25s is generous (most CF JS challenges resolve in 5–10s). On timeout, raise `RuntimeError` pointing operator at the CDP browser (`Open <qu_url> in the CDP browser (currently on :9222) and manually clear any challenge, then retry`) — clearer + simpler than the prior `--headed` Playwright dance.

Parent design: `docs/DESIGN-qu-scraper-in-page-fetch.md` §3.
Task plan: `docs/TASK-PLAN-qu-verify-and-cf-recover-9f39.md`.

## Review

- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 2)

Zero review-iter commits; worker's 2 commits passed both reviewers as-is. 5 new tests added across 2 new test files; 1 existing test updated. 1009/7 pytest pass; ruff clean.

## Test plan

- [ ] CI green (Lint + Test + Build)
- [ ] Once merged: cron should resume without intervention. The fresh cf_clearance the operator manually obtained (by opening QU in their CDP Chrome) carries through.
- [ ] If a future CF rotation surfaces the 25s-stuck path, the new error message directs the operator to the CDP browser (faster recovery than the prior `--headed` Playwright dance).

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Fleet coord 585203b8