### PR TITLE
feat(etf-dash): replace Sector column with Name (full ETF longName) + yfinance backfill (P1)

### DIFF
--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -80,6 +80,24 @@ jobs:
     discord_on_failure: true
     enabled: false
 
+  # ETF names cache refresh — DESIGN-etf-dashboard-name-column.md §3.4.
+  #
+  # The ETF dashboard's Name column reads from data/cache/etf_names.parquet.
+  # Names rarely change so we refresh on a 30-day stale window: `--refresh-stale`
+  # is a no-op when the parquet is < 30 days old, keeping daily yfinance load
+  # near zero. The one-shot initial seed is operator-run via
+  # `uv run rainier thematic backfill-names`; from there cron keeps it fresh.
+  #
+  # Slot 12:35 — 5 min before the ETF publish job below so a refresh-day
+  # write is in place by the time the publish chain renders the HTML.
+  - name: etf-names-refresh
+    description: "Refresh ETF names cache (yfinance longName) if >30 days old"
+    schedule: "35 12 * * 1-5"   # 12:35 PST, 5 min before etf-dashboard-publish
+    command: "uv run rainier thematic backfill-names --refresh-stale"
+    log: "data/etf-names-refresh.log"
+    discord_on_failure: true
+    enabled: true
+
   # ETF ranks dashboard — DESIGN-etf-dashboard-publish.md §4/§5.
   # 20 min before US market close: render today's snapshot, publish to
   # fengshen.dev/trading/etf-ranks/ via git push to fengshen-site (Cloudflare

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3435,6 +3435,63 @@ def thematic_backfill(
     click.echo(f"seeded sector registry  -> {sector_registry}")
 
 
+@thematic.command("backfill-names")
+@click.option(
+    "--universe-yaml",
+    "yaml_path",
+    type=click.Path(exists=True),
+    default="config/thematic_universe.yaml",
+    show_default=True,
+    help="Path to the thematic universe YAML — flattens to the symbol list.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(),
+    default="data/cache/etf_names.parquet",
+    show_default=True,
+    help="Destination parquet cache for yfinance long/short names.",
+)
+@click.option(
+    "--refresh-stale",
+    is_flag=True,
+    default=False,
+    help=(
+        "When set, skip the backfill if the parquet exists and is newer "
+        "than 30 days. Cron-friendly: ETF names rarely change so daily "
+        "refetch is wasteful."
+    ),
+)
+def thematic_backfill_names(
+    yaml_path: str, output_path: str, refresh_stale: bool
+) -> None:
+    """One-shot backfill: fetch yfinance long/short names for the thematic universe.
+
+    Writes ``data/cache/etf_names.parquet`` (schema:
+    ``symbol, long_name, short_name, fetched_at``). The ETF dashboard
+    renderer reads this on each invocation to populate the Name column.
+
+    Idempotent — re-running upserts on ``symbol``. yfinance rate-limit
+    triggers ONE retry, then surfaces a clean non-zero exit so the cron
+    Discord alert fires.
+    """
+    from rainier.breadth import universe_loader
+    from rainier.dashboard import etf_names_backfill
+
+    out = Path(output_path)
+    if refresh_stale and not etf_names_backfill.is_stale(out):
+        click.echo(f"etf_names parquet is fresh (<30d); skipping -> {out}")
+        return
+
+    spec = universe_loader.load_universe(Path(yaml_path))
+    symbols = list(spec.all_tickers)
+    if not symbols:
+        raise click.ClickException("thematic_universe.yaml flattened to zero tickers")
+
+    written = etf_names_backfill.backfill_names(symbols=symbols, out_path=out)
+    click.echo(f"wrote etf_names ({len(symbols)} symbols) -> {written}")
+
+
 @thematic.command("snapshot-universe")
 @click.option(
     "--yaml",
@@ -4346,6 +4403,18 @@ def dashboard() -> None:
     default="out/dashboards/etf-ranks.html",
     show_default=True,
 )
+@click.option(
+    "--names-path",
+    "names_path",
+    type=click.Path(),
+    default="data/cache/etf_names.parquet",
+    show_default=True,
+    help=(
+        "Optional ETF names parquet (from `thematic backfill-names`). "
+        "When present, the Name column renders yfinance longName; "
+        "missing or unreadable → falls back to the symbol itself."
+    ),
+)
 def dashboard_render_etf_html(
     features_path: str,
     registry_path: str,
@@ -4353,6 +4422,7 @@ def dashboard_render_etf_html(
     rendered_at_pt: str,
     history_days: int,
     output_path: str,
+    names_path: str,
 ) -> None:
     """Render the ETF-ranks self-contained HTML dashboard.
 
@@ -4365,6 +4435,10 @@ def dashboard_render_etf_html(
     from rainier.dashboard.render_etf import write_etf_html
 
     asof_dt = _date.fromisoformat(asof)
+    # CLI default points at the cache path; pass None to the renderer when
+    # the file doesn't exist so the renderer's fallback kicks in cleanly
+    # (no spurious "file not found" surprise).
+    names_arg: str | None = names_path if Path(names_path).exists() else None
     written = write_etf_html(
         features_path=features_path,
         registry_path=registry_path,
@@ -4372,6 +4446,7 @@ def dashboard_render_etf_html(
         asof=asof_dt,
         rendered_at_pt=rendered_at_pt,
         history_days=history_days,
+        names_path=names_arg,
     )
     click.echo(f"wrote ETF dashboard -> {written}")
 

--- a/src/rainier/dashboard/etf_names_backfill.py
+++ b/src/rainier/dashboard/etf_names_backfill.py
@@ -1,0 +1,327 @@
+"""ETF names cache backfill — yfinance ``longName`` / ``shortName`` → parquet.
+
+The ETF dashboard renderer reads this cache on each invocation so the
+Name column shows ``iShares MSCI EAFE ETF`` instead of just ``EFA``. We
+keep names in a side-cache parquet (not the main features parquet) so:
+
+  * a one-shot backfill seeds names for every ticker in the YAML universe
+    without waiting on the daily ranks compute path,
+  * a 30-day ``--refresh-stale`` cron step keeps the cache current with
+    minimal yfinance load (names rarely change),
+  * the renderer degrades gracefully — when the parquet is missing or a
+    symbol is absent, the Name cell falls back to the symbol itself.
+
+Parquet schema::
+
+    symbol      str   primary key (Wikipedia spelling, BRK.B not BRK-B)
+    long_name   str   yfinance info.longName (None → blank string)
+    short_name  str   yfinance info.shortName (None → blank string)
+    fetched_at  ts    UTC tz-aware, when the row was last refreshed
+
+Upsert-on-symbol semantics: re-running ``backfill_names`` reads the
+existing parquet (if any), merges new rows over old ones keyed by
+``symbol``, then atomic-writes the merged frame back. Atomic write =
+``<out>.tmp`` then ``os.replace`` — a mid-run crash leaves the previous
+parquet intact and the tmp file cleaned up.
+
+Retry pattern mirrors ``market_breadth/ohlcv_backfill.py``: tests inject
+a synthetic ``RateLimitError`` via the ``fetch_fn`` kwarg; production
+callers leave ``fetch_fn=None`` to hit the network via ``_yfinance_fetch``.
+
+Design refs:
+    docs/DESIGN-etf-dashboard-name-column.md §3.1 / §3.2
+    docs/TASK-PLAN-etf-dashboard-name-column.md §Acceptance / §Tests
+
+Flow (single chunk → fetch → upsert → atomic write)::
+
+    +-----------+    +----------+    +---------+    +--------+
+    | symbols   |--->| fetch_fn |--->| new_df  |--->| upsert |
+    | (YAML)    |    | (yf info)|    | (sym,   |    | by sym |
+    +-----------+    +----+-----+    |  ln,sn, |    +---+----+
+                          |          |  ts)    |        |
+                          v retry?   +---------+        v
+                     +----+----+                   +----+----+
+                     | retry x1|                   | atomic  |
+                     +----+----+                   | write   |
+                          | fail                   +---------+
+                          v
+                     RateLimitError
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+__all__ = [
+    "RateLimitError",
+    "backfill_names",
+    "DEFAULT_OUT",
+]
+
+
+DEFAULT_OUT = Path("data/cache/etf_names.parquet")
+DEFAULT_RETRIES = 1
+STALE_THRESHOLD_DAYS = 30
+
+_COLUMN_ORDER: tuple[str, ...] = ("symbol", "long_name", "short_name", "fetched_at")
+
+_SCHEMA = pa.schema(
+    [
+        ("symbol", pa.string()),
+        ("long_name", pa.string()),
+        ("short_name", pa.string()),
+        ("fetched_at", pa.timestamp("ns", tz="UTC")),
+    ]
+)
+
+
+class RateLimitError(RuntimeError):
+    """yfinance rate-limit (transient). Retried once by ``backfill_names``.
+
+    yfinance versions raise different exception types for rate-limit
+    failures; this synthetic wrapper gives tests + the prod fetcher a
+    single retryable signal.
+    """
+
+
+# Signature: ``(symbols) -> {symbol: {"long_name": str|None, "short_name": str|None}}``.
+# A missing or None ``long_name`` triggers the renderer's fallback to the
+# symbol itself.
+FetchFn = Callable[[list[str]], dict[str, dict[str, str | None]]]
+
+
+# ---------------------------------------------------------------------------
+# Prod fetcher (real network)
+# ---------------------------------------------------------------------------
+
+
+def _yfinance_fetch(symbols: list[str]) -> dict[str, dict[str, str | None]]:
+    """Fetch yfinance ``info`` for each symbol; return {sym: {long, short}}.
+
+    yfinance's per-ticker ``info`` is sequential by design; for the ~100
+    ETFs in the thematic universe this is fast enough and simpler than
+    bulk pulling. Each Ticker construction is cheap; the network call
+    happens lazily on the first ``.info`` access.
+
+    Symbol translation (``BRK.B`` → ``BRK-B``) mirrors the OHLCV
+    backfill: yfinance wants the dash form, our YAML + parquet keep the
+    Wikipedia (dot) form.
+    """
+    import yfinance as yf  # local import → tests stay offline
+
+    out: dict[str, dict[str, str | None]] = {}
+    for sym in symbols:
+        yf_sym = sym.replace(".", "-")
+        try:
+            info = yf.Ticker(yf_sym).info or {}
+        except Exception as exc:  # noqa: BLE001 — surface as RateLimitError
+            msg = str(exc).lower()
+            if "rate" in msg or "limit" in msg or "429" in msg or "throttle" in msg:
+                raise RateLimitError(str(exc)) from exc
+            # Other failures (network reset, JSON decode, etc.) treat as
+            # missing — name falls back to symbol in the renderer.
+            info = {}
+        out[sym] = {
+            "long_name": _coerce_str(info.get("longName")),
+            "short_name": _coerce_str(info.get("shortName")),
+        }
+    return out
+
+
+def _coerce_str(value) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s if s else None
+
+
+# ---------------------------------------------------------------------------
+# Retry wrapper
+# ---------------------------------------------------------------------------
+
+
+def _fetch_with_retry(
+    fetch_fn: FetchFn,
+    symbols: list[str],
+    retries: int,
+    retry_sleep: Callable[[int], None],
+) -> dict[str, dict[str, str | None]]:
+    """Call ``fetch_fn`` with up to ``retries`` retries on ``RateLimitError``.
+
+    Mirrors ``ohlcv_backfill._fetch_with_retry``: deterministic counter,
+    no wall-clock inside the test path. Tests pass
+    ``retry_sleep=lambda _: None`` to short-circuit the back-off.
+    """
+    attempt = 0
+    while True:
+        try:
+            return fetch_fn(symbols)
+        except RateLimitError:
+            if attempt >= retries:
+                raise
+            retry_sleep(attempt)
+            attempt += 1
+
+
+# ---------------------------------------------------------------------------
+# Upsert + atomic write
+# ---------------------------------------------------------------------------
+
+
+def _new_frame(
+    fetched: dict[str, dict[str, str | None]], fetched_at: datetime
+) -> pd.DataFrame:
+    """Convert the fetcher's dict payload to the canonical long-format frame."""
+    rows = []
+    for sym, payload in fetched.items():
+        rows.append(
+            {
+                "symbol": sym,
+                "long_name": payload.get("long_name") or "",
+                "short_name": payload.get("short_name") or "",
+                "fetched_at": fetched_at,
+            }
+        )
+    if not rows:
+        return pd.DataFrame(columns=list(_COLUMN_ORDER))
+    df = pd.DataFrame(rows)
+    return df[list(_COLUMN_ORDER)]
+
+
+def _upsert(new_df: pd.DataFrame, out_path: Path) -> pd.DataFrame:
+    """Merge ``new_df`` into the existing parquet (if any) on ``symbol``.
+
+    Latest write wins for any overlap — rows in ``new_df`` replace prior
+    rows with the same symbol. New symbols are appended.
+    """
+    if not out_path.exists():
+        return new_df
+    existing = pd.read_parquet(out_path)
+    if existing.empty:
+        return new_df
+    # Filter out rows in `existing` that are being replaced, then concat.
+    new_symbols = set(new_df["symbol"].astype(str))
+    kept = existing.loc[~existing["symbol"].astype(str).isin(new_symbols)]
+    merged = pd.concat([kept, new_df], ignore_index=True)
+    return merged[list(_COLUMN_ORDER)]
+
+
+def _write_parquet_atomic(df: pd.DataFrame, out_path: Path) -> None:
+    """pyarrow write + os.replace — never leaves a half-written parquet visible."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_suffix(out_path.suffix + ".tmp")
+    table = pa.Table.from_pandas(df, schema=_SCHEMA, preserve_index=False)
+    try:
+        pq.write_table(table, tmp, compression="snappy")
+        os.replace(tmp, out_path)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def backfill_names(
+    symbols: Iterable[str],
+    out_path: str | Path = DEFAULT_OUT,
+    *,
+    fetch_fn: FetchFn | None = None,
+    retries: int = DEFAULT_RETRIES,
+    retry_sleep: Callable[[int], None] | None = None,
+) -> Path:
+    """Fetch ETF long/short names from yfinance and atomic-write the cache parquet.
+
+    Parameters
+    ----------
+    symbols:
+        Tickers in YAML (Wikipedia) spelling. The internal fetcher
+        translates dots to dashes when talking to yfinance.
+    out_path:
+        Destination parquet. Atomic-written. Default: ``data/cache/etf_names.parquet``.
+    fetch_fn:
+        Override the yfinance fetcher (tests inject a stub). Production
+        callers leave this ``None`` to hit the network.
+    retries:
+        Per-call retries on ``RateLimitError``. Default 1 (one retry, then surface).
+    retry_sleep:
+        Callback invoked between retries; receives the attempt index (0-based).
+        Default ``time.sleep(2 ** attempt)``. Tests pass ``lambda _: None``.
+
+    Returns
+    -------
+    Path
+        The path actually written (equal to ``out_path``).
+
+    Raises
+    ------
+    RateLimitError
+        After a single retry, a persistent rate limit surfaces cleanly so
+        the operator (or cron-wrapper Discord alert) sees a non-zero exit.
+    """
+    symbols = [str(s) for s in symbols]
+    if not symbols:
+        raise ValueError("backfill_names called with empty symbols list")
+
+    import time
+
+    fetcher = fetch_fn or _yfinance_fetch
+    sleep_cb = retry_sleep or (lambda attempt: time.sleep(2**attempt))
+    out = Path(out_path)
+
+    fetched_at = datetime.now(tz=timezone.utc)
+    fetched = _fetch_with_retry(
+        fetch_fn=fetcher,
+        symbols=symbols,
+        retries=retries,
+        retry_sleep=sleep_cb,
+    )
+
+    new_df = _new_frame(fetched, fetched_at)
+    merged = _upsert(new_df, out)
+    _write_parquet_atomic(merged, out)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Stale check (cron --refresh-stale)
+# ---------------------------------------------------------------------------
+
+
+def is_stale(out_path: str | Path, threshold_days: int = STALE_THRESHOLD_DAYS) -> bool:
+    """Return True iff the parquet is missing or older than ``threshold_days``.
+
+    Used by the cron-wrapper to decide whether to invoke the backfill in
+    ``--refresh-stale`` mode — keeps daily yfinance load near zero for
+    cache that rarely changes (ETF long names).
+    """
+    out = Path(out_path)
+    if not out.exists():
+        return True
+    try:
+        df = pd.read_parquet(out)
+    except Exception:  # noqa: BLE001 — corrupt parquet → refresh
+        return True
+    if df.empty or "fetched_at" not in df.columns:
+        return True
+    newest = pd.to_datetime(df["fetched_at"]).max()
+    if pd.isna(newest):
+        return True
+    now = datetime.now(tz=timezone.utc)
+    # Strip tz if absent (legacy parquet) for delta calc.
+    if newest.tzinfo is None:
+        newest = newest.tz_localize("UTC")
+    delta = now - newest
+    return delta.days >= threshold_days

--- a/src/rainier/dashboard/render_etf.py
+++ b/src/rainier/dashboard/render_etf.py
@@ -96,6 +96,7 @@ def render_etf_html(
     rendered_at_pt: str,
     history_days: int = 30,
     include_shared_styles: bool = True,
+    names_path: str | Path | None = None,
 ) -> str:
     """Render the ETF-ranks dashboard to an HTML string.
 
@@ -109,7 +110,9 @@ def render_etf_html(
         ``rank_delta_1d``, ``rank_delta_5d``, ``r_5``, ``r_10``, ``r_20``,
         ``ret_ytd``, ``top15_streak``.
     registry:
-        Sector registry parquet — ``sector_id``, ``sector_name``.
+        Sector registry parquet — ``sector_id``, ``sector_name``. Still
+        joined onto the features (the underlying parquet keeps it for
+        downstream consumers) but no longer rendered as a column.
     asof:
         Display + filter date. The renderer slices the features DataFrame
         to rows where ``asof_date == asof``.
@@ -127,10 +130,23 @@ def render_etf_html(
         no ``<html>``, no ``<head>``, no full ``<style>`` block — the
         combined trading dashboard's shared ``<head>`` provides the
         common CSS via ``shared_styles.shared_styles()``).
+    names_path:
+        Optional path to ``etf_names.parquet`` (schema:
+        ``symbol, long_name, short_name, fetched_at``). When the file
+        exists and contains the row's symbol, the Name column renders
+        ``long_name``. Otherwise it falls back to the symbol itself —
+        keeps the table shape intact and visually flags missing data.
     """
     asof_str = asof.isoformat()
     features = _normalise_asof_column(features)
     latest = features.loc[features["asof_date"] == asof_str].copy()
+
+    # Load the optional names cache once; renderer-side fallback fills in
+    # missing tickers with their symbol. None / non-existent path / unreadable
+    # parquet all degrade silently to an empty lookup — the per-row fallback
+    # keeps the page rendering.
+    name_lookup = _build_name_lookup(names_path)
+
     if latest.empty:
         # Best-effort: render empty page so the cron output is still a valid
         # file (the publish step can detect emptiness via byte size).
@@ -143,7 +159,9 @@ def render_etf_html(
             include_shared_styles=include_shared_styles,
         )
 
-    # Join sector_name onto the latest slice.
+    # Join sector_name onto the latest slice. Still kept on the row dict
+    # (other tests + future consumers may use it) but the rendered HTML no
+    # longer surfaces it as a column — that slot belongs to Name now.
     sector_map = dict(zip(registry["sector_id"].astype(int), registry["sector_name"].astype(str)))
     latest["sector_name"] = latest["sector_id"].astype(int).map(sector_map).fillna("unknown")
 
@@ -165,7 +183,7 @@ def render_etf_html(
     ).reset_index(drop=True)
     latest = latest.drop(columns=["_tier"])
 
-    rows_all = [_row_to_dict(r, history_lookup) for r in latest.to_dict(orient="records")]
+    rows_all = [_row_to_dict(r, history_lookup, name_lookup) for r in latest.to_dict(orient="records")]
 
     # Tab filters — operate on the already-rendered rows so the sparkline
     # SVG string is reused (cheap; no re-build).
@@ -200,8 +218,12 @@ def write_etf_html(
     asof: date,
     rendered_at_pt: str,
     history_days: int = 30,
+    names_path: str | Path | None = None,
 ) -> Path:
-    """Convenience wrapper: load parquets, render, atomic-write output."""
+    """Convenience wrapper: load parquets, render, atomic-write output.
+
+    ``names_path`` is forwarded to ``render_etf_html``; see that docstring.
+    """
     features = pd.read_parquet(features_path)
     registry = pd.read_parquet(registry_path)
     html = render_etf_html(
@@ -210,6 +232,7 @@ def write_etf_html(
         asof=asof,
         rendered_at_pt=rendered_at_pt,
         history_days=history_days,
+        names_path=names_path,
     )
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -266,7 +289,40 @@ def _build_history_lookup(
     return out
 
 
-def _row_to_dict(row: dict, history_lookup: dict[str, list[int]]) -> dict:
+def _build_name_lookup(names_path: str | Path | None) -> dict[str, str]:
+    """Build a {symbol: long_name} dict from the optional names parquet.
+
+    Returns an EMPTY dict when:
+      * ``names_path`` is None,
+      * the file doesn't exist,
+      * the file fails to read (corrupt parquet, etc.).
+
+    Per-row fallback in ``_row_to_dict`` handles the missing-symbol case
+    so callers don't have to defend against missing entries here.
+    """
+    if names_path is None:
+        return {}
+    path = Path(names_path)
+    if not path.exists():
+        return {}
+    try:
+        df = pd.read_parquet(path)
+    except Exception:  # noqa: BLE001 — corrupt parquet → degrade to fallback
+        return {}
+    if df.empty or "symbol" not in df.columns or "long_name" not in df.columns:
+        return {}
+    out: dict[str, str] = {}
+    for sym, name in zip(df["symbol"].astype(str), df["long_name"].astype(str)):
+        sym = sym.strip()
+        name = name.strip()
+        # Only register non-empty names; blanks fall through to the
+        # symbol-as-name fallback the same way "missing from parquet" does.
+        if sym and name:
+            out[sym] = name
+    return out
+
+
+def _row_to_dict(row: dict, history_lookup: dict[str, list[int]], name_lookup: dict[str, str]) -> dict:
     """Pre-format every cell for jinja consumption.
 
     The template is dumb on purpose — strings only, no conditionals beyond
@@ -298,8 +354,14 @@ def _row_to_dict(row: dict, history_lookup: dict[str, list[int]]) -> dict:
     r5_missing = r5_raw < 0
     r10_missing = r10_raw < 0
     r20_missing = r20_raw < 0
+    # Name column source-of-truth: yfinance long_name from etf_names.parquet
+    # via name_lookup. Falls back to the symbol when missing — preserves
+    # the table shape and visually flags the gap (Symbol cell and Name cell
+    # both show the ticker).
+    long_name = name_lookup.get(sym) or sym
     return {
         "sector_name": str(row["sector_name"]),
+        "long_name": long_name,
         "symbol": sym,
         "rank_int": rank,
         "rank_text": "—" if rank_missing else str(rank),
@@ -537,12 +599,21 @@ table.etf-table th {
   font-weight: 600;
   color: var(--gray-mute);
 }
-/* Column 1 = Symbol (ticker, mono + bold). Column 2 = Sector (plain text). */
+/* Column 1 = Symbol (ticker, mono + bold). Column 2 = Name (descriptive,
+   width-capped + ellipsis on overflow so long ETF names don't blow the
+   table out horizontally). */
 table.etf-table th:first-child, table.etf-table td:first-child {
   text-align: left; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-weight: 600;
 }
-table.etf-table th:nth-child(2), table.etf-table td:nth-child(2) { text-align: left; }
+table.etf-table th:nth-child(2), table.etf-table td:nth-child(2) {
+  text-align: left;
+  min-width: 200px;
+  max-width: 400px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .rank-cell {
   font-weight: 700;
   color: #1a1a1a;
@@ -575,7 +646,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
   <table class="etf-table" id="etf-{{ sec.tab }}">
     <thead><tr>
       <th onclick="sortEtfTable('etf-{{ sec.tab }}', 0, 'text')">Symbol</th>
-      <th onclick="sortEtfTable('etf-{{ sec.tab }}', 1, 'text')">Sector</th>
+      <th onclick="sortEtfTable('etf-{{ sec.tab }}', 1, 'text')">Name</th>
       <th onclick="sortEtfTable('etf-{{ sec.tab }}', 2, 'num')">Rank</th>
       <th onclick="sortEtfTable('etf-{{ sec.tab }}', 3, 'num')">&Delta;1d</th>
       <th onclick="sortEtfTable('etf-{{ sec.tab }}', 4, 'num')">&Delta;5d</th>
@@ -589,7 +660,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     {% for r in sec.rows %}
       <tr>
         <td>{{ r.symbol }}</td>
-        <td>{{ r.sector_name }}</td>
+        <td title="{{ r.long_name }}">{{ r.long_name }}</td>
         <td class="rank-cell" data-sort="{{ r.rank_int }}"{% if r.rank_missing %} data-missing="1"{% endif %} style="background: {{ r.rank_color }}">{{ r.rank_text }}</td>
         <td data-sort="{{ r.rank_delta_1d }}" class="{% if r.rank_delta_1d > 0 %}pos{% elif r.rank_delta_1d < 0 %}neg{% endif %}">{{ r.rank_delta_1d_text }}</td>
         <td data-sort="{{ r.rank_delta_5d }}" class="{% if r.rank_delta_5d > 0 %}pos{% elif r.rank_delta_5d < 0 %}neg{% endif %}">{{ r.rank_delta_5d_text }}</td>
@@ -734,7 +805,14 @@ table.etf-table th:first-child, table.etf-table td:first-child {
   text-align: left; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-weight: 600;
 }
-table.etf-table th:nth-child(2), table.etf-table td:nth-child(2) { text-align: left; }
+table.etf-table th:nth-child(2), table.etf-table td:nth-child(2) {
+  text-align: left;
+  min-width: 200px;
+  max-width: 400px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .rank-cell {
   font-weight: 700;
   color: #1a1a1a;
@@ -765,7 +843,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
   <table class="etf-table" id="etf-{{ sec.tab }}">
     <thead><tr>
       <th onclick="sortEtfTable('etf-{{ sec.tab }}', 0, 'text')">Symbol</th>
-      <th onclick="sortEtfTable('etf-{{ sec.tab }}', 1, 'text')">Sector</th>
+      <th onclick="sortEtfTable('etf-{{ sec.tab }}', 1, 'text')">Name</th>
       <th onclick="sortEtfTable('etf-{{ sec.tab }}', 2, 'num')">Rank</th>
       <th onclick="sortEtfTable('etf-{{ sec.tab }}', 3, 'num')">&Delta;1d</th>
       <th onclick="sortEtfTable('etf-{{ sec.tab }}', 4, 'num')">&Delta;5d</th>
@@ -779,7 +857,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     {% for r in sec.rows %}
       <tr>
         <td>{{ r.symbol }}</td>
-        <td>{{ r.sector_name }}</td>
+        <td title="{{ r.long_name }}">{{ r.long_name }}</td>
         <td class="rank-cell" data-sort="{{ r.rank_int }}"{% if r.rank_missing %} data-missing="1"{% endif %} style="background: {{ r.rank_color }}">{{ r.rank_text }}</td>
         <td data-sort="{{ r.rank_delta_1d }}" class="{% if r.rank_delta_1d > 0 %}pos{% elif r.rank_delta_1d < 0 %}neg{% endif %}">{{ r.rank_delta_1d_text }}</td>
         <td data-sort="{{ r.rank_delta_5d }}" class="{% if r.rank_delta_5d > 0 %}pos{% elif r.rank_delta_5d < 0 %}neg{% endif %}">{{ r.rank_delta_5d_text }}</td>

--- a/tests/fixtures/golden/standalone_etf.html
+++ b/tests/fixtures/golden/standalone_etf.html
@@ -87,12 +87,21 @@ table.etf-table th {
   font-weight: 600;
   color: var(--gray-mute);
 }
-/* Column 1 = Symbol (ticker, mono + bold). Column 2 = Sector (plain text). */
+/* Column 1 = Symbol (ticker, mono + bold). Column 2 = Name (descriptive,
+   width-capped + ellipsis on overflow so long ETF names don't blow the
+   table out horizontally). */
 table.etf-table th:first-child, table.etf-table td:first-child {
   text-align: left; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-weight: 600;
 }
-table.etf-table th:nth-child(2), table.etf-table td:nth-child(2) { text-align: left; }
+table.etf-table th:nth-child(2), table.etf-table td:nth-child(2) {
+  text-align: left;
+  min-width: 200px;
+  max-width: 400px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .rank-cell {
   font-weight: 700;
   color: #1a1a1a;
@@ -125,7 +134,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
   <table class="etf-table" id="etf-all">
     <thead><tr>
       <th onclick="sortEtfTable('etf-all', 0, 'text')">Symbol</th>
-      <th onclick="sortEtfTable('etf-all', 1, 'text')">Sector</th>
+      <th onclick="sortEtfTable('etf-all', 1, 'text')">Name</th>
       <th onclick="sortEtfTable('etf-all', 2, 'num')">Rank</th>
       <th onclick="sortEtfTable('etf-all', 3, 'num')">&Delta;1d</th>
       <th onclick="sortEtfTable('etf-all', 4, 'num')">&Delta;5d</th>
@@ -139,7 +148,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>SOXX</td>
-        <td>technology</td>
+        <td title="SOXX">SOXX</td>
         <td class="rank-cell" data-sort="58" style="background: #bcc52e">58</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="0" class="">0</td>
@@ -152,7 +161,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>SMH</td>
-        <td>technology</td>
+        <td title="SMH">SMH</td>
         <td class="rank-cell" data-sort="33" style="background: #d5952b">33</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="-16" class="neg">-16</td>
@@ -165,7 +174,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>XLE</td>
-        <td>energy</td>
+        <td title="XLE">XLE</td>
         <td class="rank-cell" data-sort="95" style="background: #2aa138">95</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="0" class="">0</td>
@@ -178,7 +187,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>XLK</td>
-        <td>technology</td>
+        <td title="XLK">XLK</td>
         <td class="rank-cell" data-sort="95" style="background: #2aa138">95</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="0" class="">0</td>
@@ -191,7 +200,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>XLF</td>
-        <td>finance</td>
+        <td title="XLF">XLF</td>
         <td class="rank-cell" data-sort="73" style="background: #81b632">73</td>
         <td data-sort="12" class="pos">+12</td>
         <td data-sort="0" class="">0</td>
@@ -204,7 +213,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>KRE</td>
-        <td>finance</td>
+        <td title="KRE">KRE</td>
         <td class="rank-cell" data-sort="95" style="background: #2aa138">95</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="0" class="">0</td>
@@ -217,7 +226,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>VGT</td>
-        <td>technology</td>
+        <td title="VGT">VGT</td>
         <td class="rank-cell" data-sort="73" style="background: #81b632">73</td>
         <td data-sort="12" class="pos">+12</td>
         <td data-sort="0" class="">0</td>
@@ -230,7 +239,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>XOP</td>
-        <td>energy</td>
+        <td title="XOP">XOP</td>
         <td class="rank-cell" data-sort="73" style="background: #81b632">73</td>
         <td data-sort="12" class="pos">+12</td>
         <td data-sort="0" class="">0</td>
@@ -243,7 +252,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>KBE</td>
-        <td>finance</td>
+        <td title="KBE">KBE</td>
         <td class="rank-cell" data-sort="58" style="background: #bcc52e">58</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="0" class="">0</td>
@@ -256,7 +265,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>OIH</td>
-        <td>energy</td>
+        <td title="OIH">OIH</td>
         <td class="rank-cell" data-sort="58" style="background: #bcc52e">58</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="0" class="">0</td>
@@ -269,7 +278,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>IAI</td>
-        <td>finance</td>
+        <td title="IAI">IAI</td>
         <td class="rank-cell" data-sort="33" style="background: #d5952b">33</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="-16" class="neg">-16</td>
@@ -282,7 +291,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>XES</td>
-        <td>energy</td>
+        <td title="XES">XES</td>
         <td class="rank-cell" data-sort="33" style="background: #d5952b">33</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="-16" class="neg">-16</td>
@@ -301,7 +310,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
   <table class="etf-table" id="etf-top15">
     <thead><tr>
       <th onclick="sortEtfTable('etf-top15', 0, 'text')">Symbol</th>
-      <th onclick="sortEtfTable('etf-top15', 1, 'text')">Sector</th>
+      <th onclick="sortEtfTable('etf-top15', 1, 'text')">Name</th>
       <th onclick="sortEtfTable('etf-top15', 2, 'num')">Rank</th>
       <th onclick="sortEtfTable('etf-top15', 3, 'num')">&Delta;1d</th>
       <th onclick="sortEtfTable('etf-top15', 4, 'num')">&Delta;5d</th>
@@ -315,7 +324,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>XLE</td>
-        <td>energy</td>
+        <td title="XLE">XLE</td>
         <td class="rank-cell" data-sort="95" style="background: #2aa138">95</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="0" class="">0</td>
@@ -328,7 +337,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>XLK</td>
-        <td>technology</td>
+        <td title="XLK">XLK</td>
         <td class="rank-cell" data-sort="95" style="background: #2aa138">95</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="0" class="">0</td>
@@ -341,7 +350,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>KRE</td>
-        <td>finance</td>
+        <td title="KRE">KRE</td>
         <td class="rank-cell" data-sort="95" style="background: #2aa138">95</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="0" class="">0</td>
@@ -360,7 +369,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
   <table class="etf-table" id="etf-movers">
     <thead><tr>
       <th onclick="sortEtfTable('etf-movers', 0, 'text')">Symbol</th>
-      <th onclick="sortEtfTable('etf-movers', 1, 'text')">Sector</th>
+      <th onclick="sortEtfTable('etf-movers', 1, 'text')">Name</th>
       <th onclick="sortEtfTable('etf-movers', 2, 'num')">Rank</th>
       <th onclick="sortEtfTable('etf-movers', 3, 'num')">&Delta;1d</th>
       <th onclick="sortEtfTable('etf-movers', 4, 'num')">&Delta;5d</th>
@@ -374,7 +383,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>SMH</td>
-        <td>technology</td>
+        <td title="SMH">SMH</td>
         <td class="rank-cell" data-sort="33" style="background: #d5952b">33</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="-16" class="neg">-16</td>
@@ -387,7 +396,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>XLF</td>
-        <td>finance</td>
+        <td title="XLF">XLF</td>
         <td class="rank-cell" data-sort="73" style="background: #81b632">73</td>
         <td data-sort="12" class="pos">+12</td>
         <td data-sort="0" class="">0</td>
@@ -400,7 +409,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>VGT</td>
-        <td>technology</td>
+        <td title="VGT">VGT</td>
         <td class="rank-cell" data-sort="73" style="background: #81b632">73</td>
         <td data-sort="12" class="pos">+12</td>
         <td data-sort="0" class="">0</td>
@@ -413,7 +422,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>XOP</td>
-        <td>energy</td>
+        <td title="XOP">XOP</td>
         <td class="rank-cell" data-sort="73" style="background: #81b632">73</td>
         <td data-sort="12" class="pos">+12</td>
         <td data-sort="0" class="">0</td>
@@ -426,7 +435,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>IAI</td>
-        <td>finance</td>
+        <td title="IAI">IAI</td>
         <td class="rank-cell" data-sort="33" style="background: #d5952b">33</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="-16" class="neg">-16</td>
@@ -439,7 +448,7 @@ svg.spark { vertical-align: middle; fill: none; stroke: var(--spark); stroke-wid
     
       <tr>
         <td>XES</td>
-        <td>energy</td>
+        <td title="XES">XES</td>
         <td class="rank-cell" data-sort="33" style="background: #d5952b">33</td>
         <td data-sort="0" class="">0</td>
         <td data-sort="-16" class="neg">-16</td>

--- a/tests/test_dashboard/test_etf_names_backfill.py
+++ b/tests/test_dashboard/test_etf_names_backfill.py
@@ -1,0 +1,205 @@
+"""Unit tests for the ETF names backfill (yfinance longName cache).
+
+Backfill module:
+    src/rainier/dashboard/etf_names_backfill.py
+
+Public surface under test:
+    backfill_names(symbols, out_path, *, fetch_fn=..., retries=1,
+                   retry_sleep=lambda _: None) -> Path
+
+Tests:
+    1. parquet schema matches (symbol, long_name, short_name, fetched_at)
+    2. re-running upserts on symbol (no duplicates)
+    3. RateLimitError → one retry → succeed
+    4. RateLimitError twice → surfaces a clean error (no infinite loop)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _stub_fetch(payload: dict[str, dict[str, str | None]]):
+    """Build a stub fetcher that returns ``payload`` for any symbol list.
+
+    Each value is a dict with keys ``long_name`` and ``short_name``. Missing
+    symbols default to (None, None) — matching yfinance behaviour for
+    delisted / unknown tickers.
+    """
+
+    def _fetch(symbols: list[str]) -> dict[str, dict[str, str | None]]:
+        out: dict[str, dict[str, str | None]] = {}
+        for sym in symbols:
+            out[sym] = payload.get(sym, {"long_name": None, "short_name": None})
+        return out
+
+    return _fetch
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_names_writes_parquet_with_expected_schema(tmp_path):
+    """Parquet has the right columns + dtypes (symbol, long_name, short_name, fetched_at)."""
+    from rainier.dashboard.etf_names_backfill import backfill_names
+
+    fetch_fn = _stub_fetch(
+        {
+            "EFA": {
+                "long_name": "iShares MSCI EAFE ETF",
+                "short_name": "iShares MSCI EAFE",
+            },
+            "SPY": {
+                "long_name": "SPDR S&P 500 ETF Trust",
+                "short_name": "SPDR S&P 500",
+            },
+        }
+    )
+    out = tmp_path / "etf_names.parquet"
+    written = backfill_names(
+        symbols=["EFA", "SPY"],
+        out_path=out,
+        fetch_fn=fetch_fn,
+        retry_sleep=lambda _: None,
+    )
+    assert written == out
+    assert out.exists(), "expected parquet to be written"
+
+    df = pd.read_parquet(out)
+    assert set(df.columns) == {"symbol", "long_name", "short_name", "fetched_at"}, (
+        f"unexpected columns: {df.columns.tolist()}"
+    )
+    assert len(df) == 2
+    assert set(df["symbol"]) == {"EFA", "SPY"}
+    # long_name pulled from the payload.
+    efa = df.loc[df["symbol"] == "EFA"].iloc[0]
+    assert efa["long_name"] == "iShares MSCI EAFE ETF"
+    assert efa["short_name"] == "iShares MSCI EAFE"
+    # fetched_at must be a UTC tz-aware timestamp column so re-reads stay
+    # comparable across runs.
+    assert pd.api.types.is_datetime64_any_dtype(df["fetched_at"]), (
+        "fetched_at must be a datetime column"
+    )
+
+
+def test_backfill_names_upserts_on_symbol(tmp_path):
+    """Re-running on the same symbol replaces the row (no duplicates)."""
+    from rainier.dashboard.etf_names_backfill import backfill_names
+
+    out = tmp_path / "etf_names.parquet"
+
+    # First write — EFA only.
+    backfill_names(
+        symbols=["EFA"],
+        out_path=out,
+        fetch_fn=_stub_fetch(
+            {"EFA": {"long_name": "iShares MSCI EAFE ETF", "short_name": "EAFE"}}
+        ),
+        retry_sleep=lambda _: None,
+    )
+    df1 = pd.read_parquet(out)
+    assert len(df1) == 1
+
+    # Second write — EFA again (refreshed long_name) + SPY (new). After the
+    # upsert there should be exactly TWO rows: EFA replaced + SPY appended.
+    backfill_names(
+        symbols=["EFA", "SPY"],
+        out_path=out,
+        fetch_fn=_stub_fetch(
+            {
+                "EFA": {
+                    "long_name": "iShares MSCI EAFE ETF (renamed)",
+                    "short_name": "EAFE",
+                },
+                "SPY": {
+                    "long_name": "SPDR S&P 500 ETF Trust",
+                    "short_name": "SPDR",
+                },
+            }
+        ),
+        retry_sleep=lambda _: None,
+    )
+    df2 = pd.read_parquet(out)
+    assert len(df2) == 2, f"expected 2 rows after upsert, got {len(df2)}: {df2}"
+    assert set(df2["symbol"]) == {"EFA", "SPY"}
+    efa = df2.loc[df2["symbol"] == "EFA"].iloc[0]
+    assert efa["long_name"] == "iShares MSCI EAFE ETF (renamed)", (
+        "EFA row should reflect the latest fetch payload"
+    )
+
+
+def test_backfill_names_handles_yfinance_rate_limit_with_one_retry(tmp_path):
+    """One transient RateLimitError → one retry → success."""
+    from rainier.dashboard.etf_names_backfill import (
+        RateLimitError,
+        backfill_names,
+    )
+
+    calls = {"n": 0}
+
+    def _fetch_flaky(symbols: list[str]) -> dict[str, dict[str, str | None]]:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RateLimitError("synthetic yfinance rate limit")
+        return {
+            sym: {"long_name": f"{sym} long name", "short_name": sym}
+            for sym in symbols
+        }
+
+    out = tmp_path / "etf_names.parquet"
+    written = backfill_names(
+        symbols=["EFA"],
+        out_path=out,
+        fetch_fn=_fetch_flaky,
+        retry_sleep=lambda _: None,
+    )
+    assert written == out
+    assert calls["n"] == 2, (
+        f"fetcher should have been called twice (1 fail + 1 retry); got {calls['n']}"
+    )
+    df = pd.read_parquet(out)
+    assert df.loc[df["symbol"] == "EFA"].iloc[0]["long_name"] == "EFA long name"
+
+
+def test_backfill_names_surfaces_persistent_rate_limit(tmp_path):
+    """After ONE retry, a persistent RateLimitError must surface cleanly.
+
+    Acceptance gate from TASK-PLAN: "yfinance rate-limit triggers ONE retry,
+    then surfaces a clean error" — no infinite loop, no silent skip.
+    """
+    from rainier.dashboard.etf_names_backfill import (
+        RateLimitError,
+        backfill_names,
+    )
+
+    calls = {"n": 0}
+
+    def _always_rate_limit(symbols: list[str]) -> dict[str, dict[str, str | None]]:
+        calls["n"] += 1
+        raise RateLimitError("synthetic persistent yfinance rate limit")
+
+    out = tmp_path / "etf_names.parquet"
+    with pytest.raises(RateLimitError):
+        backfill_names(
+            symbols=["EFA"],
+            out_path=out,
+            fetch_fn=_always_rate_limit,
+            retry_sleep=lambda _: None,
+        )
+    # Should have called twice (initial + one retry), then surfaced.
+    assert calls["n"] == 2, (
+        f"expected exactly 2 calls (1 initial + 1 retry) before raising; "
+        f"got {calls['n']}"
+    )
+    # No partial parquet on the failure path — prior file (if any) is preserved.
+    assert not out.exists(), "no parquet should be written when backfill fails"

--- a/tests/test_dashboard/test_etf_names_backfill.py
+++ b/tests/test_dashboard/test_etf_names_backfill.py
@@ -16,11 +16,8 @@ Tests:
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pandas as pd
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Test fixtures

--- a/tests/test_dashboard/test_render_etf.py
+++ b/tests/test_dashboard/test_render_etf.py
@@ -817,7 +817,11 @@ def test_html_escapes_untrusted_name_strings(tmp_path):
     features["asof_date"] = features["asof_date"].astype("string")
     registry = pd.DataFrame([{"sector_id": 1, "sector_name": "energy"}])
 
-    payload = "<script>document.title='PWNED'</script>"
+    # Embed a double-quote in the payload so we exercise BOTH the body-cell
+    # autoescape AND the title="..." attribute-value autoescape — a regex
+    # like the one below would miss attribute-boundary breaks if the
+    # template ever swapped autoescape for raw Markup on the title path.
+    payload = "<script>document.title='PWNED'</script> evil\"onload=alert(1)"
     names_df = pd.DataFrame(
         [
             {
@@ -840,6 +844,16 @@ def test_html_escapes_untrusted_name_strings(tmp_path):
     )
     assert payload not in html, "untrusted long_name leaked into HTML unescaped"
     assert "&lt;script&gt;" in html, "long_name was not HTML-escaped"
+    # The Name column also renders long_name inside the cell's `title="..."`
+    # attribute for the hover tooltip. Autoescape escapes attribute values
+    # too, but the test asserted only the body cell — guard the title path
+    # explicitly so a future template tweak that bypasses autoescape on the
+    # attribute (e.g., wrapping in Markup) is caught by CI, not by a live
+    # XSS in /trading/etf-ranks/.
+    attr_break = '"onload='  # what an unescaped double-quote would produce
+    assert attr_break not in html, (
+        f"unescaped double-quote in title attribute (XSS surface): {attr_break!r}"
+    )
     # Sparkline SVG (pre-rendered, marked Markup) must still pass through
     # raw — verify the autoescape didn't double-escape pre-built HTML.
     assert "<svg" in html and "<path" in html, "sparkline SVG was double-escaped"

--- a/tests/test_dashboard/test_render_etf.py
+++ b/tests/test_dashboard/test_render_etf.py
@@ -4,10 +4,12 @@ The renderer is a pure function over parquet inputs → HTML output. Tests
 exercise it on a small deterministic fixture (3 sectors × 4 tickers × 35
 days) and assert on the rendered HTML.
 
-Acceptance gates (from docs/TASK-PLAN-etf-dashboard-renderer-efed.md):
+Acceptance gates (from docs/TASK-PLAN-etf-dashboard-renderer-efed.md +
+docs/TASK-PLAN-etf-dashboard-name-column.md):
     - self-contained HTML (no external <link>, <script src>, <img src=http>)
-    - default sort = sector ASC → rank DESC within sector
+    - default sort = importance-tier ASC → rank DESC within tier
     - one <path> per ticker in the All-ETFs tab sparkline column
+    - Symbol | Name | Rank | ... column order (sector dropped)
     - Top-15 tab filters rank ≥ 85
     - Movers tab filters |Δ1d|≥10 OR |Δ5d|≥15
     - header timestamp: literal "Last updated: YYYY-MM-DD HH:MM PT"
@@ -83,8 +85,8 @@ def test_render_html_is_self_contained(rendered_html):
     assert "src=\"//" not in html and "href=\"//" not in html, "protocol-relative URL"
 
 
-def test_columns_symbol_first_sector_second(rendered_html):
-    """Header row of the All-ETFs table is Symbol, Sector, Rank, Δ1d, Δ5d, R5, R10, R20, YTD, 30d."""
+def test_columns_symbol_first_name_second(rendered_html):
+    """Header row: Symbol, Name, Rank, Δ1d, Δ5d, R5, R10, R20, YTD, 30d."""
     html = rendered_html
     all_block = _extract_tab_block(html, "all")
     # Pull the <thead> row's <th> texts.
@@ -94,7 +96,7 @@ def test_columns_symbol_first_sector_second(rendered_html):
     # The Δ characters come through as &Delta;; normalise for compare.
     th_texts = [t.replace("&Delta;", "Δ") for t in th_texts]
     assert th_texts[0] == "Symbol", f"first column should be Symbol, got: {th_texts}"
-    assert th_texts[1] == "Sector", f"second column should be Sector, got: {th_texts}"
+    assert th_texts[1] == "Name", f"second column should be Name, got: {th_texts}"
     assert th_texts[2] == "Rank", f"third column should be Rank, got: {th_texts}"
     # Tail columns unchanged.
     assert th_texts[3] == "Δ1d"
@@ -104,6 +106,189 @@ def test_columns_symbol_first_sector_second(rendered_html):
     assert th_texts[7] == "R20"
     assert th_texts[8] == "YTD"
     assert th_texts[9] == "30d"
+
+
+def test_sector_column_not_rendered(rendered_html):
+    """Explicit regression: the Sector column header must not appear in the table.
+
+    Sector column was dropped per DESIGN-etf-dashboard-name-column §2.1.
+    sector_name still lives on the underlying parquet for other consumers
+    but the rendered ETF table no longer surfaces it as a visible column.
+    """
+    html = rendered_html
+    all_block = _extract_tab_block(html, "all")
+    thead = re.search(r"<thead>(.*?)</thead>", all_block, re.DOTALL)
+    assert thead, "no <thead> in All-ETFs table"
+    th_texts = [_TAGS_RE.sub("", c).strip() for c in re.findall(r"<th\b[^>]*>(.*?)</th>", thead.group(1), re.DOTALL)]
+    assert "Sector" not in th_texts, (
+        f"Sector column header still present after name-column refactor: {th_texts}"
+    )
+
+
+def test_no_section_group_bands_in_html(rendered_html):
+    """No yellow-band group headers or sector-band <thead> rows.
+
+    Operator design doc explicitly excluded the screenshot's yellow
+    "Global Markets" / "U.S. Market" bands. Future tasks must not
+    re-introduce them. Guard: no group-band css class, no extra
+    <thead> rows beyond the column-header row inside each table.
+    """
+    html = rendered_html
+    # 1) No CSS classes that look like band headers.
+    forbidden_classes = [
+        "section-band",
+        "group-band",
+        "yellow-band",
+        "sector-band",
+        "tier-band",
+    ]
+    for cls in forbidden_classes:
+        assert cls not in html, f"forbidden group-band css class present: {cls!r}"
+    # 2) Each etf table should have exactly ONE <thead> (the column header row),
+    #    not a sequence of group headers.
+    for tab in ("all", "top15", "movers"):
+        block = _extract_tab_block(html, tab)
+        # If the tab is empty there may be no thead — only count when the
+        # table has at least one body row.
+        theads = re.findall(r"<thead\b", block)
+        assert len(theads) <= 1, (
+            f"tab {tab!r}: expected at most 1 <thead> (column headers only), "
+            f"got {len(theads)} — group-band reintroduction?"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Name column — yfinance longName + parquet-driven cache + fallback
+# ---------------------------------------------------------------------------
+
+
+def _name_features_single(symbol: str) -> pd.DataFrame:
+    """Single-row features frame for name-column tests."""
+    df = pd.DataFrame(
+        [
+            {
+                "asof_date": "2026-05-25",
+                "symbol": symbol,
+                "sector_id": 1,
+                "rank": 50,
+                "rank_delta_1d": 0,
+                "rank_delta_5d": 0,
+                "r_5": 50,
+                "r_10": 50,
+                "r_20": 50,
+                "ret_ytd": 0.05,
+                "top15_streak": 0,
+            }
+        ]
+    )
+    df["asof_date"] = df["asof_date"].astype("string")
+    return df
+
+
+def _energy_registry() -> pd.DataFrame:
+    return pd.DataFrame([{"sector_id": 1, "sector_name": "energy"}])
+
+
+def test_name_cell_shows_long_name_when_parquet_present(tmp_path):
+    """When etf_names.parquet has the symbol, the Name cell renders longName."""
+    from rainier.dashboard.render_etf import render_etf_html
+
+    names_df = pd.DataFrame(
+        [
+            {
+                "symbol": "EFA",
+                "long_name": "iShares MSCI EAFE ETF",
+                "short_name": "iShares MSCI EAFE",
+                "fetched_at": pd.Timestamp("2026-05-20", tz="UTC"),
+            }
+        ]
+    )
+    names_path = tmp_path / "etf_names.parquet"
+    names_df.to_parquet(names_path)
+
+    html = render_etf_html(
+        features=_name_features_single("EFA"),
+        registry=_energy_registry(),
+        asof=date(2026, 5, 25),
+        rendered_at_pt="12:40",
+        names_path=names_path,
+    )
+    # Row's cell 2 contains the long name.
+    row = re.search(r"<tr>\s*<td>EFA</td>\s*<td[^>]*>([^<]+)</td>", html, re.DOTALL)
+    assert row, "EFA row not found in rendered HTML"
+    assert row.group(1).strip() == "iShares MSCI EAFE ETF", (
+        f"Name cell should show longName; got {row.group(1)!r}"
+    )
+
+
+def test_name_cell_falls_back_to_symbol_when_parquet_missing(tmp_path):
+    """When names_path is None or the file does not exist, render symbol in the cell."""
+    from rainier.dashboard.render_etf import render_etf_html
+
+    # Path that does not exist on disk.
+    missing_path = tmp_path / "does_not_exist.parquet"
+
+    html = render_etf_html(
+        features=_name_features_single("XYZ"),
+        registry=_energy_registry(),
+        asof=date(2026, 5, 25),
+        rendered_at_pt="12:40",
+        names_path=missing_path,
+    )
+    row = re.search(r"<tr>\s*<td>XYZ</td>\s*<td[^>]*>([^<]+)</td>", html, re.DOTALL)
+    assert row, "XYZ row not found in rendered HTML"
+    assert row.group(1).strip() == "XYZ", (
+        f"Name cell should fall back to the symbol when parquet missing; "
+        f"got {row.group(1)!r}"
+    )
+
+    # And the None case — no parquet path supplied at all.
+    html2 = render_etf_html(
+        features=_name_features_single("XYZ"),
+        registry=_energy_registry(),
+        asof=date(2026, 5, 25),
+        rendered_at_pt="12:40",
+        names_path=None,
+    )
+    row2 = re.search(r"<tr>\s*<td>XYZ</td>\s*<td[^>]*>([^<]+)</td>", html2, re.DOTALL)
+    assert row2, "XYZ row not found when names_path=None"
+    assert row2.group(1).strip() == "XYZ", (
+        f"Name cell should fall back to the symbol when names_path=None; "
+        f"got {row2.group(1)!r}"
+    )
+
+
+def test_name_cell_falls_back_to_symbol_for_unknown_ticker(tmp_path):
+    """When the parquet exists but the symbol is missing from it, render symbol."""
+    from rainier.dashboard.render_etf import render_etf_html
+
+    names_df = pd.DataFrame(
+        [
+            {
+                "symbol": "EFA",
+                "long_name": "iShares MSCI EAFE ETF",
+                "short_name": "iShares MSCI EAFE",
+                "fetched_at": pd.Timestamp("2026-05-20", tz="UTC"),
+            }
+        ]
+    )
+    names_path = tmp_path / "etf_names.parquet"
+    names_df.to_parquet(names_path)
+
+    # Render with a ticker that is NOT in the parquet (NEWETF).
+    html = render_etf_html(
+        features=_name_features_single("NEWETF"),
+        registry=_energy_registry(),
+        asof=date(2026, 5, 25),
+        rendered_at_pt="12:40",
+        names_path=names_path,
+    )
+    row = re.search(r"<tr>\s*<td>NEWETF</td>\s*<td[^>]*>([^<]+)</td>", html, re.DOTALL)
+    assert row, "NEWETF row not found in rendered HTML"
+    assert row.group(1).strip() == "NEWETF", (
+        f"Unknown ticker should fall back to symbol in Name cell; "
+        f"got {row.group(1)!r}"
+    )
 
 
 def test_tier_default_is_3():
@@ -228,7 +413,7 @@ def test_top15_tab_filters_rank_ge_85(rendered_html, features_df):
     block = _extract_tab_block(html, "top15")
     rows = _parse_table_rows(block)
     assert rows, "no rows in Top-15 tab"
-    for _sec, _sym, rk in rows:
+    for _sym, _name, rk in rows:
         assert rk >= 85, f"Top-15 row has rank<85: {_sym}={rk}"
     # Cross-check against the fixture: count of rank≥85 on latest day.
     latest_asof = features_df["asof_date"].max()
@@ -365,8 +550,11 @@ def test_missing_cells_get_data_missing_marker():
         asof=date(2026, 5, 25), rendered_at_pt="12:40",
     )
 
-    miss_block = re.search(r"<tr>\s*<td>MISS</td>\s*<td>energy</td>(.*?)</tr>", html, re.DOTALL)
-    full_block = re.search(r"<tr>\s*<td>FULL</td>\s*<td>energy</td>(.*?)</tr>", html, re.DOTALL)
+    # After the sector→name refactor, cell 2 is the name (or symbol fallback
+    # when no names_path was supplied). The fixture above doesn't pass
+    # names_path so cell 2 == cell 1 (the symbol).
+    miss_block = re.search(r"<tr>\s*<td>MISS</td>\s*<td[^>]*>MISS</td>(.*?)</tr>", html, re.DOTALL)
+    full_block = re.search(r"<tr>\s*<td>FULL</td>\s*<td[^>]*>FULL</td>(.*?)</tr>", html, re.DOTALL)
     assert miss_block and full_block, "rows not found"
 
     # MISS row: every numeric cell with a missing value must carry data-missing="1"
@@ -439,7 +627,7 @@ def test_negative_rank_sentinels_render_as_em_dash():
 
     # NEW row's <td> cells should NOT contain a literal `>-1<` for any
     # rank-like column.
-    new_block = re.search(r"<tr>\s*<td>NEW</td>\s*<td>energy</td>(.*?)</tr>", html, re.DOTALL)
+    new_block = re.search(r"<tr>\s*<td>NEW</td>\s*<td[^>]*>NEW</td>(.*?)</tr>", html, re.DOTALL)
     assert new_block, "NEW row not found in rendered HTML"
     new_cells = new_block.group(1)
     assert ">-1<" not in new_cells, (
@@ -451,7 +639,7 @@ def test_negative_rank_sentinels_render_as_em_dash():
     assert 'data-sort="-1"' in new_cells, "rank sort key not preserved"
 
     # OLD row still displays its real values.
-    old_block = re.search(r"<tr>\s*<td>OLD</td>\s*<td>energy</td>(.*?)</tr>", html, re.DOTALL)
+    old_block = re.search(r"<tr>\s*<td>OLD</td>\s*<td[^>]*>OLD</td>(.*?)</tr>", html, re.DOTALL)
     assert old_block, "OLD row not found"
     old_cells = old_block.group(1)
     assert ">90<" in old_cells, "OLD rank display value missing"
@@ -599,13 +787,13 @@ def test_tab_radios_are_hidden_by_a_matching_selector(rendered_html):
     )
 
 
-def test_html_escapes_untrusted_registry_strings():
-    """Regression: sector_name from sector_registry.parquet must be HTML-escaped.
+def test_html_escapes_untrusted_name_strings(tmp_path):
+    """Regression: ETF long_name from etf_names.parquet must be HTML-escaped.
 
     The rendered dashboard is published to a public path. Even though the
-    registry is operator-edited, treating it as trusted means a typo with
-    a stray `<` breaks the page and a copy/paste with `<script>` becomes
-    an XSS in any browser that opens the file. Autoescape MUST be on.
+    names parquet is yfinance-sourced, treating it as trusted means a
+    delisted-rename containing `<script>` becomes an XSS in any browser
+    that opens the file. Autoescape MUST be on.
     """
     from rainier.dashboard.render_etf import render_etf_html
 
@@ -627,17 +815,31 @@ def test_html_escapes_untrusted_registry_strings():
         ]
     )
     features["asof_date"] = features["asof_date"].astype("string")
+    registry = pd.DataFrame([{"sector_id": 1, "sector_name": "energy"}])
+
     payload = "<script>document.title='PWNED'</script>"
-    registry = pd.DataFrame([{"sector_id": 1, "sector_name": payload}])
+    names_df = pd.DataFrame(
+        [
+            {
+                "symbol": "XLE",
+                "long_name": payload,
+                "short_name": "XLE",
+                "fetched_at": pd.Timestamp("2026-05-20", tz="UTC"),
+            }
+        ]
+    )
+    names_path = tmp_path / "etf_names.parquet"
+    names_df.to_parquet(names_path)
 
     html = render_etf_html(
         features=features,
         registry=registry,
         asof=date(2026, 5, 25),
         rendered_at_pt="12:40",
+        names_path=names_path,
     )
-    assert payload not in html, "untrusted sector_name leaked into HTML unescaped"
-    assert "&lt;script&gt;" in html, "sector_name was not HTML-escaped"
+    assert payload not in html, "untrusted long_name leaked into HTML unescaped"
+    assert "&lt;script&gt;" in html, "long_name was not HTML-escaped"
     # Sparkline SVG (pre-rendered, marked Markup) must still pass through
     # raw — verify the autoescape didn't double-escape pre-built HTML.
     assert "<svg" in html and "<path" in html, "sparkline SVG was double-escaped"
@@ -674,7 +876,7 @@ def test_render_works_with_missing_history(features_df, registry_df):
 # The HTML structure is a contract between the renderer and the test:
 #   - Each tab is a <section data-tab="all|top15|movers"> ... </section>
 #   - Inside each section there's a <table class="etf-table"> ... </table>
-#   - Each data <tr> has cells in order: sector, symbol, rank, ...
+#   - Each data <tr> has cells in order: symbol, name, rank, ...
 # Tests parse via cheap regex; if the renderer changes the surface the
 # tests update alongside.
 
@@ -698,31 +900,30 @@ _TAGS_RE = re.compile(r"<[^>]+>")
 
 
 def _parse_table_rows(html_block: str) -> list[tuple[str, str, int]]:
-    """Return list of (sector, symbol, rank) tuples from data rows.
+    """Return list of (symbol, name, rank) tuples from data rows.
 
-    Column order in the rendered table is Symbol | Sector | Rank | ...,
-    but the returned tuple keeps the legacy (sector, symbol, rank) shape
-    so test assertions don't need to flip.
+    Column order in the rendered table is Symbol | Name | Rank | ...
+    after the sector→name refactor (DESIGN-etf-dashboard-name-column).
     """
     rows: list[tuple[str, str, int]] = []
     for tr in _TR_RE.finditer(html_block):
         cells = _TD_RE.findall(tr.group(1))
         if len(cells) < 3:
             continue
-        # Strip inner tags + whitespace. Column order: symbol, sector, rank.
+        # Strip inner tags + whitespace. Column order: symbol, name, rank.
         symbol = _TAGS_RE.sub("", cells[0]).strip()
-        sector = _TAGS_RE.sub("", cells[1]).strip()
+        name = _TAGS_RE.sub("", cells[1]).strip()
         rank_text = _TAGS_RE.sub("", cells[2]).strip()
         try:
             rank = int(rank_text)
         except ValueError:
             # header row or non-numeric — skip.
             continue
-        if not sector or not symbol:
+        if not symbol:
             continue
-        rows.append((sector, symbol, rank))
+        rows.append((symbol, name, rank))
     return rows
 
 
 def _extract_symbols(html_block: str) -> list[str]:
-    return [sym for _sec, sym, _rk in _parse_table_rows(html_block)]
+    return [sym for sym, _name, _rk in _parse_table_rows(html_block)]


### PR DESCRIPTION
## Summary
- Replace the Sector column in the ETF ranks table with a Name column showing the full ETF longName from yfinance
- New `rainier thematic backfill-names` CLI: one-shot per-ticker yfinance fetch, atomic parquet upsert at `data/cache/etf_names.parquet`, rate-limit retry with clean error on persistent rate-limit
- New cron step `etf-names-refresh` at 12:35 PT M-F runs `--refresh-stale` (30-day threshold) so daily cron doesn't refetch when fresh
- Renderer accepts `names_path` kwarg; falls back gracefully to symbol-in-name-cell when parquet missing or symbol absent — page renders cleanly with no data
- Column order: **Symbol | Name | Rank | Sparkline | ...**
- Per operator request: no section-band group headers (test_no_section_group_bands_in_html enforces regression)

Operator screenshot (Symbol | Long-Description-Name) was the design reference. Operator AskUserQuestion answers: replace Sector column entirely with Name; no yellow group bands.

Parent design: docs/DESIGN-etf-dashboard-name-column.md
Task plan: docs/TASK-PLAN-etf-dashboard-name-column.md

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 2)

## Deferred follow-ups
- [P2] cli.py `--refresh-stale` early-returns before loading universe; new tickers added to thematic_universe.yaml stay on symbol-fallback for up to 30 days. Follow-up: load universe first and force refresh when any current symbol is absent from cache.
- [P2] Combined `/trading/` dashboard calls `render_etf_html(include_shared_styles=False)` without `names_path` → Name column always shows symbol-fallback on the primary published surface. Follow-up: thread `names_path` through `render_combined_html` / `write_combined_html` / `dashboard render-combined` CLI.

## Test plan
- [ ] CI green (lint + pytest + build)
- [ ] One-shot backfill: `uv run rainier thematic backfill-names`
- [ ] Local re-render: `uv run rainier dashboard render-etf-html --asof 2026-05-22 --rendered-at-pt \"\$(TZ='America/Los_Angeles' date +'%Y-%m-%d %H:%M:%S %Z')\" --output out/dashboards/etf-ranks.html`
- [ ] Visual: Symbol | Name | Rank columns, no Sector, no group bands
- [ ] Operator visual check