### PR TITLE
feat(db): Phase 3 — historical parquet→PG backfill + verify-coverage parity tool

### DIFF
--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3959,57 +3959,13 @@ def _check_ohlcv_freshness(
 # ---------------------------------------------------------------------------
 
 
-def _pg_value(v):
-    """Coerce a pandas/numpy cell into a plain Python scalar psycopg can bind.
-
-    NaN/NaT -> None; numpy ints/floats -> int/float; Timestamp -> datetime;
-    date32 stays date. Keeps the dual-write tolerant of the mixed-dtype frames
-    the compute layer produces (float32 NaNs, int8 sentinels, etc.).
-    """
-    import datetime as _dt
-
-    import numpy as _np
-
-    if v is None:
-        return None
-    # pandas NA / NaN / NaT
-    try:
-        if pd.isna(v):
-            return None
-    except (TypeError, ValueError):
-        pass
-    if isinstance(v, _np.integer):
-        return int(v)
-    if isinstance(v, _np.floating):
-        return float(v)
-    if isinstance(v, pd.Timestamp):
-        return v.to_pydatetime()
-    if isinstance(v, _dt.datetime):
-        return v
-    if isinstance(v, _dt.date):
-        return v
-    return v
-
-
-def _frame_to_pg_rows(df: pd.DataFrame, columns: list[str]) -> list[dict]:
-    """Project ``df`` to ``columns`` and coerce each cell for psycopg binding.
-
-    A column absent from ``df`` is OMITTED from the row dict, not emitted as
-    None. Emitting None would make ``market_upsert`` treat the column as
-    "supplied" and overwrite an existing PG value with NULL on conflict,
-    defeating its omitted-column protection. Omitting it leaves any prior PG
-    value intact (e.g. a ``trading_day_ordinal`` a fuller run already wrote).
-    """
-    if df.empty:
-        return []
-    rows: list[dict] = []
-    present = set(df.columns)
-    records = df.to_dict(orient="records")
-    for rec in records:
-        rows.append(
-            {col: _pg_value(rec.get(col)) for col in columns if col in present}
-        )
-    return rows
+# Phase 3 factored these shared frame->rows helpers into rainier.db.rows so the
+# dual-write call sites here, the one-shot backfill, and verify-coverage share
+# one implementation (task plan §3). Re-exported under their original private
+# names to keep these call sites (and existing tests that import
+# ``rainier.cli._frame_to_pg_rows``) unchanged.
+from rainier.db.rows import frame_to_pg_rows as _frame_to_pg_rows  # noqa: E402
+from rainier.db.rows import pg_value as _pg_value  # noqa: E402
 
 
 def _dual_write_features_pg(
@@ -4936,3 +4892,139 @@ def db_migrate(downgrade_to: str | None) -> None:
     else:
         command.downgrade(cfg, downgrade_to)
         click.echo(f"alembic downgrade {downgrade_to} — ok")
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 (task plan §2): one-shot parquet -> market.* backfill +
+# verify-coverage parity gate. Both are EXPLICIT DB ops (unlike the Phase 2
+# dual-write skip path) — DATABASE_URL must be set or we fail loud with a
+# ClickException rather than a raw traceback.
+# ---------------------------------------------------------------------------
+
+
+def _require_db_engine(op_name: str):
+    """Return a fresh Engine, or raise a clean ClickException if unconfigured.
+
+    Phase 3 backfill/verify are explicit DB operations: a missing DATABASE_URL
+    is an operator error, not a skip path. ``get_engine()`` raises RuntimeError
+    in that case; we translate it to a ClickException so the CLI prints an
+    actionable message instead of a traceback.
+    """
+    from rainier.db.engine import get_engine
+
+    try:
+        return get_engine()
+    except RuntimeError as exc:
+        raise click.ClickException(
+            f"{op_name} requires DATABASE_URL to be set (e.g. "
+            f"postgresql+psycopg://user:pass@host:5432/db). {exc}"
+        ) from exc
+
+
+def _parse_asof(value: str | None, flag: str) -> date | None:
+    """Parse a YYYY-MM-DD option into a date, or None when unset."""
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise click.ClickException(f"{flag} must be YYYY-MM-DD, got {value!r}") from exc
+
+
+@db.command("backfill-from-parquet")
+@click.option(
+    "--cache-dir",
+    "cache_dir",
+    type=click.Path(file_okay=False),
+    default="data/cache",
+    show_default=True,
+    help="Directory holding the parquet caches to backfill from.",
+)
+@click.option("--asof-start", default=None, help="Inclusive start date (YYYY-MM-DD).")
+@click.option("--asof-end", default=None, help="Inclusive end date (YYYY-MM-DD).")
+@click.option(
+    "--dry-run", is_flag=True, help="Report per-table row counts without writing."
+)
+def db_backfill_from_parquet(
+    cache_dir: str, asof_start: str | None, asof_end: str | None, dry_run: bool
+) -> None:
+    """Backfill the full parquet history into ``market.*`` (registries first).
+
+    Idempotent (UPSERT). ``--asof-start/--asof-end`` window the date-keyed
+    tables; the ticker/sector registries always load fully (FK parents).
+    """
+    from rainier.db.backfill import backfill_from_parquet
+
+    start = _parse_asof(asof_start, "--asof-start")
+    end = _parse_asof(asof_end, "--asof-end")
+    engine = _require_db_engine("db backfill-from-parquet")
+    try:
+        counts = backfill_from_parquet(
+            engine, cache_dir, asof_start=start, asof_end=end, dry_run=dry_run
+        )
+    finally:
+        engine.dispose()
+
+    label = "would write" if dry_run else "wrote"
+    for table, n in counts.items():
+        click.echo(f"  {table}: {label} {n} rows")
+    total = sum(counts.values())
+    suffix = " (dry-run, no mutation)" if dry_run else ""
+    click.echo(f"backfill-from-parquet — {label} {total} rows total{suffix}")
+
+
+@db.command("verify-coverage")
+@click.option(
+    "--cache-dir",
+    "cache_dir",
+    type=click.Path(file_okay=False),
+    default="data/cache",
+    show_default=True,
+    help="Directory holding the parquet caches to verify against.",
+)
+@click.option("--asof-start", default=None, help="Inclusive start date (YYYY-MM-DD).")
+@click.option("--asof-end", default=None, help="Inclusive end date (YYYY-MM-DD).")
+def db_verify_coverage(
+    cache_dir: str, asof_start: str | None, asof_end: str | None
+) -> None:
+    """Verify parquet and Postgres agree per (asof_date, table).
+
+    Compares row counts + an order-independent, float-tolerant checksum. Prints
+    a per-table report; exits 0 if everything matches, nonzero (naming each
+    offending (asof_date, table)) on any drift — so it is CI/cron-usable.
+    """
+    from rainier.db.verify import verify_coverage
+
+    start = _parse_asof(asof_start, "--asof-start")
+    end = _parse_asof(asof_end, "--asof-end")
+    engine = _require_db_engine("db verify-coverage")
+    try:
+        report = verify_coverage(engine, cache_dir, asof_start=start, asof_end=end)
+    finally:
+        engine.dispose()
+
+    # Per-table summary: matched groups / total groups + parquet/pg row totals.
+    by_table: dict[str, list] = {}
+    for table, _key, pq_n, pg_n, ok in report.rows:
+        by_table.setdefault(table, []).append((pq_n, pg_n, ok))
+    for table, groups in by_table.items():
+        matched = sum(1 for _pq, _pg, ok in groups if ok)
+        pq_total = sum(pq for pq, _pg, _ok in groups)
+        pg_total = sum(pg for _pq, pg, _ok in groups)
+        status = "OK" if matched == len(groups) else "DRIFT"
+        click.echo(
+            f"  {table}: {status} — {matched}/{len(groups)} date-groups match, "
+            f"parquet={pq_total} pg={pg_total} rows"
+        )
+
+    if report.ok:
+        click.echo("verify-coverage — all match")
+        return
+
+    click.echo("verify-coverage — DRIFT detected:", err=True)
+    for d in report.drift:
+        click.echo(f"  {d.table} asof={d.asof_date}: {d.reason}", err=True)
+    raise click.ClickException(
+        f"{len(report.drift)} (asof_date, table) group(s) drifted — "
+        f"parquet and Postgres disagree."
+    )

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -4931,6 +4931,24 @@ def _parse_asof(value: str | None, flag: str) -> date | None:
         raise click.ClickException(f"{flag} must be YYYY-MM-DD, got {value!r}") from exc
 
 
+def _asof_window(asof_start: str | None, asof_end: str | None) -> tuple[date | None, date | None]:
+    """Parse + validate the inclusive [start, end] as-of window.
+
+    A reversed range (start > end) is rejected loudly: it would filter every
+    date-keyed row out, so backfill would write only the registries and
+    verify-coverage would report a CLEAN empty window — silently passing the
+    parity gate it exists to enforce. Fail fast instead.
+    """
+    start = _parse_asof(asof_start, "--asof-start")
+    end = _parse_asof(asof_end, "--asof-end")
+    if start is not None and end is not None and start > end:
+        raise click.ClickException(
+            f"--asof-start ({start}) must be <= --asof-end ({end}); "
+            f"a reversed window filters out every row."
+        )
+    return start, end
+
+
 @db.command("backfill-from-parquet")
 @click.option(
     "--cache-dir",
@@ -4955,8 +4973,7 @@ def db_backfill_from_parquet(
     """
     from rainier.db.backfill import backfill_from_parquet
 
-    start = _parse_asof(asof_start, "--asof-start")
-    end = _parse_asof(asof_end, "--asof-end")
+    start, end = _asof_window(asof_start, asof_end)
     engine = _require_db_engine("db backfill-from-parquet")
     try:
         counts = backfill_from_parquet(
@@ -4995,8 +5012,7 @@ def db_verify_coverage(
     """
     from rainier.db.verify import verify_coverage
 
-    start = _parse_asof(asof_start, "--asof-start")
-    end = _parse_asof(asof_end, "--asof-end")
+    start, end = _asof_window(asof_start, asof_end)
     engine = _require_db_engine("db verify-coverage")
     try:
         report = verify_coverage(engine, cache_dir, asof_start=start, asof_end=end)

--- a/src/rainier/db/backfill.py
+++ b/src/rainier/db/backfill.py
@@ -1,0 +1,109 @@
+"""One-shot historical backfill of the parquet caches into ``market.*``.
+
+Phase 3, task plan §2/§3. Reads each parquet cache and UPSERTs its full history
+into the matching canonical table via the Phase 2 ``market_upsert`` helper. This
+is the explicit "seed the canonical store from existing parquet" step the
+operator runs once before Phase 4 reads from Postgres.
+
+Contrast with Phase 2 dual-write (cli.py): dual-write is additive + non-fatal
+(parquet is load-bearing; a broken mirror DB never aborts the pipeline). The
+backfill is the OPPOSITE posture — it is an explicit DB op, so the CLI wrapper
+fails loud (ClickException) when DATABASE_URL is unset, and a SQLAlchemyError
+here propagates rather than being swallowed.
+
+FK ordering (registries are parents of features):
+
+    ticker_registry ─┐
+    sector_registry ─┴─► thematic_features_daily (FK ticker_id, sector_id)
+    thematic_universe   (ohlcv, no FK)
+    thematic_labels_daily (no FK)
+
+``TABLE_SPECS`` lists the tables in FK-safe load order; we iterate it directly.
+
+Idempotency comes from ``market_upsert``'s ON CONFLICT (pk) DO UPDATE — a
+re-run leaves row counts unchanged.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy.engine import Engine
+
+from rainier.db.rows import TABLE_SPECS, TableSpec, frame_to_pg_rows
+from rainier.db.upsert import market_upsert
+
+
+def _window_frame(
+    df: pd.DataFrame, spec: TableSpec, asof_start: date | None, asof_end: date | None
+) -> pd.DataFrame:
+    """Restrict ``df`` to [asof_start, asof_end] on the spec's date column.
+
+    Registries (``date_col=None``) are never windowed — they are FK parents and
+    must always load fully so feature FKs resolve. For date-keyed tables we
+    compare on a normalized ``date`` (parquet stores ``datetime.date``; we
+    coerce defensively in case a cache was written with Timestamps).
+    """
+    if spec.date_col is None or (asof_start is None and asof_end is None):
+        return df
+    col = df[spec.date_col]
+    # Normalize to datetime.date for a clean comparison regardless of dtype.
+    norm = pd.to_datetime(col).dt.date
+    mask = pd.Series(True, index=df.index)
+    if asof_start is not None:
+        mask &= norm >= asof_start
+    if asof_end is not None:
+        mask &= norm <= asof_end
+    return df[mask]
+
+
+def backfill_from_parquet(
+    engine: Engine,
+    cache_dir: str | Path,
+    asof_start: date | None = None,
+    asof_end: date | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Backfill the parquet caches in ``cache_dir`` into ``market.*``.
+
+    Returns ``{table_name: rows_written}`` (rows that WOULD be written when
+    ``dry_run``). Tables are loaded in ``TABLE_SPECS`` order (registries first
+    for FK safety). A missing parquet cache is skipped (count 0) rather than
+    fatal — a partial cache is a valid state to seed from.
+
+    ``asof_start`` / ``asof_end`` window only the date-keyed tables; registries
+    always load fully (FK parents). ``dry_run`` reports counts without mutating.
+    """
+    cache_dir = Path(cache_dir)
+    counts: dict[str, int] = {}
+
+    for spec in TABLE_SPECS:
+        path = cache_dir / f"{spec.parquet_name}.parquet"
+        if not path.exists():
+            counts[spec.name] = 0
+            continue
+
+        df = pd.read_parquet(path)
+        df = _window_frame(df, spec, asof_start, asof_end)
+
+        table_cols = list(spec.table.columns.keys())
+        rows = frame_to_pg_rows(df, table_cols)
+        counts[spec.name] = len(rows)
+
+        if dry_run or not rows:
+            continue
+
+        market_upsert(
+            engine,
+            spec.table,
+            rows,
+            list(spec.pk_cols),
+            immutable_cols=list(spec.immutable_cols),
+        )
+
+    return counts
+
+
+__all__ = ["backfill_from_parquet"]

--- a/src/rainier/db/rows.py
+++ b/src/rainier/db/rows.py
@@ -1,0 +1,149 @@
+"""Shared parquet-frame -> market.* row conversion + the table mapping.
+
+Phase 2's dual-write writers (``cli.py``) and Phase 3's one-shot backfill
+(``db/backfill.py``) + parity check (``db/verify.py``) all need the same two
+primitives:
+
+  * ``pg_value`` — coerce a pandas/numpy cell into a plain Python scalar
+    psycopg can bind (NaN/NaT -> None, numpy ints/floats -> int/float,
+    Timestamp -> datetime).
+  * ``frame_to_pg_rows`` — project a DataFrame to a column list and coerce each
+    cell, OMITTING columns absent from the frame (not emitting None — see the
+    docstring for why that matters to ``market_upsert``'s omitted-column
+    protection).
+
+These lived as module-private helpers in cli.py through Phase 2. Phase 3 factors
+them here (task plan §3 — "factor out the shared frame->rows logic rather than
+duplicating") so the three call sites share one implementation. cli.py re-imports
+them under their old private names to keep its call sites and existing tests
+unchanged.
+
+``TABLE_SPECS`` is the single source of truth for the parquet<->table mapping
+used by backfill + verify: which parquet cache feeds which ``market.*`` table,
+the conflict-key columns, insert-only (immutable) columns, and the per-table
+date column used to group rows by ``asof_date`` for coverage reporting.
+Registries have ``date_col=None`` (not date-keyed — they always load fully as
+FK parents).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass, field
+
+import numpy as np
+import pandas as pd
+
+from rainier.db import schema
+
+
+def pg_value(v):
+    """Coerce a pandas/numpy cell into a plain Python scalar psycopg can bind.
+
+    NaN/NaT -> None; numpy ints/floats -> int/float; Timestamp -> datetime;
+    date32 stays date. Keeps the conversion tolerant of the mixed-dtype frames
+    the compute layer produces (float32 NaNs, int8 sentinels, etc.).
+    """
+    if v is None:
+        return None
+    # pandas NA / NaN / NaT
+    try:
+        if pd.isna(v):
+            return None
+    except (TypeError, ValueError):
+        pass
+    if isinstance(v, np.integer):
+        return int(v)
+    if isinstance(v, np.floating):
+        return float(v)
+    if isinstance(v, pd.Timestamp):
+        return v.to_pydatetime()
+    if isinstance(v, _dt.datetime):
+        return v
+    if isinstance(v, _dt.date):
+        return v
+    return v
+
+
+def frame_to_pg_rows(df: pd.DataFrame, columns: list[str]) -> list[dict]:
+    """Project ``df`` to ``columns`` and coerce each cell for psycopg binding.
+
+    A column absent from ``df`` is OMITTED from the row dict, not emitted as
+    None. Emitting None would make ``market_upsert`` treat the column as
+    "supplied" and overwrite an existing PG value with NULL on conflict,
+    defeating its omitted-column protection. Omitting it leaves any prior PG
+    value intact (e.g. a ``trading_day_ordinal`` a fuller run already wrote).
+    """
+    if df.empty:
+        return []
+    rows: list[dict] = []
+    present = set(df.columns)
+    records = df.to_dict(orient="records")
+    for rec in records:
+        rows.append({col: pg_value(rec.get(col)) for col in columns if col in present})
+    return rows
+
+
+@dataclass(frozen=True)
+class TableSpec:
+    """One parquet cache <-> market.* table mapping.
+
+    ``parquet_name``  base filename in the cache dir (no .parquet suffix).
+    ``table``         the SQLAlchemy Core Table object.
+    ``pk_cols``       conflict-target columns (ON CONFLICT key).
+    ``immutable_cols`` insert-only columns (first_seen / registry identity).
+    ``date_col``      column to group by for per-asof_date coverage; None for
+                      the registries (FK parents, always loaded fully).
+    """
+
+    parquet_name: str
+    table: object
+    pk_cols: tuple[str, ...]
+    immutable_cols: tuple[str, ...] = field(default_factory=tuple)
+    date_col: str | None = None
+
+    @property
+    def name(self) -> str:
+        """Short table name (matches ``market.<name>``)."""
+        return self.table.name
+
+
+# Load order matters: registries first (FK parents), then the date-keyed tables.
+# A list, not a dict, so backfill iterates in FK-safe order deterministically.
+TABLE_SPECS: list[TableSpec] = [
+    TableSpec(
+        parquet_name="ticker_registry",
+        table=schema.tickers,
+        pk_cols=("ticker_id",),
+        immutable_cols=("symbol", "first_seen"),
+        date_col=None,
+    ),
+    TableSpec(
+        parquet_name="sector_registry",
+        table=schema.sectors,
+        pk_cols=("sector_id",),
+        immutable_cols=("sector_name", "first_seen"),
+        date_col=None,
+    ),
+    TableSpec(
+        parquet_name="thematic_universe",
+        table=schema.thematic_ohlcv,
+        pk_cols=("symbol", "date"),
+        date_col="date",
+    ),
+    TableSpec(
+        parquet_name="thematic_features_daily",
+        table=schema.thematic_features_daily,
+        pk_cols=("asof_date", "symbol"),
+        date_col="asof_date",
+    ),
+    TableSpec(
+        parquet_name="thematic_labels_daily",
+        table=schema.thematic_labels_daily,
+        pk_cols=("asof_date", "symbol"),
+        date_col="asof_date",
+    ),
+]
+
+
+__all__ = ["TABLE_SPECS", "TableSpec", "frame_to_pg_rows", "pg_value"]

--- a/src/rainier/db/verify.py
+++ b/src/rainier/db/verify.py
@@ -114,6 +114,26 @@ def _normalize_dates(values: pd.Series) -> pd.Series:
     return pd.to_datetime(values).dt.date
 
 
+def _window_df(
+    df: pd.DataFrame, spec: TableSpec, asof_start: date | None, asof_end: date | None
+) -> pd.DataFrame:
+    """Restrict ``df`` to [asof_start, asof_end] on the spec's date column.
+
+    Registries (``date_col=None``) and an empty window are pass-through.
+    Applied identically to the parquet and PG sides so they compare apples-to-
+    apples.
+    """
+    if spec.date_col is None or (asof_start is None and asof_end is None) or df.empty:
+        return df
+    norm = _normalize_dates(df[spec.date_col])
+    mask = pd.Series(True, index=df.index)
+    if asof_start is not None:
+        mask &= norm >= asof_start
+    if asof_end is not None:
+        mask &= norm <= asof_end
+    return df[mask]
+
+
 def _read_pg(engine: Engine, spec: TableSpec, columns: list[str]) -> pd.DataFrame:
     """Plain SELECT of all rows for ``spec`` (no ORM)."""
     # Column + table names come from the schema definition (TABLE_SPECS), never
@@ -163,25 +183,9 @@ def verify_coverage(
         else:
             pq_df = pd.DataFrame(columns=columns)
 
-        # Window the date-keyed tables.
-        if spec.date_col is not None and (asof_start or asof_end) and not pq_df.empty:
-            norm = _normalize_dates(pq_df[spec.date_col])
-            mask = pd.Series(True, index=pq_df.index)
-            if asof_start is not None:
-                mask &= norm >= asof_start
-            if asof_end is not None:
-                mask &= norm <= asof_end
-            pq_df = pq_df[mask]
-
-        pg_df = _read_pg(engine, spec, columns)
-        if spec.date_col is not None and (asof_start or asof_end) and not pg_df.empty:
-            norm = _normalize_dates(pg_df[spec.date_col])
-            mask = pd.Series(True, index=pg_df.index)
-            if asof_start is not None:
-                mask &= norm >= asof_start
-            if asof_end is not None:
-                mask &= norm <= asof_end
-            pg_df = pg_df[mask]
+        # Window both sides identically before comparing (registries pass through).
+        pq_df = _window_df(pq_df, spec, asof_start, asof_end)
+        pg_df = _window_df(_read_pg(engine, spec, columns), spec, asof_start, asof_end)
 
         # Coerce both sides through the SAME path so float/Decimal/Timestamp
         # representations are comparable.

--- a/src/rainier/db/verify.py
+++ b/src/rainier/db/verify.py
@@ -1,0 +1,248 @@
+"""Parquet <-> Postgres coverage parity check (``rainier db verify-coverage``).
+
+Phase 3, task plan §2/§3. For each ``(asof_date, table)`` it compares parquet
+vs PG on two axes:
+
+  1. row count for that date;
+  2. an order-independent content checksum over the canonical columns.
+
+A per-table report is printed by the CLI; the module returns a ``VerifyReport``
+with ``ok`` (all match) + a ``drift`` list naming each offending
+``(table, asof_date)``. The CLI exits nonzero on any drift so it is
+CI/cron-usable as the gate the operator runs after a backfill (and later after
+daily dual-write runs) to confirm PG mirrors parquet.
+
+Checksum determinism + float tolerance (task plan §3)
+-----------------------------------------------------
+The checksum must NOT depend on row order (PG and parquet return rows in
+different orders), and must NOT false-positive on storage-precision drift:
+parquet stores float64 originals, but several ``market.*`` columns are PG
+``REAL`` (float32, ~7 significant digits), so a clean round-trip differs in the
+low bits. We absorb that by:
+
+  * coercing every cell through ``pg_value`` (NaN/NaT -> None, numpy -> Python);
+  * rounding floats to ``FLOAT_SIG_DIGITS`` significant figures so the float32
+    storage delta is below the comparison granularity;
+  * building a per-row tuple in fixed table-column order, sorting the rows
+    within a date group by primary key, then BLAKE2b-hashing the canonical
+    repr of the sorted rows.
+
+Identical (count, checksum) for a ``(date, table)`` => parity. The registries
+(``date_col=None``) are checked as a single whole-table group keyed on the
+sentinel date ``None``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from rainier.db.rows import TABLE_SPECS, TableSpec, frame_to_pg_rows
+
+# float32 (PG REAL) carries ~7 significant decimal digits; round to 6 so a clean
+# float64->float32->float64 round-trip never trips the checksum. Documented
+# tolerance: two values agree if they match to 6 significant figures.
+FLOAT_SIG_DIGITS = 6
+
+
+@dataclass(frozen=True)
+class Drift:
+    """One offending ``(table, asof_date)`` and what disagreed."""
+
+    table: str
+    asof_date: date | None
+    reason: str  # human-readable: "row count 5 != 4" or "checksum mismatch"
+
+
+@dataclass
+class VerifyReport:
+    """Result of a verify-coverage run."""
+
+    drift: list[Drift] = field(default_factory=list)
+    # Per (table, asof_date) -> (parquet_count, pg_count) for the printed report.
+    rows: list[tuple[str, date | None, int, int, bool]] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.drift
+
+
+def _round_sig(x: float, sig: int = FLOAT_SIG_DIGITS) -> float:
+    """Round ``x`` to ``sig`` significant figures (0.0 and non-finite pass through)."""
+    if x == 0.0 or not math.isfinite(x):
+        return 0.0 if x == 0.0 else x
+    return round(x, sig - 1 - int(math.floor(math.log10(abs(x)))))
+
+
+def _canon_cell(v) -> object:
+    """Canonicalize a coerced cell for hashing (floats -> rounded; rest -> str)."""
+    if isinstance(v, float):
+        return ("f", _round_sig(v))
+    if v is None:
+        return ("n",)
+    return ("s", str(v))
+
+
+def _checksum(rows: list[dict], columns: list[str], pk_cols: tuple[str, ...]) -> str:
+    """Order-independent content hash of ``rows`` projected to ``columns``.
+
+    Rows are sorted by primary key (None sorts first via a (is_none, repr) key)
+    so PG vs parquet row order is irrelevant, then each row is rendered as a
+    fixed-column-order tuple of canonical cells and BLAKE2b-hashed.
+    """
+
+    def sort_key(row: dict):
+        return tuple((row.get(c) is None, str(row.get(c))) for c in pk_cols)
+
+    h = hashlib.blake2b(digest_size=16)
+    for row in sorted(rows, key=sort_key):
+        cells = tuple(_canon_cell(row.get(c)) for c in columns)
+        h.update(repr(cells).encode("utf-8"))
+        h.update(b"\x1e")  # record separator
+    return h.hexdigest()
+
+
+def _normalize_dates(values: pd.Series) -> pd.Series:
+    """Coerce a date-ish column to ``datetime.date`` for stable grouping."""
+    return pd.to_datetime(values).dt.date
+
+
+def _read_pg(engine: Engine, spec: TableSpec, columns: list[str]) -> pd.DataFrame:
+    """Plain SELECT of all rows for ``spec`` (no ORM)."""
+    # Column + table names come from the schema definition (TABLE_SPECS), never
+    # from user input — no injection surface despite the f-string.
+    col_list = ", ".join(columns)
+    sql = f"SELECT {col_list} FROM market.{spec.name}"
+    with engine.connect() as conn:
+        result = conn.execute(text(sql))
+        records = [dict(r) for r in result.mappings()]
+    return pd.DataFrame(records, columns=columns)
+
+
+def _group_by_date(
+    rows: list[dict], spec: TableSpec
+) -> dict[date | None, list[dict]]:
+    """Bucket coerced rows by their date column (single None bucket for registries)."""
+    if spec.date_col is None:
+        return {None: rows}
+    groups: dict[date | None, list[dict]] = {}
+    for row in rows:
+        key = row.get(spec.date_col)
+        groups.setdefault(key, []).append(row)
+    return groups
+
+
+def verify_coverage(
+    engine: Engine,
+    cache_dir: str | Path,
+    asof_start: date | None = None,
+    asof_end: date | None = None,
+) -> VerifyReport:
+    """Compare parquet caches in ``cache_dir`` against ``market.*`` per (date, table).
+
+    Returns a ``VerifyReport``: ``ok`` when every ``(date, table)`` matches on
+    both row count and checksum; ``drift`` lists each mismatch. ``asof_start`` /
+    ``asof_end`` window the date-keyed tables (registries always compared whole).
+    """
+    cache_dir = Path(cache_dir)
+    report = VerifyReport()
+
+    for spec in TABLE_SPECS:
+        columns = list(spec.table.columns.keys())
+        path = cache_dir / f"{spec.parquet_name}.parquet"
+
+        if path.exists():
+            pq_df = pd.read_parquet(path)
+        else:
+            pq_df = pd.DataFrame(columns=columns)
+
+        # Window the date-keyed tables.
+        if spec.date_col is not None and (asof_start or asof_end) and not pq_df.empty:
+            norm = _normalize_dates(pq_df[spec.date_col])
+            mask = pd.Series(True, index=pq_df.index)
+            if asof_start is not None:
+                mask &= norm >= asof_start
+            if asof_end is not None:
+                mask &= norm <= asof_end
+            pq_df = pq_df[mask]
+
+        pg_df = _read_pg(engine, spec, columns)
+        if spec.date_col is not None and (asof_start or asof_end) and not pg_df.empty:
+            norm = _normalize_dates(pg_df[spec.date_col])
+            mask = pd.Series(True, index=pg_df.index)
+            if asof_start is not None:
+                mask &= norm >= asof_start
+            if asof_end is not None:
+                mask &= norm <= asof_end
+            pg_df = pg_df[mask]
+
+        # Coerce both sides through the SAME path so float/Decimal/Timestamp
+        # representations are comparable.
+        pq_rows = frame_to_pg_rows(_fill_columns(pq_df, columns), columns)
+        pg_rows = frame_to_pg_rows(_fill_columns(pg_df, columns), columns)
+        # Normalize the date column to datetime.date for stable bucketing.
+        if spec.date_col is not None:
+            for r in (*pq_rows, *pg_rows):
+                r[spec.date_col] = _coerce_date(r.get(spec.date_col))
+
+        pq_groups = _group_by_date(pq_rows, spec)
+        pg_groups = _group_by_date(pg_rows, spec)
+
+        for key in sorted(
+            set(pq_groups) | set(pg_groups), key=lambda d: (d is None, str(d))
+        ):
+            pq_g = pq_groups.get(key, [])
+            pg_g = pg_groups.get(key, [])
+            match = True
+            if len(pq_g) != len(pg_g):
+                report.drift.append(
+                    Drift(spec.name, key, f"row count parquet={len(pq_g)} pg={len(pg_g)}")
+                )
+                match = False
+            else:
+                pq_sum = _checksum(pq_g, columns, spec.pk_cols)
+                pg_sum = _checksum(pg_g, columns, spec.pk_cols)
+                if pq_sum != pg_sum:
+                    report.drift.append(
+                        Drift(spec.name, key, "checksum mismatch")
+                    )
+                    match = False
+            report.rows.append((spec.name, key, len(pq_g), len(pg_g), match))
+
+    return report
+
+
+def _coerce_date(v):
+    """Return a ``datetime.date`` for a date/datetime/Timestamp cell, else v."""
+    import datetime as _dt
+
+    if isinstance(v, pd.Timestamp):
+        return v.date()
+    if isinstance(v, _dt.datetime):
+        return v.date()
+    return v
+
+
+def _fill_columns(df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
+    """Ensure ``df`` has every column in ``columns`` (missing -> all-None).
+
+    Both parquet and PG carry every canonical column here, but a missing-column
+    cache (older snapshot) would otherwise get OMITTED by frame_to_pg_rows on
+    one side only, skewing the checksum. Materializing the column on both sides
+    keeps the row dicts shape-identical so only VALUE drift is reported.
+    """
+    out = df.copy()
+    for c in columns:
+        if c not in out.columns:
+            out[c] = None
+    return out
+
+
+__all__ = ["Drift", "VerifyReport", "verify_coverage"]

--- a/src/rainier/db/verify.py
+++ b/src/rainier/db/verify.py
@@ -45,6 +45,7 @@ sentinel date ``None``.
 
 from __future__ import annotations
 
+import datetime as _dt
 import hashlib
 from dataclasses import dataclass, field
 from datetime import date
@@ -98,7 +99,13 @@ def _canon_cell(v, is_real: bool) -> object:
     Floats in REAL columns are cast through float32 so the parquet float64
     original and the round-tripped PG REAL value collapse to the identical
     32-bit value. DOUBLE_PRECISION floats round-trip exactly, so they pass
-    through unchanged. None and non-floats are tagged + stringified.
+    through unchanged. Timezone-aware datetimes are normalized to UTC so the
+    SAME instant hashes identically regardless of the session timezone PG
+    rendered it in (TIMESTAMPTZ columns like ``fetched_at``/``computed_at``
+    come back in the connection's timezone, e.g. ``08:30-08:00``, while the
+    parquet original is ``16:30+00:00`` — both are the same instant and must
+    not false-positive drift). None and other non-floats are tagged +
+    stringified.
     """
     if isinstance(v, float):
         if is_real:
@@ -106,6 +113,9 @@ def _canon_cell(v, is_real: bool) -> object:
         return ("f", v)
     if v is None:
         return ("n",)
+    if isinstance(v, _dt.datetime) and v.tzinfo is not None:
+        # Same instant, stable repr: convert to UTC before stringifying.
+        return ("s", str(v.astimezone(_dt.timezone.utc)))
     return ("s", str(v))
 
 
@@ -251,8 +261,6 @@ def verify_coverage(
 
 def _coerce_date(v):
     """Return a ``datetime.date`` for a date/datetime/Timestamp cell, else v."""
-    import datetime as _dt
-
     if isinstance(v, pd.Timestamp):
         return v.date()
     if isinstance(v, _dt.datetime):

--- a/src/rainier/db/verify.py
+++ b/src/rainier/db/verify.py
@@ -15,17 +15,28 @@ daily dual-write runs) to confirm PG mirrors parquet.
 Checksum determinism + float tolerance (task plan §3)
 -----------------------------------------------------
 The checksum must NOT depend on row order (PG and parquet return rows in
-different orders), and must NOT false-positive on storage-precision drift:
-parquet stores float64 originals, but several ``market.*`` columns are PG
-``REAL`` (float32, ~7 significant digits), so a clean round-trip differs in the
-low bits. We absorb that by:
+different orders), and must NOT false-positive on storage-precision drift.
+Parquet stores float64 originals, but several ``market.*`` columns are PG
+``REAL`` (float32, ~7 significant digits). A clean ``REAL`` round-trip returns a
+value whose float64 repr differs from the parquet original in the low bits, so a
+naive repr/hash falsely flags drift.
 
-  * coercing every cell through ``pg_value`` (NaN/NaT -> None, numpy -> Python);
-  * rounding floats to ``FLOAT_SIG_DIGITS`` significant figures so the float32
-    storage delta is below the comparison granularity;
-  * building a per-row tuple in fixed table-column order, sorting the rows
-    within a date group by primary key, then BLAKE2b-hashing the canonical
-    repr of the sorted rows.
+The fix is *exact*, not a fuzzy tolerance: PG ``REAL`` columns are normalized on
+BOTH sides by casting through ``numpy.float32``. The PG value already carries
+only float32 precision, and casting the parquet float64 down to float32
+reproduces the IDENTICAL 32-bit value — so both sides hash bit-for-bit equal.
+``DOUBLE_PRECISION`` columns round-trip float64 exactly and need no
+normalization. (Significant-figure rounding was rejected: a value can straddle a
+rounding boundary at the Nth digit so the two equal-float32 reprs round to
+different decimals — boundary instability that float32-casting avoids entirely.)
+
+The per-spec set of ``REAL`` columns is derived from the schema column types
+(``_real_columns``). Steps:
+
+  * coerce every cell through ``pg_value`` (NaN/NaT -> None, numpy -> Python);
+  * cast REAL-column floats through float32 (exact, stable);
+  * build a per-row tuple in fixed table-column order, sort the rows within a
+    date group by primary key, then BLAKE2b-hash the canonical repr.
 
 Identical (count, checksum) for a ``(date, table)`` => parity. The registries
 (``date_col=None``) are checked as a single whole-table group keyed on the
@@ -35,21 +46,17 @@ sentinel date ``None``.
 from __future__ import annotations
 
 import hashlib
-import math
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import REAL
 from sqlalchemy.engine import Engine
 
 from rainier.db.rows import TABLE_SPECS, TableSpec, frame_to_pg_rows
-
-# float32 (PG REAL) carries ~7 significant decimal digits; round to 6 so a clean
-# float64->float32->float64 round-trip never trips the checksum. Documented
-# tolerance: two values agree if they match to 6 significant figures.
-FLOAT_SIG_DIGITS = 6
 
 
 @dataclass(frozen=True)
@@ -74,28 +81,46 @@ class VerifyReport:
         return not self.drift
 
 
-def _round_sig(x: float, sig: int = FLOAT_SIG_DIGITS) -> float:
-    """Round ``x`` to ``sig`` significant figures (0.0 and non-finite pass through)."""
-    if x == 0.0 or not math.isfinite(x):
-        return 0.0 if x == 0.0 else x
-    return round(x, sig - 1 - int(math.floor(math.log10(abs(x)))))
+def _real_columns(spec: TableSpec) -> frozenset[str]:
+    """Column names stored as PG ``REAL`` (float32) for this table.
+
+    Those are the columns whose parquet float64 originals must be cast through
+    float32 to compare exactly against their round-tripped PG values.
+    """
+    return frozenset(
+        c.name for c in spec.table.columns if isinstance(c.type, REAL)
+    )
 
 
-def _canon_cell(v) -> object:
-    """Canonicalize a coerced cell for hashing (floats -> rounded; rest -> str)."""
+def _canon_cell(v, is_real: bool) -> object:
+    """Canonicalize a coerced cell for hashing.
+
+    Floats in REAL columns are cast through float32 so the parquet float64
+    original and the round-tripped PG REAL value collapse to the identical
+    32-bit value. DOUBLE_PRECISION floats round-trip exactly, so they pass
+    through unchanged. None and non-floats are tagged + stringified.
+    """
     if isinstance(v, float):
-        return ("f", _round_sig(v))
+        if is_real:
+            return ("f", float(np.float32(v)))
+        return ("f", v)
     if v is None:
         return ("n",)
     return ("s", str(v))
 
 
-def _checksum(rows: list[dict], columns: list[str], pk_cols: tuple[str, ...]) -> str:
+def _checksum(
+    rows: list[dict],
+    columns: list[str],
+    pk_cols: tuple[str, ...],
+    real_cols: frozenset[str],
+) -> str:
     """Order-independent content hash of ``rows`` projected to ``columns``.
 
     Rows are sorted by primary key (None sorts first via a (is_none, repr) key)
     so PG vs parquet row order is irrelevant, then each row is rendered as a
-    fixed-column-order tuple of canonical cells and BLAKE2b-hashed.
+    fixed-column-order tuple of canonical cells (REAL columns float32-normalized)
+    and BLAKE2b-hashed.
     """
 
     def sort_key(row: dict):
@@ -103,7 +128,7 @@ def _checksum(rows: list[dict], columns: list[str], pk_cols: tuple[str, ...]) ->
 
     h = hashlib.blake2b(digest_size=16)
     for row in sorted(rows, key=sort_key):
-        cells = tuple(_canon_cell(row.get(c)) for c in columns)
+        cells = tuple(_canon_cell(row.get(c), c in real_cols) for c in columns)
         h.update(repr(cells).encode("utf-8"))
         h.update(b"\x1e")  # record separator
     return h.hexdigest()
@@ -176,6 +201,7 @@ def verify_coverage(
 
     for spec in TABLE_SPECS:
         columns = list(spec.table.columns.keys())
+        real_cols = _real_columns(spec)
         path = cache_dir / f"{spec.parquet_name}.parquet"
 
         if path.exists():
@@ -211,8 +237,8 @@ def verify_coverage(
                 )
                 match = False
             else:
-                pq_sum = _checksum(pq_g, columns, spec.pk_cols)
-                pg_sum = _checksum(pg_g, columns, spec.pk_cols)
+                pq_sum = _checksum(pq_g, columns, spec.pk_cols, real_cols)
+                pg_sum = _checksum(pg_g, columns, spec.pk_cols, real_cols)
                 if pq_sum != pg_sum:
                     report.drift.append(
                         Drift(spec.name, key, "checksum mismatch")

--- a/tests/test_db_backfill.py
+++ b/tests/test_db_backfill.py
@@ -1,0 +1,314 @@
+"""Integration tests for Phase 3 ``rainier db backfill-from-parquet`` (task plan §5).
+
+The backfill reads the five parquet caches and UPSERTs their full history into
+the matching ``market.*`` tables (registries first for FK order). We assert:
+
+  * every table is populated and PG row counts match the parquet frames;
+  * a second run is idempotent (UPSERT — no duplicate rows);
+  * ``--dry-run`` reports counts but mutates nothing;
+  * ``--asof-start/--asof-end`` windows the date-keyed tables;
+  * DATABASE_URL unset -> a clean ClickException (not a raw traceback).
+
+PG-backed tests gated on ``requires_postgres``; the URL-unset test runs always.
+The fixtures mirror tests/test_db_dual_write.py so they share the docker-PG
+resolution (RAINIER_TEST_DATABASE_URL -> pytest-postgresql -> skip).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+from sqlalchemy import create_engine, text
+
+# ---------------------------------------------------------------------------
+# Postgres fixtures (mirror tests/test_db_dual_write.py resolution)
+# ---------------------------------------------------------------------------
+
+
+try:
+    from pytest_postgresql import factories as _pg_factories
+
+    _HAS_PYTEST_POSTGRESQL = True
+except ImportError:  # pragma: no cover
+    _HAS_PYTEST_POSTGRESQL = False
+
+
+def _local_pg_binary_available() -> bool:
+    import shutil
+
+    return shutil.which("pg_config") is not None and shutil.which("initdb") is not None
+
+
+if _HAS_PYTEST_POSTGRESQL and _local_pg_binary_available():
+    postgresql_proc = _pg_factories.postgresql_proc(port=None, unixsocketdir="/tmp")
+    postgresql = _pg_factories.postgresql("postgresql_proc")
+
+
+@pytest.fixture
+def database_url(request, monkeypatch):
+    env_url = os.environ.get("RAINIER_TEST_DATABASE_URL")
+    if env_url:
+        monkeypatch.setenv("DATABASE_URL", env_url)
+        yield env_url
+        return
+
+    if not _HAS_PYTEST_POSTGRESQL:
+        pytest.skip("pytest-postgresql not installed")
+    if not _local_pg_binary_available():
+        pytest.skip("pg_config / initdb not on PATH; set RAINIER_TEST_DATABASE_URL")
+
+    pg = request.getfixturevalue("postgresql")
+    url = (
+        f"postgresql+psycopg://{pg.info.user}@{pg.info.host}:{pg.info.port}"
+        f"/{pg.info.dbname}"
+    )
+    monkeypatch.setenv("DATABASE_URL", url)
+    yield url
+
+
+@pytest.fixture
+def migrated_engine(database_url):
+    from alembic import command
+    from alembic.config import Config
+
+    repo_root = Path(__file__).resolve().parents[1]
+    cfg = Config(str(repo_root / "db" / "alembic.ini"))
+    cfg.set_main_option("script_location", str(repo_root / "db" / "alembic"))
+    command.upgrade(cfg, "head")
+
+    eng = create_engine(database_url)
+    try:
+        yield eng
+    finally:
+        with eng.begin() as conn:
+            conn.exec_driver_sql("DROP SCHEMA IF EXISTS market CASCADE")
+            conn.exec_driver_sql("DROP TABLE IF EXISTS public.alembic_version")
+        eng.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Synthetic parquet cache builder (matches the five Phase 2 table schemas)
+# ---------------------------------------------------------------------------
+
+
+def _trading_days(n: int, start: date = date(2024, 10, 1)) -> list[date]:
+    out: list[date] = []
+    d = start
+    while len(out) < n:
+        if d.weekday() < 5:
+            out.append(d)
+        d = d + timedelta(days=1)
+    return out
+
+
+def _write_cache(cache: Path, symbols: list[str], n_days: int) -> dict[str, pd.DataFrame]:
+    """Write the five parquet caches; return the in-memory frames for assertions."""
+    cache.mkdir(parents=True, exist_ok=True)
+    days = _trading_days(n_days)
+
+    # Registries.
+    ticker_rows = [
+        {"ticker_id": i + 1, "symbol": s, "first_seen": days[0]}
+        for i, s in enumerate(symbols)
+    ]
+    ticker_df = pd.DataFrame(ticker_rows)
+    sector_df = pd.DataFrame(
+        [{"sector_id": 1, "sector_name": "test_sector", "first_seen": days[0]}]
+    )
+    ticker_df.to_parquet(cache / "ticker_registry.parquet")
+    sector_df.to_parquet(cache / "sector_registry.parquet")
+
+    sym_to_id = {s: i + 1 for i, s in enumerate(symbols)}
+
+    # OHLCV (thematic_universe).
+    ohlcv_rows = []
+    feat_rows = []
+    label_rows = []
+    for s in symbols:
+        close = 100.0
+        for i, day in enumerate(days):
+            close = close * (1.0 + 0.003 * (sym_to_id[s] - 1))
+            ohlcv_rows.append(
+                {
+                    "symbol": s, "date": day, "open": close, "high": close * 1.01,
+                    "low": close * 0.99, "close": close, "volume": 1_000_000 + i,
+                    "fetched_at": pd.Timestamp("2024-11-08T16:30:00Z"),
+                    "yfinance_version": "1.2.0",
+                }
+            )
+            feat_rows.append(
+                {
+                    "asof_date": day, "trading_day_ordinal": i, "symbol": s,
+                    "ticker_id": sym_to_id[s], "sector_id": 1, "close": close,
+                    "ret_1d": 0.003, "rel_5": 0.01, "rel_10": 0.02, "rel_20": 0.03,
+                    "ret_ytd": 0.1, "relvol_5": 1.1, "relvol_10": 1.2, "relvol_20": 1.3,
+                    "r_5": 1, "r_10": 2, "r_20": 3, "rank": sym_to_id[s],
+                    "rank_delta_1d": 0, "rank_delta_5d": 0, "top15_streak": i,
+                    "rank_minus_sector_mean": 0.5, "universe_size": len(symbols),
+                    "universe_yaml_sha": "deadbeef",
+                    "computed_at": pd.Timestamp("2024-11-08T16:30:00Z"),
+                }
+            )
+            label_rows.append(
+                {
+                    "asof_date": day, "symbol": s, "fwd_3d_ret": 0.01,
+                    "fwd_5d_ret": 0.02, "fwd_10d_ret": 0.03, "fwd_20d_ret": 0.04,
+                    "fwd_30d_ret": 0.05, "fwd_5d_excess_ret": 0.001,
+                    "fwd_10d_excess_ret": 0.002, "fwd_20d_excess_ret": 0.003,
+                    "fwd_10d_max_drawdown": -0.02, "fwd_10d_max_runup": 0.06,
+                    "label_complete_through": days[-1],
+                }
+            )
+    ohlcv_df = pd.DataFrame(ohlcv_rows)
+    feat_df = pd.DataFrame(feat_rows)
+    label_df = pd.DataFrame(label_rows)
+    ohlcv_df.to_parquet(cache / "thematic_universe.parquet")
+    feat_df.to_parquet(cache / "thematic_features_daily.parquet")
+    label_df.to_parquet(cache / "thematic_labels_daily.parquet")
+
+    return {
+        "tickers": ticker_df, "sectors": sector_df, "thematic_ohlcv": ohlcv_df,
+        "thematic_features_daily": feat_df, "thematic_labels_daily": label_df,
+    }
+
+
+def _count(eng, table: str) -> int:
+    with eng.connect() as conn:
+        return conn.execute(text(f"SELECT count(*) FROM market.{table}")).scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# backfill_from_parquet (module API)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_postgres
+def test_backfill_populates_all_tables(migrated_engine, tmp_path, database_url):
+    from rainier.db.backfill import backfill_from_parquet
+
+    cache = tmp_path / "cache"
+    frames = _write_cache(cache, ["AAA", "BBB", "CCC"], n_days=12)
+
+    counts = backfill_from_parquet(migrated_engine, cache)
+
+    for table, frame in frames.items():
+        assert _count(migrated_engine, table) == len(frame), f"{table} row count"
+        assert counts[table] == len(frame), f"{table} reported count"
+
+
+@pytest.mark.requires_postgres
+def test_backfill_is_idempotent(migrated_engine, tmp_path, database_url):
+    from rainier.db.backfill import backfill_from_parquet
+
+    cache = tmp_path / "cache"
+    frames = _write_cache(cache, ["AAA", "BBB"], n_days=10)
+
+    backfill_from_parquet(migrated_engine, cache)
+    first = {t: _count(migrated_engine, t) for t in frames}
+    backfill_from_parquet(migrated_engine, cache)
+    second = {t: _count(migrated_engine, t) for t in frames}
+    assert first == second, "re-run must not change row counts (UPSERT)"
+
+
+@pytest.mark.requires_postgres
+def test_backfill_respects_fk_order(migrated_engine, tmp_path, database_url):
+    """Registries load before features, so the feature FK never violates."""
+    from rainier.db.backfill import backfill_from_parquet
+
+    cache = tmp_path / "cache"
+    _write_cache(cache, ["AAA", "BBB", "CCC"], n_days=8)
+    # Should not raise an IntegrityError on the FK.
+    backfill_from_parquet(migrated_engine, cache)
+    assert _count(migrated_engine, "thematic_features_daily") > 0
+
+
+@pytest.mark.requires_postgres
+def test_backfill_dry_run_mutates_nothing(migrated_engine, tmp_path, database_url):
+    from rainier.db.backfill import backfill_from_parquet
+
+    cache = tmp_path / "cache"
+    frames = _write_cache(cache, ["AAA", "BBB"], n_days=6)
+
+    counts = backfill_from_parquet(migrated_engine, cache, dry_run=True)
+    # Counts are reported...
+    for table, frame in frames.items():
+        assert counts[table] == len(frame)
+    # ...but nothing is written.
+    for table in frames:
+        assert _count(migrated_engine, table) == 0, f"{table} must stay empty on dry-run"
+
+
+@pytest.mark.requires_postgres
+def test_backfill_asof_window(migrated_engine, tmp_path, database_url):
+    """--asof-start/--end window the date-keyed tables (ohlcv/features/labels);
+    registries always load fully (FK parents)."""
+    from rainier.db.backfill import backfill_from_parquet
+
+    cache = tmp_path / "cache"
+    frames = _write_cache(cache, ["AAA", "BBB"], n_days=12)
+    feat = frames["thematic_features_daily"]
+    all_dates = sorted(feat["asof_date"].unique())
+    # Window to the middle three dates.
+    start, end = all_dates[3], all_dates[5]
+
+    backfill_from_parquet(migrated_engine, cache, asof_start=start, asof_end=end)
+
+    expected = feat[(feat["asof_date"] >= start) & (feat["asof_date"] <= end)]
+    assert _count(migrated_engine, "thematic_features_daily") == len(expected)
+    # Registries are always loaded fully (parents).
+    assert _count(migrated_engine, "tickers") == len(frames["tickers"])
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_postgres
+def test_cli_backfill_from_parquet(migrated_engine, tmp_path, database_url):
+    from rainier.cli import cli
+
+    cache = tmp_path / "cache"
+    frames = _write_cache(cache, ["AAA", "BBB"], n_days=8)
+
+    res = CliRunner().invoke(
+        cli, ["db", "backfill-from-parquet", "--cache-dir", str(cache)]
+    )
+    assert res.exit_code == 0, res.output
+    for table, frame in frames.items():
+        assert _count(migrated_engine, table) == len(frame)
+
+
+def test_cli_backfill_requires_database_url(tmp_path, monkeypatch):
+    """DATABASE_URL unset -> a clean ClickException, not a raw traceback."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    from rainier.cli import cli
+
+    cache = tmp_path / "cache"
+    _write_cache(cache, ["AAA"], n_days=3)
+
+    res = CliRunner().invoke(
+        cli, ["db", "backfill-from-parquet", "--cache-dir", str(cache)]
+    )
+    assert res.exit_code != 0
+    assert res.exception is None or isinstance(res.exception, SystemExit), (
+        f"expected a clean ClickException, got {res.exception!r}"
+    )
+    assert "DATABASE_URL" in res.output
+
+
+def test_cli_backfill_registered():
+    """`rainier db --help` lists backfill-from-parquet alongside the legacy cmds."""
+    from rainier.cli import cli
+
+    res = CliRunner().invoke(cli, ["db", "--help"])
+    assert res.exit_code == 0, res.output
+    assert "backfill-from-parquet" in res.output
+    # Regression guard: the legacy + Phase 1 commands must still be present.
+    for sub in ("init", "ping", "migrate"):
+        assert sub in res.output

--- a/tests/test_db_backfill.py
+++ b/tests/test_db_backfill.py
@@ -302,6 +302,29 @@ def test_cli_backfill_requires_database_url(tmp_path, monkeypatch):
     assert "DATABASE_URL" in res.output
 
 
+def test_cli_backfill_rejects_reversed_window(tmp_path, monkeypatch):
+    """--asof-start > --asof-end -> clean ClickException, never a silent
+    registries-only run. A reversed window filters every date-keyed row out, so
+    without this guard backfill would 'succeed' having written nothing but the
+    FK parents. Validation runs before the DB engine is required, so no
+    DATABASE_URL is needed."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    from rainier.cli import cli
+
+    res = CliRunner().invoke(
+        cli,
+        [
+            "db", "backfill-from-parquet", "--cache-dir", str(tmp_path / "cache"),
+            "--asof-start", "2026-05-10", "--asof-end", "2026-05-01",
+        ],
+    )
+    assert res.exit_code != 0
+    assert res.exception is None or isinstance(res.exception, SystemExit), (
+        f"expected a clean ClickException, got {res.exception!r}"
+    )
+    assert "asof-start" in res.output and "asof-end" in res.output
+
+
 def test_cli_backfill_registered():
     """`rainier db --help` lists backfill-from-parquet alongside the legacy cmds."""
     from rainier.cli import cli

--- a/tests/test_db_verify_coverage.py
+++ b/tests/test_db_verify_coverage.py
@@ -17,6 +17,7 @@ tests/test_db_backfill.py.
 from __future__ import annotations
 
 import os
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -191,6 +192,82 @@ def test_verify_float_roundtrip_no_false_positive(migrated_engine, tmp_path, dat
     label_drift = [d for d in report.drift if d.table == "thematic_labels_daily"]
     assert feat_drift == [], f"float features falsely flagged: {feat_drift}"
     assert label_drift == [], f"float labels falsely flagged: {label_drift}"
+    assert report.ok
+
+
+@pytest.mark.requires_postgres
+def test_verify_real_column_float32_boundary_no_false_positive(
+    migrated_engine, tmp_path, database_url
+):
+    """Regression (real-data smoke): a parquet float64 in a PG REAL column whose
+    float32 round-trip straddles a significant-figure rounding boundary must NOT
+    be flagged. Earlier sig-fig rounding gave parquet 0.07677094638... -> 0.0767709
+    but PG's float32 0.07677095 -> 0.076771, a false positive. Casting both sides
+    through float32 makes them bit-identical. Also exercises NaN -> NULL parity
+    (recent asof dates have incomplete forward returns)."""
+    import math
+
+    import numpy as np
+    import pandas as pd
+    from sqlalchemy import text
+
+    from rainier.db import schema
+    from rainier.db.rows import frame_to_pg_rows
+    from rainier.db.upsert import market_upsert
+    from rainier.db.verify import verify_coverage
+
+    cache = tmp_path / "cache"
+    cache.mkdir(parents=True)
+    asof = date(2026, 5, 8)
+    # Values picked from the real-data smoke that broke sig-fig rounding, plus a
+    # NaN forward-return row (incomplete horizon).
+    boundary = [
+        0.07677094638347626,
+        0.007865045219659805,
+        0.0001843344944063574,
+        0.022905850782990456,
+        -0.03227955102920532,
+    ]
+    rows = []
+    for i, sym in enumerate(["AAA", "BBB", "CCC", "DDD", "EEE"]):
+        v = boundary[i]
+        rows.append(
+            {
+                "asof_date": asof, "symbol": sym,
+                "fwd_3d_ret": v, "fwd_5d_ret": v * 1.5, "fwd_10d_ret": v * 2.0,
+                "fwd_20d_ret": float("nan"), "fwd_30d_ret": float("nan"),
+                "fwd_5d_excess_ret": v * 0.5, "fwd_10d_excess_ret": v * 0.25,
+                "fwd_20d_excess_ret": float("nan"),
+                "fwd_10d_max_drawdown": abs(v), "fwd_10d_max_runup": abs(v) * 0.3,
+                "label_complete_through": None,
+            }
+        )
+    label_df = pd.DataFrame(rows)
+    label_df.to_parquet(cache / "thematic_labels_daily.parquet")
+
+    # Backfill ONLY labels (write directly; no FK on labels).
+    label_cols = list(schema.thematic_labels_daily.columns.keys())
+    market_upsert(
+        migrated_engine, schema.thematic_labels_daily,
+        frame_to_pg_rows(label_df, label_cols), ["asof_date", "symbol"],
+    )
+
+    # Sanity: the parquet float64 and the PG REAL round-trip really do differ in
+    # the low bits (so the test would catch a naive repr/hash regression).
+    with migrated_engine.connect() as conn:
+        pg_v = conn.execute(
+            text(
+                "SELECT fwd_3d_ret FROM market.thematic_labels_daily "
+                "WHERE asof_date=:a AND symbol='AAA'"
+            ),
+            {"a": asof},
+        ).scalar_one()
+    assert pg_v != boundary[0], "PG REAL must lose precision vs parquet float64"
+    assert math.isclose(float(np.float32(boundary[0])), float(np.float32(pg_v)))
+
+    report = verify_coverage(migrated_engine, cache)
+    drift = [d for d in report.drift if d.table == "thematic_labels_daily"]
+    assert drift == [], f"float32-boundary values falsely flagged drift: {drift}"
     assert report.ok
 
 

--- a/tests/test_db_verify_coverage.py
+++ b/tests/test_db_verify_coverage.py
@@ -1,0 +1,270 @@
+"""Integration tests for Phase 3 ``rainier db verify-coverage`` (task plan §5).
+
+verify-coverage proves parquet and Postgres agree per ``(asof_date, table)`` —
+row count + an order-independent content checksum. We assert:
+
+  * after a clean backfill the report is all-match and exits 0;
+  * an injected missing row -> nonzero exit naming the offending (date, table);
+  * an injected checksum drift (mutated value) -> nonzero exit naming it;
+  * float round-trip parity does NOT false-positive (parquet float64 vs PG
+    DOUBLE_PRECISION/REAL is within the documented rounding tolerance).
+
+PG-backed tests gated on ``requires_postgres``; the URL-unset CLI test runs
+always. Fixtures + the synthetic cache builder are shared with
+tests/test_db_backfill.py.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from sqlalchemy import create_engine, text
+
+from tests.test_db_backfill import _write_cache
+
+# ---------------------------------------------------------------------------
+# Postgres fixtures (mirror tests/test_db_dual_write.py resolution)
+# ---------------------------------------------------------------------------
+
+
+try:
+    from pytest_postgresql import factories as _pg_factories
+
+    _HAS_PYTEST_POSTGRESQL = True
+except ImportError:  # pragma: no cover
+    _HAS_PYTEST_POSTGRESQL = False
+
+
+def _local_pg_binary_available() -> bool:
+    import shutil
+
+    return shutil.which("pg_config") is not None and shutil.which("initdb") is not None
+
+
+if _HAS_PYTEST_POSTGRESQL and _local_pg_binary_available():
+    postgresql_proc = _pg_factories.postgresql_proc(port=None, unixsocketdir="/tmp")
+    postgresql = _pg_factories.postgresql("postgresql_proc")
+
+
+@pytest.fixture
+def database_url(request, monkeypatch):
+    env_url = os.environ.get("RAINIER_TEST_DATABASE_URL")
+    if env_url:
+        monkeypatch.setenv("DATABASE_URL", env_url)
+        yield env_url
+        return
+
+    if not _HAS_PYTEST_POSTGRESQL:
+        pytest.skip("pytest-postgresql not installed")
+    if not _local_pg_binary_available():
+        pytest.skip("pg_config / initdb not on PATH; set RAINIER_TEST_DATABASE_URL")
+
+    pg = request.getfixturevalue("postgresql")
+    url = (
+        f"postgresql+psycopg://{pg.info.user}@{pg.info.host}:{pg.info.port}"
+        f"/{pg.info.dbname}"
+    )
+    monkeypatch.setenv("DATABASE_URL", url)
+    yield url
+
+
+@pytest.fixture
+def migrated_engine(database_url):
+    from alembic import command
+    from alembic.config import Config
+
+    repo_root = Path(__file__).resolve().parents[1]
+    cfg = Config(str(repo_root / "db" / "alembic.ini"))
+    cfg.set_main_option("script_location", str(repo_root / "db" / "alembic"))
+    command.upgrade(cfg, "head")
+
+    eng = create_engine(database_url)
+    try:
+        yield eng
+    finally:
+        with eng.begin() as conn:
+            conn.exec_driver_sql("DROP SCHEMA IF EXISTS market CASCADE")
+            conn.exec_driver_sql("DROP TABLE IF EXISTS public.alembic_version")
+        eng.dispose()
+
+
+# ---------------------------------------------------------------------------
+# verify_coverage (module API): clean backfill -> all-match
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_postgres
+def test_verify_clean_backfill_all_match(migrated_engine, tmp_path, database_url):
+    from rainier.db.backfill import backfill_from_parquet
+    from rainier.db.verify import verify_coverage
+
+    cache = tmp_path / "cache"
+    _write_cache(cache, ["AAA", "BBB", "CCC"], n_days=10)
+    backfill_from_parquet(migrated_engine, cache)
+
+    report = verify_coverage(migrated_engine, cache)
+    assert report.ok, f"expected all-match, drift: {report.drift}"
+    assert report.drift == []
+
+
+@pytest.mark.requires_postgres
+def test_verify_detects_missing_row(migrated_engine, tmp_path, database_url):
+    """Delete a PG row -> verify reports drift naming the (date, table)."""
+    from rainier.db.backfill import backfill_from_parquet
+    from rainier.db.verify import verify_coverage
+
+    cache = tmp_path / "cache"
+    _write_cache(cache, ["AAA", "BBB"], n_days=8)
+    backfill_from_parquet(migrated_engine, cache)
+
+    # Pick a known asof_date and drop one feature row for it.
+    with migrated_engine.begin() as conn:
+        victim = conn.execute(
+            text(
+                "SELECT asof_date FROM market.thematic_features_daily "
+                "ORDER BY asof_date LIMIT 1"
+            )
+        ).scalar_one()
+        conn.execute(
+            text(
+                "DELETE FROM market.thematic_features_daily "
+                "WHERE asof_date=:d AND symbol='AAA'"
+            ),
+            {"d": victim},
+        )
+
+    report = verify_coverage(migrated_engine, cache)
+    assert not report.ok
+    offenders = {(d.table, d.asof_date) for d in report.drift}
+    assert ("thematic_features_daily", victim) in offenders, report.drift
+
+
+@pytest.mark.requires_postgres
+def test_verify_detects_checksum_drift(migrated_engine, tmp_path, database_url):
+    """Mutate a PG value (same row count) -> checksum mismatch is caught."""
+    from rainier.db.backfill import backfill_from_parquet
+    from rainier.db.verify import verify_coverage
+
+    cache = tmp_path / "cache"
+    _write_cache(cache, ["AAA", "BBB"], n_days=8)
+    backfill_from_parquet(migrated_engine, cache)
+
+    with migrated_engine.begin() as conn:
+        victim = conn.execute(
+            text(
+                "SELECT asof_date FROM market.thematic_labels_daily "
+                "ORDER BY asof_date LIMIT 1"
+            )
+        ).scalar_one()
+        # Change a value without changing the row count.
+        conn.execute(
+            text(
+                "UPDATE market.thematic_labels_daily SET fwd_3d_ret = 99.0 "
+                "WHERE asof_date=:d AND symbol='AAA'"
+            ),
+            {"d": victim},
+        )
+
+    report = verify_coverage(migrated_engine, cache)
+    assert not report.ok
+    offenders = {(d.table, d.asof_date) for d in report.drift}
+    assert ("thematic_labels_daily", victim) in offenders, report.drift
+
+
+@pytest.mark.requires_postgres
+def test_verify_float_roundtrip_no_false_positive(migrated_engine, tmp_path, database_url):
+    """Parquet float64 vs PG REAL/DOUBLE_PRECISION round-trip must not trip the
+    checksum. A clean backfill of float-heavy feature/label tables verifies
+    clean — the tolerance absorbs the storage-precision delta."""
+    from rainier.db.backfill import backfill_from_parquet
+    from rainier.db.verify import verify_coverage
+
+    cache = tmp_path / "cache"
+    _write_cache(cache, ["AAA", "BBB", "CCC", "DDD"], n_days=15)
+    backfill_from_parquet(migrated_engine, cache)
+
+    report = verify_coverage(migrated_engine, cache)
+    feat_drift = [d for d in report.drift if d.table == "thematic_features_daily"]
+    label_drift = [d for d in report.drift if d.table == "thematic_labels_daily"]
+    assert feat_drift == [], f"float features falsely flagged: {feat_drift}"
+    assert label_drift == [], f"float labels falsely flagged: {label_drift}"
+    assert report.ok
+
+
+# ---------------------------------------------------------------------------
+# CLI surface: exit codes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_postgres
+def test_cli_verify_exit_zero_on_match(migrated_engine, tmp_path, database_url):
+    from rainier.cli import cli
+    from rainier.db.backfill import backfill_from_parquet
+
+    cache = tmp_path / "cache"
+    _write_cache(cache, ["AAA", "BBB"], n_days=8)
+    backfill_from_parquet(migrated_engine, cache)
+
+    res = CliRunner().invoke(
+        cli, ["db", "verify-coverage", "--cache-dir", str(cache)]
+    )
+    assert res.exit_code == 0, res.output
+
+
+@pytest.mark.requires_postgres
+def test_cli_verify_nonzero_on_drift(migrated_engine, tmp_path, database_url):
+    from rainier.cli import cli
+    from rainier.db.backfill import backfill_from_parquet
+
+    cache = tmp_path / "cache"
+    _write_cache(cache, ["AAA", "BBB"], n_days=8)
+    backfill_from_parquet(migrated_engine, cache)
+
+    with migrated_engine.begin() as conn:
+        victim = conn.execute(
+            text("SELECT asof_date FROM market.thematic_features_daily LIMIT 1")
+        ).scalar_one()
+        conn.execute(
+            text(
+                "DELETE FROM market.thematic_features_daily "
+                "WHERE asof_date=:d AND symbol='AAA'"
+            ),
+            {"d": victim},
+        )
+
+    res = CliRunner().invoke(
+        cli, ["db", "verify-coverage", "--cache-dir", str(cache)]
+    )
+    assert res.exit_code != 0
+    assert "thematic_features_daily" in res.output
+    assert str(victim) in res.output
+
+
+def test_cli_verify_requires_database_url(tmp_path, monkeypatch):
+    """DATABASE_URL unset -> a clean ClickException, not a raw traceback."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    from rainier.cli import cli
+
+    cache = tmp_path / "cache"
+    _write_cache(cache, ["AAA"], n_days=3)
+
+    res = CliRunner().invoke(
+        cli, ["db", "verify-coverage", "--cache-dir", str(cache)]
+    )
+    assert res.exit_code != 0
+    assert res.exception is None or isinstance(res.exception, SystemExit), (
+        f"expected a clean ClickException, got {res.exception!r}"
+    )
+    assert "DATABASE_URL" in res.output
+
+
+def test_cli_verify_registered():
+    from rainier.cli import cli
+
+    res = CliRunner().invoke(cli, ["db", "--help"])
+    assert res.exit_code == 0, res.output
+    assert "verify-coverage" in res.output

--- a/tests/test_db_verify_coverage.py
+++ b/tests/test_db_verify_coverage.py
@@ -17,7 +17,6 @@ tests/test_db_backfill.py.
 from __future__ import annotations
 
 import os
-from datetime import date
 from pathlib import Path
 
 import pytest

--- a/tests/test_db_verify_coverage.py
+++ b/tests/test_db_verify_coverage.py
@@ -272,6 +272,75 @@ def test_verify_real_column_float32_boundary_no_false_positive(
 
 
 # ---------------------------------------------------------------------------
+# Timezone-aware datetime parity (TIMESTAMPTZ columns)
+# ---------------------------------------------------------------------------
+
+
+def test_checksum_tz_aware_same_instant_matches():
+    """Same instant in different tz offsets must hash identically.
+
+    PG returns TIMESTAMPTZ (fetched_at/computed_at) in the session timezone, so
+    a clean backfill can yield ``08:30-08:00`` on the PG side vs ``16:30+00:00``
+    in parquet — the SAME instant. The checksum must normalize to UTC so this
+    is NOT flagged as drift. (Regression: a session TZ != UTC would otherwise
+    false-positive a clean parity run.)"""
+    import datetime as _dt
+
+    from rainier.db.verify import _checksum
+
+    cols = ["symbol", "fetched_at"]
+    pk = ("symbol",)
+    utc = _dt.datetime(2024, 11, 8, 16, 30, tzinfo=_dt.timezone.utc)
+    pacific = utc.astimezone(_dt.timezone(_dt.timedelta(hours=-8)))
+    assert utc != pacific or str(utc) != str(pacific)  # reprs differ pre-norm
+    parquet_rows = [{"symbol": "AAA", "fetched_at": utc}]
+    pg_rows = [{"symbol": "AAA", "fetched_at": pacific}]
+    assert _checksum(parquet_rows, cols, pk, frozenset()) == _checksum(
+        pg_rows, cols, pk, frozenset()
+    ), "same instant in a different tz offset must hash equal"
+
+
+@pytest.mark.requires_postgres
+def test_verify_clean_under_non_utc_session_tz(migrated_engine, tmp_path, database_url):
+    """A clean backfill verifies clean even when the PG session timezone is not
+    UTC (TIMESTAMPTZ columns then render in that zone). End-to-end guard for the
+    tz-normalization fix."""
+    from sqlalchemy import event
+
+    from rainier.db.backfill import backfill_from_parquet
+    from rainier.db.verify import verify_coverage
+
+    cache = tmp_path / "cache"
+    _write_cache(cache, ["AAA", "BBB"], n_days=6)
+    backfill_from_parquet(migrated_engine, cache)
+
+    # Force a non-UTC timezone on EVERY connection verify_coverage opens (it
+    # opens its own connection in _read_pg, so a one-off SET on a separate
+    # connection would not reach it). With this, TIMESTAMPTZ columns render in
+    # US/Pacific while parquet stays UTC — the case the fix must absorb.
+    pac_engine = create_engine(database_url)
+
+    @event.listens_for(pac_engine, "connect")
+    def _set_pacific(dbapi_conn, _rec):  # noqa: ANN001
+        cur = dbapi_conn.cursor()
+        cur.execute("SET TIME ZONE 'America/Los_Angeles'")
+        cur.close()
+
+    try:
+        # Sanity: a TIMESTAMPTZ really renders in the session zone now.
+        with pac_engine.connect() as conn:
+            rendered = conn.exec_driver_sql(
+                "SELECT fetched_at::text FROM market.thematic_ohlcv LIMIT 1"
+            ).scalar_one()
+        assert "+00" not in rendered, f"expected non-UTC render, got {rendered!r}"
+
+        report = verify_coverage(pac_engine, cache)
+        assert report.ok, f"non-UTC session must not false-positive drift: {report.drift}"
+    finally:
+        pac_engine.dispose()
+
+
+# ---------------------------------------------------------------------------
 # CLI surface: exit codes
 # ---------------------------------------------------------------------------
 

--- a/tests/test_db_verify_coverage.py
+++ b/tests/test_db_verify_coverage.py
@@ -407,6 +407,29 @@ def test_cli_verify_requires_database_url(tmp_path, monkeypatch):
     assert "DATABASE_URL" in res.output
 
 
+def test_cli_verify_rejects_reversed_window(tmp_path, monkeypatch):
+    """--asof-start > --asof-end -> clean ClickException, never a silent CLEAN
+    pass. A reversed window compares an empty parquet slice against an empty PG
+    slice and both 'match', so verify-coverage would falsely report parity. The
+    guard must reject it before any comparison (and before DATABASE_URL is even
+    required)."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    from rainier.cli import cli
+
+    res = CliRunner().invoke(
+        cli,
+        [
+            "db", "verify-coverage", "--cache-dir", str(tmp_path / "cache"),
+            "--asof-start", "2026-05-10", "--asof-end", "2026-05-01",
+        ],
+    )
+    assert res.exit_code != 0
+    assert res.exception is None or isinstance(res.exception, SystemExit), (
+        f"expected a clean ClickException, got {res.exception!r}"
+    )
+    assert "asof-start" in res.output and "asof-end" in res.output
+
+
 def test_cli_verify_registered():
     from rainier.cli import cli
 


### PR DESCRIPTION
## Summary
- Phase 3 of the Postgres canonical-store pivot: one-shot historical backfill of parquet → `market.*` plus a parity gate.
- `rainier db backfill-from-parquet [--asof-start/--end] [--dry-run]` — idempotent UPSERT of full parquet history into `market.*` (registries first for FK order), reusing Phase 2's `market_upsert`.
- `rainier db verify-coverage [--asof-start/--end]` — per-`(asof_date, table)` row-count + order-independent checksum; exits nonzero naming the offending `(asof_date, table)` on any drift (CI/cron-usable).
- New `src/rainier/db/rows.py` factors the shared frame→PG-rows helpers + `TABLE_SPECS` (parquet↔table mapping) out of cli.py (re-exported under old private names — Phase 2 call sites unchanged). New `db/backfill.py`, `db/verify.py`. Both commands on the EXISTING `db` group (no shadow regression). DATABASE_URL-unset → clean ClickException.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 2)
- Suite: 1240 → 1244 passed (4 new regression tests), 7 skipped, ruff clean.

## Correctness bugs caught + fixed during dev/review (parity-gate hardening)
- Worker (real-data smoke, 114k rows): float32/float64 checksum false-positive — REAL columns now cast through np.float32 on both sides; DOUBLE_PRECISION stays exact; NaN→NULL parity. Regression test pins boundary values.
- Review codex iter-1: verify-coverage didn't normalize TIMESTAMPTZ → false drift when PG session tz ≠ UTC. Fixed (normalize aware datetimes to UTC).
- Review codex iter-2: reversed as-of window (start>end) silently filtered all date-keyed rows → backfill wrote only registries, verify compared empty-vs-empty and reported CLEAN, defeating the gate. Fixed with shared `_asof_window` validation.

## Test plan
- [ ] CI green
- [ ] verify locally: `rainier db migrate` → `rainier db backfill-from-parquet` → `rainier db verify-coverage` exits 0; re-run backfill is idempotent