### PR TITLE
fix(db): guard downgrade base from dropping foreign objects in market schema

### DIFF
--- a/db/alembic/versions/0001_initial_market_schema.py
+++ b/db/alembic/versions/0001_initial_market_schema.py
@@ -169,11 +169,82 @@ def upgrade() -> None:
     )
 
 
-def downgrade() -> None:
-    """Drop the whole market schema (cascades through tables + indexes).
+# Tables this revision's upgrade() created, in reverse dependency order so a
+# plain DROP TABLE works without CASCADE-ing into anything outside this set.
+# CASCADE is still passed to clean up each table's own indexes/constraints; it
+# does NOT reach foreign objects because we name each table explicitly.
+#
+#     thematic_features_daily ──FK──► tickers, sectors   (drop dependent first)
+#     thematic_ohlcv          (standalone)
+#     thematic_labels_daily   (standalone)
+_REVISION_TABLES = (
+    "thematic_features_daily",
+    "thematic_labels_daily",
+    "thematic_ohlcv",
+    "tickers",
+    "sectors",
+)
 
-    Cleaner than dropping tables one-by-one: avoids FK ordering issues and
-    matches the semantics of "go back to before this migration ran". The
-    alembic_version table lives in `public`, so it survives this drop.
+
+def downgrade() -> None:
+    """Reverse this revision without wiping foreign objects.
+
+    The original implementation issued an unconditional
+    ``DROP SCHEMA market CASCADE``. That is safe only while rainier solely owns
+    ``market``; the moment the schema holds a non-rainier object (a future
+    multi-writer deployment), a ``downgrade base`` would silently destroy it.
+
+    Guarded reversal:
+
+      1. Drop only the 5 tables THIS revision's ``upgrade()`` created (reverse
+         dependency order; CASCADE reaches each table's own indexes/constraints
+         but never foreign objects because every name is listed explicitly).
+      2. Drop the ``market`` schema only if it is now empty. If any foreign
+         object remains, leave the (now rainier-free) schema in place. Using
+         ``DROP SCHEMA ... RESTRICT`` (no CASCADE) is the belt-and-suspenders
+         guard — even a logic error in the emptiness check cannot wipe a
+         populated schema, because RESTRICT refuses to drop a non-empty schema.
+
+    The ``alembic_version`` table lives in ``public`` (see env.py), so it
+    survives regardless.
     """
-    op.execute(f"DROP SCHEMA IF EXISTS {SCHEMA} CASCADE")
+    for table in _REVISION_TABLES:
+        op.execute(f"DROP TABLE IF EXISTS {SCHEMA}.{table} CASCADE")
+
+    # Drop the schema only when nothing else lives in it. RESTRICT makes the
+    # DROP a no-op-or-error against a populated schema; we gate on the object
+    # count so it's a clean no-op (foreign objects survive) rather than a
+    # raised error that would abort the downgrade.
+    #
+    # Probe pg_class (tables, views, sequences, materialized views, indexes),
+    # pg_proc (functions/procedures), and pg_type (user-defined types). A
+    # tables-only check (information_schema.tables) would miss a foreign
+    # sequence/function/type, letting the RESTRICT drop raise and abort the
+    # downgrade. Dropping our 5 tables above also removed their auto-created
+    # composite rowtypes, array types, and indexes (verified: a clean schema
+    # has zero rows across all three catalogs), so any remaining row here is a
+    # foreign object and the schema must be left in place.
+    op.execute(
+        f"""
+        DO $$
+        DECLARE
+            ns oid;
+            obj_count integer;
+        BEGIN
+            SELECT oid INTO ns FROM pg_namespace WHERE nspname = '{SCHEMA}';
+            IF ns IS NULL THEN
+                RETURN;  -- schema already gone (idempotent downgrade)
+            END IF;
+
+            SELECT
+                (SELECT count(*) FROM pg_class WHERE relnamespace = ns)
+              + (SELECT count(*) FROM pg_proc  WHERE pronamespace = ns)
+              + (SELECT count(*) FROM pg_type  WHERE typnamespace = ns)
+            INTO obj_count;
+
+            IF obj_count = 0 THEN
+                EXECUTE 'DROP SCHEMA IF EXISTS {SCHEMA} RESTRICT';
+            END IF;
+        END $$;
+        """
+    )

--- a/db/alembic/versions/0001_initial_market_schema.py
+++ b/db/alembic/versions/0001_initial_market_schema.py
@@ -170,9 +170,14 @@ def upgrade() -> None:
 
 
 # Tables this revision's upgrade() created, in reverse dependency order so a
-# plain DROP TABLE works without CASCADE-ing into anything outside this set.
-# CASCADE is still passed to clean up each table's own indexes/constraints; it
-# does NOT reach foreign objects because we name each table explicitly.
+# non-cascading DROP TABLE works: our own FK (thematic_features_daily → tickers,
+# sectors) is gone before its parents are dropped. We deliberately do NOT pass
+# CASCADE — a plain DROP TABLE removes the table's own indexes/constraints but
+# RESTRICTs against *foreign* dependents (a non-rainier view/FK/materialized
+# view over one of these tables), failing loudly instead of silently destroying
+# them. That loud failure is the correct outcome in the multi-writer scenario
+# this revision's downgrade is meant to protect: the operator sees the foreign
+# dependency and resolves it rather than losing it.
 #
 #     thematic_features_daily ──FK──► tickers, sectors   (drop dependent first)
 #     thematic_ohlcv          (standalone)
@@ -196,9 +201,12 @@ def downgrade() -> None:
 
     Guarded reversal:
 
-      1. Drop only the 5 tables THIS revision's ``upgrade()`` created (reverse
-         dependency order; CASCADE reaches each table's own indexes/constraints
-         but never foreign objects because every name is listed explicitly).
+      1. Drop only the 5 tables THIS revision's ``upgrade()`` created, in
+         reverse dependency order with NON-cascading ``DROP TABLE``. A plain
+         drop removes each table's own indexes/constraints but RESTRICTs
+         against foreign dependents (a non-rainier view/FK over one of these
+         tables), so the downgrade fails loudly rather than silently dropping
+         or mutating a foreign object. CASCADE is intentionally NOT used.
       2. Drop the ``market`` schema only if it is now empty. If any foreign
          object remains, leave the (now rainier-free) schema in place. Using
          ``DROP SCHEMA ... RESTRICT`` (no CASCADE) is the belt-and-suspenders
@@ -209,7 +217,7 @@ def downgrade() -> None:
     survives regardless.
     """
     for table in _REVISION_TABLES:
