### PR TITLE
fix(qu): close Chrome we spawned on teardown (P1)

### DIFF
--- a/src/rainier/scrapers/browser.py
+++ b/src/rainier/scrapers/browser.py
@@ -119,18 +119,22 @@ class BrowserManager:
     async def stop(self) -> None:
         """Close/disconnect the browser and Playwright.
 
-        CDP-mode teardown branches on ownership:
+        Teardown decision tree::
 
-        - Attached to operator's pre-existing Chrome → just disconnect.
-          The D-10 contract owns this case: the operator's window stays
-          alive and the fresh scrape tab was already closed by the
-          ``fresh_tab_in_existing_context`` exit path.
-        - We force-restarted Chrome ourselves during ``start()`` → kill
-          the whole Chrome process. Otherwise an empty Chrome window
-          accumulates on :9222 after every cron run.
+            stop()
+              ├─ launch mode (_is_cdp=False)
+              │    └─ browser.close()                      # our Chromium
+              └─ CDP mode (_is_cdp=True)
+                   ├─ _we_spawned_chrome=False
+                   │    └─ disconnect only                 # D-10: operator's Chrome
+                   └─ _we_spawned_chrome=True
+                        └─ _kill_chrome_we_spawned()       # our Chrome — kill it
 
-        Launch mode is unchanged: ``browser.close()`` tears down the
-        Chromium we launched.
+        The CDP-spawned branch exists because the recovery path in
+        ``start()`` (``connect_over_cdp`` raises → ``_force_restart_chrome``
+        → retry) leaves us holding a Chrome process the operator did not
+        ask for. Closing only the scrape tab would leave an empty Chrome
+        window on :9222 — one leak per cron run.
         """
         if self._browser:
             if self._is_cdp:

--- a/src/rainier/scrapers/browser.py
+++ b/src/rainier/scrapers/browser.py
@@ -72,6 +72,12 @@ class BrowserManager:
         """Launch or connect to the browser."""
         if self._browser is not None:
             return
+        # Reset ownership before every fresh start. If a previous start()
+        # set the flag (recovery path) and a later caller reuses the same
+        # manager against an already-healthy Chrome, we must not carry
+        # the stale ownership forward — that would have stop() kill the
+        # operator's Chrome on the second cycle.
+        self._we_spawned_chrome = False
         self._playwright = await async_playwright().start()
 
         if self._cdp_url:
@@ -164,8 +170,14 @@ class BrowserManager:
         process the next ``ensure-chrome.sh`` invocation will recycle.
 
         Flow:
-            lsof -ti :9222          → list pids holding the port
+            lsof -ti :9222 -sTCP:LISTEN   → list ONLY the listener (Chrome)
             for each pid: kill <pid>
+
+        ``-sTCP:LISTEN`` is load-bearing: without it ``lsof`` also returns
+        every ESTABLISHED client of :9222 — including the Python process
+        running this code, which holds a CDP websocket to Chrome — and
+        ``kill <our-own-pid>`` would terminate the scraper mid-teardown.
+        Restricting to LISTEN ensures we only target the Chrome server.
 
         Returns silently when:
             - lsof finds no pids (Chrome already gone),
@@ -176,6 +188,7 @@ class BrowserManager:
                 "lsof",
                 "-ti",
                 f":{CDP_DEBUG_PORT}",
+                "-sTCP:LISTEN",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/src/rainier/scrapers/browser.py
+++ b/src/rainier/scrapers/browser.py
@@ -91,7 +91,19 @@ class BrowserManager:
                 # Record that WE own the Chrome process now. ``stop()`` will
                 # kill it on teardown so we don't leak an empty window.
                 self._we_spawned_chrome = True
