### PR TITLE
feat(dashboard): publish-dashboard.sh + 12:40 PT cron for ETF ranks (P1)

### DIFF
--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -71,3 +71,17 @@ jobs:
     log: "data/thematic-ranks.log"
     discord_on_failure: true
     enabled: false
+
+  # ETF ranks dashboard — DESIGN-etf-dashboard-publish.md §4/§5.
+  # 20 min before US market close: render today's snapshot, publish to
+  # fengshen.dev/trading/etf-ranks/ via git push to fengshen-site (Cloudflare
+  # Pages auto-deploys on push). The publish step is a no-op when the
+  # rendered HTML didn't change (market holiday, identical day), so cron
+  # retries are safe.
+  - name: etf-dashboard-publish
+    description: "Render ETF ranks HTML + publish to fengshen.dev/trading/etf-ranks/"
+    schedule: "40 12 * * 1-5"   # 12:40 PST, Mon-Fri (20 min pre-close)
+    command: "uv run rainier dashboard render-etf-html --asof $(date +%Y-%m-%d) --rendered-at-pt $(date +%H:%M) --output $HOME/projects/rainier/out/dashboards/etf-ranks.html && scripts/publish-dashboard.sh etf-ranks"
+    log: "data/etf-dashboard.log"
+    discord_on_failure: true
+    enabled: true

--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -84,6 +84,15 @@ jobs:
   # line terminator + stdin marker, which would silently truncate the job.
   # The script also guards against publishing an empty render (no data for
   # `asof`), which the renderer produces as a valid-but-empty HTML page.
+  #
+  # DATA DEPENDENCY: this job reads `data/cache/thematic_features_daily.parquet`
+  # for today's asof_date. That file is updated by `thematic-ranks-daily`
+  # above, which is currently `enabled: false` pending daily OHLCV refresh
+  # wiring (see that job's comment). Until both upstream steps are running,
+  # this job will hit the empty-render guard on weekdays and fire a Discord
+  # alert (loud-fail, not silent corruption). Operator decision: keep
+  # `enabled: true` so the empty-render alert surfaces the data-readiness
+  # gap; flip to `false` to suppress alerts during the transition.
   - name: etf-dashboard-publish
     description: "Render ETF ranks HTML + publish to fengshen.dev/trading/etf-ranks/"
     schedule: "40 12 * * 1-5"   # 12:40 PST, Mon-Fri (20 min pre-close)

--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -78,10 +78,16 @@ jobs:
   # Pages auto-deploys on push). The publish step is a no-op when the
   # rendered HTML didn't change (market holiday, identical day), so cron
   # retries are safe.
+  #
+  # The chain lives in scripts/publish-etf-dashboard.sh so the crontab line
+  # never contains `%` — cron's command field treats unescaped `%` as a
+  # line terminator + stdin marker, which would silently truncate the job.
+  # The script also guards against publishing an empty render (no data for
+  # `asof`), which the renderer produces as a valid-but-empty HTML page.
   - name: etf-dashboard-publish
     description: "Render ETF ranks HTML + publish to fengshen.dev/trading/etf-ranks/"
     schedule: "40 12 * * 1-5"   # 12:40 PST, Mon-Fri (20 min pre-close)
-    command: "uv run rainier dashboard render-etf-html --asof $(date +%Y-%m-%d) --rendered-at-pt $(date +%H:%M) --output $HOME/projects/rainier/out/dashboards/etf-ranks.html && scripts/publish-dashboard.sh etf-ranks"
+    command: "scripts/publish-etf-dashboard.sh"
     log: "data/etf-dashboard.log"
     discord_on_failure: true
     enabled: true

--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -87,12 +87,19 @@ jobs:
   #
   # DATA DEPENDENCY: this job reads `data/cache/thematic_features_daily.parquet`
   # for today's asof_date. That file is updated by `thematic-ranks-daily`
-  # above, which is currently `enabled: false` pending daily OHLCV refresh
-  # wiring (see that job's comment). Until both upstream steps are running,
-  # this job will hit the empty-render guard on weekdays and fire a Discord
-  # alert (loud-fail, not silent corruption). Operator decision: keep
-  # `enabled: true` so the empty-render alert surfaces the data-readiness
-  # gap; flip to `false` to suppress alerts during the transition.
+  # above, which (a) is currently `enabled: false` pending daily OHLCV refresh
+  # wiring, AND (b) is scheduled at 13:30 PT (post-close) while this publish
+  # job runs at 12:40 PT (pre-close, per the design's "20 min pre-close
+  # snapshot" intent). Even after OHLCV is wired, the producer would need a
+  # pre-close compute pass — or this job would need to render the latest
+  # available asof — for today's data to be ready at 12:40 PT.
+  #
+  # Until that's reconciled, this job will hit the empty-render guard on
+  # weekdays and fire a Discord alert (loud-fail, not silent corruption).
+  # Operator decision: keep `enabled: true` so the empty-render alert
+  # surfaces the data-readiness gap; flip to `false` to suppress alerts
+  # during the transition. Fixing the timing belongs to a follow-up PR that
+  # owns the pre-close compute path; this PR only ships the publish chain.
   - name: etf-dashboard-publish
     description: "Render ETF ranks HTML + publish to fengshen.dev/trading/etf-ranks/"
     schedule: "40 12 * * 1-5"   # 12:40 PST, Mon-Fri (20 min pre-close)

