### PR TITLE
fix(cli): wrap db migrate misconfig errors in ClickException

### DIFF
--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -4906,7 +4906,7 @@ def db_migrate(downgrade_to: str | None) -> None:
             click.echo(f"alembic downgrade {downgrade_to} — ok")
     except click.ClickException:
         raise
-    except Exception as exc:  # pragma: no cover — exercised via stubbed tests
+    except Exception as exc:
         action = "upgrade head" if downgrade_to is None else f"downgrade {downgrade_to}"
         raise click.ClickException(f"db migrate ({action}) failed: {exc}") from exc
 

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -4891,12 +4891,24 @@ def db_migrate(downgrade_to: str | None) -> None:
 
     cfg = _resolve_alembic_config()
 
-    if downgrade_to is None:
-        command.upgrade(cfg, "head")
-        click.echo("alembic upgrade head — ok")
-    else:
-        command.downgrade(cfg, downgrade_to)
-        click.echo(f"alembic downgrade {downgrade_to} — ok")
+    # Mirror db_ping's wrapping idiom: misconfig (missing DATABASE_URL, an
+    # unreachable host, or an Alembic config error) raises RuntimeError /
+    # OperationalError / alembic.* exceptions from the upgrade/downgrade call.
+    # Catch them all and re-raise as ClickException so the CLI prints a single
+    # actionable `Error:` line instead of a raw traceback. (_resolve_alembic_config
+    # already raises ClickException on its own failure path, so it stays outside.)
+    try:
+        if downgrade_to is None:
+            command.upgrade(cfg, "head")
+            click.echo("alembic upgrade head — ok")
+        else:
+            command.downgrade(cfg, downgrade_to)
+            click.echo(f"alembic downgrade {downgrade_to} — ok")
+    except click.ClickException:
+        raise
+    except Exception as exc:  # pragma: no cover — exercised via stubbed tests
+        action = "upgrade head" if downgrade_to is None else f"downgrade {downgrade_to}"
+        raise click.ClickException(f"db migrate ({action}) failed: {exc}") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -74,6 +74,72 @@ def test_db_ping_fails_loud_without_database_url(monkeypatch):
     assert "DATABASE_URL" in combined
 
 
