### PR TITLE
feat(etf-dashboard): symbol-first column + importance-tier default sort (P1)

### DIFF
--- a/src/rainier/dashboard/render_etf.py
+++ b/src/rainier/dashboard/render_etf.py
@@ -44,7 +44,43 @@ from markupsafe import Markup
 __all__ = [
     "render_etf_html",
     "write_etf_html",
+    "IMPORTANCE_TIER",
+    "TIER_DEFAULT",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Importance tiers — operator-curated row ordering
+# ---------------------------------------------------------------------------
+#
+# Lower tier number = higher importance = appears earlier in the default view.
+# Tier 3 is the implicit default for any symbol not explicitly mapped.
+#
+# Tier 0: broad-index + semiconductor leveraged ETFs (operator "highest").
+# Tier 1: the eleven S&P 500 GICS sector ETFs (operator "most important").
+# Tier 2: major industry / sub-sector ETFs (coord-decided per operator
+#         delegation in the 64dc task brief).
+#
+# The mapping deliberately includes symbols (QQQ, DIA, IWM, SPY, SOXL,
+# USD, XSD) that aren't in the current `thematic_universe.yaml`. They'll
+# simply be absent from the rendered table until the universe is widened;
+# carrying them here costs nothing and means the constant is already
+# correct when that future expansion lands.
+IMPORTANCE_TIER: dict[str, int] = {
+    # Tier 0 — broad indexes + semiconductors (operator-set "highest").
+    **{s: 0 for s in ("QQQ", "DIA", "IWM", "SPY",
+                       "SMH", "SOXX", "SOXL", "USD", "XSD")},
+    # Tier 1 — S&P 500 GICS sector ETFs (operator-set "most important").
+    **{s: 1 for s in ("XLE", "XLF", "XLK", "XLV", "XLY",
+                       "XLP", "XLI", "XLB", "XLU", "XLRE", "XLC")},
+    # Tier 2 — major industry / sub-sector ETFs.
+    **{s: 2 for s in ("VGT", "IXN", "QTEC", "IBB", "XBI", "IHI",
+                       "IYT", "JETS", "ITA", "ITB", "XHB",
+                       "KRE", "KBE", "IAI",
+                       "GDX", "COPX", "XRT", "XOP", "OIH",
+                       "VNQ", "KWEB", "FDN", "IGV", "PAVE")},
+}
+TIER_DEFAULT: int = 3
 
 
 # ---------------------------------------------------------------------------
@@ -107,12 +143,18 @@ def render_etf_html(
     # to a single mid-line.
     history_lookup = _build_history_lookup(features, asof_str, history_days)
 
-    # Default sort: sector ASC → rank DESC (within sector) → symbol ASC tiebreaker.
+    # Default sort: IMPORTANCE_TIER ASC → rank DESC within tier →
+    # symbol ASC tiebreaker. The inline JS on column headers re-sorts on
+    # click; the tier-based order only governs the default-rendered state.
+    latest["_tier"] = (
+        latest["symbol"].astype(str).map(IMPORTANCE_TIER).fillna(TIER_DEFAULT).astype(int)
+    )
     latest = latest.sort_values(
-        by=["sector_name", "rank", "symbol"],
+        by=["_tier", "rank", "symbol"],
         ascending=[True, False, True],
         kind="mergesort",  # stable
     ).reset_index(drop=True)
+    latest = latest.drop(columns=["_tier"])
 
     rows_all = [_row_to_dict(r, history_lookup) for r in latest.to_dict(orient="records")]
 
@@ -485,11 +527,12 @@ table.etf-table th {
   font-weight: 600;
   color: var(--gray-mute);
 }
-table.etf-table th:first-child, table.etf-table td:first-child { text-align: left; }
-table.etf-table th:nth-child(2), table.etf-table td:nth-child(2) {
+/* Column 1 = Symbol (ticker, mono + bold). Column 2 = Sector (plain text). */
+table.etf-table th:first-child, table.etf-table td:first-child {
   text-align: left; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-weight: 600;
 }
+table.etf-table th:nth-child(2), table.etf-table td:nth-child(2) { text-align: left; }
 .rank-cell {
   font-weight: 700;
   color: #1a1a1a;
@@ -521,8 +564,8 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
 <section data-tab="{{ sec.tab }}">
   <table class="etf-table" id="etf-{{ sec.tab }}">
     <thead><tr>
-      <th onclick="sortEtfTable('etf-{{ sec.tab }}', 0, 'text')">Sector</th>
-      <th onclick="sortEtfTable('etf-{{ sec.tab }}', 1, 'text')">Symbol</th>
+      <th onclick="sortEtfTable('etf-{{ sec.tab }}', 0, 'text')">Symbol</th>
+      <th onclick="sortEtfTable('etf-{{ sec.tab }}', 1, 'text')">Sector</th>
       <th onclick="sortEtfTable('etf-{{ sec.tab }}', 2, 'num')">Rank</th>
       <th onclick="sortEtfTable('etf-{{ sec.tab }}', 3, 'num')">&Delta;1d</th>
       <th onclick="sortEtfTable('etf-{{ sec.tab }}', 4, 'num')">&Delta;5d</th>
@@ -535,8 +578,8 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     <tbody>
     {% for r in sec.rows %}
       <tr>
-        <td>{{ r.sector_name }}</td>
         <td>{{ r.symbol }}</td>
+        <td>{{ r.sector_name }}</td>
         <td class="rank-cell" data-sort="{{ r.rank_int }}"{% if r.rank_missing %} data-missing="1"{% endif %} style="background: {{ r.rank_color }}">{{ r.rank_text }}</td>
         <td data-sort="{{ r.rank_delta_1d }}" class="{% if r.rank_delta_1d > 0 %}pos{% elif r.rank_delta_1d < 0 %}neg{% endif %}">{{ r.rank_delta_1d_text }}</td>
         <td data-sort="{{ r.rank_delta_5d }}" class="{% if r.rank_delta_5d > 0 %}pos{% elif r.rank_delta_5d < 0 %}neg{% endif %}">{{ r.rank_delta_5d_text }}</td>

--- a/tests/test_dashboard/test_render_etf.py
+++ b/tests/test_dashboard/test_render_etf.py
@@ -83,28 +83,128 @@ def test_render_html_is_self_contained(rendered_html):
     assert "src=\"//" not in html and "href=\"//" not in html, "protocol-relative URL"
 
 
-def test_sort_is_sector_then_rank_desc(rendered_html):
-    """Default All-ETFs table is sorted by sector ASC, then rank DESC within sector."""
+def test_columns_symbol_first_sector_second(rendered_html):
+    """Header row of the All-ETFs table is Symbol, Sector, Rank, Δ1d, Δ5d, R5, R10, R20, YTD, 30d."""
     html = rendered_html
-    # Pull the All-ETFs table block.
     all_block = _extract_tab_block(html, "all")
-    rows = _parse_table_rows(all_block)
-    # Rows are (sector, symbol, rank); pair-wise check.
-    assert rows, "no rows parsed from All ETFs tab"
-    # Sectors must appear in alphabetical order overall.
-    sector_order = []
-    seen = set()
-    for sector, _sym, _rank in rows:
-        if sector not in seen:
-            sector_order.append(sector)
-            seen.add(sector)
-    assert sector_order == sorted(sector_order), f"sectors not alphabetical: {sector_order}"
-    # Within each sector, rank must be monotone non-increasing.
-    by_sector: dict[str, list[int]] = {}
-    for sec, _sym, rk in rows:
-        by_sector.setdefault(sec, []).append(rk)
-    for sec, ranks in by_sector.items():
-        assert ranks == sorted(ranks, reverse=True), f"sector={sec} ranks not desc: {ranks}"
+    # Pull the <thead> row's <th> texts.
+    thead = re.search(r"<thead>(.*?)</thead>", all_block, re.DOTALL)
+    assert thead, "no <thead> in All-ETFs table"
+    th_texts = [_TAGS_RE.sub("", c).strip() for c in re.findall(r"<th\b[^>]*>(.*?)</th>", thead.group(1), re.DOTALL)]
+    # The Δ characters come through as &Delta;; normalise for compare.
+    th_texts = [t.replace("&Delta;", "Δ") for t in th_texts]
+    assert th_texts[0] == "Symbol", f"first column should be Symbol, got: {th_texts}"
+    assert th_texts[1] == "Sector", f"second column should be Sector, got: {th_texts}"
+    assert th_texts[2] == "Rank", f"third column should be Rank, got: {th_texts}"
+    # Tail columns unchanged.
+    assert th_texts[3] == "Δ1d"
+    assert th_texts[4] == "Δ5d"
+    assert th_texts[5] == "R5"
+    assert th_texts[6] == "R10"
+    assert th_texts[7] == "R20"
+    assert th_texts[8] == "YTD"
+    assert th_texts[9] == "30d"
+
+
+def test_tier_default_is_3():
+    """`IMPORTANCE_TIER.get("UNKNOWN_SYMBOL", TIER_DEFAULT)` returns 3."""
+    from rainier.dashboard.render_etf import IMPORTANCE_TIER, TIER_DEFAULT
+
+    assert TIER_DEFAULT == 3
+    assert IMPORTANCE_TIER.get("UNKNOWN_SYMBOL", TIER_DEFAULT) == 3
+    # Spot-check a few known mappings.
+    assert IMPORTANCE_TIER["SMH"] == 0
+    assert IMPORTANCE_TIER["XLE"] == 1
+    assert IMPORTANCE_TIER["XBI"] == 2
+
+
+def _build_tier_features(rows: list[dict]) -> pd.DataFrame:
+    """Build a features DataFrame for tier-sort tests. Each row needs the
+    required numeric columns; tests vary symbol/sector_id/rank."""
+    base_cols = {
+        "rank_delta_1d": 0,
+        "rank_delta_5d": 0,
+        "r_5": 50,
+        "r_10": 50,
+        "r_20": 50,
+        "ret_ytd": 0.05,
+        "top15_streak": 0,
+    }
+    full_rows = []
+    for r in rows:
+        full_rows.append({**base_cols, "asof_date": "2026-05-25", **r})
+    df = pd.DataFrame(full_rows)
+    df["asof_date"] = df["asof_date"].astype("string")
+    return df
+
+
+def test_default_sort_is_importance_then_rank_desc():
+    """Tier dominates rank: tier 0 first, then 1, then 2, then 3."""
+    from rainier.dashboard.render_etf import render_etf_html
+
+    features = _build_tier_features([
+        {"symbol": "XLE",  "sector_id": 1, "rank": 80},   # tier 1
+        {"symbol": "XBI",  "sector_id": 2, "rank": 95},   # tier 2
+        {"symbol": "MEME", "sector_id": 3, "rank": 99},   # tier 3
+        {"symbol": "SMH",  "sector_id": 4, "rank": 50},   # tier 0
+    ])
+    registry = pd.DataFrame([
+        {"sector_id": 1, "sector_name": "energy"},
+        {"sector_id": 2, "sector_name": "biotech"},
+        {"sector_id": 3, "sector_name": "meme"},
+        {"sector_id": 4, "sector_name": "semis"},
+    ])
+    html = render_etf_html(
+        features=features, registry=registry,
+        asof=date(2026, 5, 25), rendered_at_pt="12:40",
+    )
+    all_block = _extract_tab_block(html, "all")
+    symbols = _extract_symbols(all_block)
+    assert symbols == ["SMH", "XLE", "XBI", "MEME"], (
+        f"tier sort wrong; got {symbols}, expected [SMH, XLE, XBI, MEME]"
+    )
+
+
+def test_default_sort_within_tier_uses_rank_desc():
+    """Within the same tier, higher rank comes first."""
+    from rainier.dashboard.render_etf import render_etf_html
+
+    # Two tier-1 ETFs with different ranks.
+    features = _build_tier_features([
+        {"symbol": "XLE", "sector_id": 1, "rank": 80},
+        {"symbol": "XLF", "sector_id": 1, "rank": 90},
+    ])
+    registry = pd.DataFrame([{"sector_id": 1, "sector_name": "energy"}])
+    html = render_etf_html(
+        features=features, registry=registry,
+        asof=date(2026, 5, 25), rendered_at_pt="12:40",
+    )
+    all_block = _extract_tab_block(html, "all")
+    symbols = _extract_symbols(all_block)
+    assert symbols == ["XLF", "XLE"], (
+        f"within-tier rank-desc wrong; got {symbols}, expected [XLF, XLE]"
+    )
+
+
+def test_within_tier_ties_sort_alphabetically():
+    """Within the same (tier, rank), tiebreak by symbol ascending."""
+    from rainier.dashboard.render_etf import render_etf_html
+
+    # Two tier-1 ETFs with identical ranks.
+    features = _build_tier_features([
+        {"symbol": "XLC", "sector_id": 1, "rank": 85},
+        {"symbol": "XLB", "sector_id": 1, "rank": 85},
+    ])
+    registry = pd.DataFrame([{"sector_id": 1, "sector_name": "materials"}])
+    html = render_etf_html(
+        features=features, registry=registry,
+        asof=date(2026, 5, 25), rendered_at_pt="12:40",
+    )
+    all_block = _extract_tab_block(html, "all")
+    symbols = _extract_symbols(all_block)
+    assert symbols == ["XLB", "XLC"], (
+        f"alphabetical tiebreak wrong; got {symbols}, expected [XLB, XLC]"
+    )
 
 
 def test_sparkline_path_count(rendered_html, features_df):
@@ -265,8 +365,8 @@ def test_missing_cells_get_data_missing_marker():
         asof=date(2026, 5, 25), rendered_at_pt="12:40",
     )
 
-    miss_block = re.search(r"<tr>\s*<td>energy</td>\s*<td>MISS</td>(.*?)</tr>", html, re.DOTALL)
-    full_block = re.search(r"<tr>\s*<td>energy</td>\s*<td>FULL</td>(.*?)</tr>", html, re.DOTALL)
+    miss_block = re.search(r"<tr>\s*<td>MISS</td>\s*<td>energy</td>(.*?)</tr>", html, re.DOTALL)
+    full_block = re.search(r"<tr>\s*<td>FULL</td>\s*<td>energy</td>(.*?)</tr>", html, re.DOTALL)
     assert miss_block and full_block, "rows not found"
 
     # MISS row: every numeric cell with a missing value must carry data-missing="1"
@@ -339,7 +439,7 @@ def test_negative_rank_sentinels_render_as_em_dash():
 
     # NEW row's <td> cells should NOT contain a literal `>-1<` for any
     # rank-like column.
-    new_block = re.search(r"<tr>\s*<td>energy</td>\s*<td>NEW</td>(.*?)</tr>", html, re.DOTALL)
+    new_block = re.search(r"<tr>\s*<td>NEW</td>\s*<td>energy</td>(.*?)</tr>", html, re.DOTALL)
     assert new_block, "NEW row not found in rendered HTML"
     new_cells = new_block.group(1)
     assert ">-1<" not in new_cells, (
@@ -351,7 +451,7 @@ def test_negative_rank_sentinels_render_as_em_dash():
     assert 'data-sort="-1"' in new_cells, "rank sort key not preserved"
 
     # OLD row still displays its real values.
-    old_block = re.search(r"<tr>\s*<td>energy</td>\s*<td>OLD</td>(.*?)</tr>", html, re.DOTALL)
+    old_block = re.search(r"<tr>\s*<td>OLD</td>\s*<td>energy</td>(.*?)</tr>", html, re.DOTALL)
     assert old_block, "OLD row not found"
     old_cells = old_block.group(1)
     assert ">90<" in old_cells, "OLD rank display value missing"
@@ -598,15 +698,20 @@ _TAGS_RE = re.compile(r"<[^>]+>")
 
 
 def _parse_table_rows(html_block: str) -> list[tuple[str, str, int]]:
-    """Return list of (sector, symbol, rank) tuples from data rows."""
+    """Return list of (sector, symbol, rank) tuples from data rows.
+
+    Column order in the rendered table is Symbol | Sector | Rank | ...,
+    but the returned tuple keeps the legacy (sector, symbol, rank) shape
+    so test assertions don't need to flip.
+    """
     rows: list[tuple[str, str, int]] = []
     for tr in _TR_RE.finditer(html_block):
         cells = _TD_RE.findall(tr.group(1))
         if len(cells) < 3:
             continue
-        # Strip inner tags + whitespace.
-        sector = _TAGS_RE.sub("", cells[0]).strip()
-        symbol = _TAGS_RE.sub("", cells[1]).strip()
+        # Strip inner tags + whitespace. Column order: symbol, sector, rank.
+        symbol = _TAGS_RE.sub("", cells[0]).strip()
+        sector = _TAGS_RE.sub("", cells[1]).strip()
         rank_text = _TAGS_RE.sub("", cells[2]).strip()
         try:
             rank = int(rank_text)


### PR DESCRIPTION
## Summary
Two UX changes to `src/rainier/dashboard/render_etf.py` from operator-driven dogfood iteration (2026-05-26):

- **Column order swap:** Symbol FIRST, Sector SECOND (was Sector → Symbol). Operator: \"put symbol on the left most, sector put on the second left\".
- **Default sort = importance tier → Rank desc within tier.** New module-level `IMPORTANCE_TIER` map (45 symbols across tiers 0/1/2; everything else defaults to tier 3). Operator-set tiers:
  - **Tier 0:** broad indexes + semiconductors (QQQ, DIA, IWM, SPY, SMH, SOXX, SOXL, USD, XSD) — operator's \"highest important\"
  - **Tier 1:** S&P 500 GICS sector ETFs (XLE, XLF, XLK, XLV, XLY, XLP, XLI, XLB, XLU, XLRE, XLC) — operator's \"most important\"
  - **Tier 2:** major industry/sub-sector ETFs (24 symbols incl. VGT, IBB, XBI, KRE, IYT, JETS, ITA, GDX, KWEB, etc.) — coord-decided per operator delegation
  - Tier 3 default
- Symbols in tier 0 not yet in `config/thematic_universe.yaml` (QQQ, DIA, IWM, SPY, SOXL, USD, XSD) won't appear in the table — visible-on-universe-expansion follow-up.
- Inline JS column-header sort unaffected — clicking any column header still re-sorts by that column.

## Review
- /review: passed (claude rounds: 2) — zero findings across both rounds; adversarial second-pass clean.
- codex review: passed (codex rounds: 2) — \"No actionable correctness issues.\"
- No fix commits needed. Full test suite 1125 passed / 7 skipped, ruff clean.

## Operator local preview (pre-merge, approved)
Top 15 rows under new default sort (against 2026-05-22 data):
\`\`\`
1. SOXX  technology       ← tier 0
2. SMH   technology       ← tier 0
3. XLV   healthcare       ← tier 1 (Rank desc within tier)
4. XLK   technology       ← tier 1
... XL* sector ETFs 5-13
14. QTEC technology       ← tier 2
15. IGV  technology       ← tier 2
\`\`\`

## Test plan
- [ ] CI green
- [ ] Re-render against live data confirms top rows = tier-0 symbols then tier-1 then tier-2