### PR TITLE
fix(qu-coverage): thread --config settings into coverage session

### DIFF
--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1416,13 +1416,17 @@ def qu_group() -> None:
     default=False,
     help="Emit JSON instead of the textual report (for cron + structured logs).",
 )
-def qu_money_flow_coverage(asof_str: str | None, lookback_days: int, as_json: bool) -> None:
+@click.pass_context
+def qu_money_flow_coverage(
+    ctx, asof_str: str | None, lookback_days: int, as_json: bool,
+) -> None:
     """Audit money_flow_snapshots coverage; exit non-zero on alarm.
 
-    Reads the production DB (via core.database.get_session) unless tests
-    monkey-patch coverage._open_session — keeps the CLI a thin wrapper
-    over the pure-function audit so the same code path runs in unit tests
-    against an in-memory sqlite session.
+    Reads the DB selected by the root ``--config`` flag (we thread
+    ``ctx.obj["settings"]`` into ``coverage._open_session`` so
+    ``rainier --config staging.yaml qu money-flow-coverage`` hits staging,
+    not the default DB). Tests monkey-patch ``coverage._open_session`` to run
+    the same code path against an in-memory sqlite session.
     """
     import json as _json
     import sys
@@ -1439,7 +1443,8 @@ def qu_money_flow_coverage(asof_str: str | None, lookback_days: int, as_json: bo
     else:
         asof = date.today()
 
-    with coverage._open_session() as session:
+    settings = (getattr(ctx, "obj", None) or {}).get("settings")
+    with coverage._open_session(settings) as session:
         report = coverage.compute_report(
             session=session, asof=asof, lookback_days=lookback_days,
         )

--- a/src/rainier/scrapers/qu/coverage.py
+++ b/src/rainier/scrapers/qu/coverage.py
@@ -516,10 +516,16 @@ def _open_session(settings: Settings | None = None) -> Iterator[Session]:
     """Yield a production DB session (postgres / timescale).
 
     When ``settings`` is provided (the CLI threads ``ctx.obj["settings"]`` here
-    so ``--config staging.yaml`` selects the right DB), bind the session to the
-    config-derived engine. Without it, fall back to the process-default
-    singleton session — preserving prior behaviour for callers that don't pass
-    a config-context.
+    so ``--config staging.yaml`` selects the right DB), bind the session to a
+    dedicated engine built from those settings. We deliberately bypass
+    ``core.database.get_engine`` here: that helper caches a process-global
+    ``_engine`` singleton and ignores its ``settings`` arg once initialized, so
+    a prior DB-using command in the same process (scheduler/test harness or an
+    embedded CLI) would otherwise pin us to the wrong DB and silently defeat
+    ``--config``. The per-call engine is disposed in ``finally`` to avoid
+    leaking a connection pool. Without ``settings``, fall back to the
+    process-default singleton session — preserving prior behaviour for callers
+    that don't pass a config-context.
     """
     if settings is None:
         from rainier.core.database import get_session as _get_session
@@ -528,9 +534,16 @@ def _open_session(settings: Settings | None = None) -> Iterator[Session]:
             yield s
         return
 
-    from rainier.core.database import get_session_factory
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
 
-    session = get_session_factory(settings)()
+    engine = create_engine(
+        settings.database_url,
+        echo=settings.database.echo,
+        pool_size=settings.database.pool_size,
+        pool_pre_ping=True,
+    )
+    session = sessionmaker(bind=engine)()
     try:
         yield session
         session.commit()
@@ -539,6 +552,7 @@ def _open_session(settings: Settings | None = None) -> Iterator[Session]:
         raise
     finally:
         session.close()
+        engine.dispose()
 
 
 # --------------------------------------------------------------------------- #

--- a/src/rainier/scrapers/qu/coverage.py
+++ b/src/rainier/scrapers/qu/coverage.py
@@ -53,7 +53,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from statistics import median
-from typing import Any, Iterator
+from typing import TYPE_CHECKING, Any, Iterator
 
 from sqlalchemy import (
     Column,
@@ -68,6 +68,9 @@ from sqlalchemy import (
 )
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
+
+if TYPE_CHECKING:
+    from rainier.core.config import Settings
 
 # --------------------------------------------------------------------------- #
 # Test table — mirrors the production money_flow_snapshots logical shape but
@@ -509,12 +512,33 @@ def compute_report(
 
 
 @contextmanager
-def _open_session() -> Iterator[Session]:
-    """Yield a production DB session (postgres / timescale)."""
-    from rainier.core.database import get_session as _get_session
+def _open_session(settings: Settings | None = None) -> Iterator[Session]:
+    """Yield a production DB session (postgres / timescale).
 
-    with _get_session() as s:
-        yield s
+    When ``settings`` is provided (the CLI threads ``ctx.obj["settings"]`` here
+    so ``--config staging.yaml`` selects the right DB), bind the session to the
+    config-derived engine. Without it, fall back to the process-default
+    singleton session — preserving prior behaviour for callers that don't pass
+    a config-context.
+    """
+    if settings is None:
+        from rainier.core.database import get_session as _get_session
+
+        with _get_session() as s:
+            yield s
+        return
+
+    from rainier.core.database import get_session_factory
+
+    session = get_session_factory(settings)()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_scrapers/test_money_flow_coverage.py
+++ b/tests/test_scrapers/test_money_flow_coverage.py
@@ -449,3 +449,43 @@ def test_cli_money_flow_coverage_honors_config(in_memory_session, tmp_path, monk
         "coverage session did not receive --config-resolved settings "
         f"(got pool_size={settings.database.pool_size!r})"
     )
+
+
+def test_open_session_bypasses_engine_singleton(tmp_path, monkeypatch):
+    """``_open_session(settings)`` must bind to an engine built from ``settings``
+    even when ``core.database``'s global ``_engine`` singleton was already
+    initialized to a *different* DB earlier in the process.
+
+    Regression for codex iter-1 [P2]: ``get_session_factory(settings)`` routed
+    through ``get_engine``, which returns the cached singleton and ignores its
+    ``settings`` arg once set — so a prior DB-using command in the same process
+    silently pinned ``--config staging.yaml`` to the wrong DB. The fix builds a
+    dedicated engine directly from ``settings`` instead.
+
+    Deterministic: pre-seed the singleton with a sentinel ``default.sqlite``
+    engine, then assert the session yielded for a ``staging.sqlite`` settings
+    binds to staging, not the sentinel.
+    """
+    from rainier.core import database
+    from rainier.core.config import Settings
+
+    default_db = tmp_path / "default.sqlite"
+    staging_db = tmp_path / "staging.sqlite"
+
+    # Pre-initialize the global singleton against the default DB, as any earlier
+    # DB-using command in the same process would.
+    sentinel = create_engine(f"sqlite:///{default_db}")
+    monkeypatch.setattr(database, "_engine", sentinel)
+    monkeypatch.setattr(database, "_session_factory", None)
+
+    staging_settings = Settings(database_url=f"sqlite:///{staging_db}")
+
+    with coverage._open_session(staging_settings) as session:
+        bound_url = str(session.get_bind().url)
+
+    assert bound_url == f"sqlite:///{staging_db}", (
+        "config-scoped session bound to the wrong DB — singleton leaked through "
+        f"(got {bound_url!r})"
+    )
+    # Sentinel singleton remains untouched (we never mutated it).
+    assert database._engine is sentinel

--- a/tests/test_scrapers/test_money_flow_coverage.py
+++ b/tests/test_scrapers/test_money_flow_coverage.py
@@ -374,7 +374,7 @@ def test_cli_money_flow_coverage_exit_code(in_memory_session, monkeypatch):
     from contextlib import contextmanager
 
     @contextmanager
-    def _fake_session():
+    def _fake_session(settings=None):
         yield in_memory_session
 
     monkeypatch.setattr(coverage, "_open_session", _fake_session)
@@ -395,3 +395,57 @@ def test_cli_money_flow_coverage_exit_code(in_memory_session, monkeypatch):
     )
     assert result.exit_code == 1
     assert "missing" in result.output.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Regression: --config threads config-derived settings into the coverage session
+# (codex iter-2 of PR #92, deferred [P2]). Before the fix, the coverage command
+# opened the session via the no-arg singleton get_session(), silently ignoring
+# `--config staging.yaml` and reading the default DB.
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_money_flow_coverage_honors_config(in_memory_session, tmp_path, monkeypatch):
+    """`rainier --config <yaml> qu money-flow-coverage` must open the session
+    with the settings resolved from that YAML — not the process default.
+
+    Deterministic: spy on ``coverage._open_session`` to capture the settings it
+    receives, and use a distinguishing ``database.pool_size`` (7) in the temp
+    config that the default (5) would never produce.
+    """
+    from contextlib import contextmanager
+
+    from rainier import cli as cli_module
+
+    asof = date(2026, 5, 21)
+    start = date(2026, 5, 7)
+    _seed_clean_window(in_memory_session, start=start, end=asof, rows_per_day=20)
+
+    # A config whose database.pool_size (7) is distinct from the default (5),
+    # so we can prove the --config-resolved settings reached _open_session.
+    config_path = tmp_path / "staging.yaml"
+    config_path.write_text("database:\n  pool_size: 7\n")
+
+    captured: dict[str, object] = {}
+
+    @contextmanager
+    def _spy_open_session(settings=None):
+        captured["settings"] = settings
+        yield in_memory_session
+
+    monkeypatch.setattr(coverage, "_open_session", _spy_open_session)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        ["--config", str(config_path), "qu", "money-flow-coverage",
+         "--asof", asof.isoformat()],
+    )
+
+    assert result.exit_code == 0, result.output
+    settings = captured.get("settings")
+    assert settings is not None, "_open_session was called without config-derived settings"
+    assert settings.database.pool_size == 7, (
+        "coverage session did not receive --config-resolved settings "
+        f"(got pool_size={settings.database.pool_size!r})"
+    )


### PR DESCRIPTION
## Summary
- Make `rainier --config <yaml> qu money-flow-coverage` honor `--config`: coverage._open_session now builds a config-scoped engine from the resolved settings (disposed in finally) instead of the no-arg get_session() singleton; cli command threads ctx.obj["settings"] via @click.pass_context. Default (no --config) behavior unchanged.
- Regression tests: --config threads settings to the coverage session; config-scoped session bypasses the cached engine singleton.

## Review
- /review: passed (claude rounds: 1)
- codex review: passed (codex rounds: 3) — caught that get_session_factory/get_engine returned the cached singleton ignoring passed settings; fixed by building a dedicated engine from settings + dispose in finally.

## Deferred (P2, non-blocking — needs operator design)
- load_settings() doesn't populate top-level `database_url` from YAML (only nested sections + env). Pre-existing config-architecture decision in core/config.py affecting every command; tracked as config-yaml-database-url-d4a1.

## Test plan
- [ ] CI green
- [ ] verify locally

Origin: codex iter-2 of PR #92 (deferred P2). coord-authorized P2 dispatch.