+def test_db_migrate_fails_loud_without_database_url(monkeypatch):
+    """`db migrate` without DATABASE_URL exits non-zero with a clean message.
+
+    Mirrors `test_db_ping_fails_loud_without_database_url`: alembic env.py
+    raises RuntimeError("DATABASE_URL not set ...") the moment `command.upgrade`
+    resolves the engine config. Without wrapping, that surfaced as a raw
+    traceback (codex iter-5 / PR #102 deferred [P2]). The command must catch it
+    and re-raise as a ClickException so the CLI prints a single `Error:` line.
+    """
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["db", "migrate"])
+    assert result.exit_code != 0
+    # A wrapped ClickException leaves no traceback frames on stdout/stderr.
+    assert "Traceback" not in (result.output or "")
+    # The ClickException carries the underlying RuntimeError text (DATABASE_URL).
+    combined = (result.output or "") + (str(result.exception) if result.exception else "")
+    assert "DATABASE_URL" in combined
+    # And it must be a ClickException, not a bare RuntimeError leaking through.
+    if result.exception is not None:
+        import click
+
+        assert isinstance(result.exception, click.ClickException), (
+            f"db migrate leaked a {type(result.exception).__name__} instead of "
+            f"wrapping it in click.ClickException: {result.exception!r}"
+        )
+
+
+def test_db_migrate_wraps_unreachable_db_in_click_exception(monkeypatch):
+    """`db migrate` against an unreachable DB exits clean, not with a traceback.
+
+    Stub `alembic.command.upgrade` to raise OperationalError (what a real
+    unreachable host produces). The command must catch any migration-time
+    failure and re-raise as ClickException — no traceback, non-zero exit.
+    """
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://u:p@unreachable:5432/x")
+
+    from sqlalchemy.exc import OperationalError
+
+    from rainier import cli as cli_mod
+
+    def _boom(*_args, **_kwargs):
+        raise OperationalError("SELECT 1", {}, Exception("connection refused"))
+
+    # Patch the alembic command surface the migrate body calls into. The body
+    # does `from alembic import command` then `command.upgrade(...)`, so we
+    # patch the attribute on the alembic.command module itself.
+    import alembic.command as alembic_command
+
+    monkeypatch.setattr(alembic_command, "upgrade", _boom)
+    # Avoid touching the real filesystem-resolved config (irrelevant here).
+    monkeypatch.setattr(cli_mod, "_resolve_alembic_config", lambda: object())
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["db", "migrate"])
+    assert result.exit_code != 0
+    assert "Traceback" not in (result.output or "")
+    if result.exception is not None:
+        import click
+
+        assert isinstance(result.exception, click.ClickException), (
+            f"db migrate leaked a {type(result.exception).__name__}: "
+            f"{result.exception!r}"
+        )
+
+
 def test_wheel_packages_db_assets_under_rainier_db_assets():
     """Regression: pyproject.toml's `[tool.hatch.build.targets.wheel]` must
     `force-include` the top-level db/ tree at `rainier/_db_assets/` inside

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -87,19 +87,16 @@ def test_db_migrate_fails_loud_without_database_url(monkeypatch):
     runner = CliRunner()
     result = runner.invoke(cli, ["db", "migrate"])
     assert result.exit_code != 0
-    # A wrapped ClickException leaves no traceback frames on stdout/stderr.
+    # A wrapped ClickException is rendered as a clean `Error:` line and click
+    # exits via SystemExit — a bare RuntimeError would leave a traceback and a
+    # non-SystemExit exception on the result instead.
+    assert not isinstance(result.exception, RuntimeError), (
+        f"db migrate leaked a raw RuntimeError instead of wrapping it in "
+        f"click.ClickException: {result.exception!r}"
+    )
     assert "Traceback" not in (result.output or "")
-    # The ClickException carries the underlying RuntimeError text (DATABASE_URL).
-    combined = (result.output or "") + (str(result.exception) if result.exception else "")
-    assert "DATABASE_URL" in combined
-    # And it must be a ClickException, not a bare RuntimeError leaking through.
-    if result.exception is not None:
-        import click
-
-        assert isinstance(result.exception, click.ClickException), (
-            f"db migrate leaked a {type(result.exception).__name__} instead of "
-            f"wrapping it in click.ClickException: {result.exception!r}"
-        )
+    # The wrapped message names the concrete cause (the missing env var).
+    assert "DATABASE_URL" in (result.output or "")
 
 
 def test_db_migrate_wraps_unreachable_db_in_click_exception(monkeypatch):
@@ -131,13 +128,15 @@ def test_db_migrate_wraps_unreachable_db_in_click_exception(monkeypatch):
     result = runner.invoke(cli, ["db", "migrate"])
     assert result.exit_code != 0
     assert "Traceback" not in (result.output or "")
-    if result.exception is not None:
-        import click
-
-        assert isinstance(result.exception, click.ClickException), (
-            f"db migrate leaked a {type(result.exception).__name__}: "
-            f"{result.exception!r}"
-        )
+    # The OperationalError must be wrapped, not leaked: a wrapped ClickException
+    # exits via SystemExit, while an unwrapped failure leaves the OperationalError
+    # on result.exception.
+    assert not isinstance(result.exception, OperationalError), (
+        f"db migrate leaked a raw OperationalError instead of wrapping it in "
+        f"click.ClickException: {result.exception!r}"
+    )
+    # And the clean error line names the command + carries the cause.
+    assert "db migrate" in (result.output or "")
 
 
 def test_wheel_packages_db_assets_under_rainier_db_assets():


### PR DESCRIPTION
## Summary
- Wrap `rainier db migrate` Alembic/DB failures in click.ClickException (mirrors db_ping idiom) — clean one-line CLI error on misconfig instead of a raw traceback.
- 2 regression tests in tests/test_cli/test_db.py (missing DATABASE_URL; unreachable DB via OperationalError).

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 2)
- codex iterations: 0 fixes needed (clean)
- /review invocations: 2
- deferred [P2]/[P3]: none

Origin: codex iter-5 of PR #102 (deferred P2). coord-authorized P2 dispatch.

## Test plan
- [ ] CI green
- [ ] verify locally