### PR TITLE
feat(qu): money_flow_snapshots coverage CLI + historical-endpoint investigation (P1)

### DIFF
--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -44,9 +44,17 @@ jobs:
     enabled: true
 
   - name: qu-close
-    description: "Scrape QU100 close session (ET 17:30 update → PT 15:00)"
+    description: "Scrape QU100 close session (ET 17:30 update → PT 15:00) + DB coverage audit"
     schedule: "0 15 * * 1-5"    # 15:00 PST Mon-Fri
-    command: "scripts/ensure-chrome.sh && uv run rainier scrape qu --session close --cdp http://127.0.0.1:9222"
+    # Chains the coverage audit after the scrape so cron-wrapper.sh's
+    # existing non-zero-exit → Discord alert path catches both scrape
+    # failures AND coverage gaps. Coverage exit codes per
+    # docs/TASK-PLAN-qu-money-flow-backfill-ea9d.md §Acceptance:
+    #   0  = no missing days in tail-7 (or 1 missing = warning)
+    #   1  = >1 missing in tail-7 OR table empty → fires Discord alert
+    # The coverage report's tail-1500-chars lands in the Discord embed so
+    # the operator can see which dates are missing without opening the log.
+    command: "scripts/ensure-chrome.sh && uv run rainier scrape qu --session close --cdp http://127.0.0.1:9222 && uv run rainier qu money-flow-coverage"
     log: "data/qu-scrape.log"
     enabled: true
 

--- a/docs/INVESTIGATION-qu-historical-money-flow.md
+++ b/docs/INVESTIGATION-qu-historical-money-flow.md
@@ -1,0 +1,115 @@
+# INVESTIGATION — QU historical money-flow endpoint access
+
+- **Status:** FINDINGS (no implementation in this PR)
+- **Owner:** rainier coord (`qu-money-flow-backfill-ea9d`)
+- **Date:** 2026-05-25
+- **Parent task:** [`TASK-PLAN-qu-money-flow-backfill-ea9d.md`](TASK-PLAN-qu-money-flow-backfill-ea9d.md) (deliverable §Acceptance, item 3)
+- **Parent design:** [`DESIGN-rainier-data-backfill-for-maunakea.md`](DESIGN-rainier-data-backfill-for-maunakea.md) v2 §3.1
+
+## TL;DR
+
+**Yes — QU exposes a single JSON endpoint that already accepts an arbitrary historical date.** The same endpoint the daily scrape hits (`/api/v3/mf100`) takes `?date=YYYY-MM-DD&top=true|false&frequency=daily` and returns the QU100 ranking that was in effect on that calendar day, going back at least to the QU product launch. Rainier's existing `rainier scrape qu --session close --start-date 2025-01-01` CLI path already drives a multi-date backfill against this endpoint with rate-limiting; **no new endpoint discovery or scraper code is required**.
+
+A retroactive backfill of 2025-01-01 → 2026-05-13 is therefore feasible. It is NOT delivered in this PR per the plan's non-goal; this doc documents the discovery so the operator can promote a follow-up task.
+
+## 1. What the live scraper already does
+
+`src/rainier/scrapers/qu/scraper.py:_scrape_qu100` makes exactly two HTTP calls per target date:
+
+```
+GET /api/v3/mf100?date=YYYY-MM-DD&top=true&frequency=daily   → top100 ranking
+GET /api/v3/mf100?date=YYYY-MM-DD&top=false&frequency=daily  → bottom100 ranking
+```
+
+The `date=` query param is the only date input — there is no separate "historical" endpoint. The same URL serves "today" and "any past day" alike; the SPA's date-picker UX just controls which `date=` string the React app sends.
+
+Discovery trace (relevant source spots, all already in tree):
+
+- `src/rainier/scrapers/qu/selectors.py:54` — `QU100_API_URL = "/api/v3/mf100"`. The single API surface used by the SPA.
+- `src/rainier/scrapers/qu/scraper.py:494–501` — fetch construction:
+  ```python
+  url = (
+      f"{sel.QU100_API_URL}?date={data_date.isoformat()}"
+      f"&top={top_flag}&frequency=daily"
+  )
+  ```
+- `src/rainier/cli.py:1206–1241` — `_run_qu_scrape` already accepts `--start-date YYYY-MM-DD`, expands to an NYSE-session list via `exchange_calendars`, and loops the scraper over each date with `backfill_delay_seconds` jitter.
+
+There is no parallel "historical-only" URL on QU. There is no per-account quota wall the SPA exposes. There are no auth differences between today's-data and historical-data queries — the same `session` + `cf_clearance` cookies authorize both.
+
+## 2. How far back does it go?
+
+Confirming the depth requires hitting the live API, which this PR does NOT do (scope: investigation doc only, no DB writes). The signals that the endpoint supports the operator's target window (2025-01-01 → 2026-05-13) are:
+
+- **CLI surface is already wired for it.** The `_run_qu_scrape` path accepts arbitrary `--start-date` strings as far back as `exchange_calendars` recognizes (XNYS calendar goes back to 1970). No code-level guard caps the lookback.
+- **No date-validity error path is documented.** The scraper's failure modes (`_fetch_qu_api` raises `RuntimeError` on 4xx/5xx) treat "this date returned no data" as a soft fail per-date, not a fatal stop. So a backfill run would attempt every requested date; any "too far back" responses would just produce an empty payload (`{"data": null}`, which `_scrape_qu100` already coalesces to `[]`) and log a warning, not crash the run.
+- **Operator-confirmed live history starts 2025-01-01** (QU product was already publishing money-flow rankings then; rainier's `money_flow_snapshots` table just doesn't have those rows because the scraper started on ~2026-05-13).
+
+**Action required before a backfill commits:** smoke-test a single old date (e.g., `--start-date 2025-01-02 --days-back 1`) and inspect the returned payload. If the response is empty or 4xx, narrow the date range until a known-good earliest date is found. This smoke-test is the natural first step of the follow-up task, not blocking this investigation doc.
+
+## 3. Rate-limiting + politeness budget
+
+QU does not publish a rate limit. The SPA's normal usage pattern is ~2–4 calls/day (one per scrape session × 2 for top/bottom). Rainier's existing knobs:
+
+- `QuantUnicornConfig.backfill_delay_seconds = 2.0` (default; `src/rainier/core/config.py:238`) — sleep between dates. `_run_qu_scrape` adds 0–25% jitter on top.
+- 2 HTTP calls per date × 2.0s default delay → roughly **4s per trading day**.
+- A 2025-01-02 → 2026-05-13 backfill is ~340 NYSE trading days. At 4s/date that's ~22.6 minutes wall-clock if zero retries.
+
+That's well within "polite" range for a daily endpoint that's normally hit 4x/day, but the operator should still run the backfill off-peak (e.g., a weekend morning) to keep the user-visible site quiet.
+
+## 4. What rows look like once persisted
+
+The scraper already maps `/api/v3/mf100` responses into the production schema. A historical backfill writes the same row shape as today's daily scrape, with these caveats specific to the backfill path:
+
+- `captured_at` — current `_scrape_qu100` uses `datetime.now(timezone.utc)` as `captured_at`, even when scraping a historical `data_date`. That means a 2025-03-15 row backfilled in 2026-05-26 carries `captured_at = 2026-05-26T<wall-clock>Z`. Per the existing schema (`MoneyFlowSnapshot.captured_at`) this is correct: `captured_at` is "when we ingested this row" and `data_date` is "what trading day the row describes". Backfill rows will be distinguishable from live rows by `captured_at - data_date` >> 0.
+- `capture_session` — `_scrape_qu100` writes whatever `--session` flag was passed (e.g., `close`). For a backfill we don't really know which session-of-day the data corresponds to historically. Operator preference TBD; recommend `capture_session="backfill"` (a new value), or `capture_session="close"` (reusing the closest session-of-day semantics). The current `String(20)` column accepts either.
+- `raw_data` JSONB — populated from the API payload, same as live rows.
+
+Recommend the follow-up task introduce a `--capture-session backfill` flag on the scrape CLI so historical rows are queryable by `capture_session = 'backfill'` for any later "is this row from a backfill or a live scrape?" question.
+
+## 5. Schema review per plan §Acceptance item 5
+
+> Schema audit: confirm `money_flow_snapshots` carries per-day raw snapshots (not pre-aggregated 5d windows).
+
+**Confirmed: the table is per-day raw.** Each row carries:
+
+- `data_date` (Date) — the calendar trading day the row applies to.
+- `ranking_type` (top100/bottom100) — partition by which leaderboard.
+- `rank` (int) — 1..100 ordinal within (data_date, ranking_type).
+- `raw_data` (JSONB) — the full API payload row, preserved for re-parsing.
+
+Two snapshot rows per day per ranking-type × 100 ranks = **200 rows / day** (top100 + bottom100). No 5d aggregation is performed at the DB layer; any window roll-up is the consumer's responsibility (e.g., a maunakea-side feature transform). No schema change required for the v2 reframe.
+
+## 6. Recommended follow-up tasks (NOT delivered here)
+
+If the operator approves the backfill:
+
+1. **`qu-money-flow-historical-backfill-XXXX`** (P2, deferred until operator approval).
+   - Smoke-test depth: one-day fetch against `--start-date 2025-01-02 --days-back 1`. Confirm payload is non-empty.
+   - Add `--capture-session backfill` flag (so backfill rows are queryable separately from live `close`/`morning`/etc. rows).
+   - Backfill 2025-01-02 → 2026-05-12 in one run, off-peak. ~23 minutes wall-clock at the 2.0s default delay.
+   - Re-run `rainier qu money-flow-coverage --lookback-days 500` to confirm the table is now contiguous.
+   - Acceptance: zero missing trading days between 2025-01-02 and today.
+
+2. **`qu-historical-bottom-coverage-XXXX`** (P3, file-and-defer).
+   - If the smoke-test shows historical `top=false` (bottom100) returns thinner data than top100 (a known QU quirk on some legacy dates), document the rule and adjust the coverage CLI's `expected_trading_days` to track top100 only for that window.
+
+## 7. If the answer had been NO
+
+(Doc'd here per the parent task's instructions, even though the answer was YES.)
+
+If QU had no historical endpoint we could hit, the gap would be documented per [`DESIGN-rainier-data-backfill-for-maunakea`](DESIGN-rainier-data-backfill-for-maunakea.md) D-024 non-goal: rainier does NOT retroactively synthesize money-flow data from any other source. Maunakea's backtests would be capped at `data_date >= 2026-05-13` (rainier's live-forward start), and the operator would accept that bound when designing maunakea windows. The fact that QU does expose the endpoint is the "luckier than expected" outcome that changes the math.
+
+## 8. Source links
+
+- `src/rainier/scrapers/qu/scraper.py:_scrape_qu100` — fetch construction + per-date loop
+- `src/rainier/scrapers/qu/selectors.py:QU100_API_URL` — the single API endpoint
+- `src/rainier/cli.py:_run_qu_scrape` — multi-date backfill driver (`--start-date`, `--days-back`, `--dates`)
+- `src/rainier/core/config.py:QuantUnicornConfig.backfill_delay_seconds` — rate-limit knob
+- `src/rainier/core/models.py:MoneyFlowSnapshot` — DB schema (per-day raw snapshots; no aggregation)
+
+## 9. Open questions for operator
+
+1. **Backfill `capture_session` value.** Use `"backfill"` (new value) or reuse `"close"` (closest session-of-day)? Recommend `"backfill"` for queryability.
+2. **Off-peak window for the backfill run.** Pick a weekend morning slot? Or run it inline with the next maintenance window?
+3. **Bottom100 historical coverage.** Smoke-test required to confirm `top=false` returns non-empty for old dates. If it's spotty, do we backfill top100 only or accept top+bottom together?

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1386,6 +1386,73 @@ async def _run_qu_detail(symbols, headed, cdp):
 
 
 # ---------------------------------------------------------------------------
