### PR TITLE
feat(combined): thread names_path through combined trading dashboard (P1)

### DIFF
--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -196,6 +196,18 @@ jobs:
   # commits to the same fengshen-site checkout; only one can hold it at a
   # time).
   #
+  # WALL-CLOCK DEPENDENCIES (jobs.py installs each job as an independent
+  # crontab line — no `depends_on:` graph). The schedule below assumes:
+  #   - `etf-names-refresh`       (12:35 PT) — keeps data/cache/etf_names.parquet
+  #                                fresh so the ETF tab's Name column shows
+  #                                yfinance longName instead of the symbol
+  #                                fallback (PR #100 / this PR).
+  #   - `etf-dashboard-publish`   (12:40 PT) — refreshes the ETF features
+  #                                parquet read by the combined render.
+  #   - `market-breadth-daily`    (12:45 PT) — refreshes the breadth parquet.
+  # 15-minute lead time on names-refresh leaves comfortable headroom; if
+  # any of those slots shift, re-verify this job still runs LAST.
+  #
   # D4 from the design: standalone URLs `/trading/etf-ranks/` and
   # `/trading/market-breadth/` keep publishing in addition to this one —
   # no 301 redirects. All three URLs go live on the same publish push

--- a/scripts/publish-trading-dashboard.sh
+++ b/scripts/publish-trading-dashboard.sh
@@ -69,9 +69,18 @@ cd "$PROJECT_DIR"
 # Don't pass --asof — the renderer pulls the latest row from the breadth
 # parquet itself (same auto-resolution as `market-breadth render-html`).
 # Keeps this script agnostic to weekend / holiday timing.
+#
+# --names-path threads PR #100's Name-column behavior through the combined
+# render so the ETF tab inside /trading/ shows yfinance longName, not the
+# symbol-only fallback. The CLI default already points at
+# `data/cache/etf_names.parquet`, but pass it explicitly so the publish
+# chain is self-documenting + future-proof against any default drift.
+# Cron sequencing keeps the parquet fresh: `etf-names-refresh` (12:35 PT)
+# runs before this script (12:50 PT), so the file is in place by render.
 log "render rendered_at_pt=$RENDERED_AT_PT output=$OUTPUT"
 "$UV" run rainier dashboard render-combined \
     --rendered-at-pt "$RENDERED_AT_PT" \
+    --names-path "data/cache/etf_names.parquet" \
     --output "$OUTPUT"
 
 # Empty-render guard — combined page is degenerate when BOTH sub-renders are

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -4522,6 +4522,20 @@ def dashboard_render_etf_html(
     default="out/dashboards/trading.html",
     show_default=True,
 )