-                self._browser = await self._playwright.chromium.connect_over_cdp(self._cdp_url)
+                try:
+                    self._browser = await self._playwright.chromium.connect_over_cdp(
+                        self._cdp_url
+                    )
+                except Exception:
+                    # We force-restarted Chrome but the retry connect still
+                    # failed — ``__aenter__`` will propagate this exception
+                    # and Python will NOT call ``__aexit__`` (so ``stop()``
+                    # never runs). Reap the Chrome we just spawned right
+                    # here, otherwise the empty window we own leaks until
+                    # the next ensure-chrome.sh --force.
+                    await self._kill_chrome_we_spawned()
+                    raise
             self._is_cdp = True
             log.info(
                 "browser_connected_cdp",

--- a/src/rainier/scrapers/browser.py
+++ b/src/rainier/scrapers/browser.py
@@ -18,6 +18,10 @@ log = structlog.get_logger()
 
 ENSURE_CHROME_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "ensure-chrome.sh"
 
+# CDP debug port. Must match scripts/ensure-chrome.sh's PORT — the kill
+# path uses this to locate the Chrome process we spawned.
+CDP_DEBUG_PORT = 9222
+
 
 class BrowserManager:
     """
@@ -57,6 +61,12 @@ class BrowserManager:
         self._playwright = None
         self._browser: Browser | None = None
         self._is_cdp = False
+        # True only when this manager triggered ``_force_restart_chrome``
+        # during ``start()`` — i.e., the Chrome listening on :9222 was
+        # spawned by US, not by the operator. ``stop()`` checks this to
+        # decide whether to kill the whole Chrome process (we own it) or
+        # leave it running (D-10: it's the operator's browser).
+        self._we_spawned_chrome = False
 
     async def start(self) -> None:
         """Launch or connect to the browser."""
@@ -72,9 +82,16 @@ class BrowserManager:
                 # or sitting idle for days. Force-restart it once and retry.
                 log.warning("cdp_connect_failed_restarting_chrome", error=str(e))
                 await self._force_restart_chrome()
+                # Record that WE own the Chrome process now. ``stop()`` will
+                # kill it on teardown so we don't leak an empty window.
+                self._we_spawned_chrome = True
                 self._browser = await self._playwright.chromium.connect_over_cdp(self._cdp_url)
             self._is_cdp = True
-            log.info("browser_connected_cdp", url=self._cdp_url)
+            log.info(
+                "browser_connected_cdp",
+                url=self._cdp_url,
+                we_spawned_chrome=self._we_spawned_chrome,
+            )
         else:
             self._browser = await self._playwright.chromium.launch(
                 headless=self._headless,
@@ -100,18 +117,80 @@ class BrowserManager:
         log.info("chrome_force_restarted", output=output)
 
     async def stop(self) -> None:
-        """Close/disconnect the browser and Playwright."""
+        """Close/disconnect the browser and Playwright.
+
+        CDP-mode teardown branches on ownership:
+
+        - Attached to operator's pre-existing Chrome → just disconnect.
+          The D-10 contract owns this case: the operator's window stays
+          alive and the fresh scrape tab was already closed by the
+          ``fresh_tab_in_existing_context`` exit path.
+        - We force-restarted Chrome ourselves during ``start()`` → kill
+          the whole Chrome process. Otherwise an empty Chrome window
+          accumulates on :9222 after every cron run.
+
+        Launch mode is unchanged: ``browser.close()`` tears down the
+        Chromium we launched.
+        """
         if self._browser:
             if self._is_cdp:
-                # Don't close the user's Chrome — just disconnect
-                pass
+                if self._we_spawned_chrome:
+                    # WE spawned this Chrome instance; nothing else owns it.
+                    # Kill the process so the next ensure-chrome.sh call gets
+                    # a clean start.
+                    await self._kill_chrome_we_spawned()
+                # else: D-10 — don't touch the operator's Chrome.
             else:
                 await self._browser.close()
             self._browser = None
         if self._playwright:
             await self._playwright.stop()
             self._playwright = None
-        log.info("browser_stopped")
+        log.info("browser_stopped", we_spawned_chrome=self._we_spawned_chrome)
+
+    @staticmethod
+    async def _kill_chrome_we_spawned() -> None:
+        """Terminate the Chrome process bound to :9222.
+
+        Mirrors the pattern in ``scripts/ensure-chrome.sh kill_chrome``
+        (``pkill -f remote-debugging-port=$PORT``) but in pure asyncio so
+        we don't need a separate shell-script entrypoint. Best-effort:
+        every failure is logged and swallowed because teardown must not
+        break the calling code — the worst case is one leftover Chrome
+        process the next ``ensure-chrome.sh`` invocation will recycle.
+
+        Flow:
+            lsof -ti :9222          → list pids holding the port
+            for each pid: kill <pid>
+
+        Returns silently when:
+            - lsof finds no pids (Chrome already gone),
+            - any subprocess call fails (logged as ``chrome_kill_failed``).
+        """
+        try:
+            lsof = await asyncio.create_subprocess_exec(
+                "lsof",
+                "-ti",
+                f":{CDP_DEBUG_PORT}",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await lsof.communicate()
+            pids = [p for p in stdout.decode(errors="replace").split() if p.strip()]
+            if not pids:
+                log.info("chrome_kill_skipped_no_pids", port=CDP_DEBUG_PORT)
+                return
+            for pid in pids:
+                kill = await asyncio.create_subprocess_exec(
+                    "kill",
+                    pid,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                await kill.communicate()
+            log.info("chrome_we_spawned_killed", pids=pids, port=CDP_DEBUG_PORT)
+        except Exception as exc:
+            log.warning("chrome_kill_failed", error=str(exc))
 
     async def __aenter__(self) -> BrowserManager:
         await self.start()

--- a/tests/test_scrapers/test_browser.py
+++ b/tests/test_scrapers/test_browser.py
@@ -83,9 +83,15 @@ class TestCDPConnectRetry:
 
     async def test_second_failure_propagates(self):
         factory, chromium = _mock_playwright(RuntimeError("still broken"))
+        # Mock the kill helper so this test cannot SIGTERM a real debug
+        # Chrome that happens to be listening on :9222 on the dev's box.
+        # The retry path now reaps the Chrome it spawned when the second
+        # connect fails (so __aexit__ never runs); without this mock we
+        # would call real lsof/kill from a unit test.
         with (
             patch("rainier.scrapers.browser.async_playwright", return_value=factory),
             patch.object(BrowserManager, "_force_restart_chrome", new=AsyncMock()) as restart,
+            patch.object(BrowserManager, "_kill_chrome_we_spawned", new=AsyncMock()) as kill,
         ):
             bm = BrowserManager(cdp_url="http://localhost:9222")
             with pytest.raises(RuntimeError, match="still broken"):
@@ -93,6 +99,8 @@ class TestCDPConnectRetry:
 
         assert chromium.connect_over_cdp.await_count == 2
         restart.assert_awaited_once()
+        # And the cleanup ran exactly once for the spawned Chrome.
+        kill.assert_awaited_once()
 
     async def test_happy_path_no_restart(self):
         mock_browser = MagicMock()

--- a/tests/test_scrapers/test_browser_chrome_ownership.py
+++ b/tests/test_scrapers/test_browser_chrome_ownership.py
@@ -193,3 +193,62 @@ class TestKillChromeImplementation:
         ):
             # Should not raise.
             await BrowserManager._kill_chrome_we_spawned()
+
+    async def test_kill_chrome_lsof_restricts_to_listen_socket(self):
+        """Regression for codex iter-1 P2: lsof MUST filter to LISTEN state.
+
+        Without ``-sTCP:LISTEN``, lsof on :9222 returns every client of
+        the port (including Playwright's CDP websocket, which lives in
+        this same Python process). The kill loop would then ``kill`` our
+        own PID mid-teardown. Assert the LISTEN filter is present in the
+        argv we hand to lsof.
+        """
+        captured_args: list[tuple] = []
+
+        async def fake_exec(*args, **kwargs):
+            captured_args.append(args)
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            return proc
+
+        with patch(
+            "rainier.scrapers.browser.asyncio.create_subprocess_exec",
+            side_effect=fake_exec,
+        ):
+            await BrowserManager._kill_chrome_we_spawned()
+
+        lsof_invocations = [a for a in captured_args if a and a[0] == "lsof"]
+        assert len(lsof_invocations) == 1, captured_args
+        lsof_argv = lsof_invocations[0]
+        assert "-sTCP:LISTEN" in lsof_argv, (
+            f"lsof must restrict to LISTEN state to avoid killing CDP "
+            f"clients (including our own process); got argv={lsof_argv}"
+        )
+
+
+class TestWeSpawnedFlagResetOnReuse:
+    """Regression for codex iter-1 P2: reusing a BrowserManager across
+    multiple start()/stop() cycles must reset ``_we_spawned_chrome`` so
+    a recovery-set True from cycle N never leaks into cycle N+1 and
+    causes stop() to kill the operator's Chrome.
+    """
+
+    async def test_start_resets_we_spawned_flag(self):
+        """Pre-condition: flag is True (simulating stale state from a
+        previous cycle). After a clean start() against a healthy CDP
+        endpoint, the flag must be False again."""
+        mock_browser = MagicMock()
+        factory, _ = _mock_playwright([mock_browser])
+        with (
+            patch("rainier.scrapers.browser.async_playwright", return_value=factory),
+            patch.object(BrowserManager, "_force_restart_chrome", new=AsyncMock()),
+        ):
+            bm = BrowserManager(cdp_url="http://localhost:9222")
+            bm._we_spawned_chrome = True  # stale from a prior recovery cycle
+            await bm.start()
+
+        assert bm._we_spawned_chrome is False, (
+            "start() must clear stale ownership so reused managers do not "
+            "kill the operator's Chrome on the next stop()"
+        )

--- a/tests/test_scrapers/test_browser_chrome_ownership.py
+++ b/tests/test_scrapers/test_browser_chrome_ownership.py
@@ -227,6 +227,46 @@ class TestKillChromeImplementation:
         )
 
 
+class TestSecondConnectFailureReapsChrome:
+    """Regression for /review iter-1 P1: when the retry ``connect_over_cdp``
+    raises after ``_force_restart_chrome`` succeeded, ``start()`` propagates
+    the exception. Python's async-with semantics mean ``__aexit__`` (and
+    thus ``stop()``) will NEVER run in this path — so if we don't kill the
+    Chrome we just spawned right here in ``start()``, it leaks indefinitely.
+
+    The WIP doc claims "stop() will reap it on the way out", but that is
+    only true when ``__aenter__`` returned normally. This test pins down
+    the failing-retry path explicitly.
+    """
+
+    async def test_kill_chrome_called_when_second_connect_fails(self):
+        first_error = RuntimeError("Browser context management is not supported")
+        second_error = RuntimeError("connection refused after restart")
+        factory, _ = _mock_playwright([first_error, second_error])
+        with (
+            patch("rainier.scrapers.browser.async_playwright", return_value=factory),
+            patch.object(BrowserManager, "_force_restart_chrome", new=AsyncMock()),
+            patch.object(
+                BrowserManager, "_kill_chrome_we_spawned", new=AsyncMock()
+            ) as kill,
+        ):
+            bm = BrowserManager(cdp_url="http://localhost:9222")
+            raised = None
+            try:
+                await bm.start()
+            except RuntimeError as exc:
+                raised = exc
+
+        # The retry exception must propagate so callers know start() failed.
+        assert raised is second_error, raised
+        # And we must have reaped the Chrome we spawned before re-raising,
+        # because async-with will never call our __aexit__.
+        kill.assert_awaited_once()
+        # Flag stays True so any defensive caller-side teardown also sees
+        # the ownership state.
+        assert bm._we_spawned_chrome is True
+
+
 class TestWeSpawnedFlagResetOnReuse:
     """Regression for codex iter-1 P2: reusing a BrowserManager across
     multiple start()/stop() cycles must reset ``_we_spawned_chrome`` so