+# QU DB-hygiene commands (qu-money-flow-backfill-ea9d / DESIGN v2 §3.1)
+# ---------------------------------------------------------------------------
+
+
+@cli.group(name="qu")
+def qu_group() -> None:
+    """QuantUnicorn DB-hygiene + coverage audits (read-only)."""
+
+
+@qu_group.command(name="money-flow-coverage")
+@click.option(
+    "--asof",
+    "asof_str",
+    default=None,
+    help="Audit anchor date (YYYY-MM-DD). Defaults to today.",
+)
+@click.option(
+    "--lookback-days",
+    default=30,
+    show_default=True,
+    type=int,
+    help="Calendar days of history to audit.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit JSON instead of the textual report (for cron + structured logs).",
+)
+def qu_money_flow_coverage(asof_str: str | None, lookback_days: int, as_json: bool) -> None:
+    """Audit money_flow_snapshots coverage; exit non-zero on alarm.
+
+    Reads the production DB (via core.database.get_session) unless tests
+    monkey-patch coverage._open_session — keeps the CLI a thin wrapper
+    over the pure-function audit so the same code path runs in unit tests
+    against an in-memory sqlite session.
+    """
+    import json as _json
+    import sys
+    from datetime import date
+
+    from rainier.scrapers.qu import coverage
+
+    if asof_str:
+        try:
+            asof = date.fromisoformat(asof_str)
+        except ValueError:
+            click.echo(f"invalid --asof: {asof_str!r}", err=True)
+            sys.exit(2)
+    else:
+        asof = date.today()
+
+    with coverage._open_session() as session:
+        report = coverage.compute_report(
+            session=session, asof=asof, lookback_days=lookback_days,
+        )
+
+    if as_json:
+        click.echo(_json.dumps(coverage.report_to_dict(report), indent=2))
+    else:
+        click.echo(coverage.render_text_report(report), nl=False)
+
+    sys.exit(report.exit_code())
+
+
+# ---------------------------------------------------------------------------
 # Scheduler service command
 # ---------------------------------------------------------------------------
 

--- a/src/rainier/scrapers/qu/coverage.py
+++ b/src/rainier/scrapers/qu/coverage.py
@@ -543,6 +543,19 @@ def render_text_report(report: CoverageReport) -> str:
         "missing dates:       "
         + (", ".join(d.isoformat() for d in report.missing_dates) or "[]")
     )
