### PR TITLE
fix(db): value-driven verify checksum — float32 + NaN/NULL parity (verify#8aab)

### DIFF
--- a/src/rainier/db/verify.py
+++ b/src/rainier/db/verify.py
@@ -12,29 +12,41 @@ with ``ok`` (all match) + a ``drift`` list naming each offending
 CI/cron-usable as the gate the operator runs after a backfill (and later after
 daily dual-write runs) to confirm PG mirrors parquet.
 
-Checksum determinism + float tolerance (task plan §3)
------------------------------------------------------
+Checksum determinism + float/NaN canonicalization (task plan §3, verify#8aab)
+-----------------------------------------------------------------------------
 The checksum must NOT depend on row order (PG and parquet return rows in
-different orders), and must NOT false-positive on storage-precision drift.
-Parquet stores float64 originals, but several ``market.*`` columns are PG
-``REAL`` (float32, ~7 significant digits). A clean ``REAL`` round-trip returns a
-value whose float64 repr differs from the parquet original in the low bits, so a
-naive repr/hash falsely flags drift.
+different orders), and must NOT false-positive on differences that are purely
+about how a faithful value is *stored* on each side. Two such differences are
+neutralized, uniformly for EVERY table (no per-column or per-table special-case
+— ``_canon_cell`` is value-driven, it takes no schema input):
 
-The fix is *exact*, not a fuzzy tolerance: PG ``REAL`` columns are normalized on
-BOTH sides by casting through ``numpy.float32``. The PG value already carries
-only float32 precision, and casting the parquet float64 down to float32
-reproduces the IDENTICAL 32-bit value — so both sides hash bit-for-bit equal.
-``DOUBLE_PRECISION`` columns round-trip float64 exactly and need no
-normalization. (Significant-figure rounding was rejected: a value can straddle a
-rounding boundary at the Nth digit so the two equal-float32 reprs round to
-different decimals — boundary instability that float32-casting avoids entirely.)
+  1. Float width. The parquet stores some forward-return / feature columns as
+     float32; the PG column may be ``REAL`` *or* ``DOUBLE PRECISION``. The live
+     DDL can diverge from the static schema — observed on
+     ``thematic_labels_daily`` (``DOUBLE`` in Neon, ``REAL`` in the schema
+     source), which produced ~100 spurious mismatches in a live backfill while
+     every other table was true parity. A naive repr/hash flags the
+     float32-vs-float64 low-bit delta as drift. Casting EVERY float through
+     ``numpy.float32`` on BOTH sides collapses a float32 value and its
+     widened-to-float64 counterpart to the IDENTICAL 32-bit value, so they hash
+     bit-for-bit equal regardless of which side stored which width. float32
+     truncation is stable (no rounding-boundary instability) — significant-
+     figure rounding was rejected because a value can straddle a boundary at the
+     Nth digit. It never blinds the gate: two numbers that differ beyond float32
+     precision still hash differently.
 
-The per-spec set of ``REAL`` columns is derived from the schema column types
-(``_real_columns``). Steps:
+  2. NaN vs SQL NULL. Recent asof dates legitimately carry NaN forward returns
+     (the forward window has not elapsed); ``pg_value`` writes NaN as PG NULL
+     (Python ``None``). Both a float NaN and ``None`` canonicalize to the single
+     ``("n",)`` token so this representation difference is not flagged — while a
+     real float value stays a distinct ``("f", ...)`` token, so a
+     NaN/NULL-vs-real-value difference is still caught.
+
+Steps:
 
   * coerce every cell through ``pg_value`` (NaN/NaT -> None, numpy -> Python);
-  * cast REAL-column floats through float32 (exact, stable);
+  * canonicalize via ``_canon_cell`` (every float -> float32; NaN/NULL -> one
+    token; tz-aware datetimes -> UTC);
   * build a per-row tuple in fixed table-column order, sort the rows within a
     date group by primary key, then BLAKE2b-hash the canonical repr.
 
@@ -54,7 +66,6 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from sqlalchemy import text
-from sqlalchemy.dialects.postgresql import REAL
 from sqlalchemy.engine import Engine
 
 from rainier.db.rows import TABLE_SPECS, TableSpec, frame_to_pg_rows
@@ -82,37 +93,44 @@ class VerifyReport:
         return not self.drift
 
 
-def _real_columns(spec: TableSpec) -> frozenset[str]:
-    """Column names stored as PG ``REAL`` (float32) for this table.
+def _canon_cell(v) -> object:
+    """Canonicalize a coerced cell for hashing — value-driven, no schema input.
 
-    Those are the columns whose parquet float64 originals must be cast through
-    float32 to compare exactly against their round-tripped PG values.
+    The checksum must report TRUE parity for data that is faithful but stored at
+    a different float width or with a different missing-value representation on
+    the two sides. Two such differences are neutralized here, uniformly for
+    EVERY table (no per-column or per-table special-case):
+
+    1. Float width. The parquet stores some forward-return / feature columns as
+       float32 while the PG column may be REAL *or* DOUBLE PRECISION — the live
+       DDL can diverge from the static schema (observed on
+       ``thematic_labels_daily``: DOUBLE in Neon, REAL in the schema source).
+       Casting EVERY float through float32 collapses a float32 parquet value and
+       its widened-to-float64 PG counterpart to the identical 32-bit value, so
+       they hash equal regardless of which side stored which width. float32
+       truncation is stable (no rounding-boundary instability) and never blinds
+       the gate: two numbers that differ beyond float32 precision still hash
+       differently.
+
+    2. NaN vs SQL NULL. Recent asof dates carry NaN forward returns (the forward
+       window has not elapsed); ``pg_value`` writes NaN as PG NULL, which comes
+       back as Python ``None``. Both a float NaN and ``None`` canonicalize to the
+       single ``("n",)`` token so the representation difference is not flagged —
+       a *real* float value stays a distinct ``("f", ...)`` token, so a
+       NaN/NULL-vs-real-value difference is still caught as drift.
+
+    Timezone-aware datetimes are normalized to UTC so the SAME instant hashes
+    identically regardless of the session timezone PG rendered it in (TIMESTAMPTZ
+    columns like ``fetched_at``/``computed_at`` come back in the connection's
+    timezone, e.g. ``08:30-08:00``, while the parquet original is ``16:30+00:00``
+    — both the same instant). Other non-floats are tagged + stringified.
     """
-    return frozenset(
-        c.name for c in spec.table.columns if isinstance(c.type, REAL)
-    )
-
-
-def _canon_cell(v, is_real: bool) -> object:
-    """Canonicalize a coerced cell for hashing.
-
-    Floats in REAL columns are cast through float32 so the parquet float64
-    original and the round-tripped PG REAL value collapse to the identical
-    32-bit value. DOUBLE_PRECISION floats round-trip exactly, so they pass
-    through unchanged. Timezone-aware datetimes are normalized to UTC so the
-    SAME instant hashes identically regardless of the session timezone PG
-    rendered it in (TIMESTAMPTZ columns like ``fetched_at``/``computed_at``
-    come back in the connection's timezone, e.g. ``08:30-08:00``, while the
-    parquet original is ``16:30+00:00`` — both are the same instant and must
-    not false-positive drift). None and other non-floats are tagged +
-    stringified.
-    """
-    if isinstance(v, float):
-        if is_real:
-            return ("f", float(np.float32(v)))
-        return ("f", v)
     if v is None:
         return ("n",)
+    if isinstance(v, float):
+        if v != v:  # NaN: collapse to the NULL token (faithful NaN<->NULL).
+            return ("n",)
+        return ("f", float(np.float32(v)))
     if isinstance(v, _dt.datetime) and v.tzinfo is not None:
         # Same instant, stable repr: convert to UTC before stringifying.
         return ("s", str(v.astimezone(_dt.timezone.utc)))
@@ -123,14 +141,13 @@ def _checksum(
     rows: list[dict],
     columns: list[str],
     pk_cols: tuple[str, ...],
-    real_cols: frozenset[str],
 ) -> str:
     """Order-independent content hash of ``rows`` projected to ``columns``.
 
     Rows are sorted by primary key (None sorts first via a (is_none, repr) key)
     so PG vs parquet row order is irrelevant, then each row is rendered as a
-    fixed-column-order tuple of canonical cells (REAL columns float32-normalized)
-    and BLAKE2b-hashed.
+    fixed-column-order tuple of canonical cells (every float float32-normalized,
+    NaN/NULL collapsed — see ``_canon_cell``) and BLAKE2b-hashed.
     """
 
     def sort_key(row: dict):
@@ -138,7 +155,7 @@ def _checksum(
 
     h = hashlib.blake2b(digest_size=16)
     for row in sorted(rows, key=sort_key):
-        cells = tuple(_canon_cell(row.get(c), c in real_cols) for c in columns)
+        cells = tuple(_canon_cell(row.get(c)) for c in columns)
         h.update(repr(cells).encode("utf-8"))
         h.update(b"\x1e")  # record separator
     return h.hexdigest()
@@ -211,7 +228,6 @@ def verify_coverage(
 
     for spec in TABLE_SPECS:
         columns = list(spec.table.columns.keys())
-        real_cols = _real_columns(spec)
         path = cache_dir / f"{spec.parquet_name}.parquet"
 
         if path.exists():
@@ -247,8 +263,8 @@ def verify_coverage(
                 )
                 match = False
             else:
-                pq_sum = _checksum(pq_g, columns, spec.pk_cols, real_cols)
-                pg_sum = _checksum(pg_g, columns, spec.pk_cols, real_cols)
+                pq_sum = _checksum(pq_g, columns, spec.pk_cols)
+                pg_sum = _checksum(pg_g, columns, spec.pk_cols)
                 if pq_sum != pg_sum:
                     report.drift.append(
                         Drift(spec.name, key, "checksum mismatch")

--- a/src/rainier/db/verify.py
+++ b/src/rainier/db/verify.py
@@ -19,27 +19,34 @@ different orders), and must NOT false-positive on differences that are purely
 about how a faithful value is *stored* on each side. Two such differences are
 neutralized:
 
-  1. Float width — scoped to columns the PARQUET actually stores as float32.
-     Those forward-return / feature columns carry only float32 precision; the PG
-     mirror may be ``REAL`` *or* ``DOUBLE PRECISION`` (the live DDL can diverge
-     from the static schema — observed on ``thematic_labels_daily``: ``DOUBLE``
-     in Neon, ``REAL`` in the schema source — which produced ~100 spurious
-     mismatches in a live backfill). A naive repr/hash flags the
-     float32-vs-widened-float64 low-bit delta as drift. Casting both sides of a
-     float32-origin column through ``numpy.float32`` collapses the stored
-     float32 value and its widened-to-float64 PG counterpart to the IDENTICAL
-     32-bit value, so they hash equal regardless of which side stored which
-     width. The set of float32 columns is derived from the live parquet dtypes
-     (``_float32_columns``), NOT the static schema — that is what fixed the
-     ``thematic_labels_daily`` divergence the old schema-``REAL`` lookup missed.
+  1. Float width — scoped to columns that are float32-precision-limited on at
+     least one side. A column is float32-normalized when EITHER the parquet
+     stores it as float32 OR the PG schema declares it ``REAL`` (the union, see
+     ``_float32_columns`` + ``_real_columns``). Both signals are needed:
 
-     Crucially this is NOT applied to float64-origin columns. A column the
-     parquet stores as float64 (OHLC prices, ``breadth_indicator_daily.value``)
-     is hashed at full float64 precision on both sides, so genuine sub-float32
-     drift in a DOUBLE column is still caught — the gate is not blinded for the
-     data that legitimately needs full precision. float32 truncation is stable
-     (no rounding-boundary instability) — significant-figure rounding was
-     rejected because a value can straddle a boundary at the Nth digit.
+       * Parquet float32 (live dtype): forward-return / feature columns the
+         parquet persisted as float32. Their PG mirror may be ``REAL`` *or*
+         ``DOUBLE PRECISION`` — the live DDL can diverge from the static schema
+         (observed on ``thematic_labels_daily``: ``DOUBLE`` in Neon, ``REAL`` in
+         the schema source), so the schema lookup alone missed it and produced
+         ~100 spurious mismatches in a live backfill.
+       * Schema ``REAL`` (static): when a parquet cache stores a column as
+         float64 but the PG column is ``REAL``, PG rounds the value to float32
+         on round-trip while the parquet float64 keeps full bits, so the parquet
+         dtype alone misses it. The schema ``REAL`` membership catches it.
+
+     For a column in the union, casting both sides through ``numpy.float32``
+     collapses the float32 value (whichever side carries it) and its
+     widened/un-rounded counterpart to the IDENTICAL 32-bit value, so faithful
+     data hashes equal. float32 truncation is stable (no rounding-boundary
+     instability) — significant-figure rounding was rejected because a value can
+     straddle a boundary at the Nth digit.
+
+     Crucially this is NOT applied to columns that are float64 on BOTH sides
+     (parquet float64 + PG ``DOUBLE``: OHLC prices, ``breadth_indicator_daily``
+     ``value``). Those are hashed at full float64 precision, so genuine
+     sub-float32 drift in a DOUBLE column is still caught — the gate is not
+     blinded for the data that legitimately needs full precision.
 
   2. NaN vs SQL NULL (every column). Recent asof dates legitimately carry NaN
      forward returns (the forward window has not elapsed); ``pg_value`` writes
@@ -51,9 +58,10 @@ neutralized:
 Steps:
 
   * coerce every cell through ``pg_value`` (NaN/NaT -> None, numpy -> Python);
-  * derive the float32-origin column set from the parquet frame's dtypes
-    (``_float32_columns``); the PG side is hashed against the SAME set so a
-    float32 parquet value and its widened PG mirror collapse identically;
+  * derive the float32 column set = parquet float32 dtypes (``_float32_columns``)
+    UNION schema ``REAL`` columns (``_real_columns``); both sides are hashed
+    against the SAME set so a float32 value and its widened/rounded counterpart
+    collapse identically;
   * canonicalize via ``_canon_cell`` (float in a float32 column -> float32;
     NaN/NULL -> one token; tz-aware datetimes -> UTC);
   * build a per-row tuple in fixed table-column order, sort the rows within a
@@ -75,6 +83,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import REAL
 from sqlalchemy.engine import Engine
 
 from rainier.db.rows import TABLE_SPECS, TableSpec, frame_to_pg_rows
@@ -102,21 +111,31 @@ class VerifyReport:
         return not self.drift
 
 
+def _real_columns(spec: TableSpec) -> frozenset[str]:
+    """Column names the static schema declares as PG ``REAL`` (float32) for ``spec``.
+
+    Needed because a parquet cache can store a column as float64 while the PG
+    column is ``REAL``: PG rounds it to float32 on round-trip, so the parquet
+    dtype alone (``_float32_columns``) would miss it and false-positive drift on
+    faithful data. The schema lookup catches that direction; the parquet-dtype
+    lookup catches the live-DDL-diverged-DOUBLE direction. Their union is the
+    float32-normalized set.
+    """
+    return frozenset(
+        c.name for c in spec.table.columns if isinstance(c.type, REAL)
+    )
+
+
 def _float32_columns(df: pd.DataFrame) -> frozenset[str]:
-    """Column names the parquet frame stores at float32 precision.
+    """Column names the parquet frame physically stores at float32 precision.
 
-    The parquet is the source-of-precision: a column physically stored as
-    float32 carries only ~7 significant digits, so its PG mirror (REAL or a
-    schema-diverged DOUBLE) can never hold more than the float32 round-trip.
-    Those are exactly the columns whose float64-widened PG values must be cast
-    back through float32 to compare equal. float64-stored columns (OHLC prices,
-    ``breadth_indicator_daily.value``) are NOT in this set, so they stay full
-    precision and real drift in them is still caught.
-
-    Derived from the live parquet dtypes — NOT the static schema — because the
-    live DDL can diverge from the schema (``thematic_labels_daily`` is REAL in
-    the schema source but DOUBLE in Neon), and only the parquet dtype reliably
-    tells us the actual precision the data was persisted at.
+    A column persisted as float32 carries only ~7 significant digits, so its PG
+    mirror (``REAL`` or a schema-diverged ``DOUBLE``) can never hold more than
+    the float32 round-trip — those columns must be float32-normalized on both
+    sides to compare faithfully. Derived from the LIVE parquet dtypes (not the
+    static schema) so it catches ``thematic_labels_daily``, which is ``REAL`` in
+    the schema source but ``DOUBLE`` in Neon. Unioned with ``_real_columns`` to
+    also cover the float64-parquet-into-PG-``REAL`` direction.
     """
     return frozenset(
         str(name)
@@ -275,11 +294,12 @@ def verify_coverage(
         else:
             pq_df = pd.DataFrame(columns=columns)
 
-        # The parquet is the source-of-precision: only columns physically stored
-        # as float32 get the float32 round-trip normalization (applied to BOTH
-        # sides). float64 columns stay full precision so real DOUBLE drift is
-        # still caught. Derived from live dtypes, not the static schema.
-        float32_cols = _float32_columns(pq_df)
+        # float32-normalize a column when EITHER the parquet stores it as float32
+        # (live-DDL-diverged DOUBLE case) OR the PG schema declares it REAL
+        # (float64-parquet-into-REAL case). Both signals are needed; their union
+        # is applied to BOTH sides. Columns that are float64 on both sides stay
+        # full precision, so real DOUBLE drift is still caught.
+        float32_cols = _float32_columns(pq_df) | _real_columns(spec)
 
         # Window both sides identically before comparing (registries pass through).
         pq_df = _window_df(pq_df, spec, asof_start, asof_end)

--- a/src/rainier/db/verify.py
+++ b/src/rainier/db/verify.py
@@ -17,36 +17,45 @@ Checksum determinism + float/NaN canonicalization (task plan §3, verify#8aab)
 The checksum must NOT depend on row order (PG and parquet return rows in
 different orders), and must NOT false-positive on differences that are purely
 about how a faithful value is *stored* on each side. Two such differences are
-neutralized, uniformly for EVERY table (no per-column or per-table special-case
-— ``_canon_cell`` is value-driven, it takes no schema input):
+neutralized:
 
-  1. Float width. The parquet stores some forward-return / feature columns as
-     float32; the PG column may be ``REAL`` *or* ``DOUBLE PRECISION``. The live
-     DDL can diverge from the static schema — observed on
-     ``thematic_labels_daily`` (``DOUBLE`` in Neon, ``REAL`` in the schema
-     source), which produced ~100 spurious mismatches in a live backfill while
-     every other table was true parity. A naive repr/hash flags the
-     float32-vs-float64 low-bit delta as drift. Casting EVERY float through
-     ``numpy.float32`` on BOTH sides collapses a float32 value and its
-     widened-to-float64 counterpart to the IDENTICAL 32-bit value, so they hash
-     bit-for-bit equal regardless of which side stored which width. float32
-     truncation is stable (no rounding-boundary instability) — significant-
-     figure rounding was rejected because a value can straddle a boundary at the
-     Nth digit. It never blinds the gate: two numbers that differ beyond float32
-     precision still hash differently.
+  1. Float width — scoped to columns the PARQUET actually stores as float32.
+     Those forward-return / feature columns carry only float32 precision; the PG
+     mirror may be ``REAL`` *or* ``DOUBLE PRECISION`` (the live DDL can diverge
+     from the static schema — observed on ``thematic_labels_daily``: ``DOUBLE``
+     in Neon, ``REAL`` in the schema source — which produced ~100 spurious
+     mismatches in a live backfill). A naive repr/hash flags the
+     float32-vs-widened-float64 low-bit delta as drift. Casting both sides of a
+     float32-origin column through ``numpy.float32`` collapses the stored
+     float32 value and its widened-to-float64 PG counterpart to the IDENTICAL
+     32-bit value, so they hash equal regardless of which side stored which
+     width. The set of float32 columns is derived from the live parquet dtypes
+     (``_float32_columns``), NOT the static schema — that is what fixed the
+     ``thematic_labels_daily`` divergence the old schema-``REAL`` lookup missed.
 
-  2. NaN vs SQL NULL. Recent asof dates legitimately carry NaN forward returns
-     (the forward window has not elapsed); ``pg_value`` writes NaN as PG NULL
-     (Python ``None``). Both a float NaN and ``None`` canonicalize to the single
-     ``("n",)`` token so this representation difference is not flagged — while a
-     real float value stays a distinct ``("f", ...)`` token, so a
-     NaN/NULL-vs-real-value difference is still caught.
+     Crucially this is NOT applied to float64-origin columns. A column the
+     parquet stores as float64 (OHLC prices, ``breadth_indicator_daily.value``)
+     is hashed at full float64 precision on both sides, so genuine sub-float32
+     drift in a DOUBLE column is still caught — the gate is not blinded for the
+     data that legitimately needs full precision. float32 truncation is stable
+     (no rounding-boundary instability) — significant-figure rounding was
+     rejected because a value can straddle a boundary at the Nth digit.
+
+  2. NaN vs SQL NULL (every column). Recent asof dates legitimately carry NaN
+     forward returns (the forward window has not elapsed); ``pg_value`` writes
+     NaN as PG NULL (Python ``None``). Both a float NaN and ``None`` canonicalize
+     to the single ``("n",)`` token so this representation difference is not
+     flagged — while a real float value stays a distinct ``("f", ...)`` token, so
+     a NaN/NULL-vs-real-value difference is still caught.
 
 Steps:
 
   * coerce every cell through ``pg_value`` (NaN/NaT -> None, numpy -> Python);
-  * canonicalize via ``_canon_cell`` (every float -> float32; NaN/NULL -> one
-    token; tz-aware datetimes -> UTC);
+  * derive the float32-origin column set from the parquet frame's dtypes
+    (``_float32_columns``); the PG side is hashed against the SAME set so a
+    float32 parquet value and its widened PG mirror collapse identically;
+  * canonicalize via ``_canon_cell`` (float in a float32 column -> float32;
+    NaN/NULL -> one token; tz-aware datetimes -> UTC);
   * build a per-row tuple in fixed table-column order, sort the rows within a
     date group by primary key, then BLAKE2b-hash the canonical repr.
 
@@ -93,31 +102,55 @@ class VerifyReport:
         return not self.drift
 
 
-def _canon_cell(v) -> object:
-    """Canonicalize a coerced cell for hashing — value-driven, no schema input.
+def _float32_columns(df: pd.DataFrame) -> frozenset[str]:
+    """Column names the parquet frame stores at float32 precision.
 
-    The checksum must report TRUE parity for data that is faithful but stored at
-    a different float width or with a different missing-value representation on
-    the two sides. Two such differences are neutralized here, uniformly for
-    EVERY table (no per-column or per-table special-case):
+    The parquet is the source-of-precision: a column physically stored as
+    float32 carries only ~7 significant digits, so its PG mirror (REAL or a
+    schema-diverged DOUBLE) can never hold more than the float32 round-trip.
+    Those are exactly the columns whose float64-widened PG values must be cast
+    back through float32 to compare equal. float64-stored columns (OHLC prices,
+    ``breadth_indicator_daily.value``) are NOT in this set, so they stay full
+    precision and real drift in them is still caught.
 
-    1. Float width. The parquet stores some forward-return / feature columns as
-       float32 while the PG column may be REAL *or* DOUBLE PRECISION — the live
-       DDL can diverge from the static schema (observed on
+    Derived from the live parquet dtypes — NOT the static schema — because the
+    live DDL can diverge from the schema (``thematic_labels_daily`` is REAL in
+    the schema source but DOUBLE in Neon), and only the parquet dtype reliably
+    tells us the actual precision the data was persisted at.
+    """
+    return frozenset(
+        str(name)
+        for name, dtype in df.dtypes.items()
+        if dtype == np.float32
+    )
+
+
+def _canon_cell(v, is_float32: bool) -> object:
+    """Canonicalize a coerced cell for hashing.
+
+    ``is_float32`` is True only for columns the parquet stores at float32
+    precision (see ``_float32_columns``). Two storage-only differences are
+    neutralized so faithful data reports TRUE parity:
+
+    1. Float width (float32 columns only). The parquet stores the column at
+       float32 while the PG mirror may be REAL *or* DOUBLE PRECISION (the live
+       DDL can diverge from the static schema — observed on
        ``thematic_labels_daily``: DOUBLE in Neon, REAL in the schema source).
-       Casting EVERY float through float32 collapses a float32 parquet value and
-       its widened-to-float64 PG counterpart to the identical 32-bit value, so
-       they hash equal regardless of which side stored which width. float32
-       truncation is stable (no rounding-boundary instability) and never blinds
-       the gate: two numbers that differ beyond float32 precision still hash
-       differently.
+       Casting both sides of a float32-origin column through float32 collapses a
+       float32 parquet value and its widened-to-float64 PG counterpart to the
+       identical 32-bit value, so they hash equal regardless of which side
+       stored which width. float32 truncation is stable (no rounding-boundary
+       instability). A float64-origin column (``is_float32`` False) is hashed at
+       FULL float64 precision, so genuine sub-float32 drift in a DOUBLE column is
+       still caught — the gate is not blinded for full-precision data.
 
-    2. NaN vs SQL NULL. Recent asof dates carry NaN forward returns (the forward
-       window has not elapsed); ``pg_value`` writes NaN as PG NULL, which comes
-       back as Python ``None``. Both a float NaN and ``None`` canonicalize to the
-       single ``("n",)`` token so the representation difference is not flagged —
-       a *real* float value stays a distinct ``("f", ...)`` token, so a
-       NaN/NULL-vs-real-value difference is still caught as drift.
+    2. NaN vs SQL NULL (every column). Recent asof dates carry NaN forward
+       returns (the forward window has not elapsed); ``pg_value`` writes NaN as
+       PG NULL, which comes back as Python ``None``. Both a float NaN and
+       ``None`` canonicalize to the single ``("n",)`` token so the
+       representation difference is not flagged — a *real* float value stays a
+       distinct ``("f", ...)`` token, so a NaN/NULL-vs-real-value difference is
+       still caught as drift.
 
     Timezone-aware datetimes are normalized to UTC so the SAME instant hashes
     identically regardless of the session timezone PG rendered it in (TIMESTAMPTZ
@@ -130,7 +163,9 @@ def _canon_cell(v) -> object:
     if isinstance(v, float):
         if v != v:  # NaN: collapse to the NULL token (faithful NaN<->NULL).
             return ("n",)
-        return ("f", float(np.float32(v)))
+        if is_float32:
+            return ("f", float(np.float32(v)))
+        return ("f", v)
     if isinstance(v, _dt.datetime) and v.tzinfo is not None:
         # Same instant, stable repr: convert to UTC before stringifying.
         return ("s", str(v.astimezone(_dt.timezone.utc)))
@@ -141,13 +176,16 @@ def _checksum(
     rows: list[dict],
     columns: list[str],
     pk_cols: tuple[str, ...],
+    float32_cols: frozenset[str] = frozenset(),
 ) -> str:
     """Order-independent content hash of ``rows`` projected to ``columns``.
 
     Rows are sorted by primary key (None sorts first via a (is_none, repr) key)
     so PG vs parquet row order is irrelevant, then each row is rendered as a
-    fixed-column-order tuple of canonical cells (every float float32-normalized,
-    NaN/NULL collapsed — see ``_canon_cell``) and BLAKE2b-hashed.
+    fixed-column-order tuple of canonical cells. Floats in ``float32_cols`` are
+    float32-normalized (faithful float32<->widened-float64 parity); all other
+    floats keep full float64 precision; NaN/NULL collapse to one token — see
+    ``_canon_cell``. The result is BLAKE2b-hashed.
     """
 
     def sort_key(row: dict):
@@ -155,7 +193,9 @@ def _checksum(
 
     h = hashlib.blake2b(digest_size=16)
     for row in sorted(rows, key=sort_key):
-        cells = tuple(_canon_cell(row.get(c)) for c in columns)
+        cells = tuple(
+            _canon_cell(row.get(c), c in float32_cols) for c in columns
+        )
         h.update(repr(cells).encode("utf-8"))
         h.update(b"\x1e")  # record separator
     return h.hexdigest()
@@ -235,6 +275,12 @@ def verify_coverage(
         else:
             pq_df = pd.DataFrame(columns=columns)
 
+        # The parquet is the source-of-precision: only columns physically stored
+        # as float32 get the float32 round-trip normalization (applied to BOTH
+        # sides). float64 columns stay full precision so real DOUBLE drift is
+        # still caught. Derived from live dtypes, not the static schema.
+        float32_cols = _float32_columns(pq_df)
+
         # Window both sides identically before comparing (registries pass through).
         pq_df = _window_df(pq_df, spec, asof_start, asof_end)
         pg_df = _window_df(_read_pg(engine, spec, columns), spec, asof_start, asof_end)
@@ -263,8 +309,8 @@ def verify_coverage(
                 )
                 match = False
             else:
-                pq_sum = _checksum(pq_g, columns, spec.pk_cols)
-                pg_sum = _checksum(pg_g, columns, spec.pk_cols)
+                pq_sum = _checksum(pq_g, columns, spec.pk_cols, float32_cols)
+                pg_sum = _checksum(pg_g, columns, spec.pk_cols, float32_cols)
                 if pq_sum != pg_sum:
                     report.drift.append(
                         Drift(spec.name, key, "checksum mismatch")

--- a/tests/test_db_verify_coverage.py
+++ b/tests/test_db_verify_coverage.py
@@ -272,6 +272,96 @@ def test_verify_real_column_float32_boundary_no_false_positive(
 
 
 # ---------------------------------------------------------------------------
+# Float-width + NaN/NULL parity (live-Neon labels artifact, verify#8aab)
+# ---------------------------------------------------------------------------
+#
+# Live verify against Neon flagged ~100 spurious checksum mismatches on
+# market.thematic_labels_daily while every other table was TRUE parity. Root
+# cause: the parquet stores forward-return columns as float32 while the live PG
+# column is DOUBLE PRECISION (the live DDL diverged from the static REAL schema).
+# The old normalization keyed float32-casting off the STATIC schema's REAL
+# membership (_real_columns); when reality is DOUBLE the value never gets
+# normalized and the float32->float64 widen plus NaN<->NULL on recent
+# (incomplete-horizon) rows false-positives drift. The fix makes the checksum
+# value-driven: every float cell is canonicalized through float32 and NaN/NULL
+# collapse to one token — uniformly, with NO schema-type or labels special-case.
+
+
+def _float_truncated_by_f32() -> tuple[float, float]:
+    """A float64 whose float32 cast changes its bit value, plus that cast.
+
+    Returns ``(orig64, parquet_f32)`` where ``orig64`` is what a DOUBLE PRECISION
+    PG column would hold from a full-precision load, and ``parquet_f32`` is the
+    same number after a float32 parquet round-trip. They differ in float64 bits;
+    a float32-canonicalizing checksum must collapse them to equal.
+    """
+    import numpy as np
+
+    orig64 = 0.06948674738744653
+    parquet_f32 = float(np.float32(orig64))
+    assert orig64 != parquet_f32, "value must actually lose bits under float32"
+    return orig64, parquet_f32
+
+
+def test_checksum_float32_vs_double_no_false_positive():
+    """A float column NOT in the schema REAL set (mirrors a live DOUBLE column)
+    must still hash equal across a float32 parquet value and its full-precision
+    float64 PG counterpart. RED before the value-driven fix: with an empty
+    real_cols set the old code skipped float32-canonicalization and the two
+    sides hashed differently."""
+    from rainier.db.verify import _checksum
+
+    orig64, parquet_f32 = _float_truncated_by_f32()
+    cols = ["symbol", "fwd_20d_ret"]
+    pk = ("symbol",)
+    parquet_rows = [{"symbol": "AAA", "fwd_20d_ret": parquet_f32}]
+    pg_rows = [{"symbol": "AAA", "fwd_20d_ret": orig64}]
+    # The checksum is value-driven (no schema/REAL input): a DOUBLE live column
+    # gets float32-normalized just like a REAL one, so both sides hash equal.
+    assert _checksum(parquet_rows, cols, pk) == _checksum(
+        pg_rows, cols, pk
+    ), "float32 parquet vs float64 PG must hash equal (value-driven normalize)"
+
+
+def test_checksum_nan_equals_sql_null():
+    """A parquet float NaN and a SQL NULL (None) for the same cell must hash
+    equal. Recent asof dates legitimately carry NaN forward returns (window not
+    elapsed) that are written as NULL in PG; that representation difference must
+    not be flagged as drift."""
+    from rainier.db.verify import _checksum
+
+    cols = ["symbol", "fwd_20d_ret"]
+    pk = ("symbol",)
+    nan_rows = [{"symbol": "AAA", "fwd_20d_ret": float("nan")}]
+    null_rows = [{"symbol": "AAA", "fwd_20d_ret": None}]
+    assert _checksum(nan_rows, cols, pk) == _checksum(
+        null_rows, cols, pk
+    ), "NaN (parquet) and NULL (PG) must canonicalize to one token"
+
+
+def test_checksum_different_values_still_mismatch():
+    """NEGATIVE gate: genuinely different numbers must STILL mismatch. The
+    width/NaN canonicalization must not blind the gate to real drift — two
+    values that differ beyond float32 precision (and a NaN-vs-real-value pair)
+    must hash differently."""
+    from rainier.db.verify import _checksum
+
+    cols = ["symbol", "fwd_20d_ret"]
+    pk = ("symbol",)
+    a = [{"symbol": "AAA", "fwd_20d_ret": 0.05}]
+    b = [{"symbol": "AAA", "fwd_20d_ret": 0.06}]
+    assert _checksum(a, cols, pk) != _checksum(
+        b, cols, pk
+    ), "0.05 vs 0.06 is real drift and must mismatch"
+    # NaN/NULL must NOT collapse into a real value: a present number != absent.
+    real_val = [{"symbol": "AAA", "fwd_20d_ret": 0.0}]
+    nan_val = [{"symbol": "AAA", "fwd_20d_ret": float("nan")}]
+    assert _checksum(real_val, cols, pk) != _checksum(
+        nan_val, cols, pk
+    ), "a real 0.0 and a missing (NaN/NULL) cell must remain distinguishable"
+
+
+# ---------------------------------------------------------------------------
 # Timezone-aware datetime parity (TIMESTAMPTZ columns)
 # ---------------------------------------------------------------------------
 
@@ -295,8 +385,8 @@ def test_checksum_tz_aware_same_instant_matches():
     assert utc != pacific or str(utc) != str(pacific)  # reprs differ pre-norm
     parquet_rows = [{"symbol": "AAA", "fetched_at": utc}]
     pg_rows = [{"symbol": "AAA", "fetched_at": pacific}]
-    assert _checksum(parquet_rows, cols, pk, frozenset()) == _checksum(
-        pg_rows, cols, pk, frozenset()
+    assert _checksum(parquet_rows, cols, pk) == _checksum(
+        pg_rows, cols, pk
     ), "same instant in a different tz offset must hash equal"
 
 

--- a/tests/test_db_verify_coverage.py
+++ b/tests/test_db_verify_coverage.py
@@ -407,6 +407,47 @@ def test_float32_columns_derives_from_parquet_dtypes():
     assert _float32_columns(df) == frozenset({"fwd_20d_ret"})
 
 
+def test_real_columns_from_schema():
+    """``_real_columns`` reports the PG ``REAL`` columns of a table spec — the
+    second normalization signal (float64-parquet-into-REAL direction)."""
+    from rainier.db import rows as rows_mod
+    from rainier.db.verify import _real_columns
+
+    labels_spec = next(
+        s for s in rows_mod.TABLE_SPECS if s.name == "thematic_labels_daily"
+    )
+    real_cols = _real_columns(labels_spec)
+    # The schema declares the forward-return columns REAL; assert a representative
+    # one is present and a non-float key column is absent.
+    assert "fwd_3d_ret" in real_cols
+    assert "symbol" not in real_cols
+
+
+def test_checksum_float64_parquet_into_real_pg_no_false_positive():
+    """codex iter-1 P1 regression: a column stored float64 in parquet but
+    ``REAL`` in PG must NOT false-positive. PG rounds the value to float32 on
+    round-trip while the parquet float64 keeps full bits; because the column is
+    in the schema-``REAL`` set the checksum normalizes both sides through float32
+    and they hash equal. (Parquet-dtype alone returns empty here and would
+    falsely flag drift.)"""
+    import numpy as np
+
+    from rainier.db.verify import _checksum
+
+    cols = ["symbol", "fwd_3d_ret"]
+    pk = ("symbol",)
+    orig64 = 0.06948674738744653  # what the float64 parquet holds
+    pg_real = float(np.float32(orig64))  # what PG REAL returns after rounding
+    assert orig64 != pg_real
+    # Union set includes the schema-REAL column even though parquet dtype is f64.
+    f32_cols = frozenset({"fwd_3d_ret"})
+    parquet_rows = [{"symbol": "AAA", "fwd_3d_ret": orig64}]
+    pg_rows = [{"symbol": "AAA", "fwd_3d_ret": pg_real}]
+    assert _checksum(parquet_rows, cols, pk, f32_cols) == _checksum(
+        pg_rows, cols, pk, f32_cols
+    ), "float64 parquet vs rounded PG REAL must hash equal (schema-REAL signal)"
+
+
 # ---------------------------------------------------------------------------
 # Timezone-aware datetime parity (TIMESTAMPTZ columns)
 # ---------------------------------------------------------------------------

--- a/tests/test_db_verify_coverage.py
+++ b/tests/test_db_verify_coverage.py
@@ -279,12 +279,14 @@ def test_verify_real_column_float32_boundary_no_false_positive(
 # market.thematic_labels_daily while every other table was TRUE parity. Root
 # cause: the parquet stores forward-return columns as float32 while the live PG
 # column is DOUBLE PRECISION (the live DDL diverged from the static REAL schema).
-# The old normalization keyed float32-casting off the STATIC schema's REAL
-# membership (_real_columns); when reality is DOUBLE the value never gets
-# normalized and the float32->float64 widen plus NaN<->NULL on recent
-# (incomplete-horizon) rows false-positives drift. The fix makes the checksum
-# value-driven: every float cell is canonicalized through float32 and NaN/NULL
-# collapse to one token — uniformly, with NO schema-type or labels special-case.
+# Keying float32-casting off the STATIC schema's REAL membership missed it.
+#
+# The fix derives the float32 column set from the PARQUET dtypes (the
+# source-of-precision) and applies the float32 round-trip ONLY to those columns
+# — on both sides. A float64-stored column (OHLC prices, breadth value) keeps
+# FULL float64 precision, so genuine sub-float32 drift in a DOUBLE column is
+# still caught (codex P1: an unconditional float32 cast would blind the gate to
+# real drift in DOUBLE columns). NaN<->NULL collapses for every column.
 
 
 def _float_truncated_by_f32() -> tuple[float, float]:
@@ -303,62 +305,106 @@ def _float_truncated_by_f32() -> tuple[float, float]:
     return orig64, parquet_f32
 
 
-def test_checksum_float32_vs_double_no_false_positive():
-    """A float column NOT in the schema REAL set (mirrors a live DOUBLE column)
-    must still hash equal across a float32 parquet value and its full-precision
-    float64 PG counterpart. RED before the value-driven fix: with an empty
-    real_cols set the old code skipped float32-canonicalization and the two
-    sides hashed differently."""
+def test_checksum_float32_column_no_false_positive():
+    """A column the parquet stores as float32 must hash equal across the float32
+    parquet value and its widened-to-float64 PG mirror (REAL *or* a
+    schema-diverged DOUBLE). The column is named in ``float32_cols`` so both
+    sides take the float32 round-trip and collapse to the same 32-bit value."""
     from rainier.db.verify import _checksum
 
     orig64, parquet_f32 = _float_truncated_by_f32()
     cols = ["symbol", "fwd_20d_ret"]
     pk = ("symbol",)
+    f32_cols = frozenset({"fwd_20d_ret"})
     parquet_rows = [{"symbol": "AAA", "fwd_20d_ret": parquet_f32}]
     pg_rows = [{"symbol": "AAA", "fwd_20d_ret": orig64}]
-    # The checksum is value-driven (no schema/REAL input): a DOUBLE live column
-    # gets float32-normalized just like a REAL one, so both sides hash equal.
-    assert _checksum(parquet_rows, cols, pk) == _checksum(
-        pg_rows, cols, pk
-    ), "float32 parquet vs float64 PG must hash equal (value-driven normalize)"
+    assert _checksum(parquet_rows, cols, pk, f32_cols) == _checksum(
+        pg_rows, cols, pk, f32_cols
+    ), "float32-stored column: parquet f32 vs widened PG f64 must hash equal"
+
+
+def test_checksum_double_column_catches_subfloat32_drift():
+    """codex P1 regression: a float64-stored (DOUBLE) column must STILL catch
+    real drift below a float32 ULP. ``100.00000001`` vs ``100.00000002`` are
+    distinct float64s that collapse to the same float32 bucket — an
+    unconditional float32 cast would silently pass corrupted data. Because the
+    column is NOT in ``float32_cols`` it is hashed at full float64 precision, so
+    the two values mismatch (drift detected)."""
+    import numpy as np
+
+    from rainier.db.verify import _checksum
+
+    cols = ["symbol", "close"]
+    pk = ("symbol",)
+    a64, b64 = 100.00000001, 100.00000002
+    # Precondition: these collapse to one float32 bucket (the blinding hazard).
+    assert np.float32(a64) == np.float32(b64), "test premise: same float32 bucket"
+    assert a64 != b64, "but distinct as float64"
+    # close is a DOUBLE-stored column -> NOT in float32_cols -> full precision.
+    a = [{"symbol": "AAA", "close": a64}]
+    b = [{"symbol": "AAA", "close": b64}]
+    assert _checksum(a, cols, pk, frozenset()) != _checksum(
+        b, cols, pk, frozenset()
+    ), "DOUBLE column drift below float32 ULP must STILL be detected"
 
 
 def test_checksum_nan_equals_sql_null():
     """A parquet float NaN and a SQL NULL (None) for the same cell must hash
-    equal. Recent asof dates legitimately carry NaN forward returns (window not
-    elapsed) that are written as NULL in PG; that representation difference must
-    not be flagged as drift."""
+    equal — for every column, float32 or not. Recent asof dates legitimately
+    carry NaN forward returns (window not elapsed) written as NULL in PG; that
+    representation difference must not be flagged as drift."""
     from rainier.db.verify import _checksum
 
     cols = ["symbol", "fwd_20d_ret"]
     pk = ("symbol",)
+    f32_cols = frozenset({"fwd_20d_ret"})
     nan_rows = [{"symbol": "AAA", "fwd_20d_ret": float("nan")}]
     null_rows = [{"symbol": "AAA", "fwd_20d_ret": None}]
-    assert _checksum(nan_rows, cols, pk) == _checksum(
-        null_rows, cols, pk
+    assert _checksum(nan_rows, cols, pk, f32_cols) == _checksum(
+        null_rows, cols, pk, f32_cols
     ), "NaN (parquet) and NULL (PG) must canonicalize to one token"
 
 
 def test_checksum_different_values_still_mismatch():
     """NEGATIVE gate: genuinely different numbers must STILL mismatch. The
     width/NaN canonicalization must not blind the gate to real drift — two
-    values that differ beyond float32 precision (and a NaN-vs-real-value pair)
-    must hash differently."""
+    float32-column values that differ beyond float32 precision (and a
+    NaN-vs-real-value pair) must hash differently."""
     from rainier.db.verify import _checksum
 
     cols = ["symbol", "fwd_20d_ret"]
     pk = ("symbol",)
+    f32_cols = frozenset({"fwd_20d_ret"})
     a = [{"symbol": "AAA", "fwd_20d_ret": 0.05}]
     b = [{"symbol": "AAA", "fwd_20d_ret": 0.06}]
-    assert _checksum(a, cols, pk) != _checksum(
-        b, cols, pk
+    assert _checksum(a, cols, pk, f32_cols) != _checksum(
+        b, cols, pk, f32_cols
     ), "0.05 vs 0.06 is real drift and must mismatch"
     # NaN/NULL must NOT collapse into a real value: a present number != absent.
     real_val = [{"symbol": "AAA", "fwd_20d_ret": 0.0}]
     nan_val = [{"symbol": "AAA", "fwd_20d_ret": float("nan")}]
-    assert _checksum(real_val, cols, pk) != _checksum(
-        nan_val, cols, pk
+    assert _checksum(real_val, cols, pk, f32_cols) != _checksum(
+        nan_val, cols, pk, f32_cols
     ), "a real 0.0 and a missing (NaN/NULL) cell must remain distinguishable"
+
+
+def test_float32_columns_derives_from_parquet_dtypes():
+    """``_float32_columns`` reports exactly the float32-dtype columns of a frame
+    (the live source-of-precision), so a float64 column is excluded and stays
+    full precision in the checksum."""
+    import numpy as np
+    import pandas as pd
+
+    from rainier.db.verify import _float32_columns
+
+    df = pd.DataFrame(
+        {
+            "symbol": pd.Series(["AAA"], dtype="object"),
+            "fwd_20d_ret": pd.Series([0.1], dtype=np.float32),
+            "close": pd.Series([100.0], dtype=np.float64),
+        }
+    )
+    assert _float32_columns(df) == frozenset({"fwd_20d_ret"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix verify-coverage false-positive checksum drift on `market.thematic_labels_daily` (discovered during the live Neon cutover): the parity hash was sensitive to float32(parquet)↔float64(PG) width and NaN↔NULL.
- verify.py `_canon_cell` now float32-normalizes a column iff it is parquet-float32 OR schema-REAL (union), collapses NaN≡NULL, and leaves float64-on-both-sides columns at full precision so genuine DOUBLE drift is still caught. Verify-side only — no parquet/source or PG schema change.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 4) — codex caught that an unconditional float32 cast blinded the gate to sub-float32-ULP DOUBLE drift (P1); fixed via the parquet-float32 ∪ schema-REAL union; permanent negative-gate test (`test_checksum_double_column_catches_subfloat32_drift`).

## Context
- Found by `db verify-coverage` after the Neon backfill; the labels column is DOUBLE in Neon though the schema REAL-set expected float32 (live DDL divergence) — the value-driven canon handles it. 7 unit tests (both parity directions, DOUBLE-drift negative gate, NaN/NULL).

## Test plan
- [ ] CI green
- [ ] `db verify-coverage` fully green against the backfilled Neon