--- a/scripts/publish-dashboard.sh
+++ b/scripts/publish-dashboard.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# publish-dashboard.sh — copy a rendered dashboard HTML into the fengshen-site
+# Astro `public/` tree, commit + push so Cloudflare Pages auto-deploys.
+#
+# Usage:
+#   scripts/publish-dashboard.sh <name>
+#
+# <name> is the dashboard slug (e.g. `etf-ranks`, `market-breadth`).
+# The same script is reused across dashboards — keep it generic.
+#
+# ASCII flow:
+#
+#   rainier render CLI ─▶ $DASHBOARD_SOURCE_DIR/<name>.html
+#                                │
+#                                ▼   cp (creates dirs)
+#                    $DASHBOARD_PUBLISH_TARGET_DIR/public/trading/<name>/index.html
+#                                │
+#                                ▼   git diff --quiet ?
+#                          ┌──────┴───────┐
+#                       yes│              │no
+#                          ▼              ▼
+#                       exit 0     git add → commit "<name>: YYYY-MM-DD daily render"
+#                       (no-op)                 → git push (origin/main)
+#                                                       │
+#                                                       ▼
+#                                            Cloudflare Pages auto-deploys
+#
+# Environment overrides (defaults match the operator's machine):
+#   DASHBOARD_SOURCE_DIR          rendered HTML lives here ($HOME/projects/rainier/out/dashboards)
+#   DASHBOARD_PUBLISH_TARGET_DIR  fengshen-site checkout    ($HOME/projects/fengshen-site)
+#
+# Bootstrap note: the first publish for a brand-new <name> creates
+# `public/trading/<name>/` inside fengshen-site automatically — no manual
+# `.gitkeep` pre-step required. Astro serves `public/` verbatim, so the
+# rendered HTML lives at `https://fengshen.dev/trading/<name>/`.
+
+set -euo pipefail
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { printf '%s [publish-dashboard] %s\n' "$(ts)" "$*"; }
+
+if [ $# -lt 1 ]; then
+    echo "usage: $(basename "$0") <name>" >&2
+    exit 2
+fi
+
+NAME="$1"
+
+# Sanity: slug must be filesystem-safe (no path traversal).
+case "$NAME" in
+    */*|*..*|"")
+        echo "error: invalid dashboard name: $NAME" >&2
+        exit 2
+        ;;
+esac
+
+SOURCE_DIR="${DASHBOARD_SOURCE_DIR:-$HOME/projects/rainier/out/dashboards}"
+TARGET_DIR="${DASHBOARD_PUBLISH_TARGET_DIR:-$HOME/projects/fengshen-site}"
+SRC="$SOURCE_DIR/$NAME.html"
+DST_REL="public/trading/$NAME/index.html"
+DST="$TARGET_DIR/$DST_REL"
+
+log "name=$NAME source=$SRC target=$TARGET_DIR"
+
+if [ ! -f "$SRC" ]; then
+    log "ERROR rendered HTML missing: $SRC"
+    exit 1
+fi
+
+if [ ! -d "$TARGET_DIR/.git" ]; then
+    log "ERROR target is not a git checkout: $TARGET_DIR"
+    exit 1
+fi
+
+cd "$TARGET_DIR"
+
+# Bail if working tree has unrelated dirt — don't auto-stash.
+if [ -n "$(git status --porcelain)" ]; then
+    log "ERROR target working tree dirty (uncommitted changes); refusing to publish"
+    git status --short >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$DST")"
+cp "$SRC" "$DST"
+
+# Track new files explicitly so `git diff --quiet --` sees the intent below.
+git add -- "$DST_REL"
+
+# `git diff --cached --quiet` returns 0 when staged tree matches HEAD, 1 otherwise.
+if git diff --cached --quiet -- "$DST_REL"; then
+    # Reset the noop stage to keep the working tree pristine.
+    git reset --quiet HEAD -- "$DST_REL" >/dev/null 2>&1 || true
+    log "no-op: rendered HTML matches the published copy (no commit)"
+    exit 0
+fi
+
+DATE_TAG="$(date -u +%Y-%m-%d)"
+MSG="$NAME: $DATE_TAG daily render"
+log "committing: $MSG"
+git commit -m "$MSG" --quiet -- "$DST_REL"
+
+log "pushing to origin"
+git push --quiet
+log "done"

--- a/scripts/publish-dashboard.sh
+++ b/scripts/publish-dashboard.sh
@@ -91,6 +91,17 @@ git add -- "$DST_REL"
 if git diff --cached --quiet -- "$DST_REL"; then
     # Reset the noop stage to keep the working tree pristine.
     git reset --quiet HEAD -- "$DST_REL" >/dev/null 2>&1 || true
+    # Recovery: if a prior run's commit never made it upstream (e.g., a
+    # non-fast-forward `git push` failure from an unrelated remote advance),
+    # the local branch is ahead of @{u}. Without this check, today's no-op
+    # would silently abandon that unpushed commit. Detect + push it now.
+    AHEAD="$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)"
+    if [ "$AHEAD" -gt 0 ]; then
+        log "no-op render, but $AHEAD local commit(s) ahead of upstream — pushing"
+        git push --quiet
+        log "done (recovered unpushed commits)"
+        exit 0
+    fi
     log "no-op: rendered HTML matches the published copy (no commit)"
     exit 0
 fi

--- a/scripts/publish-etf-dashboard.sh
+++ b/scripts/publish-etf-dashboard.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# publish-etf-dashboard.sh — render today's ETF ranks HTML and publish to
+# fengshen.dev. Single entry point for the cron job, isolating two concerns
+# from the cron command field:
+#
+#   1. `%` characters in `$(date +%Y-%m-%d)` would be split by cron's
+#      command-field parser (everything after `%` becomes stdin). Moving the
+#      date computation inside a script keeps the crontab line `%`-free.
+#   2. The renderer's "no data" path produces a valid-but-empty HTML page
+#      (`Universe: 0 sector/theme ETFs`). Publishing that would overwrite a
+#      good dashboard on a market holiday or stale cache. Guard against it
+#      here before handing off to the generic publisher.
+#
+# Usage:
+#   scripts/publish-etf-dashboard.sh
+#
+# Environment overrides (defaults match the operator's machine):
+#   DASHBOARD_SOURCE_DIR  rendered HTML lives here ($HOME/projects/rainier/out/dashboards)
+#   RAINIER_UV            uv binary to use (auto-detected via `command -v uv`)
+#
+# Fails fast on any step; cron-wrapper.sh converts non-zero exit into a
+# Discord alert (config/cron.yaml: discord_on_failure: true).
+
+set -euo pipefail
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { printf '%s [publish-etf-dashboard] %s\n' "$(ts)" "$*"; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+SOURCE_DIR="${DASHBOARD_SOURCE_DIR:-$HOME/projects/rainier/out/dashboards}"
+OUTPUT="$SOURCE_DIR/etf-ranks.html"
+mkdir -p "$SOURCE_DIR"
+
+ASOF="$(date +%Y-%m-%d)"
+RENDERED_AT_PT="$(date +%H:%M)"
+
+# Resolve uv binary. cron's PATH is minimal, so prefer an explicit override or
+# the operator's standard install location before falling back to PATH.
+UV="${RAINIER_UV:-}"
+if [ -z "$UV" ]; then
+    if [ -x "$HOME/.local/bin/uv" ]; then
+        UV="$HOME/.local/bin/uv"
+    elif command -v uv >/dev/null 2>&1; then
+        UV="$(command -v uv)"
+    else
+        log "ERROR uv not found (set RAINIER_UV=/path/to/uv or install uv)"
+        exit 1
+    fi
+fi
+
+cd "$PROJECT_DIR"
+
+log "render asof=$ASOF rendered_at_pt=$RENDERED_AT_PT output=$OUTPUT"
+"$UV" run rainier dashboard render-etf-html \
+    --asof "$ASOF" \
+    --rendered-at-pt "$RENDERED_AT_PT" \
+    --output "$OUTPUT"
+
+# Empty-render guard: the renderer produces a valid-but-empty HTML page when
+# no features exist for ASOF (market holiday, stale OHLCV cache, etc).
+# That page contains the literal "Universe: 0" — match against it so we don't
+# overwrite the last good dashboard with an empty one.
+#
+# The renderer's comment in render_etf.py explicitly delegates this guard to
+# the publish step:
+#   "Best-effort: render empty page so the cron output is still a valid file
+#    (the publish step can detect emptiness via byte size)."
+if grep -q 'Universe: 0 ' "$OUTPUT"; then
+    log "ERROR rendered ETF dashboard is empty (no features for asof=$ASOF) — refusing to publish"
+    exit 1
+fi
+
+log "publish slug=etf-ranks"
+"$SCRIPT_DIR/publish-dashboard.sh" etf-ranks
+log "done"

--- a/tests/test_scripts/test_publish_dashboard.py
+++ b/tests/test_scripts/test_publish_dashboard.py
@@ -1,0 +1,328 @@
+"""Unit tests for scripts/publish-dashboard.sh.
+
+Generic dashboard publisher — copies `out/dashboards/<name>.html` into a
+target git repo's `public/trading/<name>/index.html` and pushes when
+the content actually changed.
+
+Tests use temporary git repos as both the source dashboard dir and
+the publish target (no writes to ~/projects/fengshen-site). The
+script is selected via the `DASHBOARD_PUBLISH_TARGET_DIR` env var
+so CI never touches the operator's real fengshen-site checkout.
+
+Test plan pinned by docs/TASK-PLAN-etf-dashboard-publish-cr-31aa.md §Tests.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "publish-dashboard.sh"
+CRON_WRAPPER = ROOT / "scripts" / "cron-wrapper.sh"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str, cwd: Path, check: bool = True, env: dict | None = None) -> str:
+    """Run git with deterministic identity so commits don't pull from the
+    operator's global config."""
+    full_env = os.environ.copy()
+    full_env.update(
+        {
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+    )
+    if env:
+        full_env.update(env)
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=full_env,
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"git {' '.join(args)} failed (rc={result.returncode}):\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    return result.stdout
+
+
+@pytest.fixture
+def target_repo(tmp_path: Path) -> Path:
+    """A bare-ish git repo that simulates the fengshen-site checkout.
+
+    We create both a 'remote' bare repo and a 'local' working clone, so the
+    publish script can `git push` against a real remote (locally) without
+    touching the network or the operator's real repo.
+    """
+    remote = tmp_path / "fengshen-site-remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+    )
+
+    local = tmp_path / "fengshen-site"
+    subprocess.run(
+        ["git", "clone", str(remote), str(local)], check=True, capture_output=True
+    )
+
+    # Need an initial commit on `main` so the push has something to fast-forward
+    # from. Astro project layout: `public/` is the static asset root.
+    (local / "public").mkdir()
+    (local / "public" / ".gitkeep").write_text("")
+    _git("checkout", "-B", "main", cwd=local)
+    _git("add", "public/.gitkeep", cwd=local)
+    _git("commit", "-m", "init", cwd=local)
+    _git("push", "-u", "origin", "main", cwd=local)
+    return local
+
+
+@pytest.fixture
+def source_dir(tmp_path: Path) -> Path:
+    """Simulated rainier `out/dashboards/` directory."""
+    d = tmp_path / "out" / "dashboards"
+    d.mkdir(parents=True)
+    return d
+
+
+def _run_publisher(
+    name: str,
+    *,
+    source_dir: Path,
+    target_repo: Path,
+    extra_env: dict | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "DASHBOARD_SOURCE_DIR": str(source_dir),
+            "DASHBOARD_PUBLISH_TARGET_DIR": str(target_repo),
+            # Deterministic git identity inside the script as well.
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+    )
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(SCRIPT), name],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — no-op when rendered HTML is identical to what's already published.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_no_op_on_clean(source_dir: Path, target_repo: Path):
+    """Re-running with byte-identical HTML must exit 0 without a new commit."""
+    name = "etf-ranks"
+    html = "<html><body>identical</body></html>"
+    (source_dir / f"{name}.html").write_text(html)
+
+    # Pre-seed the destination with the same content + commit it so the next
+    # publish is a true no-op.
+    dest_dir = target_repo / "public" / "trading" / name
+    dest_dir.mkdir(parents=True)
+    (dest_dir / "index.html").write_text(html)
+    _git("add", f"public/trading/{name}/index.html", cwd=target_repo)
+    _git("commit", "-m", f"{name}: pre-seed", cwd=target_repo)
+    _git("push", "origin", "main", cwd=target_repo)
+
+    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
+    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+
+    assert result.returncode == 0, (
+        f"expected clean exit on no-op, got rc={result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert head_before == head_after, "no-op must not create a new commit"
+    # Friendly log so the operator can grep cron logs for "no-op".
+    assert "no-op" in result.stdout.lower() or "no change" in result.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — fresh target gets dir created + file copied + committed.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_creates_dir(source_dir: Path, target_repo: Path):
+    """First-ever publish creates `public/trading/<name>/` and lands index.html."""
+    name = "etf-ranks"
+    html = "<html><body>first publish</body></html>"
+    (source_dir / f"{name}.html").write_text(html)
+
+    dest = target_repo / "public" / "trading" / name / "index.html"
+    assert not dest.exists(), "test precondition: destination should not exist"
+
+    result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
+    assert result.returncode == 0, (
+        f"rc={result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    assert dest.exists(), "destination index.html must be created"
+    assert dest.read_text() == html
+
+    # Commit must have happened.
+    log = _git(
+        "log", "--oneline", "-n", "1", "--", f"public/trading/{name}/index.html",
+        cwd=target_repo,
+    )
+    assert name in log, f"commit log missing dashboard name: {log!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — when the source HTML differs, script commits with expected
+# message format and runs `git push`.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_commits_when_changed(source_dir: Path, target_repo: Path):
+    """A modified source HTML produces a commit `<name>: YYYY-MM-DD daily render`
+    and the commit lands on origin/main."""
+    name = "etf-ranks"
+    # Seed an initial publish.
+    (source_dir / f"{name}.html").write_text("<html>v1</html>")
+    r1 = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
+    assert r1.returncode == 0, r1.stderr
+
+    # Now modify the source and re-publish.
+    (source_dir / f"{name}.html").write_text("<html>v2 updated</html>")
+    r2 = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
+    assert r2.returncode == 0, (
+        f"rc={r2.returncode}\nstdout: {r2.stdout}\nstderr: {r2.stderr}"
+    )
+
+    # Latest commit message: `<name>: YYYY-MM-DD daily render`
+    head_msg = _git("log", "-1", "--pretty=%s", cwd=target_repo).strip()
+    assert re.match(
+        rf"^{re.escape(name)}: \d{{4}}-\d{{2}}-\d{{2}} daily render$", head_msg
+    ), f"unexpected commit subject: {head_msg!r}"
+
+    # And the push made it to the remote.
+    local_head = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    remote_head = _git("rev-parse", "origin/main", cwd=target_repo).strip()
+    assert local_head == remote_head, "publisher must `git push` after commit"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — bail (non-zero, no commit) when target has uncommitted changes.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_bails_on_dirty_target(source_dir: Path, target_repo: Path):
+    """Dirty target working tree → script exits non-zero and does NOT commit
+    or stash anything."""
+    name = "etf-ranks"
+    (source_dir / f"{name}.html").write_text("<html>clean source</html>")
+
+    # Dirty the target: untracked file + modified tracked file.
+    (target_repo / "public" / ".gitkeep").write_text("modified\n")
+    (target_repo / "stray.txt").write_text("untracked\n")
+
+    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
+    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+
+    assert result.returncode != 0, (
+        "publisher must exit non-zero when target is dirty\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert head_before == head_after, "publisher must not commit when bailing"
+
+    # Stray + modified files must still be there — no auto-stash.
+    assert (target_repo / "stray.txt").exists(), "must not stash untracked files"
+    assert (target_repo / "public" / ".gitkeep").read_text() == "modified\n"
+
+    # Clear, actionable error message on stdout or stderr.
+    combined = (result.stdout + result.stderr).lower()
+    assert "dirty" in combined or "uncommitted" in combined, (
+        f"expected dirty/uncommitted in output, got:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — cron-wrapper integration: invokes render then publish in order.
+# ---------------------------------------------------------------------------
+
+
+def test_cron_wrapper_invokes_render_then_publish(tmp_path: Path):
+    """`cron-wrapper.sh` runs the supplied command verbatim and logs phases.
+
+    We construct a 'fake render && fake publish' command that drops two files
+    in order, then assert the file order matches (render first, publish
+    second) and the wrapper's [OK] line appears in the log.
+
+    This is the integration shape used by the new cron entry; the wrapper is
+    already generic so we're verifying it cleanly hosts the new chained
+    command without bespoke per-job code.
+    """
+    project = tmp_path / "rainier"
+    (project / "scripts").mkdir(parents=True)
+    # Drop the real wrapper into a clone of the project layout cron-wrapper.sh
+    # expects (it cd's into `dirname(scripts)/`).
+    wrapper_dst = project / "scripts" / "cron-wrapper.sh"
+    wrapper_dst.write_text(CRON_WRAPPER.read_text())
+    wrapper_dst.chmod(0o755)
+
+    marker_render = tmp_path / "render.marker"
+    marker_publish = tmp_path / "publish.marker"
+    log = tmp_path / "cron.log"
+
+    # The command argument is `eval`d by cron-wrapper, exactly as it would be
+    # from cron.yaml. Order matters: render must touch its marker FIRST, then
+    # `&&` chains to the publisher.
+    command = (
+        f"date >> {marker_render} && "
+        # tiny sleep so mtimes differ even on coarse filesystems
+        f"sleep 0.01 && "
+        f"date >> {marker_publish}"
+    )
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(wrapper_dst),
+            "etf-dashboard-publish",  # job name
+            str(log),                  # log file
+            "",                        # webhook (empty disables Discord)
+            command,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        f"wrapper failed: rc={result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}\n"
+        f"log: {log.read_text() if log.exists() else '(no log)'}"
+    )
+    assert marker_render.exists(), "render step never ran"
+    assert marker_publish.exists(), "publish step never ran"
+
+    # Render's marker must be older than publish's marker — proves order.
+    assert marker_render.stat().st_mtime <= marker_publish.stat().st_mtime, (
+        "render must run before publish"
+    )
+
+    log_text = log.read_text()
+    assert "[START] etf-dashboard-publish" in log_text
+    assert "[OK] etf-dashboard-publish" in log_text

--- a/tests/test_scripts/test_publish_dashboard.py
+++ b/tests/test_scripts/test_publish_dashboard.py
@@ -260,7 +260,134 @@ def test_publish_bails_on_dirty_target(source_dir: Path, target_repo: Path):
 
 
 # ---------------------------------------------------------------------------
-# Test 5 — cron-wrapper integration: invokes render then publish in order.
+# Test 5 — missing source HTML produces a clean non-zero exit (no copy, no
+# commit). `set -euo pipefail` + the early `[ ! -f "$SRC" ]` guard must turn
+# this into a meaningful error, NOT a silent success.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_errors_when_source_missing(source_dir: Path, target_repo: Path):
+    """No rendered HTML at the source path → exit non-zero, no commit."""
+    name = "etf-ranks"
+    # Intentionally do NOT write `etf-ranks.html` into source_dir.
+    assert not (source_dir / f"{name}.html").exists()
+
+    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
+    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+
+    assert result.returncode != 0, (
+        f"missing source must produce non-zero exit, got rc={result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert head_before == head_after, "must not commit when source is missing"
+
+    combined = (result.stdout + result.stderr).lower()
+    assert "missing" in combined or "no such" in combined, (
+        f"expected actionable error mentioning missing source, got:\n"
+        f"{result.stdout}\n{result.stderr}"
+    )
+
+    # And no file should have been published.
+    dst = target_repo / "public" / "trading" / name / "index.html"
+    assert not dst.exists(), "must not create destination when source is missing"
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — target is not a git checkout → clean non-zero exit, no file copy.
+# Protects against misconfiguration (DASHBOARD_PUBLISH_TARGET_DIR pointing at
+# a plain directory instead of the fengshen-site clone).
+# ---------------------------------------------------------------------------
+
+
+def test_publish_errors_when_target_not_git(tmp_path: Path, source_dir: Path):
+    """Non-git target → exit non-zero, no file written."""
+    name = "etf-ranks"
+    (source_dir / f"{name}.html").write_text("<html>v1</html>")
+
+    # Plain directory, no .git/ inside.
+    not_a_git_repo = tmp_path / "fengshen-site-but-not-really"
+    not_a_git_repo.mkdir()
+    assert not (not_a_git_repo / ".git").exists()
+
+    result = _run_publisher(
+        name, source_dir=source_dir, target_repo=not_a_git_repo
+    )
+    assert result.returncode != 0, (
+        f"non-git target must produce non-zero exit, got rc={result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    combined = (result.stdout + result.stderr).lower()
+    assert "not a git" in combined or "git checkout" in combined, (
+        f"expected error mentioning git checkout, got:\n"
+        f"{result.stdout}\n{result.stderr}"
+    )
+
+    # And no destination directory created.
+    dst = not_a_git_repo / "public" / "trading" / name
+    assert not dst.exists(), "must not create destination on non-git target"
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — pending unpushed commits are recovered on the no-op path.
+# Regression for the "yesterday push failed + today identical render"
+# corner case where the local repo silently drifts ahead of origin.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_pushes_pending_commits_on_noop(
+    source_dir: Path, target_repo: Path
+):
+    """After a prior commit is left local-only (simulating a failed push),
+    a subsequent no-op render must detect the ahead-of-upstream state and
+    push the pending commit instead of exiting silently."""
+    name = "etf-ranks"
+    html = "<html>v1</html>"
+    (source_dir / f"{name}.html").write_text(html)
+
+    # First run: lands a commit and pushes.
+    r1 = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
+    assert r1.returncode == 0, r1.stderr
+
+    # Simulate "yesterday's push failed" by rewinding the remote one commit.
+    # Resolve the parent SHA in the working clone (where the reflog lives),
+    # then point the bare remote's main ref at it directly. We avoid
+    # `HEAD~1` against the bare repo because its HEAD is symbolic-only.
+    remote_url = _git("config", "remote.origin.url", cwd=target_repo).strip()
+    parent_sha = _git("rev-parse", "HEAD~1", cwd=target_repo).strip()
+    _git(
+        "update-ref",
+        "refs/heads/main",
+        parent_sha,
+        cwd=Path(remote_url),
+    )
+    # Confirm we are now ahead of origin/main.
+    _git("fetch", "origin", cwd=target_repo)
+    ahead = _git(
+        "rev-list", "--count", "origin/main..HEAD", cwd=target_repo
+    ).strip()
+    assert ahead == "1", f"setup error: expected 1 ahead, got {ahead}"
+
+    # Re-run with identical source HTML → the no-op path triggers, but the
+    # pending commit must still be pushed.
+    r2 = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
+    assert r2.returncode == 0, (
+        f"rc={r2.returncode}\nstdout: {r2.stdout}\nstderr: {r2.stderr}"
+    )
+
+    # Local and origin should be back in sync.
+    _git("fetch", "origin", cwd=target_repo)
+    local_head = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    origin_head = _git("rev-parse", "origin/main", cwd=target_repo).strip()
+    assert local_head == origin_head, (
+        f"pending commit was not recovered: local={local_head[:8]} "
+        f"origin={origin_head[:8]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — cron-wrapper integration: invokes render then publish in order.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_scripts/test_publish_etf_dashboard.py
+++ b/tests/test_scripts/test_publish_etf_dashboard.py
@@ -1,0 +1,319 @@
+"""Unit tests for scripts/publish-etf-dashboard.sh.
+
+The wrapper computes today's ASOF, invokes the renderer via `$RAINIER_UV run
+rainier dashboard render-etf-html`, guards against the renderer's
+"valid-but-empty" output (`Universe: 0 sector/theme ETFs`), and chains to
+the generic `publish-dashboard.sh etf-ranks` publisher.
+
+Tests stub `RAINIER_UV` so we never invoke the real `uv` / `rainier` /
+parquet pipeline. The stub writes deterministic HTML to the expected
+output path, then the wrapper makes the publish decision.
+
+Why this wrapper exists (re-stated for reviewers reading the test alone):
+
+  1. The crontab line cannot contain `%` characters — cron's command-field
+     parser treats unescaped `%` as a line terminator. Putting
+     `$(date +%Y-%m-%d)` directly in cron.yaml made the job silently break
+     once `rainier jobs sync` installed it into the system crontab. The
+     wrapper computes ASOF in plain shell, off the crontab line.
+
+  2. The renderer's no-data path returns a valid-but-empty HTML page on
+     market holidays / stale OHLCV cache. Without a guard, publish-
+     dashboard.sh would overwrite the last good public dashboard with an
+     empty one. The wrapper checks for "Universe: 0 " in the rendered
+     HTML and bails before handing off.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "publish-etf-dashboard.sh"
+CRON_CONFIG = ROOT / "config" / "cron.yaml"
+
+# Sentinel string the renderer emits when no features exist for ASOF.
+EMPTY_MARKER = "Universe: 0 sector/theme ETFs"
+HAPPY_MARKER = "Universe: 12 sector/theme ETFs"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str, cwd: Path, check: bool = True, env: dict | None = None) -> str:
+    full_env = os.environ.copy()
+    full_env.update(
+        {
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+    )
+    if env:
+        full_env.update(env)
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        env=full_env,
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"git {' '.join(args)} failed (rc={result.returncode}):\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    return result.stdout
+
+
+@pytest.fixture
+def target_repo(tmp_path: Path) -> Path:
+    """Bare remote + working clone, mirroring fengshen-site's layout."""
+    remote = tmp_path / "fengshen-site-remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+    )
+    local = tmp_path / "fengshen-site"
+    subprocess.run(
+        ["git", "clone", str(remote), str(local)], check=True, capture_output=True
+    )
+    (local / "public").mkdir()
+    (local / "public" / ".gitkeep").write_text("")
+    _git("checkout", "-B", "main", cwd=local)
+    _git("add", "public/.gitkeep", cwd=local)
+    _git("commit", "-m", "init", cwd=local)
+    _git("push", "-u", "origin", "main", cwd=local)
+    return local
+
+
+@pytest.fixture
+def source_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "out" / "dashboards"
+    d.mkdir(parents=True)
+    return d
+
+
+def _write_uv_stub(tmp_path: Path, source_dir: Path, content: str) -> Path:
+    """Build a stand-in for `$RAINIER_UV` that mimics `uv run rainier
+    dashboard render-etf-html` by writing the given HTML content to the
+    --output path the wrapper passes in.
+
+    The stub also asserts that the wrapper passed `--asof` in YYYY-MM-DD
+    form so we'd catch a regression in date formatting.
+    """
+    stub = tmp_path / "uv-stub.sh"
+    stub.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/bash
+            # Args from wrapper:
+            #   $1 = "run"
+            #   $2 = "rainier"
+            #   $3 = "dashboard"
+            #   $4 = "render-etf-html"
+            #   $5..$N = flag pairs (--asof DATE --rendered-at-pt HH:MM
+            #                        --output PATH ...)
+            set -euo pipefail
+            OUTPUT=""
+            ASOF=""
+            shift 4
+            while [ $# -gt 0 ]; do
+                case "$1" in
+                    --output) OUTPUT="$2"; shift 2 ;;
+                    --asof) ASOF="$2"; shift 2 ;;
+                    *) shift ;;
+                esac
+            done
+            # Sanity: wrapper should have passed YYYY-MM-DD.
+            if ! [[ "$ASOF" =~ ^[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}$ ]]; then
+                echo "uv-stub: bad --asof: $ASOF" >&2
+                exit 99
+            fi
+            mkdir -p "$(dirname "$OUTPUT")"
+            cat > "$OUTPUT" <<'HTML_EOF'
+            {content}
+            HTML_EOF
+            """
+        )
+    )
+    stub.chmod(0o755)
+    return stub
+
+
+def _run_wrapper(
+    *,
+    tmp_path: Path,
+    source_dir: Path,
+    target_repo: Path,
+    uv_stub: Path,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "RAINIER_UV": str(uv_stub),
+            "DASHBOARD_SOURCE_DIR": str(source_dir),
+            "DASHBOARD_PUBLISH_TARGET_DIR": str(target_repo),
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+    )
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — cron.yaml command field is `%`-free.
+#
+# Cron's command-field parser treats unescaped `%` as a line terminator
+# (everything after the first `%` is sent on stdin). The etf-dashboard-publish
+# job MUST NOT contain `%` in its command — date computation moved into a
+# wrapper script. Regression for the originally-committed inline `$(date
+# +%Y-%m-%d)` form that codex flagged as P1.
+# ---------------------------------------------------------------------------
+
+
+def test_cron_command_field_is_percent_free():
+    with open(CRON_CONFIG) as f:
+        data = yaml.safe_load(f)
+    jobs = [j for j in data["jobs"] if j["name"] == "etf-dashboard-publish"]
+    assert len(jobs) == 1, "etf-dashboard-publish job missing from cron.yaml"
+    cmd = jobs[0]["command"]
+    assert "%" not in cmd, (
+        f"etf-dashboard-publish.command must not contain `%` (crontab splits on "
+        f"it). Move date computation into a wrapper script. Got: {cmd!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — empty render is NOT published.
+#
+# Renderer emits a valid-but-empty page on market holidays / stale cache
+# ("Universe: 0 sector/theme ETFs"). Without a guard, the empty page would
+# replace the last good public dashboard. Wrapper must detect + bail.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_render_is_not_published(
+    tmp_path: Path, source_dir: Path, target_repo: Path
+):
+    empty_html = f"<html><body><p>{EMPTY_MARKER}</p></body></html>"
+    uv_stub = _write_uv_stub(tmp_path, source_dir, empty_html)
+
+    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    result = _run_wrapper(
+        tmp_path=tmp_path,
+        source_dir=source_dir,
+        target_repo=target_repo,
+        uv_stub=uv_stub,
+    )
+    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+
+    assert result.returncode != 0, (
+        f"empty render must exit non-zero, got rc={result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert head_before == head_after, "must not commit on empty render"
+
+    dst = target_repo / "public" / "trading" / "etf-ranks" / "index.html"
+    assert not dst.exists(), "must not publish empty HTML"
+
+    combined = (result.stdout + result.stderr).lower()
+    assert "empty" in combined or "no features" in combined, (
+        f"expected actionable error mentioning empty render, got:\n"
+        f"{result.stdout}\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — non-empty render flows through to publish-dashboard.sh and lands a
+# commit + push.
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_publishes(
+    tmp_path: Path, source_dir: Path, target_repo: Path
+):
+    happy_html = f"<html><body><p>{HAPPY_MARKER}</p><p>data here</p></body></html>"
+    uv_stub = _write_uv_stub(tmp_path, source_dir, happy_html)
+
+    result = _run_wrapper(
+        tmp_path=tmp_path,
+        source_dir=source_dir,
+        target_repo=target_repo,
+        uv_stub=uv_stub,
+    )
+    assert result.returncode == 0, (
+        f"happy path failed: rc={result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    dst = target_repo / "public" / "trading" / "etf-ranks" / "index.html"
+    assert dst.exists(), "publish step did not land index.html"
+    # Read against the rendered content (textwrap.dedent in the stub adds a
+    # trailing newline, so use `in` rather than equality).
+    assert HAPPY_MARKER in dst.read_text()
+
+    # Commit subject from publish-dashboard.sh.
+    head_msg = _git("log", "-1", "--pretty=%s", cwd=target_repo).strip()
+    assert re.match(
+        r"^etf-ranks: \d{4}-\d{2}-\d{2} daily render$", head_msg
+    ), f"unexpected commit subject: {head_msg!r}"
+
+    # And pushed to origin.
+    local_head = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    remote_head = _git("rev-parse", "origin/main", cwd=target_repo).strip()
+    assert local_head == remote_head, "wrapper did not push to origin"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — renderer failure halts the chain (publish-dashboard.sh is NOT
+# invoked). `set -euo pipefail` ensures non-zero `uv run ...` propagates.
+# ---------------------------------------------------------------------------
+
+
+def test_renderer_failure_halts_chain(
+    tmp_path: Path, source_dir: Path, target_repo: Path
+):
+    # Stub that always exits 1 without writing the output.
+    stub = tmp_path / "uv-fail.sh"
+    stub.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/bash
+            echo "uv-fail-stub: simulated render failure" >&2
+            exit 1
+            """
+        )
+    )
+    stub.chmod(0o755)
+
+    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    result = _run_wrapper(
+        tmp_path=tmp_path,
+        source_dir=source_dir,
+        target_repo=target_repo,
+        uv_stub=stub,
+    )
+    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+
+    assert result.returncode != 0, "renderer failure must propagate"
+    assert head_before == head_after, "no commit on renderer failure"
+
+    dst = target_repo / "public" / "trading" / "etf-ranks" / "index.html"
+    assert not dst.exists(), "must not publish when render failed"


### PR DESCRIPTION
## Summary
- New `scripts/publish-dashboard.sh <name>` — generic publisher used by ETF + the upcoming market-breadth page. Copies `out/dashboards/<name>.html` → `~/projects/fengshen-site/public/trading/<name>/index.html`, no-op exits on identical content (market holiday safe), commits + git pushes when content changed. Bails on dirty target (no auto-stash). Pushes pending no-op commits when ahead-of-upstream. `set -euo pipefail`. shellcheck + ruff clean.
- New `scripts/publish-etf-dashboard.sh` — small chain wrapper invoking `render-etf-html && publish-dashboard.sh etf-ranks`. Keeps `%` characters off the crontab line. Empty-render guard: if the render produced `Universe: 0` (data-readiness gap), publish is halted and Discord-alerted loudly rather than overwriting the live page with a stub.
- New `40 12 * * 1-5` cron job in `config/cron.yaml` (12:40 PT every trading day). `enabled: true`. Discord on failure (reuses existing webhook plumbing).
- 21/21 test_scripts pass (worker's 5 + reviewer's 7 new regression tests + 9 pre-existing).

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 5)
  - /review iter-1: ahead-of-upstream recovery on no-op path + 3 regression tests (missing source, non-git target, pending-commits push)
  - codex iter-1: extracted chain wrapper (keeps `%` off crontab) + empty-render guard against `Universe: 0` output + 4 wrapper tests
  - codex iter-2 + iter-3: docs commits — surfaced design dependency on `thematic-ranks-daily` producer + timing conflict

## Data-readiness gap (operator-actionable, NOT a blocker)
The 12:40 PT publish runs BEFORE its data producer:
- `thematic-ranks-daily` cron job is currently `enabled: false` AND scheduled at 13:30 PT.
- Result: the first 12:40 PT publish will see no fresh data and the empty-render guard will fire a loud Discord alert. NO stale content shipped.
- Reconciliation belongs in a follow-up PR that owns the pre-close compute path. (Filed as `dashboard-data-pre-close-compute-XXXX` follow-up after merge.)

## Deferred [P2] findings (documented in review log, NOT in this PR)
- `scripts/publish-dashboard.sh:70-72` — `.git` directory check rejects git-worktree targets (use `git rev-parse --is-inside-work-tree`). fengshen-site is a regular clone today, not a worktree, so unaffected.
- `scripts/publish-dashboard.sh:114-115` — no `git fetch`/rebase before commit; non-FF push fails loudly (Discord alert) and the no-op recovery path re-pushes next run, but initial failure requires operator notice.
- `scripts/publish-dashboard.sh` — no `git rev-parse --abbrev-ref HEAD == main` check; if fengshen-site is on a non-main branch, push goes to the wrong branch and Cloudflare Pages doesn't update.

## Test plan
- [ ] CI green
- [ ] Operator enables `thematic-ranks-daily` cron OR reschedules to run before 12:40 PT (reconciliation follow-up task)
- [ ] First 12:40 PT cron tick — confirm Discord alert fires for empty render (gap signal working) OR confirm page publishes if data is somehow available