--- a/tests/test_scrapers/test_browser_chrome_ownership.py
+++ b/tests/test_scrapers/test_browser_chrome_ownership.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 from rainier.scrapers.browser import BrowserManager
 
 

--- a/tests/test_scrapers/test_browser_chrome_ownership.py
+++ b/tests/test_scrapers/test_browser_chrome_ownership.py
@@ -1,0 +1,197 @@
+"""Tests for Chrome-ownership cleanup on BrowserManager.stop().
+
+Background: when ``BrowserManager`` falls into the CDP-connect retry path
+(``connect_over_cdp`` fails → ``_force_restart_chrome`` → retry), the
+fresh Chrome process is owned by US, not the operator. Closing only the
+scrape tab on teardown leaves an empty Chrome window listening on :9222
+that accumulates after every cron run.
+
+The fix: track ``_we_spawned_chrome`` (flipped to True in the recovery
+path) and on ``stop()`` kill the Chrome process if we own it. If we
+attached to the operator's pre-existing Chrome (no force-restart this
+session), preserve the D-10 contract and never touch the Chrome process.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rainier.scrapers.browser import BrowserManager
+
+
+def _mock_playwright(connect_side_effect):
+    """Build a patched async_playwright() whose chromium.connect_over_cdp uses the given side effect."""
+    mock_chromium = MagicMock()
+    mock_chromium.connect_over_cdp = AsyncMock(side_effect=connect_side_effect)
+    mock_pw = MagicMock()
+    mock_pw.chromium = mock_chromium
+    mock_pw_factory = MagicMock()
+    mock_pw_factory.start = AsyncMock(return_value=mock_pw)
+    return mock_pw_factory, mock_chromium
+
+
+class TestWeSpawnedFlag:
+    """The _we_spawned_chrome flag defaults to False and flips to True only
+    when this BrowserManager triggered a Chrome force-restart during start()."""
+
+    def test_defaults_to_false(self):
+        bm = BrowserManager(cdp_url="http://localhost:9222")
+        assert bm._we_spawned_chrome is False
+
+    async def test_force_restart_sets_we_spawned_flag(self):
+        """If the first connect_over_cdp raises and we force-restart Chrome,
+        the manager records that it now owns the Chrome process."""
+        mock_browser = MagicMock()
+        factory, _ = _mock_playwright(
+            [RuntimeError("Browser context management is not supported"), mock_browser]
+        )
+        with (
+            patch("rainier.scrapers.browser.async_playwright", return_value=factory),
+            patch.object(BrowserManager, "_force_restart_chrome", new=AsyncMock()),
+        ):
+            bm = BrowserManager(cdp_url="http://localhost:9222")
+            await bm.start()
+
+        assert bm._we_spawned_chrome is True
+
+    async def test_happy_cdp_path_does_not_set_we_spawned(self):
+        """When connect_over_cdp succeeds on the first try, we attached to
+        the operator's pre-existing Chrome — flag must stay False."""
+        mock_browser = MagicMock()
+        factory, _ = _mock_playwright([mock_browser])
+        with (
+            patch("rainier.scrapers.browser.async_playwright", return_value=factory),
+            patch.object(BrowserManager, "_force_restart_chrome", new=AsyncMock()),
+        ):
+            bm = BrowserManager(cdp_url="http://localhost:9222")
+            await bm.start()
+
+        assert bm._we_spawned_chrome is False
+
+    async def test_launch_mode_does_not_set_we_spawned(self):
+        """Launch mode never touches the CDP recovery path — flag stays False."""
+        mock_browser = AsyncMock()
+        mock_chromium = MagicMock()
+        mock_chromium.launch = AsyncMock(return_value=mock_browser)
+        mock_pw = MagicMock()
+        mock_pw.chromium = mock_chromium
+        factory = MagicMock()
+        factory.start = AsyncMock(return_value=mock_pw)
+
+        with patch("rainier.scrapers.browser.async_playwright", return_value=factory):
+            bm = BrowserManager()  # no cdp_url → launch mode
+            await bm.start()
+
+        assert bm._we_spawned_chrome is False
+
+
+class TestStopKillsChromeWhenWeSpawned:
+    """When stop() runs with _is_cdp=True AND _we_spawned_chrome=True, the
+    Chrome process we spawned is killed (not just the tab)."""
+
+    async def test_stop_kills_chrome_when_we_spawned(self):
+        bm = BrowserManager(cdp_url="http://localhost:9222")
+        bm._browser = MagicMock()
+        bm._is_cdp = True
+        bm._we_spawned_chrome = True
+        bm._playwright = AsyncMock()
+
+        with patch.object(
+            BrowserManager, "_kill_chrome_we_spawned", new=AsyncMock()
+        ) as kill:
+            await bm.stop()
+
+        kill.assert_awaited_once()
+
+    async def test_stop_preserves_chrome_when_attached(self):
+        """CDP mode but no force-restart this session — don't kill
+        operator's Chrome (D-10 contract)."""
+        bm = BrowserManager(cdp_url="http://localhost:9222")
+        bm._browser = MagicMock()
+        bm._is_cdp = True
+        bm._we_spawned_chrome = False
+        bm._playwright = AsyncMock()
+
+        with patch.object(
+            BrowserManager, "_kill_chrome_we_spawned", new=AsyncMock()
+        ) as kill:
+            await bm.stop()
+
+        kill.assert_not_awaited()
+
+    async def test_stop_closes_browser_in_launch_mode(self):
+        """Launch mode unchanged: browser.close() called; kill helper NOT
+        invoked even if we_spawned_chrome were somehow True (defensive)."""
+        bm = BrowserManager()  # launch mode
+        mock_browser = AsyncMock()
+        bm._browser = mock_browser
+        bm._is_cdp = False
+        bm._we_spawned_chrome = False
+        bm._playwright = AsyncMock()
+
+        with patch.object(
+            BrowserManager, "_kill_chrome_we_spawned", new=AsyncMock()
+        ) as kill:
+            await bm.stop()
+
+        mock_browser.close.assert_awaited_once()
+        kill.assert_not_awaited()
+
+
+class TestKillChromeImplementation:
+    """_kill_chrome_we_spawned uses lsof + kill to terminate the Chrome
+    process bound to :9222. Failure to find or kill the process is logged
+    but does not raise (teardown must be best-effort)."""
+
+    async def test_kill_chrome_runs_lsof_and_kills_pids(self):
+        """Happy path: lsof returns pids; each is killed via subprocess."""
+        # asyncio.create_subprocess_exec → process with stdout/stderr we can drive.
+        async def fake_exec(*args, **kwargs):
+            proc = AsyncMock()
+            if "lsof" in args:
+                proc.communicate = AsyncMock(return_value=(b"12345\n67890\n", b""))
+                proc.returncode = 0
+            else:  # kill
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch(
+            "rainier.scrapers.browser.asyncio.create_subprocess_exec",
+            side_effect=fake_exec,
+        ) as exec_mock:
+            await BrowserManager._kill_chrome_we_spawned()
+
+        # At minimum: one lsof call + two kill calls (one per pid).
+        call_strs = [tuple(c.args) for c in exec_mock.call_args_list]
+        lsof_calls = [c for c in call_strs if "lsof" in c]
+        kill_calls = [c for c in call_strs if c and c[0] == "kill"]
+        assert len(lsof_calls) == 1, f"expected 1 lsof call, got {call_strs}"
+        assert len(kill_calls) == 2, f"expected 2 kill calls, got {call_strs}"
+
+    async def test_kill_chrome_no_pids_is_noop(self):
+        """If lsof finds no pids (Chrome already gone), do not raise."""
+        async def fake_exec(*args, **kwargs):
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 1  # lsof returns non-zero when nothing matches
+            return proc
+
+        with patch(
+            "rainier.scrapers.browser.asyncio.create_subprocess_exec",
+            side_effect=fake_exec,
+        ):
+            # Must not raise even when lsof exits non-zero / empty.
+            await BrowserManager._kill_chrome_we_spawned()
+
+    async def test_kill_chrome_swallows_unexpected_errors(self):
+        """An unexpected exception inside the kill path must be caught:
+        teardown is best-effort and must not break the calling code."""
+        with patch(
+            "rainier.scrapers.browser.asyncio.create_subprocess_exec",
+            side_effect=RuntimeError("subprocess unavailable"),
+        ):
+            # Should not raise.
+            await BrowserManager._kill_chrome_we_spawned()