+@click.option(
+    "--names-path",
+    "names_path",
+    type=click.Path(),
+    default="data/cache/etf_names.parquet",
+    show_default=True,
+    help=(
+        "Optional ETF names parquet (from `thematic backfill-names`). "
+        "When present, the ETF tab's Name column renders yfinance "
+        "longName; missing or unreadable → falls back to the symbol "
+        "itself (same fallback semantics as the standalone "
+        "`/trading/etf-ranks/` page)."
+    ),
+)
 def dashboard_render_combined(
     breadth_path: str,
     features_path: str,
@@ -4532,6 +4546,7 @@ def dashboard_render_combined(
     history_days: int,
     window_days: int,
     output_path: str,
+    names_path: str,
 ) -> None:
     """Render the combined trading dashboard (breadth + ETF ranks) to HTML.
 
@@ -4576,6 +4591,12 @@ def dashboard_render_combined(
     else:
         asof_dt = _date.fromisoformat(asof)
 
+    # Mirror the standalone `render-etf-html` CLI: the default points at
+    # the cache path, but pass None to the renderer when the file doesn't
+    # exist so the renderer's symbol-fallback kicks in cleanly (no
+    # spurious "file not found" surprise).
+    names_arg: str | None = names_path if Path(names_path).exists() else None
+
     written = write_combined_html(
         breadth_path=breadth_path,
         features_path=features_path,
@@ -4586,5 +4607,6 @@ def dashboard_render_combined(
         rendered_at_pt=rendered_at_pt,
         history_days=history_days,
         window_days=window_days,
+        names_path=names_arg,
     )
     click.echo(f"wrote trading dashboard -> {written}")

--- a/src/rainier/dashboard/render_combined.py
+++ b/src/rainier/dashboard/render_combined.py
@@ -86,6 +86,7 @@ def render_combined_html(
     spy_ohlcv: pd.DataFrame | None = None,
     history_days: int = 30,
     window_days: int = 504,
+    names_path: str | Path | None = None,
 ) -> str:
     """Render the combined trading dashboard to a single HTML string.
 
@@ -93,7 +94,18 @@ def render_combined_html(
     composition step picks the regime-chip pct from the latest
     ``pct_above_ma_200`` row in ``breadth``.
 
-    Pure function — no I/O, no DB, no wall-clock reads inside.
+    Pure function — no I/O, no DB, no wall-clock reads inside (the
+    optional ``names_path`` read is delegated to ``render_etf_html``,
+    which handles a missing / unreadable path by falling back to the
+    symbol-only display — same semantics as the standalone path in
+    PR #100).
+
+    ``names_path`` threads PR #100's ETF Name-column behavior through
+    the combined-dashboard composition. When provided + readable, the
+    ETF tab inside ``/trading/`` renders yfinance ``longName`` in the
+    Name column; otherwise it falls back to the symbol itself, matching
+    the standalone ``/trading/etf-ranks/`` page byte-for-byte on
+    identical inputs.
     """
     asof_str = asof.isoformat()
     # Defense-in-depth — `asof.isoformat()` always returns safe YYYY-MM-DD,
@@ -125,6 +137,7 @@ def render_combined_html(
         rendered_at_pt=rendered_at_pt,
         history_days=history_days,
         include_shared_styles=False,
+        names_path=names_path,
     )
 
     # Plain concatenation — `str.format()` is unsafe here because the
@@ -182,8 +195,13 @@ def write_combined_html(
     spy_path: str | Path | None = None,
     history_days: int = 30,
     window_days: int = 504,
+    names_path: str | Path | None = None,
 ) -> Path:
-    """Convenience wrapper: load parquets, render, atomic-write the HTML."""
+    """Convenience wrapper: load parquets, render, atomic-write the HTML.
+
+    ``names_path`` is forwarded to ``render_combined_html`` → the ETF
+    sub-renderer; see that docstring for fallback semantics.
+    """
     breadth = pd.read_parquet(breadth_path)
     features = pd.read_parquet(features_path)
     registry = pd.read_parquet(registry_path)
@@ -201,6 +219,7 @@ def write_combined_html(
         rendered_at_pt=rendered_at_pt,
         history_days=history_days,
         window_days=window_days,
+        names_path=names_path,
     )
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_dashboard/test_render_combined.py
+++ b/tests/test_dashboard/test_render_combined.py
@@ -537,6 +537,180 @@ def test_render_combined_cli_smoke(tmp_path):
     assert 'id="etf-all"' in html, "CLI output missing ETF table"
 
 
+# ---------------------------------------------------------------------------
+# names_path threading — PR #100 follow-up.
+# ---------------------------------------------------------------------------
+#
+# The standalone `/trading/etf-ranks/` page already accepts `names_path` and
+# renders yfinance longName in the Name column (PR #100). The combined
+# `/trading/` page — the operator's primary surface — did NOT thread the
+# kwarg through, so the ETF tab inside `/trading/` always showed
+# symbol-as-name. These four tests close that gap.
+
+
+def _names_parquet_for(symbol: str, long_name: str, tmp_path: Path) -> Path:
+    """Write a one-row etf_names parquet and return its path.
+
+    Schema matches `etf_names_backfill.py` output: ``symbol``, ``long_name``,
+    ``short_name``, ``fetched_at``. Only ``symbol`` + ``long_name`` are read
+    by the renderer's name lookup.
+    """
+    names_df = pd.DataFrame(
+        [
+            {
+                "symbol": symbol,
+                "long_name": long_name,
+                "short_name": long_name,
+                "fetched_at": pd.Timestamp("2026-05-20", tz="UTC"),
+            }
+        ]
+    )
+    out = tmp_path / "etf_names.parquet"
+    names_df.to_parquet(out)
+    return out
+
+
+def test_combined_threads_names_path_when_provided(
+    breadth_df, spy_df, features_df, registry_df, tmp_path
+):
+    """`render_combined_html(names_path=...)` must pass it through to the ETF
+    sub-renderer so the resulting HTML reflects the lookup.
+
+    Heuristic: the standalone Name-column behavior is "long_name shows in
+    the Name cell when the symbol is in the parquet". Re-rendering the
+    combined page with the same fixture but a names_path that maps
+    XLE → 'Energy Select Sector SPDR Fund' must move that string into the
+    HTML — and the symbol-only fallback ('<td>XLE</td><td title="XLE">XLE</td>')
+    must no longer appear for XLE.
+    """
+    from rainier.dashboard.render_combined import render_combined_html
+
+    names_path = _names_parquet_for("XLE", "Energy Select Sector SPDR Fund", tmp_path)
+
+    html = render_combined_html(
+        breadth=breadth_df,
+        spy_ohlcv=spy_df,
+        features=features_df,
+        registry=registry_df,
+        asof=date(2026, 5, 25),
+        rendered_at_pt="14:32",
+        names_path=names_path,
+    )
+
+    assert "Energy Select Sector SPDR Fund" in html, (
+        "combined HTML missing the XLE long_name — names_path was not "
+        "threaded through render_combined_html → render_etf_html"
+    )
+
+
+def test_combined_name_column_shows_long_name_in_etf_tab(
+    breadth_df, spy_df, features_df, registry_df, tmp_path
+):
+    """Inside the ETF tab pane the Name cell renders long_name, not the symbol.
+
+    Stronger check than the previous test — locates the actual `<tr>` row
+    for XLE and inspects its second cell.
+    """
+    from rainier.dashboard.render_combined import render_combined_html
+
+    names_path = _names_parquet_for("XLE", "Energy Select Sector SPDR Fund", tmp_path)
+
+    html = render_combined_html(
+        breadth=breadth_df,
+        spy_ohlcv=spy_df,
+        features=features_df,
+        registry=registry_df,
+        asof=date(2026, 5, 25),
+        rendered_at_pt="14:32",
+        names_path=names_path,
+    )
+
+    row = re.search(r"<tr>\s*<td>XLE</td>\s*<td[^>]*>([^<]+)</td>", html, re.DOTALL)
+    assert row, "XLE row not found in combined HTML (ETF tab pane missing?)"
+    assert row.group(1).strip() == "Energy Select Sector SPDR Fund", (
+        f"Name cell for XLE should be 'Energy Select Sector SPDR Fund'; "
+        f"got {row.group(1)!r}"
+    )
+
+
+def test_combined_name_column_falls_back_to_symbol_when_path_missing(
+    breadth_df, spy_df, features_df, registry_df, tmp_path
+):
+    """When `names_path` is None or points at a missing file, Name = symbol.
+
+    Mirrors the standalone renderer's fallback semantics (PR #100). The
+    combined renderer must NOT crash on a missing path — it degrades to
+    symbol-only display.
+    """
+    from rainier.dashboard.render_combined import render_combined_html
+
+    # Case 1: names_path=None — kwarg omitted entirely.
+    html_none = render_combined_html(
+        breadth=breadth_df,
+        spy_ohlcv=spy_df,
+        features=features_df,
+        registry=registry_df,
+        asof=date(2026, 5, 25),
+        rendered_at_pt="14:32",
+        names_path=None,
+    )
+    row = re.search(r"<tr>\s*<td>XLE</td>\s*<td[^>]*>([^<]+)</td>", html_none, re.DOTALL)
+    assert row, "XLE row not found when names_path=None"
+    assert row.group(1).strip() == "XLE", (
+        f"Name cell should fall back to symbol when names_path=None; "
+        f"got {row.group(1)!r}"
+    )
+
+    # Case 2: names_path points at a file that does NOT exist on disk.
+    missing_path = tmp_path / "does_not_exist.parquet"
+    assert not missing_path.exists(), "test setup error: path must NOT exist"
+    html_missing = render_combined_html(
+        breadth=breadth_df,
+        spy_ohlcv=spy_df,
+        features=features_df,
+        registry=registry_df,
+        asof=date(2026, 5, 25),
+        rendered_at_pt="14:32",
+        names_path=missing_path,
+    )
+    row2 = re.search(r"<tr>\s*<td>XLE</td>\s*<td[^>]*>([^<]+)</td>", html_missing, re.DOTALL)
+    assert row2, "XLE row not found when names_path is a missing file"
+    assert row2.group(1).strip() == "XLE", (
+        f"Name cell should fall back to symbol when names_path file is missing; "
+        f"got {row2.group(1)!r}"
+    )
+
+
+def test_combined_byte_identical_with_names_path_supplied(
+    breadth_df, spy_df, features_df, registry_df, tmp_path
+):
+    """3x render with names_path supplied must produce identical bytes.
+
+    Extends the existing determinism test (which uses names_path=None) so
+    that the names-lookup path can't introduce dict-ordering or
+    timestamp leaks via the parquet read.
+    """
+    from rainier.dashboard.render_combined import render_combined_html
+
+    names_path = _names_parquet_for("XLE", "Energy Select Sector SPDR Fund", tmp_path)
+
+    kwargs = dict(
+        breadth=breadth_df,
+        spy_ohlcv=spy_df,
+        features=features_df,
+        registry=registry_df,
+        asof=date(2026, 5, 25),
+        rendered_at_pt="14:32",
+        names_path=names_path,
+    )
+    a = render_combined_html(**kwargs)
+    b = render_combined_html(**kwargs)
+    c = render_combined_html(**kwargs)
+    assert a == b == c, (
+        "combined render with names_path is non-deterministic across runs"
+    )
+
+
 def test_render_combined_missing_input_errors_cleanly(tmp_path):
     """Missing input parquet → non-zero exit + a useful error message."""
     import subprocess


### PR DESCRIPTION
## Summary
- Thread `names_path` kwarg through `render_combined_html()` and `write_combined_html()` so the ETF tab inside `/trading/` shows yfinance longName instead of symbol-fallback
- Add `--names-path PATH` flag to `rainier dashboard render-combined` CLI (default `data/cache/etf_names.parquet`, mirrors render-etf-html shape; downgrades to None when file missing)
- `scripts/publish-trading-dashboard.sh` passes `--names-path` explicitly so the publish chain is self-documenting
- `config/cron.yaml` documents wall-clock dependency: etf-names-refresh (12:35) → etf-dashboard-publish (12:40) → market-breadth-daily (12:45) → trading-dashboard (12:50)

Operator-visible gap: PR #100 added the Name column to the standalone `/trading/etf-ranks/` page but the combined `/trading/` dashboard didn't thread the kwarg through, so the Name column on the operator's primary surface showed symbol-fallback only. This closes that gap.

Parent task: etf-dash-name-column-69ea (PR #100, merged)

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 2)
- 0 deferred findings

## Test plan
- [ ] CI green (lint + pytest + build)
- [ ] Local re-render: `uv run rainier dashboard render-combined --asof 2026-05-22 --rendered-at-pt "$(TZ='America/Los_Angeles' date +'%Y-%m-%d %H:%M:%S %Z')" --names-path data/cache/etf_names.parquet --output out/dashboards/trading.html`
- [ ] Visual: ETF tab inside `/trading/` shows full ETF names (not symbol-fallback)