-        op.execute(f"DROP TABLE IF EXISTS {SCHEMA}.{table} CASCADE")
+        op.execute(f"DROP TABLE IF EXISTS {SCHEMA}.{table} RESTRICT")
 
     # Drop the schema only when nothing else lives in it. RESTRICT makes the
     # DROP a no-op-or-error against a populated schema; we gate on the object

--- a/tests/test_db_migrations.py
+++ b/tests/test_db_migrations.py
@@ -353,6 +353,46 @@ def test_downgrade_base_preserves_foreign_objects(database_url):
     eng.dispose()
 
 
+def test_downgrade_base_preserves_foreign_sequence(database_url):
+    """The emptiness gate covers non-table objects too: a foreign SEQUENCE in
+    ``market`` survives ``downgrade base`` and keeps the schema alive.
+
+    A tables-only gate would think the schema empty, attempt the RESTRICT drop,
+    and abort the downgrade with an error — this locks in the pg_class/pg_proc/
+    pg_type probe."""
+    from alembic import command
+
+    eng = create_engine(database_url)
+    _reset_market(eng)
+
+    cfg = _alembic_config()
+    command.upgrade(cfg, "head")
+
+    with eng.begin() as conn:
+        conn.execute(text("CREATE SEQUENCE market.foreign_seq"))
+
+    command.downgrade(cfg, "base")
+
+    insp = inspect(eng)
+    assert "market" in set(insp.get_schema_names()), (
+        "downgrade base dropped market while a foreign sequence was present"
+    )
+    with eng.connect() as conn:
+        exists = conn.execute(
+            text(
+                "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace "
+                "WHERE n.nspname = 'market' AND c.relname = 'foreign_seq' AND c.relkind = 'S'"
+            )
+        ).fetchone()
+    assert exists is not None, "foreign sequence market.foreign_seq was wiped by downgrade"
+    assert set(insp.get_table_names(schema="market")) & _expected_tables() == set(), (
+        "downgrade base left this revision's own tables behind"
+    )
+
+    _reset_market(eng)
+    eng.dispose()
+
+
 def test_downgrade_base_clean_round_trip(database_url):
     """On a DB where ``market`` is exclusively this revision's, upgrade ->
     downgrade -> upgrade still round-trips: the schema is fully removed on

--- a/tests/test_db_migrations.py
+++ b/tests/test_db_migrations.py
@@ -282,6 +282,106 @@ def test_foreign_keys_to_registries(database_url):
 
 
 # ---------------------------------------------------------------------------
+# downgrade base must not wipe foreign objects (task plan migrate-downgrade-base)
+# ---------------------------------------------------------------------------
+# codex iter-4 of PR #102 (deferred P2): 0001's downgrade() issued an
+# unconditional `DROP SCHEMA market CASCADE`. Acceptable while rainier solely
+# owns `market`, but if the schema ever holds a non-rainier object, downgrade
+# base would silently wipe it. The guard: downgrade() drops only the objects
+# THIS revision's upgrade() created, and removes the schema only when no
+# foreign objects remain.
+
+
+def _reset_market(eng) -> None:
+    """Force the DB back to a pre-0001 state regardless of prior test runs.
+
+    The ``database_url`` fixture gives a per-test isolated DB only via
+    pytest-postgresql; when an operator points ``RAINIER_TEST_DATABASE_URL`` at
+    a reused sandbox there is no isolation. Dropping ``market`` + the alembic
+    bookkeeping row makes this test deterministic on either path."""
+    with eng.begin() as conn:
+        conn.execute(text("DROP SCHEMA IF EXISTS market CASCADE"))
+        conn.execute(text("DROP TABLE IF EXISTS public.alembic_version"))
+
+
+def test_downgrade_base_preserves_foreign_objects(database_url):
+    """A non-rainier object living in ``market`` survives ``downgrade base``.
+
+    Regression for the unconditional ``DROP SCHEMA market CASCADE`` footgun:
+    seed a foreign table into ``market`` AFTER upgrade head, then downgrade
+    base. The foreign table (and the ``market`` schema it lives in) must
+    survive; this revision's own tables must be gone.
+    """
+    from alembic import command
+
+    eng = create_engine(database_url)
+    _reset_market(eng)
+
+    cfg = _alembic_config()
+    command.upgrade(cfg, "head")
+
+    # Seed a foreign object that this revision did NOT create.
+    with eng.begin() as conn:
+        conn.execute(text("CREATE TABLE market.foreign_owned (id integer primary key)"))
+        conn.execute(text("INSERT INTO market.foreign_owned (id) VALUES (1), (2)"))
+
+    command.downgrade(cfg, "base")
+
+    insp = inspect(eng)
+    schemas = set(insp.get_schema_names())
+    assert "market" in schemas, (
+        "downgrade base dropped the whole market schema while a foreign object "
+        f"was present; surviving schemas={schemas}"
+    )
+
+    tables = set(insp.get_table_names(schema="market"))
+    # Foreign object survives untouched.
+    assert "foreign_owned" in tables, (
+        f"foreign object market.foreign_owned was wiped by downgrade; tables={tables}"
+    )
+    with eng.connect() as conn:
+        rows = conn.execute(text("SELECT id FROM market.foreign_owned ORDER BY id")).fetchall()
+    assert [r[0] for r in rows] == [1, 2], "foreign object rows were not preserved"
+
+    # This revision's own tables are gone.
+    leftover = tables & _expected_tables()
+    assert leftover == set(), (
+        f"downgrade base left this revision's own tables behind: {leftover}"
+    )
+
+    _reset_market(eng)
+    eng.dispose()
+
+
+def test_downgrade_base_clean_round_trip(database_url):
+    """On a DB where ``market`` is exclusively this revision's, upgrade ->
+    downgrade -> upgrade still round-trips: the schema is fully removed on
+    downgrade and re-created on the next upgrade."""
+    from alembic import command
+
+    eng = create_engine(database_url)
+    _reset_market(eng)
+
+    cfg = _alembic_config()
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "base")
+
+    insp = inspect(eng)
+    # No foreign objects → schema is fully removed, returning to empty state.
+    assert "market" not in set(insp.get_schema_names()), (
+        "downgrade base should drop the now-empty market schema on a clean DB"
+    )
+
+    # Re-upgrade rebuilds everything.
+    command.upgrade(cfg, "head")
+    insp = inspect(eng)
+    assert set(insp.get_table_names(schema="market")) == _expected_tables()
+
+    _reset_market(eng)
+    eng.dispose()
+
+
+# ---------------------------------------------------------------------------
 # Migration 0002 — schema-seam fixes for the dual-write writers (task plan §3)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_db_migrations.py
+++ b/tests/test_db_migrations.py
@@ -421,6 +421,58 @@ def test_downgrade_base_clean_round_trip(database_url):
     eng.dispose()
 
 
+def test_downgrade_base_fails_loudly_on_foreign_dependent(database_url):
+    """A foreign object DEPENDING ON one of this revision's tables is never
+    silently destroyed: the non-cascading ``DROP TABLE ... RESTRICT`` aborts
+    the downgrade instead.
+
+    codex iter-2 (P1): the original ``DROP TABLE ... CASCADE`` would silently
+    drop a foreign view/FK built on top of ``market.tickers`` even though the
+    schema is preserved — the exact data/DDL loss this revision is meant to
+    prevent. With RESTRICT, the drop raises; the operator sees the foreign
+    dependency and resolves it rather than losing it. We assert both the raise
+    AND that the foreign view + our table are still intact afterward (the
+    downgrade transaction rolled back).
+    """
+    import sqlalchemy.exc as sa_exc
+    from alembic import command
+
+    eng = create_engine(database_url)
+    _reset_market(eng)
+
+    cfg = _alembic_config()
+    command.upgrade(cfg, "head")
+
+    # Foreign view built on a revision-owned table. CASCADE would have dropped
+    # it silently; RESTRICT must refuse.
+    with eng.begin() as conn:
+        conn.execute(
+            text("CREATE VIEW market.foreign_view AS SELECT ticker_id FROM market.tickers")
+        )
+
+    with pytest.raises(sa_exc.DBAPIError):
+        command.downgrade(cfg, "base")
+
+    # The aborted downgrade left everything intact: the foreign view, the table
+    # it depends on, and the schema all survive.
+    insp = inspect(eng)
+    assert "market" in set(insp.get_schema_names()), "schema was dropped despite a foreign dependent"
+    assert "tickers" in set(insp.get_table_names(schema="market")), (
+        "market.tickers was dropped despite a foreign view depending on it"
+    )
+    with eng.connect() as conn:
+        view_exists = conn.execute(
+            text(
+                "SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace "
+                "WHERE n.nspname = 'market' AND c.relname = 'foreign_view' AND c.relkind = 'v'"
+            )
+        ).fetchone()
+    assert view_exists is not None, "foreign view market.foreign_view was wiped by downgrade"
+
+    _reset_market(eng)
+    eng.dispose()
+
+
 # ---------------------------------------------------------------------------
 # Migration 0002 — schema-seam fixes for the dual-write writers (task plan §3)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Guard `rainier db migrate --downgrade base` from wiping the `market` schema: downgrade() now drops only this revision's 5 tables (RESTRICT, not CASCADE) and drops the schema only when empty (object-count probe + `DROP SCHEMA RESTRICT` guard). upgrade() unchanged; no new revision file.
- 4 regression tests in tests/test_db_migrations.py (foreign table/sequence/view survival, clean round-trip, fails-loudly-on-foreign-dependent).

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 4) — escalated a CASCADE→foreign-object data-loss path to P1; fixed via RESTRICT + regression test.

## Deferred (P2, non-blocking)
- Emptiness probe counts pg_class/pg_proc/pg_type but not exotic schema-owned kinds (text-search configs, collations, operators). If one existed, DROP SCHEMA RESTRICT raises and rolls back the downgrade rather than completing — degraded-but-safe (no data loss). A pg_depend/namespace-owned probe would close it.

## Test plan
- [ ] CI green
- [ ] verify locally

Origin: codex iter-4 of PR #102 (deferred P2). coord-authorized P2 dispatch.