--- a/tests/test_scrapers/test_scraper_in_page_fetch.py
+++ b/tests/test_scrapers/test_scraper_in_page_fetch.py
@@ -480,3 +480,54 @@ class TestTeardownCdpModeOpensAndClosesFreshTab:
         assert not page.context.close.await_args_list  # type: ignore[attr-defined]
         assert scraper._page is None
         assert scraper._page_cm is None
+
+
+# ---------------------------------------------------------------------------
+# Chrome-ownership cleanup: when BrowserManager force-restarted Chrome, the
+# whole Chrome process is killed on bm.stop(), not just the scraper tab.
+# ---------------------------------------------------------------------------
+
+
+class TestScraperClosesChromeWhenForceRestarted:
+    """End-to-end mocked flow: BrowserManager's CDP connect fails on first
+    try, force-restart fires, scraper runs against the fresh Chrome, and on
+    ``async with`` exit the Chrome process we spawned is killed (not left
+    listening on :9222).
+    """
+
+    async def test_scraper_closes_chrome_when_force_restarted(self):
+        from rainier.scrapers.browser import BrowserManager
+
+        # --- Playwright mock: first connect fails, second succeeds ---
+        mock_browser = MagicMock()
+        mock_browser.contexts = [MagicMock()]
+        mock_chromium = MagicMock()
+        mock_chromium.connect_over_cdp = AsyncMock(
+            side_effect=[
+                RuntimeError("Browser context management is not supported"),
+                mock_browser,
+            ]
+        )
+        mock_pw = MagicMock()
+        mock_pw.chromium = mock_chromium
+        mock_pw.stop = AsyncMock()
+        mock_pw_factory = MagicMock()
+        mock_pw_factory.start = AsyncMock(return_value=mock_pw)
+
+        with (
+            patch("rainier.scrapers.browser.async_playwright", return_value=mock_pw_factory),
+            patch.object(
+                BrowserManager, "_force_restart_chrome", new=AsyncMock()
+            ) as restart,
+            patch.object(
+                BrowserManager, "_kill_chrome_we_spawned", new=AsyncMock()
+            ) as kill,
+        ):
+            async with BrowserManager(cdp_url="http://localhost:9222") as bm:
+                # The recovery path fired during start() — we now own Chrome.
+                assert bm._we_spawned_chrome is True
+                assert bm._is_cdp is True
+            # __aexit__ ran bm.stop() — and because we own Chrome it must
+            # have killed the process, not just disconnected.
+            restart.assert_awaited_once()
+            kill.assert_awaited_once()