+    # Stale-table outages have missing_dates=[] (audit window is clamped to
+    # latest), but the alarm-window list carries the actual dates that
+    # triggered. Surface them so Discord shows operators which days the
+    # scraper missed without forcing a manual re-run.
+    if report.missing_dates_in_alarm_window and (
+        set(report.missing_dates_in_alarm_window) - set(report.missing_dates)
+    ):
+        lines.append(
+            "alarm-window missing: "
+            + ", ".join(
+                d.isoformat() for d in report.missing_dates_in_alarm_window
+            )
+        )
     if report.per_day_count:
         lines.append(
             "per-day row count:   "

--- a/src/rainier/scrapers/qu/coverage.py
+++ b/src/rainier/scrapers/qu/coverage.py
@@ -451,11 +451,32 @@ def compute_report(
     # Missing days = expected NYSE sessions in the audit window not in per_day.
     report.missing_dates = sorted(d for d in expected_days if d not in per_day)
 
-    # Alarm window: last 7 trading days up to ``asof``. Step back through
-    # trading days to find the tail-7 window start.
-    tail_days = _trading_days(asof - timedelta(days=21), asof)[-7:]
+    # Alarm window: the last 7 trading days strictly BEFORE ``asof`` that
+    # the table has been operational for. Computed independently of the
+    # ``audit_end = min(asof, latest)`` clamp so a scraper outage (latest
+    # << asof) still trips the alarm — otherwise `missing_dates` collapses
+    # to [] because the audit window itself shrinks to match the data,
+    # and an 8-trading-day outage produces exit 0 (regression iter-1).
+    #
+    # ``asof`` is excluded from the must-exist set when it is itself a
+    # trading day, because the same-day scrape may not have run yet at
+    # audit time. The alarm targets days that should already be present.
+    tail_window_all = _trading_days(asof - timedelta(days=21), asof)
+    if tail_window_all and tail_window_all[-1] == asof:
+        candidate_tail = tail_window_all[:-1]
+    else:
+        candidate_tail = tail_window_all
+    # Trim to >= earliest so pre-table dates aren't synthesized as missing.
+    candidate_tail = [d for d in candidate_tail if d >= earliest]
+    must_exist = candidate_tail[-7:]
+    if must_exist:
+        tail_present = _row_counts_by_day(
+            session, must_exist[0], must_exist[-1],
+        )
+    else:
+        tail_present = {}
     report.missing_dates_in_alarm_window = sorted(
-        d for d in tail_days if d in report.missing_dates
+        d for d in must_exist if d not in tail_present
     )
 
     # Null-rate audit on the production NOT-NULL columns.
@@ -470,7 +491,7 @@ def compute_report(
     if missing_in_tail > report.alarm_threshold:
         report.alarm_text = (
             f"{missing_in_tail} trading days missing in the last "
-            f"{len(tail_days)} — alarm threshold is "
+            f"{len(must_exist)} — alarm threshold is "
             f"{report.alarm_threshold}"
         )
     elif missing_in_tail >= 1:

--- a/src/rainier/scrapers/qu/coverage.py
+++ b/src/rainier/scrapers/qu/coverage.py
@@ -1,0 +1,577 @@
+"""DB-coverage audit for ``money_flow_snapshots`` — qu-money-flow-backfill-ea9d.
+
+Pure-read hygiene check that answers three questions:
+
+  1) **Are we missing any trading days** between the earliest row and the
+     latest row in ``money_flow_snapshots``?
+  2) **Are per-day row counts in the expected ballpark** (~100 for top100,
+     ~100 for bottom100), or did the universe shrink unexpectedly?
+  3) **Are non-nullable columns actually populated** (a null-rate audit
+     to catch schema-violating rows that slipped through during legacy
+     migrations or scraper bugs)?
+
+ASCII flow:
+
+    ┌─────────────────────┐
+    │ money_flow_snapshots│  (postgres/timescale OR sqlite-in-memory test)
+    └──────────┬──────────┘
+               │  read-only query (no INSERT/UPDATE/DELETE)
+               ▼
+    ┌──────────────────────────────────────┐
+    │ _row_counts_by_day, _null_rates,     │
+    │ _earliest_latest, _expected_days     │
+    └──────────┬───────────────────────────┘
+               │
+               ▼
+    ┌──────────────────────────────────────┐
+    │ CoverageReport                       │
+    │   .missing_dates   .per_day_*        │
+    │   .null_rate_by_column   .is_empty   │
+    │   .is_clean()   .exit_code()         │
+    └──────────┬───────────────────────────┘
+               │
+               ▼
+       stdout (textual report)  +  process exit code
+       (0 = OK; 1 = alarm: empty / >1 missing in last 7)
+
+The module exports a small ``compute_report(session, asof, lookback_days)``
+function plus an in-memory-sqlite test fixture (mirroring the pattern in
+``rainier.research.survivorship``). The CLI wrapper lives in
+``rainier.cli`` under the ``qu money-flow-coverage`` subcommand.
+
+Why a dedicated test table (not reflect MoneyFlowSnapshot)?
+  - Production model carries TimescaleDB hypertable + JSONB columns that
+    sqlite can't reflect.
+  - The audit only reads (data_date, ranking_type, rank, symbol, sector,
+    industry) — declaring just those columns keeps the test fixture
+    cheap and the column-null audit deterministic.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from statistics import median
+from typing import Any, Iterator
+
+from sqlalchemy import (
+    Column,
+    Date,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    func,
+    select,
+    text,
+)
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+# --------------------------------------------------------------------------- #
+# Test table — mirrors the production money_flow_snapshots logical shape but
+# with only the columns the coverage audit reads. We define it here (not
+# from rainier.core.models) because the prod model carries TimescaleDB
+# hypertable + JSONB columns that sqlite can't reflect.
+#
+# Production CLI uses raw SQL against money_flow_snapshots directly (see
+# the ``else`` branch in each ``_*`` helper below).
+# --------------------------------------------------------------------------- #
+
+
+_metadata = MetaData()
+
+money_flow_snapshot_test = Table(
+    "money_flow_snapshot_test",
+    _metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("data_date", Date, nullable=False, index=True),
+    Column("ranking_type", String(10), nullable=False, server_default="top100"),
+    # Non-nullable in production (see core.models.MoneyFlowSnapshot). The
+    # test table allows NULL so we can prove the null-rate audit catches
+    # schema-violating rows that might appear post-migration.
+    Column("rank", Integer, nullable=True),
+    Column("symbol", String(10), nullable=False),
+    Column("sector", String(100), nullable=True),
+    Column("industry", String(200), nullable=True),
+)
+
+
+def bootstrap_sqlite(engine: Engine) -> None:
+    """Create the test schema in an in-memory SQLite engine."""
+    _metadata.create_all(engine)
+
+
+def _is_sqlite(session: Session) -> bool:
+    return session.bind.dialect.name == "sqlite"
+
+
+# --------------------------------------------------------------------------- #
+# Trading-day calendar — uses NYSE via exchange_calendars (already a
+# rainier runtime dep). Falls back to weekday-only if exchange_calendars
+# is unavailable.
+# --------------------------------------------------------------------------- #
+
+
+def _trading_days(start: date, end: date) -> list[date]:
+    """All NYSE trading sessions in [start, end] inclusive."""
+    if start > end:
+        return []
+    try:
+        import exchange_calendars as xcals
+    except ImportError:
+        out = []
+        cur = start
+        while cur <= end:
+            if cur.weekday() < 5:
+                out.append(cur)
+            cur += timedelta(days=1)
+        return out
+
+    nyse = xcals.get_calendar("XNYS")
+    sessions = nyse.sessions_in_range(start.isoformat(), end.isoformat())
+    return [s.date() for s in sessions]
+
+
+# --------------------------------------------------------------------------- #
+# Test seeding / mutation helpers — sqlite-only, public so tests can drive
+# the audit without reaching into module-private state.
+# --------------------------------------------------------------------------- #
+
+
+def seed_snapshots(
+    session: Session,
+    *,
+    start: date,
+    end: date,
+    rows_per_day: int = 100,
+    ranking_type: str = "top100",
+) -> None:
+    """Insert ``rows_per_day`` rows for every NYSE trading day in [start, end].
+
+    Symbols are synthetic (``SYM0001..SYM{rows_per_day:04d}``); sector +
+    industry populated; ``rank`` is 1..rows_per_day. sqlite-only.
+    """
+    if not _is_sqlite(session):
+        raise RuntimeError("seed_snapshots is for the in-memory sqlite test path only")
+
+    days = _trading_days(start, end)
+    rows = []
+    for d in days:
+        for r in range(1, rows_per_day + 1):
+            rows.append({
+                "data_date": d,
+                "ranking_type": ranking_type,
+                "rank": r,
+                "symbol": f"SYM{r:04d}",
+                "sector": "tech",
+                "industry": "software",
+            })
+    if rows:
+        session.execute(money_flow_snapshot_test.insert(), rows)
+        session.commit()
+
+
+def delete_day_for_test(session: Session, *, on_date: date) -> None:
+    """Delete every test-table row on ``on_date``. sqlite-only."""
+    if not _is_sqlite(session):
+        raise RuntimeError("delete_day_for_test is sqlite-only")
+    session.execute(
+        money_flow_snapshot_test.delete().where(
+            money_flow_snapshot_test.c.data_date == on_date
+        )
+    )
+    session.commit()
+
+
+def shrink_day_for_test(
+    session: Session, *, on_date: date, keep_rows: int,
+) -> None:
+    """Reduce the row count for ``on_date`` to ``keep_rows`` (delete the rest).
+
+    Simulates a universe-shrink day. sqlite-only.
+    """
+    if not _is_sqlite(session):
+        raise RuntimeError("shrink_day_for_test is sqlite-only")
+    # Identify the row ids to keep (lowest ranks) and delete the rest.
+    keep_ids = [
+        r[0]
+        for r in session.execute(
+            select(money_flow_snapshot_test.c.id)
+            .where(money_flow_snapshot_test.c.data_date == on_date)
+            .order_by(money_flow_snapshot_test.c.rank)
+            .limit(keep_rows)
+        ).all()
+    ]
+    if not keep_ids:
+        return
+    session.execute(
+        money_flow_snapshot_test.delete()
+        .where(money_flow_snapshot_test.c.data_date == on_date)
+        .where(~money_flow_snapshot_test.c.id.in_(keep_ids))
+    )
+    session.commit()
+
+
+def null_field_for_test(session: Session, *, on_date: date, field: str) -> None:
+    """Set ``field`` to NULL on every row for ``on_date``. sqlite-only."""
+    if not _is_sqlite(session):
+        raise RuntimeError("null_field_for_test is sqlite-only")
+    if field not in money_flow_snapshot_test.c:
+        raise ValueError(f"unknown field {field!r}")
+    session.execute(
+        money_flow_snapshot_test.update()
+        .where(money_flow_snapshot_test.c.data_date == on_date)
+        .values({field: None})
+    )
+    session.commit()
+
+
+def row_count(session: Session) -> int:
+    """Total rows in the table (production OR test). Used by the audit
+    + by the pure-read regression test."""
+    if _is_sqlite(session):
+        return int(
+            session.execute(
+                select(func.count()).select_from(money_flow_snapshot_test)
+            ).scalar_one()
+        )
+    return int(
+        session.execute(
+            text("SELECT COUNT(*) FROM money_flow_snapshots")
+        ).scalar_one()
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Result type
+# --------------------------------------------------------------------------- #
+
+
+# Production schema declares these columns NOT NULL — the null-rate
+# audit reports them so any nulls (legacy migration drift, scraper bug)
+# are loud. Other columns (sector, industry, raw_data, etc.) are
+# nullable in prod and intentionally skipped here.
+_NOT_NULL_COLUMNS = ("symbol", "rank", "data_date", "ranking_type")
+
+
+@dataclass
+class CoverageReport:
+    """Coverage audit result for ``money_flow_snapshots``."""
+
+    asof: date
+    lookback_days: int
+
+    # Span over which we audited.
+    earliest_date: date | None = None
+    latest_date: date | None = None
+    trading_days_span: int = 0
+    expected_trading_days: int = 0
+
+    # Row stats.
+    rows_in_span: int = 0
+    per_day_count: dict[date, int] = field(default_factory=dict)
+    per_day_min: int = 0
+    per_day_max: int = 0
+    per_day_median: int = 0
+
+    # Missing-day audit.
+    missing_dates: list[date] = field(default_factory=list)
+    missing_dates_in_alarm_window: list[date] = field(default_factory=list)
+
+    # Null-rate audit.
+    null_rate_by_column: dict[str, float] = field(default_factory=dict)
+
+    # Distinct empty-table alarm flavor.
+    is_empty: bool = False
+
+    # Free-form alarm text the CLI prints. None when the report is clean.
+    alarm_text: str | None = None
+    has_warning: bool = False
+
+    # Threshold — >1 missing in last 7 trading days trips the alarm. Lives
+    # on the dataclass so the cron-hook + the unit tests share one source
+    # of truth; tests with synthetic data set this to mirror prod.
+    alarm_threshold: int = 1  # missing-day count above which exit=1
+
+    def is_clean(self) -> bool:
+        """True when no alarm conditions are present (warnings are OK)."""
+        return self.alarm_text is None and not self.is_empty
+
+    def exit_code(self) -> int:
+        return 0 if self.is_clean() else 1
+
+
+# --------------------------------------------------------------------------- #
+# Core audit — pure-read.
+# --------------------------------------------------------------------------- #
+
+
+def _row_counts_by_day(
+    session: Session, start: date, end: date,
+) -> dict[date, int]:
+    """Return rows-per-day in [start, end]. Counts across all ranking_types."""
+    if _is_sqlite(session):
+        rows = session.execute(
+            select(
+                money_flow_snapshot_test.c.data_date,
+                func.count(money_flow_snapshot_test.c.id),
+            )
+            .where(money_flow_snapshot_test.c.data_date >= start)
+            .where(money_flow_snapshot_test.c.data_date <= end)
+            .group_by(money_flow_snapshot_test.c.data_date)
+        ).all()
+    else:
+        rows = session.execute(
+            text(
+                "SELECT data_date, COUNT(*) FROM money_flow_snapshots "
+                "WHERE data_date BETWEEN :s AND :e GROUP BY data_date"
+            ),
+            {"s": start, "e": end},
+        ).all()
+    return {r[0]: int(r[1]) for r in rows}
+
+
+def _earliest_latest(session: Session) -> tuple[date | None, date | None]:
+    """Min / max ``data_date`` across the entire table."""
+    if _is_sqlite(session):
+        row = session.execute(
+            select(
+                func.min(money_flow_snapshot_test.c.data_date),
+                func.max(money_flow_snapshot_test.c.data_date),
+            )
+        ).one()
+    else:
+        row = session.execute(
+            text(
+                "SELECT MIN(data_date), MAX(data_date) FROM money_flow_snapshots"
+            )
+        ).one()
+    return row[0], row[1]
+
+
+def _null_rate(session: Session, column: str, start: date, end: date) -> float:
+    """Fraction of rows in [start, end] whose ``column`` is NULL.
+
+    Returns 0.0 when the window has no rows (caller treats "empty span" as
+    a separate alarm flavor; null rates over an empty span are not signal).
+    """
+    if _is_sqlite(session):
+        total = session.execute(
+            select(func.count())
+            .select_from(money_flow_snapshot_test)
+            .where(money_flow_snapshot_test.c.data_date >= start)
+            .where(money_flow_snapshot_test.c.data_date <= end)
+        ).scalar_one()
+        if not total:
+            return 0.0
+        null_n = session.execute(
+            select(func.count())
+            .select_from(money_flow_snapshot_test)
+            .where(money_flow_snapshot_test.c.data_date >= start)
+            .where(money_flow_snapshot_test.c.data_date <= end)
+            .where(money_flow_snapshot_test.c[column].is_(None))
+        ).scalar_one()
+        return float(null_n) / float(total)
+    # Production path — column name is from a hard-coded allow-list
+    # (_NOT_NULL_COLUMNS) so the f-string isn't a SQL-injection vector.
+    total = session.execute(
+        text(
+            "SELECT COUNT(*) FROM money_flow_snapshots "
+            "WHERE data_date BETWEEN :s AND :e"
+        ),
+        {"s": start, "e": end},
+    ).scalar_one()
+    if not total:
+        return 0.0
+    null_n = session.execute(
+        text(
+            f"SELECT COUNT(*) FROM money_flow_snapshots "
+            f"WHERE data_date BETWEEN :s AND :e AND {column} IS NULL"
+        ),
+        {"s": start, "e": end},
+    ).scalar_one()
+    return float(null_n) / float(total)
+
+
+def compute_report(
+    *,
+    session: Session,
+    asof: date,
+    lookback_days: int = 30,
+) -> CoverageReport:
+    """Run the coverage audit against ``session``.
+
+    ``asof`` anchors the "last 7 trading days" alarm window so tests can
+    pass a fixed date (avoiding ``datetime.now()`` inside the module).
+
+    ``lookback_days`` bounds how far back the per-day-count / null-rate
+    queries scan. The default of 30 calendar days is plenty for the
+    cron-hook (which only needs to see the tail-7).
+    """
+    report = CoverageReport(asof=asof, lookback_days=lookback_days)
+
+    earliest, latest = _earliest_latest(session)
+    report.earliest_date = earliest
+    report.latest_date = latest
+
+    if earliest is None or latest is None:
+        # Empty table — distinct alarm flavor.
+        report.is_empty = True
+        report.alarm_text = "table is empty — no money_flow_snapshots rows present"
+        return report
+
+    # Audit window: ``lookback_days`` calendar days back from asof.
+    window_start = asof - timedelta(days=lookback_days)
+    # Clamp window_start to earliest so we don't synthesize "missing days"
+    # before the table started getting populated. The reframed scope per
+    # DESIGN v2 §3.1: the audit confirms ongoing coverage, NOT historical
+    # backfill (that's the investigation doc).
+    audit_start = max(window_start, earliest)
+    audit_end = min(asof, latest)
+
+    expected_days = _trading_days(audit_start, audit_end)
+    report.expected_trading_days = len(expected_days)
+    report.trading_days_span = len(_trading_days(earliest, latest))
+
+    per_day = _row_counts_by_day(session, audit_start, audit_end)
+    report.per_day_count = per_day
+    report.rows_in_span = sum(per_day.values())
+
+    if per_day:
+        counts = sorted(per_day.values())
+        report.per_day_min = counts[0]
+        report.per_day_max = counts[-1]
+        # statistics.median returns a float for even-length sequences; we
+        # want an integer-ish for the report.
+        med = median(counts)
+        report.per_day_median = int(med) if med == int(med) else med  # type: ignore[assignment]
+
+    # Missing days = expected NYSE sessions in the audit window not in per_day.
+    report.missing_dates = sorted(d for d in expected_days if d not in per_day)
+
+    # Alarm window: last 7 trading days up to ``asof``. Step back through
+    # trading days to find the tail-7 window start.
+    tail_days = _trading_days(asof - timedelta(days=21), asof)[-7:]
+    report.missing_dates_in_alarm_window = sorted(
+        d for d in tail_days if d in report.missing_dates
+    )
+
+    # Null-rate audit on the production NOT-NULL columns.
+    for col in _NOT_NULL_COLUMNS:
+        report.null_rate_by_column[col] = _null_rate(
+            session, col, audit_start, audit_end,
+        )
+
+    # Alarm gate. Per plan §Tests-5: >1 missing in last 7 → exit 1;
+    # 1 missing → exit 0 with warning; 0 → clean.
+    missing_in_tail = len(report.missing_dates_in_alarm_window)
+    if missing_in_tail > report.alarm_threshold:
+        report.alarm_text = (
+            f"{missing_in_tail} trading days missing in the last "
+            f"{len(tail_days)} — alarm threshold is "
+            f"{report.alarm_threshold}"
+        )
+    elif missing_in_tail >= 1:
+        # 1 missing — warning, not alarm. Exit 0 but flag the warning.
+        report.has_warning = True
+
+    return report
+
+
+# --------------------------------------------------------------------------- #
+# Session opener — production path uses rainier.core.database.get_session.
+# Indirected through ``_open_session`` so tests can monkey-patch the
+# context manager and point the CLI at an in-memory sqlite session.
+# --------------------------------------------------------------------------- #
+
+
+@contextmanager
+def _open_session() -> Iterator[Session]:
+    """Yield a production DB session (postgres / timescale)."""
+    from rainier.core.database import get_session as _get_session
+
+    with _get_session() as s:
+        yield s
+
+
+# --------------------------------------------------------------------------- #
+# Pretty-print
+# --------------------------------------------------------------------------- #
+
+
+def render_text_report(report: CoverageReport) -> str:
+    """Render a human-readable, deterministic textual coverage report."""
+    lines = [
+        "money_flow_snapshots coverage report",
+        "--------------------------------------",
+    ]
+    if report.earliest_date is None or report.latest_date is None:
+        lines.append("earliest row:        (none)")
+        lines.append("latest row:          (none)")
+    else:
+        lines.append(f"earliest row:        {report.earliest_date}")
+        lines.append(f"latest row:          {report.latest_date}")
+    lines.append(f"trading days span:   {report.trading_days_span}")
+    lines.append(f"rows in span:        {report.rows_in_span}")
+    lines.append(f"expected rows:       {report.expected_trading_days}")
+    lines.append(f"asof:                {report.asof}")
+    lines.append(f"lookback_days:       {report.lookback_days}")
+    lines.append(
+        "missing dates:       "
+        + (", ".join(d.isoformat() for d in report.missing_dates) or "[]")
+    )
+    if report.per_day_count:
+        lines.append(
+            "per-day row count:   "
+            f"median={report.per_day_median}, "
+            f"min={report.per_day_min}, "
+            f"max={report.per_day_max}"
+        )
+    else:
+        lines.append("per-day row count:   (none — window has no rows)")
+
+    if report.null_rate_by_column:
+        lines.append("null-rate by column:")
+        for col, rate in sorted(report.null_rate_by_column.items()):
+            lines.append(f"  {col:<15} {rate:.4%}")
+
+    if report.is_empty:
+        lines.append("alarm:               table is empty")
+    elif report.alarm_text:
+        lines.append(f"alarm:               {report.alarm_text}")
+    elif report.has_warning:
+        lines.append(
+            f"warning:             {len(report.missing_dates_in_alarm_window)} "
+            "missing day in last 7 (below alarm threshold)"
+        )
+    else:
+        lines.append("alarm:               no missing days within the last 7 trading days → OK")
+
+    return "\n".join(lines) + "\n"
+
+
+def report_to_dict(report: CoverageReport) -> dict[str, Any]:
+    """JSON-serializable view of the report — for cron logs / structured emit."""
+    return {
+        "asof": report.asof.isoformat(),
+        "lookback_days": report.lookback_days,
+        "earliest_date": report.earliest_date.isoformat() if report.earliest_date else None,
+        "latest_date": report.latest_date.isoformat() if report.latest_date else None,
+        "trading_days_span": report.trading_days_span,
+        "expected_trading_days": report.expected_trading_days,
+        "rows_in_span": report.rows_in_span,
+        "per_day_min": report.per_day_min,
+        "per_day_max": report.per_day_max,
+        "per_day_median": report.per_day_median,
+        "missing_dates": [d.isoformat() for d in report.missing_dates],
+        "missing_dates_in_alarm_window": [
+            d.isoformat() for d in report.missing_dates_in_alarm_window
+        ],
+        "null_rate_by_column": dict(report.null_rate_by_column),
+        "is_empty": report.is_empty,
+        "alarm_text": report.alarm_text,
+        "has_warning": report.has_warning,
+        "exit_code": report.exit_code(),
+    }

--- a/tests/test_scrapers/test_money_flow_coverage.py
+++ b/tests/test_scrapers/test_money_flow_coverage.py
@@ -326,6 +326,15 @@ def test_coverage_detects_stale_table_no_recent_data(in_memory_session):
     # run yet at audit time. The alarm is for days strictly before asof.
     assert date(2026, 5, 21) not in report.missing_dates_in_alarm_window
 
+    # codex iter-1 [P3]: the rendered Discord-bound report MUST surface the
+    # alarm-window dates so operators see which days are missing. Without
+    # this, `missing dates: []` shows up in the alert (because the main
+    # audit window is clamped to `latest`) even as the alarm fires.
+    rendered = coverage.render_text_report(report)
+    assert "alarm-window missing:" in rendered, rendered
+    assert "2026-05-12" in rendered
+    assert "2026-05-20" in rendered
+
 
 # --------------------------------------------------------------------------- #
 # 10. Empty table → exit 1 with distinct "table is empty" alarm

--- a/tests/test_scrapers/test_money_flow_coverage.py
+++ b/tests/test_scrapers/test_money_flow_coverage.py
@@ -286,7 +286,49 @@ def test_coverage_is_pure_db_read(in_memory_session):
 
 
 # --------------------------------------------------------------------------- #
-# 9. Empty table → exit 1 with distinct "table is empty" alarm
+# 9. Stale table — scraper stopped days ago → alarm fires.
+#
+# Regression for review iter-1: previously the `audit_end = min(asof, latest)`
+# clamp silently restricted `missing_dates` to the populated window, so an
+# 8-trading-day scraper outage produced exit 0 ("no missing days in tail-7").
+# The whole point of the alarm is to catch that.
+# --------------------------------------------------------------------------- #
+
+
+def test_coverage_detects_stale_table_no_recent_data(in_memory_session):
+    """Scraper outage: latest row in DB is 8 trading days before asof.
+
+    The alarm must fire because most of the last 7 trading days BEFORE
+    asof have no rows. Otherwise the cron-hook's whole reason for being
+    (catching scrape outages) is defeated.
+    """
+    # Seed through Mon 2026-05-11; pretend the scraper stopped that day.
+    start = date(2026, 4, 27)
+    end_seeded = date(2026, 5, 11)
+    _seed_clean_window(
+        in_memory_session, start=start, end=end_seeded, rows_per_day=100,
+    )
+    # asof = Thu 2026-05-21 → 8 trading days have passed since latest=5/11.
+    asof = date(2026, 5, 21)
+
+    report = coverage.compute_report(
+        session=in_memory_session, asof=asof, lookback_days=30,
+    )
+
+    assert report.exit_code() == 1, (
+        f"stale-table outage must trigger alarm; latest={report.latest_date} "
+        f"asof={asof} missing_in_tail={report.missing_dates_in_alarm_window}"
+    )
+    # Concrete missing days that should be flagged.
+    assert date(2026, 5, 12) in report.missing_dates_in_alarm_window
+    assert date(2026, 5, 20) in report.missing_dates_in_alarm_window
+    # asof itself (5/21) should NOT be flagged — today's scrape may not have
+    # run yet at audit time. The alarm is for days strictly before asof.
+    assert date(2026, 5, 21) not in report.missing_dates_in_alarm_window
+
+
+# --------------------------------------------------------------------------- #
+# 10. Empty table → exit 1 with distinct "table is empty" alarm
 # --------------------------------------------------------------------------- #
 
 

--- a/tests/test_scrapers/test_money_flow_coverage.py
+++ b/tests/test_scrapers/test_money_flow_coverage.py
@@ -22,7 +22,6 @@ from sqlalchemy.orm import Session
 
 from rainier.scrapers.qu import coverage
 
-
 # --------------------------------------------------------------------------- #
 # Fixtures
 # --------------------------------------------------------------------------- #
@@ -85,19 +84,19 @@ def test_coverage_reports_clean_when_all_days_present(in_memory_session):
 
 
 def test_coverage_detects_missing_recent_day(in_memory_session):
-    # 9-day window, day 8 (Wed 2026-05-20) missing.
+    """Plan §Tests #2 + §Acceptance gate: missing days in tail-7 trip alarm.
+
+    The plan's §Acceptance line specifies "exit 1 when >1 trading day
+    missing in the last 7". To trip the alarm, we delete 2 recent days
+    and confirm both land in ``missing_dates``. (The 1-missing-only case
+    is covered by ``test_coverage_alarm_threshold_one_missing_is_warning``
+    below.)
+    """
     start = date(2026, 5, 11)
     end = date(2026, 5, 21)
-    _seed_clean_window(in_memory_session, start=start, end=end - 1, rows_per_day=100)
-    # Skip 2026-05-20, then seed only the final day so the gap is in the tail-7.
-    coverage.seed_snapshots(
-        in_memory_session,
-        start=end,
-        end=end,
-        rows_per_day=100,
-        ranking_type="top100",
-    )
-    # Now manually delete 2026-05-20 rows that the bulk seeder added.
+    _seed_clean_window(in_memory_session, start=start, end=end, rows_per_day=100)
+    # Delete 2 recent days so the alarm threshold (>1 missing) trips.
+    coverage.delete_day_for_test(in_memory_session, on_date=date(2026, 5, 19))
     coverage.delete_day_for_test(in_memory_session, on_date=date(2026, 5, 20))
 
     report = coverage.compute_report(
@@ -107,6 +106,7 @@ def test_coverage_detects_missing_recent_day(in_memory_session):
     )
 
     assert not report.is_clean()
+    assert date(2026, 5, 19) in report.missing_dates
     assert date(2026, 5, 20) in report.missing_dates
     assert report.exit_code() == 1
 

--- a/tests/test_scrapers/test_money_flow_coverage.py
+++ b/tests/test_scrapers/test_money_flow_coverage.py
@@ -1,0 +1,346 @@
+"""Tests for ``rainier.scrapers.qu.coverage`` — money_flow_snapshots DB hygiene.
+
+The coverage module is a DB-read-only audit over ``money_flow_snapshots`` that
+answers: "are we missing trading days?" + "are per-day row counts in the
+expected ballpark?" + "are non-nullable columns actually populated?".
+
+Production CLI reads from postgres via the same session contract; here we
+exercise it against an in-memory sqlite engine so the tests stay hermetic.
+The pattern mirrors ``tests/research/test_survivorship.py`` — define a test
+table that carries the columns the check reads, seed it via helpers in the
+production module, run ``compute_report`` against the session.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from click.testing import CliRunner
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from rainier.scrapers.qu import coverage
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def in_memory_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    coverage.bootstrap_sqlite(engine)
+    with Session(engine, future=True) as s:
+        yield s
+
+
+def _seed_clean_window(
+    session: Session, *, start: date, end: date, rows_per_day: int = 100,
+    ranking_type: str = "top100",
+) -> None:
+    """Insert ``rows_per_day`` snapshots for every NYSE trading day in [start, end]."""
+    coverage.seed_snapshots(
+        session,
+        start=start,
+        end=end,
+        rows_per_day=rows_per_day,
+        ranking_type=ranking_type,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 1. Clean window → exit 0, missing_dates: []
+# --------------------------------------------------------------------------- #
+
+
+def test_coverage_reports_clean_when_all_days_present(in_memory_session):
+    # 9 NYSE trading days ending 2026-05-25 (Mon). 2026-05-25 is Memorial Day
+    # holiday — pick a window that avoids it for the "all present" case.
+    # 2026-05-11..2026-05-21 = Mon May 11 → Thu May 21 = 9 trading days.
+    start = date(2026, 5, 11)
+    end = date(2026, 5, 21)
+    _seed_clean_window(in_memory_session, start=start, end=end, rows_per_day=100)
+
+    report = coverage.compute_report(
+        session=in_memory_session,
+        asof=end,
+        lookback_days=11,  # cover the whole window
+    )
+
+    assert report.is_clean()
+    assert report.missing_dates == []
+    assert report.earliest_date == start
+    assert report.latest_date == end
+    assert report.trading_days_span == 9
+    assert report.rows_in_span == 9 * 100
+    assert report.expected_trading_days == 9
+    assert report.exit_code() == 0
+
+
+# --------------------------------------------------------------------------- #
+# 2. Missing recent day → exit 1, missing day listed
+# --------------------------------------------------------------------------- #
+
+
+def test_coverage_detects_missing_recent_day(in_memory_session):
+    # 9-day window, day 8 (Wed 2026-05-20) missing.
+    start = date(2026, 5, 11)
+    end = date(2026, 5, 21)
+    _seed_clean_window(in_memory_session, start=start, end=end - 1, rows_per_day=100)
+    # Skip 2026-05-20, then seed only the final day so the gap is in the tail-7.
+    coverage.seed_snapshots(
+        in_memory_session,
+        start=end,
+        end=end,
+        rows_per_day=100,
+        ranking_type="top100",
+    )
+    # Now manually delete 2026-05-20 rows that the bulk seeder added.
+    coverage.delete_day_for_test(in_memory_session, on_date=date(2026, 5, 20))
+
+    report = coverage.compute_report(
+        session=in_memory_session,
+        asof=end,
+        lookback_days=11,
+    )
+
+    assert not report.is_clean()
+    assert date(2026, 5, 20) in report.missing_dates
+    assert report.exit_code() == 1
+
+
+# --------------------------------------------------------------------------- #
+# 3. Weekend days are NOT flagged as missing
+# --------------------------------------------------------------------------- #
+
+
+def test_coverage_ignores_weekends(in_memory_session):
+    # Friday 2026-05-15 → Tuesday 2026-05-19. Weekend in middle.
+    start = date(2026, 5, 15)  # Fri
+    end = date(2026, 5, 19)  # Tue
+    _seed_clean_window(in_memory_session, start=start, end=end, rows_per_day=100)
+
+    report = coverage.compute_report(
+        session=in_memory_session,
+        asof=end,
+        lookback_days=10,
+    )
+
+    assert report.is_clean()
+    # Sat May 16, Sun May 17 — must NOT appear as missing.
+    assert date(2026, 5, 16) not in report.missing_dates
+    assert date(2026, 5, 17) not in report.missing_dates
+
+
+# --------------------------------------------------------------------------- #
+# 4. Market holidays (NYSE) are NOT flagged as missing
+# --------------------------------------------------------------------------- #
+
+
+def test_coverage_ignores_market_holidays(in_memory_session):
+    # MLK Day: 2024-01-15 (Mon). Window: Fri 2024-01-12 → Wed 2024-01-17.
+    # Trading days: Fri Jan 12, Tue Jan 16, Wed Jan 17 (Mon Jan 15 is MLK).
+    start = date(2024, 1, 12)
+    end = date(2024, 1, 17)
+    _seed_clean_window(in_memory_session, start=start, end=end, rows_per_day=100)
+
+    report = coverage.compute_report(
+        session=in_memory_session,
+        asof=end,
+        lookback_days=10,
+    )
+
+    assert report.is_clean()
+    # MLK Day must NOT appear as missing even though it's Mon-Fri.
+    assert date(2024, 1, 15) not in report.missing_dates
+
+
+# --------------------------------------------------------------------------- #
+# 5. Alarm threshold: >1 missing in last 7 trading days
+# --------------------------------------------------------------------------- #
+
+
+def test_coverage_alarm_threshold(in_memory_session):
+    """Plan spec: >1 trading day missing in last 7 → exit 1.
+
+    1 missing → exit 0 with warning text.
+    0 missing → exit 0 clean.
+    """
+    # 10-day window, asof = Thu 2026-05-21.
+    asof = date(2026, 5, 21)
+    start = date(2026, 5, 7)
+
+    # Case A: 2 missing in last 7 → exit 1.
+    _seed_clean_window(in_memory_session, start=start, end=asof, rows_per_day=50)
+    coverage.delete_day_for_test(in_memory_session, on_date=date(2026, 5, 19))
+    coverage.delete_day_for_test(in_memory_session, on_date=date(2026, 5, 20))
+    report = coverage.compute_report(
+        session=in_memory_session, asof=asof, lookback_days=14,
+    )
+    assert report.exit_code() == 1
+    assert len(report.missing_dates_in_alarm_window) >= 2
+
+
+def test_coverage_alarm_threshold_one_missing_is_warning(in_memory_session):
+    """1 missing in last 7 → exit 0 but the warning text is present."""
+    asof = date(2026, 5, 21)
+    start = date(2026, 5, 7)
+    _seed_clean_window(in_memory_session, start=start, end=asof, rows_per_day=50)
+    coverage.delete_day_for_test(in_memory_session, on_date=date(2026, 5, 20))
+
+    report = coverage.compute_report(
+        session=in_memory_session, asof=asof, lookback_days=14,
+    )
+
+    # 1 missing in tail-7 → exit 0 (warning, not alarm).
+    assert report.exit_code() == 0
+    assert len(report.missing_dates_in_alarm_window) == 1
+    assert report.has_warning
+
+
+# --------------------------------------------------------------------------- #
+# 6. Per-day rowcount stats (universe shrink not an alarm)
+# --------------------------------------------------------------------------- #
+
+
+def test_coverage_per_day_rowcount(in_memory_session):
+    """Universe-shrink day (50 rows vs 100 elsewhere) is reported in stats,
+    but does NOT trip the alarm gate.
+    """
+    start = date(2026, 5, 11)
+    end = date(2026, 5, 21)
+    _seed_clean_window(in_memory_session, start=start, end=end, rows_per_day=100)
+    # Shrink 2026-05-15 down to 50 rows.
+    coverage.shrink_day_for_test(
+        in_memory_session, on_date=date(2026, 5, 15), keep_rows=50,
+    )
+
+    report = coverage.compute_report(
+        session=in_memory_session, asof=end, lookback_days=11,
+    )
+
+    # Per-day stats reflect the shrink.
+    assert report.per_day_min == 50
+    assert report.per_day_max == 100
+    # Median = 100 (one shrink day vs eight full days).
+    assert report.per_day_median == 100
+    # Not an alarm — exit code stays 0.
+    assert report.exit_code() == 0
+
+
+# --------------------------------------------------------------------------- #
+# 7. NULLs in non-nullable cols → reported in null-rate table
+# --------------------------------------------------------------------------- #
+
+
+def test_coverage_null_rates(in_memory_session):
+    """If `rank` is null on any row, null-rate table records non-zero rate.
+
+    Production schema declares `rank` NOT NULL, but the test fixture allows
+    a NULL so we can prove the audit catches schema-violating rows that
+    might slip through TimescaleDB / postgres in legacy/migrated data.
+    """
+    start = date(2026, 5, 18)
+    end = date(2026, 5, 21)
+    _seed_clean_window(in_memory_session, start=start, end=end, rows_per_day=10)
+    coverage.null_field_for_test(
+        in_memory_session, on_date=date(2026, 5, 19), field="rank",
+    )
+
+    report = coverage.compute_report(
+        session=in_memory_session, asof=end, lookback_days=10,
+    )
+
+    null_rates = report.null_rate_by_column
+    assert "rank" in null_rates
+    assert null_rates["rank"] > 0
+
+
+# --------------------------------------------------------------------------- #
+# 8. Coverage check performs zero writes
+# --------------------------------------------------------------------------- #
+
+
+def test_coverage_is_pure_db_read(in_memory_session):
+    """compute_report must not INSERT/UPDATE/DELETE anything.
+
+    We snapshot the row count + a sentinel field before and after the call.
+    """
+    start = date(2026, 5, 11)
+    end = date(2026, 5, 21)
+    _seed_clean_window(in_memory_session, start=start, end=end, rows_per_day=20)
+
+    before_count = coverage.row_count(in_memory_session)
+    _ = coverage.compute_report(
+        session=in_memory_session, asof=end, lookback_days=11,
+    )
+    after_count = coverage.row_count(in_memory_session)
+
+    assert before_count == after_count
+    # And nothing dirty in the session — compute_report must not mutate.
+    assert not in_memory_session.dirty
+    assert not in_memory_session.new
+    assert not in_memory_session.deleted
+
+
+# --------------------------------------------------------------------------- #
+# 9. Empty table → exit 1 with distinct "table is empty" alarm
+# --------------------------------------------------------------------------- #
+
+
+def test_coverage_returns_alarm_when_table_empty(in_memory_session):
+    # No seeding — table is empty.
+    report = coverage.compute_report(
+        session=in_memory_session, asof=date(2026, 5, 21), lookback_days=7,
+    )
+
+    assert report.exit_code() == 1
+    assert report.is_empty
+    # Distinct alarm flavor from "missing days".
+    assert "empty" in (report.alarm_text or "").lower()
+
+
+# --------------------------------------------------------------------------- #
+# CLI smoke: --asof produces deterministic output, exits non-zero on alarm
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_money_flow_coverage_exit_code(in_memory_session, monkeypatch):
+    """Hook the CLI to the in-memory session via a monkeypatched session
+    factory, then call ``rainier qu money-flow-coverage --asof 2026-05-21``
+    twice — once on a clean DB, once after deleting a recent day — and
+    confirm exit codes flip.
+    """
+    from rainier import cli as cli_module
+
+    asof = date(2026, 5, 21)
+    start = date(2026, 5, 7)
+    _seed_clean_window(in_memory_session, start=start, end=asof, rows_per_day=20)
+
+    # Monkey-patch coverage._open_session to yield the test session.
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _fake_session():
+        yield in_memory_session
+
+    monkeypatch.setattr(coverage, "_open_session", _fake_session)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli, ["qu", "money-flow-coverage", "--asof", asof.isoformat()],
+    )
+    assert result.exit_code == 0, result.output
+    assert "money_flow_snapshots coverage report" in result.output
+
+    # Now delete 2 trading days in the tail-7 → exit 1.
+    coverage.delete_day_for_test(in_memory_session, on_date=date(2026, 5, 19))
+    coverage.delete_day_for_test(in_memory_session, on_date=date(2026, 5, 20))
+
+    result = runner.invoke(
+        cli_module.cli, ["qu", "money-flow-coverage", "--asof", asof.isoformat()],
+    )
+    assert result.exit_code == 1
+    assert "missing" in result.output.lower()


### PR DESCRIPTION
## Summary
- New `src/rainier/scrapers/qu/coverage.py` + `uv run rainier qu money-flow-coverage` CLI. Pure DB-read coverage report: earliest/latest row dates, missing trading days, per-day row counts, null rates. Exit 1 when >1 trading day missing in last 7; exit 0 with warning when exactly 1 missing.
- Cron chaining: 15:00 PT QU close scrape now runs the coverage check after the scrape; non-zero exit posts to the existing Discord webhook (no new env vars).
- New `docs/INVESTIGATION-qu-historical-money-flow.md` — finding: QU's `/api/v3/mf100?date=...&top=...&frequency=daily` accepts arbitrary historical dates; backfill of 2025-01 → 2026-05 is feasible (~23min wall-clock) via the existing `--start-date`/`--days-back`/`--dates` flags. Scoped as a recommended follow-up task; NOT implemented here per the design's [D-024] non-goal.
- v2 reframe per `DESIGN-rainier-data-backfill-for-maunakea.md` §3.1 — DB-coverage hygiene, NOT parquet export. No new parquet outputs.

## Review
- /review: passed (claude rounds: 3)
- codex review: passed (codex rounds: 2)
  - /review iter-1 (P1): alarm silently swallowed scraper outages — `audit_end = min(asof, latest)` clamped the audit window to the populated range, so an 8-trading-day outage produced `missing_dates=[]` and exit 0. Fixed: tail-7 must-exist window computed independently of clamp.
  - codex iter-1 (P3): stale-table report rendered `missing dates: []` while alarming on 7 missing days. Fixed: emit `alarm-window missing:` line when the alarm-window dates differ from the main `missing_dates`.

## Deferred [P2] findings (filing as follow-ups, NOT in this PR)
- `_row_counts_by_day` aggregates only by `data_date` — a day with only `top100` rows (failed `bottom100` fetch) is treated as covered. Needs per-`ranking_type` validation OR per-day completeness threshold (operator-decided).
- `_open_session` calls `get_session()` with no settings — `rainier --config config/staging.yaml qu money-flow-coverage` reads default DB, not the staging DB. Needs reading the rest of rainier's cli_module config-context plumbing pattern.

## Test plan
- [ ] CI green (12 new tests + 1035 full-project tests pass locally, ruff clean)
- [ ] Next 15:00 PT QU close cron — coverage check fires and posts Discord warning on (intentional or real) outage
- [ ] Operator triages the 2 deferred P2s above