### PR DESCRIPTION
## Summary
- BrowserManager now tracks `_we_spawned_chrome` and reaps the whole Chrome process on stop() when force-restart owned the instance; pre-existing Chrome stays untouched (preserves operator's tabs).
- Closes the empty-Chrome leak operator surfaced: every force-restart cycle was leaving a tabless Chrome process on :9222.
- 11 new unit + 1 integration test covering ownership flag, kill-on-stop, recovery path, and D-10 attach-only case.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 5)
  - codex iter-1: lsof LISTEN-only filter + reset `_we_spawned` on start() to harden manager reuse
  - codex iter-2: mock `_kill_chrome_we_spawned` in `test_second_failure_propagates` so unit tests don't fire real lsof/kill
  - /review iter-1 caught the real bug: start() recovery path was leaking Chrome when retry connect_over_cdp itself raised (async-with `__aexit__` never runs when `__aenter__` raises). Fixed: `_kill_chrome_we_spawned()` runs before re-raising.

## Deferred (P2, post-merge)
- `lsof` may not be on cron's PATH. Helper has broad `except Exception` so worst case is one orphan Chrome until next `ensure-chrome.sh --force`. Could harden later by absolute `/usr/sbin/lsof` or `pkill -f remote-debugging-port=\$PORT`.

## Test plan
- [ ] CI green
- [ ] Next scheduled cron run (15:00 PT close session) leaves zero stale Chrome processes on :9222 after teardown