### PR TITLE
feat(thematic): incremental daily backfill + wire thematic/breadth producer crons

### DIFF
--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -155,10 +155,14 @@ jobs:
   # the breadth side reads `sp500_universe.parquet`, schedule it on a later
   # minute (e.g., `45 12`) so this refresh has finished writing.
   #
-  # Disabled at file-commit time so a fresh checkout doesn't immediately
-  # hit yfinance from a host that hasn't yet run the one-shot backfill
-  # (which seeds data/cache/sp500_universe.parquet). Operator flips
-  # `enabled: true` once the one-shot is complete.
+  # PREREQUISITE: the one-shot full-history backfill that seeds
+  # data/cache/sp500_universe.parquet must have run on this host BEFORE this
+  # cron is active. The incremental first run fetches only the last 5 calendar
+  # days, but compute-indicators needs long history (50/100/200-day MAs,
+  # 52-week highs/lows) — without the seed the published dashboard would be
+  # mostly NaN. Enabled here because the operator's deployment host is already
+  # seeded (breadth dashboard is live). On a fresh host, run the one-shot seed
+  # first or flip this back to `enabled: false` until the seed completes.
   - name: market-breadth-daily
     description: "Refresh sp500 OHLCV + compute breadth indicators + render & publish market-breadth dashboard"
     schedule: "45 12 * * 1-5"   # 12:45 PST Mon-Fri (15 min pre-close)

--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -63,22 +63,26 @@ jobs:
   # `run-daily` short-circuits if today's Layer A row is already present, so
   # cron retries are safe.
   #
-  # DISABLED until a daily OHLCV refresh job lands (codex iter-7 [P1]).
-  # `run-daily` needs `data/cache/thematic_universe.parquet` to be current
-  # for today's asof. The Phase A `backfill_thematic_universe.py` is a
-  # one-shot bulk fetch (no `--resume`/--update mode) and is revision-
-  # immutable (`--force` writes a sibling cohort, not in-place). Until the
-  # backfill script grows a daily-refresh mode (deferred follow-up), enabling
-  # this cron would hit the stale-OHLCV guard and fail every weekday.
-  # Operator flips `enabled: true` once daily OHLCV refresh is wired up;
-  # `run-daily` itself remains operator-runnable via the CLI for ad-hoc use.
+  # Full chain (mirrors the breadth twin `market-breadth-daily`):
+  #   1. `thematic backfill --incremental` — fetch the last few calendar days
+  #      of OHLCV and upsert on (symbol, date) into the existing
+  #      data/cache/thematic_universe.parquet IN PLACE (no --force cohort).
+  #      This advances max(date) to today so run-daily's stale-OHLCV guard
+  #      (cli._check_ohlcv_freshness) passes on the very next step.
+  #   2. `thematic run-daily` — compute Layer A+B + render the dashboard.
+  #
+  # `&&` enforces serial execution and propagates the first non-zero exit to
+  # cron-wrapper.sh, which fires the Discord alert (discord_on_failure below).
+  # Previously DISABLED because step 2 alone hit the stale-OHLCV guard every
+  # weekday (the cache was never refreshed); the --incremental refresh resolves
+  # that (thematic-daily-cron-wire), so this is now enabled.
   - name: thematic-ranks-daily
-    description: "Compute thematic ranks (Layer A+B) + render dashboard"
+    description: "Refresh thematic OHLCV + compute thematic ranks (Layer A+B) + render dashboard"
     schedule: "30 13 * * 1-5"   # 13:30 PST = 16:30 ET, Mon-Fri
-    command: "uv run rainier thematic run-daily"
+    command: "uv run rainier thematic backfill --incremental && uv run rainier thematic run-daily"
     log: "data/thematic-ranks.log"
     discord_on_failure: true
-    enabled: false
+    enabled: true
 
   # ETF names cache refresh — DESIGN-etf-dashboard-name-column.md §3.4.
   #
@@ -183,7 +187,7 @@ jobs:
     command: "uv run rainier market-breadth backfill-ohlcv --incremental && uv run rainier market-breadth compute-indicators && scripts/publish-market-breadth.sh"
     log: "data/market-breadth.log"
     discord_on_failure: true
-    enabled: false
+    enabled: true
 
   # Combined trading dashboard — DESIGN-trading-dashboard-combined-v1.md.
   # Publishes /trading/ (one URL, shared header + Breadth / ETF

--- a/scripts/backfill_thematic_universe.py
+++ b/scripts/backfill_thematic_universe.py
@@ -600,10 +600,19 @@ def backfill(
 
     fetched = fetch_fn(symbols, start, end)
 
-    # Coverage gate: the incremental window is only a few calendar days, so the
-    # per-symbol bday-ratio tiers (built for the full-history backfill) don't
-    # apply — skip them. The cron's stale/partial guard in ``run-daily``
-    # (_check_ohlcv_freshness) is the load-bearing freshness check downstream.
+    # Coverage gate.
+    #
+    # One-shot: the full per-symbol bday-ratio tiers (built for full history).
+    #
+    # Incremental: the few-day window can't meet the bday-ratio tiers, so those
+    # don't apply. But a provider OUTAGE (yfinance returns empty for most/all
+    # symbols) must still fail BEFORE the atomic write — otherwise we'd upsert a
+    # thin/empty window into the cache (or write an empty cache on a fresh host)
+    # and the cron would exit 0 with no usable ranks. Mirror the breadth twin
+    # (rainier.market_breadth.ohlcv_backfill): count symbols that returned rows;
+    # raise if below the coverage fraction. This aborts before _write_parquet_*
+    # so the prior good cache stays intact and cron-wrapper's discord_on_failure
+    # fires. (codex iter-4 [P1].)
     if not incremental:
         _validate_coverage(
             fetched=fetched,
@@ -614,6 +623,29 @@ def backfill(
             allow_gaps=allow_gaps_set,
             min_coverage=min_coverage,
         )
+    elif min_coverage > 0.0:
+        present = sum(
+            1
+            for sym in symbols
+            if sym not in allow_empty_set
+            and fetched.get(sym) is not None
+            and not fetched[sym].empty
+        )
+        gated = [s for s in symbols if s not in allow_empty_set]
+        if gated and present < min_coverage * len(gated):
+            missing = sorted(
+                s
+                for s in gated
+                if fetched.get(s) is None or fetched[s].empty
+            )
+            raise ValueError(
+                f"incremental refresh outage: only {present}/{len(gated)} "
+                f"symbols returned rows for window {start}..{end} "
+                f"(need >= {min_coverage:.0%}). Likely a yfinance outage / "
+                f"rate-limit. Aborting before the cache write so the prior "
+                f"good cache stays intact. Examples missing: {missing[:8]}. "
+                f"Re-run when the provider is healthy."
+            )
 
     df = _to_normalized_frame(fetched, yfinance_version, fetched_at)
 

--- a/scripts/backfill_thematic_universe.py
+++ b/scripts/backfill_thematic_universe.py
@@ -573,6 +573,35 @@ def backfill(
         start = (today_d - timedelta(days=INCREMENTAL_WINDOW_DAYS)).isoformat()
         end = today_d.isoformat()
 
+        # Gap guard: the fixed today-N..today window can only bridge a gap of
+        # <= INCREMENTAL_WINDOW_DAYS. If the existing cache's high-water mark is
+        # older than the window start (cron was disabled for a while, or several
+        # runs were missed), the refresh would leave a HOLE in the middle of the
+        # series; rel_20/vol_20 would then be computed across a discontinuity and
+        # publish wrong ranks. Fail loud and tell the operator to run the full
+        # seed instead of silently stitching a gapped series (codex iter-6 [P1]).
+        if not dry_run and out_path.exists():
+            try:
+                _existing = pd.read_parquet(out_path, columns=["date"])
+            except Exception:  # noqa: BLE001 — unreadable cache; let downstream handle
+                _existing = None
+            if _existing is not None and not _existing.empty:
+                hwm = pd.to_datetime(_existing["date"]).dt.date.max()
+                window_start = today_d - timedelta(days=INCREMENTAL_WINDOW_DAYS)
+                if hwm < window_start:
+                    gap_days = (today_d - hwm).days
+                    raise ValueError(
+                        f"incremental gap too large: cache max(date)={hwm} is "
+                        f"{gap_days} calendar days behind today={today_d}, but "
+                        f"the incremental window is only {INCREMENTAL_WINDOW_DAYS} "
+                        f"days. Refreshing would leave a hole in the series and "
+                        f"produce wrong rel_20/vol_20 ranks. Run the full-history "
+                        f"seed instead:\n"
+                        f"  python scripts/backfill_thematic_universe.py "
+                        f"--start 2024-10-01 --end {today_d} --force\n"
+                        f"then move the new cohort into place."
+                    )
+
     if dry_run:
         return {
             "symbols": symbols,

--- a/scripts/backfill_thematic_universe.py
+++ b/scripts/backfill_thematic_universe.py
@@ -747,9 +747,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     if ns.dry_run:
         plan = result  # type: ignore[assignment]
+        # Use the plan's resolved window (incremental rewrites start/end to the
+        # recent window inside backfill()), not the raw argparse values.
         print(
             f"DRY-RUN: would fetch {len(symbols)} symbols "
-            f"{ns.start}..{ns.end} -> {plan['planned_out']}"  # type: ignore[index]
+            f"{plan['start']}..{plan['end']} -> {plan['planned_out']}"  # type: ignore[index]
         )
         for sym in symbols:
             print(f"  {sym}")

--- a/scripts/backfill_thematic_universe.py
+++ b/scripts/backfill_thematic_universe.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Iterable
 
@@ -50,6 +50,13 @@ DEFAULT_YAML = ROOT / "config" / "thematic_universe.yaml"
 DEFAULT_OUT = Path("data/cache/thematic_universe.parquet")
 DEFAULT_START = "2024-10-01"
 DEFAULT_END = "2026-05-01"
+
+# Daily-refresh window for ``--incremental``. Mirrors the breadth twin
+# (rainier.market_breadth.ohlcv_backfill.INCREMENTAL_WINDOW_DAYS): fetch the
+# last N CALENDAR days and upsert on (symbol, date) into the existing parquet.
+# 5 days is the self-healing margin so a missed cron yesterday is picked up
+# by today's run without a full re-fetch.
+INCREMENTAL_WINDOW_DAYS = 5
 # Same persistent registries the `thematic compute` / `run-daily` path uses, so
 # the PG ticker_id/sector_id the backfill mirrors match the IDs the feature
 # writer FK-references. (See _dual_write_pg for why a local counter is wrong.)
@@ -244,6 +251,40 @@ def _cohort_path(out_path: Path, fetched_at: datetime) -> Path:
         f"could not find an unused cohort path next to {out_path} after 1000 "
         "attempts; refusing to overwrite existing cohort (revision_immutability)."
     )
+
+
+def _upsert_in_place(new_df: pd.DataFrame, out_path: Path) -> pd.DataFrame:
+    """Merge ``new_df`` into the existing parquet (if any) on (symbol, date).
+
+    Mirrors ``rainier.market_breadth.ohlcv_backfill._upsert``. Latest write
+    wins for any overlapping (symbol, date) — rows in ``new_df`` replace prior
+    rows with the same key. The ``--incremental`` path rewrites only the rows
+    inside the recent window; everything else in the existing cache is kept.
+
+    Returns the merged frame in canonical column order. Caller atomic-writes it
+    back onto ``out_path`` (no sibling cohort — incremental refresh is
+    in-place, unlike ``--force``).
+    """
+    if not out_path.exists():
+        return new_df
+
+    existing = pd.read_parquet(out_path)
+    if existing.empty:
+        return new_df
+
+    # Date dtype harmonization: parquet round-trip yields python ``date`` for
+    # date32; new_df already builds ``date`` objects. Compare apples to apples.
+    existing["date"] = pd.to_datetime(existing["date"]).dt.date
+    new_df = new_df.copy()
+    if not new_df.empty:
+        new_df["date"] = pd.to_datetime(new_df["date"]).dt.date
+        key = set(new_df[["symbol", "date"]].apply(tuple, axis=1))
+        existing_key = existing[["symbol", "date"]].apply(tuple, axis=1)
+        existing = existing.loc[~existing_key.isin(key)]
+
+    merged = pd.concat([existing, new_df], ignore_index=True)
+    merged = merged.sort_values(["symbol", "date"]).reset_index(drop=True)
+    return merged[list(_COLUMN_ORDER)]
 
 
 # ---------------------------------------------------------------------------
@@ -480,6 +521,7 @@ def backfill(
     out_path: Path,
     force: bool = False,
     dry_run: bool = False,
+    incremental: bool = False,
     fetch_fn: Callable[[Iterable[str], str, str], dict[str, pd.DataFrame]]
     | None = None,
     allow_empty: Iterable[str] | None = None,
@@ -488,13 +530,27 @@ def backfill(
     yaml_path: Path | None = None,
     ticker_registry_path: Path = DEFAULT_TICKER_REGISTRY,
     sector_registry_path: Path = DEFAULT_SECTOR_REGISTRY,
+    today: date | None = None,
 ) -> Path | dict[str, object]:
     """Run the backfill.
 
+    Two write modes:
+
+      * **One-shot** (default): full ``start``..``end`` fetch. Refuses to
+        overwrite an existing cache unless ``force=True`` (which writes a dated
+        sibling cohort, never in place — revision-immutability).
+      * **Incremental** (``incremental=True``): the daily-cron refresh path
+        that mirrors the breadth twin (``market-breadth backfill-ohlcv
+        --incremental``). ``start``/``end`` are ignored; the window is the last
+        ``INCREMENTAL_WINDOW_DAYS`` calendar days ending at ``today``. The
+        fetched rows are upserted on ``(symbol, date)`` into the EXISTING cache
+        in place — no ``--force``, no sibling cohort. Network-light and
+        idempotent: a re-run over the same window adds no new rows.
+
     Returns the parquet path actually written (a sibling cohort path when
-    ``force=True`` and the destination already exists). In ``dry_run`` mode
-    returns the planned ticker × date matrix without touching the network or
-    the filesystem.
+    ``force=True`` and the destination already exists; ``out_path`` otherwise,
+    including the incremental path). In ``dry_run`` mode returns the planned
+    ticker × date matrix without touching the network or the filesystem.
 
     When ``yaml_path`` is provided, the OHLCV frame + ticker/sector registries
     are also mirrored into the ``market.*`` Postgres tables (Phase 2 dual-write,
@@ -510,6 +566,13 @@ def backfill(
     allow_empty_set: set[str] = set(allow_empty or ())
     allow_gaps_set: set[str] = set(allow_gaps or ())
 
+    # Incremental refresh fixes the fetch window to the recent gap (mirrors the
+    # breadth twin). The full-backfill start/end are ignored.
+    if incremental:
+        today_d = today or date.today()
+        start = (today_d - timedelta(days=INCREMENTAL_WINDOW_DAYS)).isoformat()
+        end = today_d.isoformat()
+
     if dry_run:
         return {
             "symbols": symbols,
@@ -518,9 +581,13 @@ def backfill(
             "planned_out": str(out_path),
         }
 
-    if out_path.exists() and not force:
+    # The one-shot path refuses to clobber an existing cache without --force.
+    # The incremental path INTENTIONALLY refreshes in place (upsert), so it
+    # skips this guard — that's the whole point of the daily-cron contract.
+    if not incremental and out_path.exists() and not force:
         raise FileExistsError(
-            f"{out_path} already exists. Pass --force to write a new cohort."
+            f"{out_path} already exists. Pass --force to write a new cohort "
+            f"or --incremental to refresh the recent window in place."
         )
 
     fetched_at = datetime.now(tz=timezone.utc)
@@ -533,24 +600,35 @@ def backfill(
 
     fetched = fetch_fn(symbols, start, end)
 
-    _validate_coverage(
-        fetched=fetched,
-        symbols=symbols,
-        start=start,
-        end=end,
-        allow_empty=allow_empty_set,
-        allow_gaps=allow_gaps_set,
-        min_coverage=min_coverage,
-    )
+    # Coverage gate: the incremental window is only a few calendar days, so the
+    # per-symbol bday-ratio tiers (built for the full-history backfill) don't
+    # apply — skip them. The cron's stale/partial guard in ``run-daily``
+    # (_check_ohlcv_freshness) is the load-bearing freshness check downstream.
+    if not incremental:
+        _validate_coverage(
+            fetched=fetched,
+            symbols=symbols,
+            start=start,
+            end=end,
+            allow_empty=allow_empty_set,
+            allow_gaps=allow_gaps_set,
+            min_coverage=min_coverage,
+        )
 
     df = _to_normalized_frame(fetched, yfinance_version, fetched_at)
 
-    target = (
-        _cohort_path(out_path, fetched_at)
-        if (out_path.exists() and force)
-        else out_path
-    )
-    _write_parquet_atomic(df, target)
+    if incremental:
+        # In-place upsert on (symbol, date) into the existing cache. No cohort.
+        target = out_path
+        merged = _upsert_in_place(df, out_path)
+        _write_parquet_atomic(merged, target)
+    else:
+        target = (
+            _cohort_path(out_path, fetched_at)
+            if (out_path.exists() and force)
+            else out_path
+        )
+        _write_parquet_atomic(df, target)
 
     # Phase 2 dual-write: mirror into market.* AFTER the parquet write (parquet
     # is the load-bearing output; PG is additive). Only when a universe YAML is
@@ -602,6 +680,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="When the cache exists, write a timestamped sibling cohort.",
     )
     p.add_argument(
+        "--incremental",
+        action="store_true",
+        help=(
+            "Daily-cron refresh: ignore --start/--end, fetch the last few "
+            "calendar days, upsert on (symbol, date) into the existing cache "
+            "in place (no --force / cohort)."
+        ),
+    )
+    p.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the planned ticker × date matrix; do not fetch or write.",
@@ -649,6 +736,7 @@ def main(argv: list[str] | None = None) -> int:
         end=ns.end,
         out_path=out_path,
         force=ns.force,
+        incremental=ns.incremental,
         dry_run=ns.dry_run,
         allow_empty=allow_empty,
         allow_gaps=allow_gaps,

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3331,6 +3331,17 @@ def thematic() -> None:
     help="When the cache exists, write a timestamped sibling cohort.",
 )
 @click.option(
+    "--incremental",
+    is_flag=True,
+    default=False,
+    help=(
+        "Daily-cron refresh: ignore --start/--end, fetch only the last few "
+        "calendar days, and upsert on (symbol, date) into the existing cache "
+        "in place (no --force / cohort). Mirrors "
+        "`market-breadth backfill-ohlcv --incremental`."
+    ),
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     default=False,
@@ -3370,6 +3381,7 @@ def thematic_backfill(
     end: str | None,
     out_path: str,
     force: bool,
+    incremental: bool,
     dry_run: bool,
     allow_empty: str,
     allow_gaps: str,
@@ -3379,7 +3391,8 @@ def thematic_backfill(
 ) -> None:
     """Backfill the OHLCV cache + seed ticker/sector registries.
 
-    Operator-run, not CI-run. Hits the yfinance network.
+    Operator-run for the one-shot mode; cron-driven for ``--incremental``.
+    Hits the yfinance network.
     """
     import importlib.util
     from datetime import date as _date
@@ -3417,6 +3430,7 @@ def thematic_backfill(
         end=end_eff,
         out_path=Path(out_path),
         force=force,
+        incremental=incremental,
         dry_run=dry_run,
         allow_empty=[s.strip() for s in allow_empty.split(",") if s.strip()],
         allow_gaps=[s.strip() for s in allow_gaps.split(",") if s.strip()],
@@ -3425,16 +3439,19 @@ def thematic_backfill(
 
     if dry_run:
         plan = result
+        # backfill() resolves the incremental window internally, so the dry-run
+        # plan reflects the actual window that would be fetched.
         click.echo(
             f"DRY-RUN: would fetch {len(symbols)} symbols "
-            f"{start_eff}..{end_eff} -> {plan['planned_out']}"
+            f"{plan['start']}..{plan['end']} -> {plan['planned_out']}"
         )
         for sym in symbols:
             click.echo(f"  {sym}")
         return
 
     written_path = result
-    click.echo(f"wrote OHLCV cache -> {written_path}")
+    mode = "incremental" if incremental else "one-shot"
+    click.echo(f"wrote OHLCV cache ({mode}) -> {written_path}")
 
     # Seed registries with the just-fetched universe. Idempotent — re-running
     # backfill does not change existing IDs (per [D-015]).

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3964,6 +3964,15 @@ def _check_ohlcv_freshness(
     both paths surface the same diagnostic (codex iter-6/8 [P1]/[P2]).
 
     Stale: panel.max(date) < asof_dt.
+    Shallow: fewer than MIN_HISTORY_TRADING_DAYS distinct dates <= asof_dt.
+             Layer A's longest rolling window is 20 trading days (rel_20 +
+             vol_20); with less history compute_thematic_features emits the
+             RANK_SENTINEL for every symbol and the job exits 0 with unusable
+             ranks. This catches the fresh-host / deleted-cache case where
+             `thematic backfill --incremental` writes only the 5-day window
+             (the incremental path is a refresh, not a substitute for the
+             full-history seed). Fail loud so the operator runs the one-shot
+             seed first.
     Partial: > 25% of YAML symbols missing on asof_dt (fail);
              > 10% missing (warning to stderr).
     """
@@ -3981,6 +3990,22 @@ def _check_ohlcv_freshness(
             f"{Path(ohlcv_path).stem}_*{Path(ohlcv_path).suffix} | head -1) "
             f"{ohlcv_path}\n"
             f"  3. uv run rainier thematic run-daily  # retry"
+        )
+
+    # Shallow-history guard: Layer A needs >= 20 trading days of history for
+    # the rel_20 / vol_20 windows. Count distinct dates at or before asof.
+    MIN_HISTORY_TRADING_DAYS = 20
+    distinct_dates = panel.loc[panel["date"] <= asof_dt, "date"].nunique()
+    if distinct_dates < MIN_HISTORY_TRADING_DAYS:
+        raise click.ClickException(
+            f"OHLCV cache too shallow: only {distinct_dates} trading day(s) "
+            f"<= asof={asof_dt}; Layer A needs >= {MIN_HISTORY_TRADING_DAYS} "
+            f"(rel_20/vol_20 windows) or every rank is the no-data sentinel. "
+            f"The --incremental refresh only fetches a few days and is NOT a "
+            f"substitute for the full-history seed. Seed first:\n"
+            f"  1. uv run python scripts/backfill_thematic_universe.py "
+            f"--start 2024-10-01 --end {asof_dt}\n"
+            f"  2. uv run rainier thematic run-daily  # retry"
         )
 
     expected_syms = {sym for syms in spec.sectors.values() for sym in syms}

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3435,6 +3435,17 @@ def thematic_backfill(
         allow_empty=[s.strip() for s in allow_empty.split(",") if s.strip()],
         allow_gaps=[s.strip() for s in allow_gaps.split(",") if s.strip()],
         min_coverage=coverage,
+        # Pass the universe YAML so backfill() mirrors the OHLCV frame +
+        # ticker/sector registries into market.* (Neon). Without this the
+        # daily cron's --incremental refresh advances the PARQUET only and
+        # leaves market.thematic_ohlcv STALE — exactly the gap a live
+        # catch-up found 2026-05-30 (features/labels reached today but
+        # thematic_ohlcv was stuck days behind). _dual_write_pg fires only
+        # when yaml_path is set and is a no-op when DATABASE_URL is unset, so
+        # this is safe on both the one-shot and incremental paths.
+        yaml_path=yaml_p,
+        ticker_registry_path=Path(ticker_registry),
+        sector_registry_path=Path(sector_registry),
     )
 
     if dry_run:

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3992,20 +3992,32 @@ def _check_ohlcv_freshness(
             f"  3. uv run rainier thematic run-daily  # retry"
         )
 
-    # Shallow-history guard: Layer A needs >= 20 trading days of history for
-    # the rel_20 / vol_20 windows. Count distinct dates at or before asof.
-    MIN_HISTORY_TRADING_DAYS = 20
+    # Shallow-history guard: Layer A's longest lookback is the 20-trading-day
+    # rel_20 window. compute_thematic_features indexes the asof row at
+    # asof_idx = (#dates <= asof) - 1 and reads prior_idx = asof_idx - 20; that
+    # is only valid (non-negative) when asof_idx >= 20, i.e. there are >= 21
+    # distinct dates at/before asof. With exactly 20, prior_idx = -1 and rel_20
+    # /vol_20 stay NaN -> sentinel ranks (codex iter-5 off-by-one). Require 21.
+    MIN_HISTORY_TRADING_DAYS = 21
     distinct_dates = panel.loc[panel["date"] <= asof_dt, "date"].nunique()
     if distinct_dates < MIN_HISTORY_TRADING_DAYS:
+        # The shallow cache already exists (--incremental created it), so the
+        # seed must replace it: the one-shot backfill refuses to overwrite
+        # without --force, and --force writes a sibling cohort that must be
+        # moved into place (revision-immutability) — same flow as the stale
+        # branch above (codex iter-5).
         raise click.ClickException(
             f"OHLCV cache too shallow: only {distinct_dates} trading day(s) "
             f"<= asof={asof_dt}; Layer A needs >= {MIN_HISTORY_TRADING_DAYS} "
             f"(rel_20/vol_20 windows) or every rank is the no-data sentinel. "
             f"The --incremental refresh only fetches a few days and is NOT a "
-            f"substitute for the full-history seed. Seed first:\n"
+            f"substitute for the full-history seed. Replace the shallow cache:\n"
             f"  1. uv run python scripts/backfill_thematic_universe.py "
-            f"--start 2024-10-01 --end {asof_dt}\n"
-            f"  2. uv run rainier thematic run-daily  # retry"
+            f"--start 2024-10-01 --end {asof_dt} --force\n"
+            f"  2. mv $(ls -t {Path(ohlcv_path).parent}/"
+            f"{Path(ohlcv_path).stem}_*{Path(ohlcv_path).suffix} | head -1) "
+            f"{ohlcv_path}\n"
+            f"  3. uv run rainier thematic run-daily  # retry"
         )
 
     expected_syms = {sym for syms in spec.sectors.values() for sym in syms}

--- a/tests/research/test_backfill_thematic_universe.py
+++ b/tests/research/test_backfill_thematic_universe.py
@@ -378,19 +378,24 @@ def test_incremental_fetches_recent_window_only(backfill_mod, tmp_path):
     from datetime import date, timedelta
 
     out = tmp_path / "thematic.parquet"
-    # Seed an existing cache with old history so we can prove the incremental
-    # fetch window is the recent gap, not a full re-fetch.
+    today = date(2026, 5, 29)
+    # Seed an existing cache whose high-water mark is INSIDE the incremental
+    # window (so the gap guard is satisfied) but with dates DISTINCT from the
+    # recent fetch dates, so we can still prove the incremental fetch window is
+    # the recent gap, not a full re-fetch.
+    seed_dates = [today - timedelta(days=d) for d in (5, 4, 3)]
+    seed_fetch = _windowed_fetch_factory(seed_dates)
     backfill_mod.backfill(
         symbols=["XLK", "SMH"],
         start="2024-10-01",
         end="2024-10-08",
         out_path=out,
-        force=False,
-        fetch_fn=_stub_fetch,
+        incremental=True,
+        fetch_fn=seed_fetch,
+        today=today,
         min_coverage=0.0,
     )
 
-    today = date(2026, 5, 29)
     recent_dates = [today - timedelta(days=2), today - timedelta(days=1), today]
     fetch = _windowed_fetch_factory(recent_dates)
 
@@ -418,19 +423,23 @@ def test_incremental_upserts_in_place_no_cohort(backfill_mod, tmp_path):
     from datetime import date, timedelta
 
     out = tmp_path / "thematic.parquet"
+    today = date(2026, 5, 29)
+    # Seed with dates inside the incremental window (gap guard satisfied) but
+    # distinct from the recent refresh dates, so the upsert genuinely appends.
+    seed_dates = [today - timedelta(days=d) for d in (5, 4, 3)]
     backfill_mod.backfill(
         symbols=["XLK", "SMH"],
         start="2024-10-01",
         end="2024-10-08",
         out_path=out,
-        force=False,
-        fetch_fn=_stub_fetch,
+        incremental=True,
+        fetch_fn=_windowed_fetch_factory(seed_dates),
+        today=today,
         min_coverage=0.0,
     )
     old_rows = len(pd.read_parquet(out))
     siblings_before = set(tmp_path.glob("thematic_*.parquet"))
 
-    today = date(2026, 5, 29)
     recent_dates = [today - timedelta(days=1), today]
     fetch = _windowed_fetch_factory(recent_dates)
 
@@ -466,17 +475,20 @@ def test_incremental_no_gap_is_noop(backfill_mod, tmp_path):
     from datetime import date, timedelta
 
     out = tmp_path / "thematic.parquet"
+    today = date(2026, 5, 29)
+    # Seed within the incremental window so the gap guard is satisfied.
+    seed_dates = [today - timedelta(days=d) for d in (5, 4)]
     backfill_mod.backfill(
         symbols=["XLK"],
         start="2024-10-01",
         end="2024-10-08",
         out_path=out,
-        force=False,
-        fetch_fn=_stub_fetch,
+        incremental=True,
+        fetch_fn=_windowed_fetch_factory(seed_dates),
+        today=today,
         min_coverage=0.0,
     )
 
-    today = date(2026, 5, 29)
     recent_dates = [today - timedelta(days=1), today]
     fetch = _windowed_fetch_factory(recent_dates)
 
@@ -542,20 +554,23 @@ def test_incremental_outage_aborts_before_write(backfill_mod, tmp_path):
     from datetime import date, timedelta
 
     out = tmp_path / "thematic.parquet"
-    # Seed a prior good cache so we can prove the outage doesn't clobber it.
+    today = date(2026, 5, 29)
+    # Seed a prior good cache WITHIN the incremental window (so the gap guard
+    # passes and we actually reach the outage gate) to prove the outage doesn't
+    # clobber it.
+    seed_dates = [today - timedelta(days=d) for d in (5, 4, 3)]
     backfill_mod.backfill(
         symbols=["XLK", "SMH", "XLE", "XLF"],
         start="2024-10-01",
         end="2024-10-08",
         out_path=out,
-        force=False,
-        fetch_fn=_stub_fetch,
+        incremental=True,
+        fetch_fn=_windowed_fetch_factory(seed_dates),
+        today=today,
         min_coverage=0.0,
     )
     good_df = pd.read_parquet(out)
     good_rows = len(good_df)
-
-    today = date(2026, 5, 29)
 
     # Outage: only 1 of 4 symbols returns rows -> 25% < 90% default coverage.
     def _outage_fetch(symbols, start, end):
@@ -592,3 +607,48 @@ def test_incremental_outage_aborts_before_write(backfill_mod, tmp_path):
     after = pd.read_parquet(out)
     assert len(after) == good_rows, "outage must not clobber the prior cache"
     assert today not in set(pd.to_datetime(after["date"]).dt.date)
+
+
+def test_incremental_gap_too_large_aborts(backfill_mod, tmp_path):
+    """If the existing cache's high-water mark is older than the incremental
+    window can bridge, the refresh must fail loud rather than stitch a gapped
+    series (which would corrupt rel_20/vol_20). (codex P1.)
+    """
+    from datetime import date, timedelta
+
+    out = tmp_path / "thematic.parquet"
+    today = date(2026, 5, 29)
+    # Seed a cache whose max date is well outside the 5-day window (e.g. the
+    # cron was disabled for weeks). Use a windowed factory centered on an old
+    # anchor so the seed write itself isn't gap-guarded (no prior cache yet).
+    old_anchor = today - timedelta(days=40)
+    old_dates = [old_anchor - timedelta(days=d) for d in (2, 1, 0)]
+    backfill_mod.backfill(
+        symbols=["XLK"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        incremental=True,
+        fetch_fn=_windowed_fetch_factory(old_dates),
+        today=old_anchor,  # seed write anchored at the old date (no gap then)
+        min_coverage=0.0,
+    )
+    seeded_rows = len(pd.read_parquet(out))
+
+    # Now refresh at the real `today`: the gap (40 days) exceeds the 5-day
+    # window -> must abort before touching the cache.
+    recent = [today - timedelta(days=1), today]
+    with pytest.raises(ValueError, match="gap too large"):
+        backfill_mod.backfill(
+            symbols=["XLK"],
+            start="2024-10-01",
+            end="2024-10-08",
+            out_path=out,
+            incremental=True,
+            fetch_fn=_windowed_fetch_factory(recent),
+            today=today,
+            min_coverage=0.0,
+        )
+
+    # Cache untouched — no gapped stitch.
+    assert len(pd.read_parquet(out)) == seeded_rows

--- a/tests/research/test_backfill_thematic_universe.py
+++ b/tests/research/test_backfill_thematic_universe.py
@@ -321,3 +321,214 @@ def test_empty_symbol_allowed_via_allowlist(backfill_mod, tmp_path):
     assert out.exists()
     df = pd.read_parquet(out)
     assert set(df["symbol"].unique()) == {"XLK"}
+
+
+# ---------------------------------------------------------------------------
+# --incremental — recent-window refresh, in-place upsert (mirrors breadth
+# backfill-ohlcv --incremental). Refreshes the existing cache without --force
+# cohort so the stale-OHLCV guard in `run-daily` is satisfied.
+# ---------------------------------------------------------------------------
+
+
+def _windowed_fetch_factory(per_symbol_dates):
+    """Return a fetch_fn that records its (symbols, start, end) args and
+    returns rows ONLY for the dates inside [start, end] (inclusive), so a test
+    can assert the incremental path fetches the recent window, not full history.
+    """
+
+    captured: dict[str, object] = {}
+
+    def _fetch(symbols, start, end):
+        captured["symbols"] = list(symbols)
+        captured["start"] = start
+        captured["end"] = end
+        start_d = pd.to_datetime(start).date()
+        end_d = pd.to_datetime(end).date()
+        out: dict[str, pd.DataFrame] = {}
+        for i, sym in enumerate(symbols):
+            base = 100.0 + i * 10.0
+            rows = []
+            for j, d in enumerate(per_symbol_dates):
+                if d < start_d or d > end_d:
+                    continue
+                rows.append(
+                    {
+                        "date": d,
+                        "open": base + j,
+                        "high": base + j + 0.5,
+                        "low": base + j - 0.5,
+                        "close": base + j + 0.25,
+                        "volume": 1000 * (j + 1),
+                    }
+                )
+            out[sym] = pd.DataFrame(
+                rows,
+                columns=["date", "open", "high", "low", "close", "volume"],
+            )
+        return out
+
+    _fetch.captured = captured  # type: ignore[attr-defined]
+    return _fetch
+
+
+def test_incremental_fetches_recent_window_only(backfill_mod, tmp_path):
+    """`incremental=True` ignores start/end and fetches a fixed recent window
+    (today - INCREMENTAL_WINDOW_DAYS .. today), not the full history.
+    """
+    from datetime import date, timedelta
+
+    out = tmp_path / "thematic.parquet"
+    # Seed an existing cache with old history so we can prove the incremental
+    # fetch window is the recent gap, not a full re-fetch.
+    backfill_mod.backfill(
+        symbols=["XLK", "SMH"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=False,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+
+    today = date(2026, 5, 29)
+    recent_dates = [today - timedelta(days=2), today - timedelta(days=1), today]
+    fetch = _windowed_fetch_factory(recent_dates)
+
+    backfill_mod.backfill(
+        symbols=["XLK", "SMH"],
+        start="2024-10-01",  # ignored under incremental
+        end="2024-10-08",  # ignored under incremental
+        out_path=out,
+        incremental=True,
+        fetch_fn=fetch,
+        today=today,
+        min_coverage=0.0,
+    )
+
+    cap = fetch.captured  # type: ignore[attr-defined]
+    expected_start = (today - timedelta(days=backfill_mod.INCREMENTAL_WINDOW_DAYS)).isoformat()
+    assert cap["start"] == expected_start
+    assert cap["end"] == today.isoformat()
+
+
+def test_incremental_upserts_in_place_no_cohort(backfill_mod, tmp_path):
+    """`incremental=True` merges the recent window INTO the existing parquet
+    on (symbol, date) — no FileExistsError, no sibling cohort file written.
+    """
+    from datetime import date, timedelta
+
+    out = tmp_path / "thematic.parquet"
+    backfill_mod.backfill(
+        symbols=["XLK", "SMH"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=False,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+    old_rows = len(pd.read_parquet(out))
+    siblings_before = set(tmp_path.glob("thematic_*.parquet"))
+
+    today = date(2026, 5, 29)
+    recent_dates = [today - timedelta(days=1), today]
+    fetch = _windowed_fetch_factory(recent_dates)
+
+    result = backfill_mod.backfill(
+        symbols=["XLK", "SMH"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        incremental=True,
+        fetch_fn=fetch,
+        today=today,
+        min_coverage=0.0,
+    )
+
+    # Wrote IN PLACE, not a cohort sibling.
+    assert result == out
+    siblings_after = set(tmp_path.glob("thematic_*.parquet"))
+    assert siblings_after == siblings_before, "incremental must not write a cohort"
+
+    df = pd.read_parquet(out)
+    # Old rows preserved + new recent rows appended (2 symbols x 2 new dates).
+    assert len(df) == old_rows + 2 * len(recent_dates)
+    assert not df.duplicated(subset=["symbol", "date"]).any()
+    # The new dates are present.
+    present_dates = set(df["date"].unique())
+    for d in recent_dates:
+        assert d in present_dates
+
+
+def test_incremental_no_gap_is_noop(backfill_mod, tmp_path):
+    """Re-running incremental with the same window produces no new rows
+    (idempotent upsert on (symbol, date))."""
+    from datetime import date, timedelta
+
+    out = tmp_path / "thematic.parquet"
+    backfill_mod.backfill(
+        symbols=["XLK"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=False,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+
+    today = date(2026, 5, 29)
+    recent_dates = [today - timedelta(days=1), today]
+    fetch = _windowed_fetch_factory(recent_dates)
+
+    backfill_mod.backfill(
+        symbols=["XLK"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        incremental=True,
+        fetch_fn=fetch,
+        today=today,
+        min_coverage=0.0,
+    )
+    rows_after_first = len(pd.read_parquet(out))
+
+    # Second incremental over the identical window: no new rows.
+    backfill_mod.backfill(
+        symbols=["XLK"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        incremental=True,
+        fetch_fn=fetch,
+        today=today,
+        min_coverage=0.0,
+    )
+    df = pd.read_parquet(out)
+    assert len(df) == rows_after_first
+    assert not df.duplicated(subset=["symbol", "date"]).any()
+
+
+def test_incremental_on_missing_cache_writes_fresh(backfill_mod, tmp_path):
+    """`incremental=True` with no existing parquet just writes the recent
+    window (no FileExistsError, no cohort) — first-run safety net."""
+    from datetime import date, timedelta
+
+    out = tmp_path / "thematic.parquet"
+    today = date(2026, 5, 29)
+    recent_dates = [today - timedelta(days=1), today]
+    fetch = _windowed_fetch_factory(recent_dates)
+
+    result = backfill_mod.backfill(
+        symbols=["XLK"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        incremental=True,
+        fetch_fn=fetch,
+        today=today,
+        min_coverage=0.0,
+    )
+    assert result == out
+    assert out.exists()
+    df = pd.read_parquet(out)
+    assert set(df["date"].unique()) == set(recent_dates)

--- a/tests/research/test_backfill_thematic_universe.py
+++ b/tests/research/test_backfill_thematic_universe.py
@@ -532,3 +532,63 @@ def test_incremental_on_missing_cache_writes_fresh(backfill_mod, tmp_path):
     assert out.exists()
     df = pd.read_parquet(out)
     assert set(df["date"].unique()) == set(recent_dates)
+
+
+def test_incremental_outage_aborts_before_write(backfill_mod, tmp_path):
+    """A provider outage in the incremental window (most/all symbols empty)
+    must raise BEFORE writing, leaving any prior good cache intact (codex P1).
+    Mirrors the breadth twin's incremental coverage gate.
+    """
+    from datetime import date, timedelta
+
+    out = tmp_path / "thematic.parquet"
+    # Seed a prior good cache so we can prove the outage doesn't clobber it.
+    backfill_mod.backfill(
+        symbols=["XLK", "SMH", "XLE", "XLF"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=False,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+    good_df = pd.read_parquet(out)
+    good_rows = len(good_df)
+
+    today = date(2026, 5, 29)
+
+    # Outage: only 1 of 4 symbols returns rows -> 25% < 90% default coverage.
+    def _outage_fetch(symbols, start, end):
+        start_d = pd.to_datetime(start).date()
+        end_d = pd.to_datetime(end).date()
+        out_map: dict[str, pd.DataFrame] = {}
+        for i, sym in enumerate(symbols):
+            cols = ["date", "open", "high", "low", "close", "volume"]
+            if sym == "XLK":
+                rows = [
+                    {"date": d, "open": 1.0, "high": 1.0, "low": 1.0,
+                     "close": 1.0, "volume": 1}
+                    for d in (today - timedelta(days=1), today)
+                    if start_d <= d <= end_d
+                ]
+                out_map[sym] = pd.DataFrame(rows, columns=cols)
+            else:
+                out_map[sym] = pd.DataFrame(columns=cols)
+        return out_map
+
+    with pytest.raises(ValueError, match="outage"):
+        backfill_mod.backfill(
+            symbols=["XLK", "SMH", "XLE", "XLF"],
+            start="2024-10-01",
+            end="2024-10-08",
+            out_path=out,
+            incremental=True,
+            fetch_fn=_outage_fetch,
+            today=today,
+            # default min_coverage (0.90) -> 25% present trips the gate.
+        )
+
+    # Prior good cache untouched (no thin/empty overwrite).
+    after = pd.read_parquet(out)
+    assert len(after) == good_rows, "outage must not clobber the prior cache"
+    assert today not in set(pd.to_datetime(after["date"]).dt.date)

--- a/tests/research/test_thematic_run_daily.py
+++ b/tests/research/test_thematic_run_daily.py
@@ -296,14 +296,37 @@ def test_incremental_backfill_satisfies_stale_guard(fake_cache):
 
     from rainier.cli import cli
 
-    # The fake_cache panel ends in late 2024 → stale relative to "today".
+    # Rebuild the cache with DEEP history (>= 21 days) ending a few days before
+    # asof — a realistic "missed the last day or two" gap that the incremental
+    # window (today-5..today) is designed to bridge. The old fixture ended in
+    # 2024 (a ~580-day gap), which the gap guard now (correctly) rejects as
+    # un-bridgeable; that is the gap-too-large path, not the refresh path.
     panel_path = fake_cache["panel"]
     pre = pd.read_parquet(panel_path)
-    pre["date"] = pd.to_datetime(pre["date"]).dt.date
-    asof = date(2026, 5, 29)
-    assert pre["date"].max() < asof, "fixture must start stale for this test"
-
     symbols = sorted(pre["symbol"].unique().tolist())
+
+    asof = date(2026, 5, 29)
+    # 30 trading days ending at asof-3 (within the 5-day incremental window).
+    deep_dates: list[date] = []
+    d = asof - timedelta(days=3)
+    while len(deep_dates) < 30:
+        if d.weekday() < 5:
+            deep_dates.append(d)
+        d = d - timedelta(days=1)
+    deep_dates.sort()
+    deep_rows = [
+        {
+            "symbol": s, "date": dd, "open": 100.0, "high": 101.0, "low": 99.0,
+            "close": 100.0 + i * 0.1, "volume": 1_000_000,
+            "fetched_at": pd.Timestamp.now(tz="UTC"), "yfinance_version": "seed",
+        }
+        for s in symbols
+        for i, dd in enumerate(deep_dates)
+    ]
+    pd.DataFrame(deep_rows).to_parquet(panel_path)
+    pre = pd.read_parquet(panel_path)
+    pre["date"] = pd.to_datetime(pre["date"]).dt.date
+    assert pre["date"].max() < asof, "cache must start stale (but within window)"
 
     # Load the backfill script module + drive its incremental path with a
     # stubbed fetch (offline) to refresh the EXISTING parquet in place.

--- a/tests/research/test_thematic_run_daily.py
+++ b/tests/research/test_thematic_run_daily.py
@@ -451,6 +451,159 @@ def test_run_daily_stale_ohlcv_surfaces_diagnostic(fake_cache):
     )
 
 
+# ---------------------------------------------------------------------------
+# Shallow-history guard — a fresh-host / deleted-cache incremental run writes
+# only the 5-day window; run-daily must FAIL LOUD rather than emit sentinel
+# ranks over <20 trading days of history (codex iter-3 [P1]).
+# ---------------------------------------------------------------------------
+
+
+def _make_universe_yaml(path: Path, symbols: list[str]) -> None:
+    body = (
+        "version: 1\n"
+        "schema: thematic_universe.v1\n"
+        "asof_seeded: 2026-05-01\n"
+        "universe:\n"
+        "  test_sector:\n"
+    )
+    body += "".join(f"    - {s}\n" for s in symbols)
+    path.write_text(body)
+
+
+def test_check_freshness_rejects_shallow_history():
+    """`_check_ohlcv_freshness` raises when the cache has < 20 trading days
+    of history at/before asof — Layer A's rel_20/vol_20 windows would all be
+    the no-data sentinel, so the job must fail loud instead of exiting 0 with
+    unusable ranks. Direct unit test on the shared guard (no DB / no network).
+    """
+    from types import SimpleNamespace
+
+    from rainier.cli import _check_ohlcv_freshness
+
+    symbols = ["AAA", "BBB", "CCC"]
+    # Only 5 trading days ending at asof — exactly what an incremental-only
+    # refresh on a fresh host produces.
+    asof = date(2026, 5, 29)
+    dates = []
+    d = asof
+    while len(dates) < 5:
+        if d.weekday() < 5:
+            dates.append(d)
+        d = d - timedelta(days=1)
+    rows = [
+        {"symbol": s, "date": dd, "close": 100.0}
+        for s in symbols
+        for dd in dates
+    ]
+    panel = pd.DataFrame(rows)
+    spec = SimpleNamespace(sectors={"test_sector": symbols})
+
+    import click
+
+    with pytest.raises(click.ClickException) as exc:
+        _check_ohlcv_freshness(panel, asof, "data/cache/thematic_universe.parquet", spec)
+    msg = str(exc.value)
+    assert "shallow" in msg.lower(), f"diagnostic must say 'shallow'; got: {msg!r}"
+    assert "backfill_thematic_universe" in msg, (
+        f"diagnostic must name the full-history seed command; got: {msg!r}"
+    )
+
+
+def test_check_freshness_accepts_deep_history():
+    """A cache with >= 20 trading days at/before asof passes the guard."""
+    from types import SimpleNamespace
+
+    from rainier.cli import _check_ohlcv_freshness
+
+    symbols = ["AAA", "BBB"]
+    panel = _build_ohlcv_panel(symbols, n_days=25)
+    panel["date"] = pd.to_datetime(panel["date"]).dt.date
+    asof = panel["date"].max()
+    spec = SimpleNamespace(sectors={"test_sector": symbols})
+
+    # Must NOT raise: deep enough history, fresh, full coverage.
+    _check_ohlcv_freshness(panel, asof, "data/cache/thematic_universe.parquet", spec)
+
+
+def test_run_daily_rejects_incremental_only_thin_cache(tmp_path):
+    """End-to-end: a thin (5-day) incremental-only cache makes run-daily fail
+    loud with the shallow-history diagnostic — the fresh-host footgun codex
+    flagged. The incremental refresh is a refresh, not a substitute for the
+    full-history seed.
+    """
+    import importlib.util
+
+    from rainier.cli import cli
+
+    symbols = ["AAA", "BBB", "CCC"]
+    asof = date(2026, 5, 29)
+    panel_path = tmp_path / "thematic_universe.parquet"
+    yaml_path = tmp_path / "universe.yaml"
+    _make_universe_yaml(yaml_path, symbols)
+
+    # Simulate a fresh-host incremental run: no existing cache, only the 5-day
+    # window gets written. Drive the real backfill script's incremental path.
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "backfill_thematic_universe.py"
+    )
+    spec = importlib.util.spec_from_file_location("backfill_thematic_universe", script)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+    recent = [asof - timedelta(days=k) for k in range(5)]
+
+    def _stub(syms, start, end):
+        start_d = pd.to_datetime(start).date()
+        end_d = pd.to_datetime(end).date()
+        return {
+            s: pd.DataFrame(
+                [
+                    {
+                        "date": dd, "open": 100.0, "high": 101.0,
+                        "low": 99.0, "close": 100.5, "volume": 1_000_000,
+                    }
+                    for dd in recent
+                    if start_d <= dd <= end_d
+                ],
+                columns=["date", "open", "high", "low", "close", "volume"],
+            )
+            for s in syms
+        }
+
+    mod.backfill(
+        symbols=symbols,
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=panel_path,
+        incremental=True,
+        fetch_fn=_stub,
+        today=asof,
+        min_coverage=0.0,
+    )
+    # The cache exists but is shallow (< 20 trading days).
+    assert pd.read_parquet(panel_path)["date"].nunique() < 20
+
+    runner = CliRunner()
+    r = runner.invoke(
+        cli,
+        [
+            "thematic", "run-daily", "--asof", asof.isoformat(),
+            "--ohlcv", str(panel_path), "--yaml", str(yaml_path),
+            "--features-out", str(tmp_path / "features.parquet"),
+            "--labels-out", str(tmp_path / "labels.parquet"),
+            "--ticker-registry", str(tmp_path / "tr.parquet"),
+            "--sector-registry", str(tmp_path / "sr.parquet"),
+            "--html-out", str(tmp_path / "out.html"),
+        ],
+    )
+    assert r.exit_code != 0, f"thin cache must fail fast; output={r.output!r}"
+    assert "shallow" in r.output.lower(), (
+        f"diagnostic must mention 'shallow' history; got: {r.output!r}"
+    )
+
+
 def test_thematic_compute_partial_universe_coverage_fails(fake_cache, tmp_path):
     """Regression — codex iter-8 [P2]: the direct `thematic compute` path
     must apply the same partial-coverage gate as `run-daily`, otherwise an

--- a/tests/research/test_thematic_run_daily.py
+++ b/tests/research/test_thematic_run_daily.py
@@ -282,6 +282,114 @@ def test_thematic_run_daily_is_idempotent(fake_cache):
     )
 
 
+def test_incremental_backfill_satisfies_stale_guard(fake_cache):
+    """A stale cache that trips the run-daily guard becomes fresh after a
+    `thematic backfill --incremental` refresh — the cron chain
+    (`backfill --incremental && run-daily`) no longer fails the stale-OHLCV
+    guard for `asof=today`.
+
+    Mirrors the breadth cron's `backfill-ohlcv --incremental && compute`
+    ordering: the incremental refresh brings max(date) up to today, so the
+    freshness guard in run-daily passes on the very next step.
+    """
+    import importlib.util
+
+    from rainier.cli import cli
+
+    # The fake_cache panel ends in late 2024 → stale relative to "today".
+    panel_path = fake_cache["panel"]
+    pre = pd.read_parquet(panel_path)
+    pre["date"] = pd.to_datetime(pre["date"]).dt.date
+    asof = date(2026, 5, 29)
+    assert pre["date"].max() < asof, "fixture must start stale for this test"
+
+    symbols = sorted(pre["symbol"].unique().tolist())
+
+    # Load the backfill script module + drive its incremental path with a
+    # stubbed fetch (offline) to refresh the EXISTING parquet in place.
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "backfill_thematic_universe.py"
+    )
+    spec = importlib.util.spec_from_file_location("backfill_thematic_universe", script)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+    recent = [asof - timedelta(days=2), asof - timedelta(days=1), asof]
+
+    def _stub(syms, start, end):
+        start_d = pd.to_datetime(start).date()
+        end_d = pd.to_datetime(end).date()
+        out = {}
+        for s in syms:
+            rows = [
+                {
+                    "date": d,
+                    "open": 100.0,
+                    "high": 101.0,
+                    "low": 99.0,
+                    "close": 100.5,
+                    "volume": 1_000_000,
+                }
+                for d in recent
+                if start_d <= d <= end_d
+            ]
+            out[s] = pd.DataFrame(
+                rows, columns=["date", "open", "high", "low", "close", "volume"]
+            )
+        return out
+
+    result_path = mod.backfill(
+        symbols=symbols,
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=panel_path,
+        incremental=True,
+        fetch_fn=_stub,
+        today=asof,
+        min_coverage=0.0,
+    )
+    assert result_path == panel_path, "incremental must refresh in place"
+
+    refreshed = pd.read_parquet(panel_path)
+    refreshed["date"] = pd.to_datetime(refreshed["date"]).dt.date
+    assert refreshed["date"].max() == asof, "incremental did not advance max(date)"
+
+    # Now run-daily for asof=today must NOT trip the stale-OHLCV guard.
+    runner = CliRunner()
+    r = runner.invoke(
+        cli,
+        [
+            "thematic",
+            "run-daily",
+            "--asof",
+            asof.isoformat(),
+            "--ohlcv",
+            str(panel_path),
+            "--yaml",
+            str(fake_cache["yaml"]),
+            "--features-out",
+            str(fake_cache["features_out"]),
+            "--labels-out",
+            str(fake_cache["labels_out"]),
+            "--ticker-registry",
+            str(fake_cache["ticker_registry"]),
+            "--sector-registry",
+            str(fake_cache["sector_registry"]),
+            "--html-out",
+            str(fake_cache["html_out"]),
+        ],
+    )
+    assert r.exit_code == 0, (
+        f"run-daily tripped after incremental refresh: "
+        f"exit={r.exit_code} output={r.output}"
+    )
+    assert "stale" not in r.output.lower(), (
+        f"stale guard should be satisfied; got: {r.output!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Stale-OHLCV diagnostic — surface-don't-silo (review iter-1 / codex iter-1)
 # ---------------------------------------------------------------------------

--- a/tests/research/test_thematic_run_daily.py
+++ b/tests/research/test_thematic_run_daily.py
@@ -509,8 +509,36 @@ def test_check_freshness_rejects_shallow_history():
     )
 
 
+def test_check_freshness_shallow_boundary_off_by_one():
+    """Boundary: exactly 20 distinct dates still fails (asof_idx=19 ->
+    prior_idx=-1 for rel_20 -> sentinel), 21 passes. Locks the off-by-one
+    (codex iter-5): the guard requires >= 21 observations, not 20.
+    """
+    from types import SimpleNamespace
+
+    import click
+
+    from rainier.cli import _check_ohlcv_freshness
+
+    symbols = ["AAA", "BBB"]
+    spec = SimpleNamespace(sectors={"test_sector": symbols})
+
+    # Exactly 20 trading days -> must still REJECT.
+    panel20 = _build_ohlcv_panel(symbols, n_days=20)
+    panel20["date"] = pd.to_datetime(panel20["date"]).dt.date
+    asof20 = panel20["date"].max()
+    with pytest.raises(click.ClickException, match="shallow"):
+        _check_ohlcv_freshness(panel20, asof20, "data/cache/thematic_universe.parquet", spec)
+
+    # 21 trading days -> must ACCEPT (boundary just clears).
+    panel21 = _build_ohlcv_panel(symbols, n_days=21)
+    panel21["date"] = pd.to_datetime(panel21["date"]).dt.date
+    asof21 = panel21["date"].max()
+    _check_ohlcv_freshness(panel21, asof21, "data/cache/thematic_universe.parquet", spec)
+
+
 def test_check_freshness_accepts_deep_history():
-    """A cache with >= 20 trading days at/before asof passes the guard."""
+    """A cache with >= 21 trading days at/before asof passes the guard."""
     from types import SimpleNamespace
 
     from rainier.cli import _check_ohlcv_freshness

--- a/tests/test_cli/test_thematic_backfill_incremental.py
+++ b/tests/test_cli/test_thematic_backfill_incremental.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 

--- a/tests/test_cli/test_thematic_backfill_incremental.py
+++ b/tests/test_cli/test_thematic_backfill_incremental.py
@@ -1,0 +1,99 @@
+"""CLI wiring tests for `rainier thematic backfill --incremental`.
+
+The CLI command loads `scripts/backfill_thematic_universe.py` and calls its
+`backfill()`. These tests confirm:
+
+  * `--incremental` is exposed on the command surface.
+  * Passing `--incremental` reaches the script's `backfill()` with
+    `incremental=True` (and does NOT require `--force`, mirroring the breadth
+    `market-breadth backfill-ohlcv --incremental` cron contract).
+
+The actual incremental fetch/upsert semantics are unit-tested in
+tests/research/test_backfill_thematic_universe.py; here we only verify the
+CLI passes the flag through, so the cron command
+`uv run rainier thematic backfill --incremental && uv run rainier thematic run-daily`
+is wired correctly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+def test_incremental_flag_in_help():
+    from rainier.cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["thematic", "backfill", "--help"])
+    assert result.exit_code == 0
+    assert "--incremental" in result.output
+
+
+def test_incremental_passes_through_to_script(monkeypatch, tmp_path):
+    """`thematic backfill --incremental` calls the script with incremental=True
+    and writes in place (no --force needed)."""
+    import rainier.cli as cli_mod
+
+    yaml_path = tmp_path / "thematic_universe.yaml"
+    yaml_path.write_text(
+        "version: 1\n"
+        "schema: thematic_universe.v1\n"
+        "asof_seeded: 2024-10-01\n"
+        "universe:\n"
+        "  test_sector:\n"
+        "    - XLK\n"
+        "    - SMH\n"
+    )
+    out_path = tmp_path / "thematic_universe.parquet"
+
+    captured: dict[str, object] = {}
+
+    def _fake_backfill(**kwargs):
+        captured.update(kwargs)
+        return Path(kwargs["out_path"])
+
+    # The CLI dynamically loads scripts/backfill_thematic_universe.py and calls
+    # its backfill(). Patch importlib.util.module_from_spec so the loaded module
+    # exposes our fake backfill — and execute the real module body first so the
+    # CLI can still read its DEFAULT_* constants and loader helpers.
+    import importlib.util as _ilu
+
+    orig_module_from_spec = _ilu.module_from_spec
+
+    def _patched_module_from_spec(spec):
+        mod = orig_module_from_spec(spec)
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+        mod.backfill = _fake_backfill  # type: ignore[attr-defined]
+        # The CLI calls spec.loader.exec_module(mod) again after building the
+        # module; make that a no-op so our fake backfill survives.
+        spec.loader.exec_module = lambda _m: None  # type: ignore[assignment]
+        return mod
+
+    monkeypatch.setattr(_ilu, "module_from_spec", _patched_module_from_spec)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        [
+            "thematic",
+            "backfill",
+            "--incremental",
+            "--yaml",
+            str(yaml_path),
+            "--out",
+            str(out_path),
+            "--ticker-registry",
+            str(tmp_path / "ticker_registry.parquet"),
+            "--sector-registry",
+            str(tmp_path / "sector_registry.parquet"),
+        ],
+    )
+    assert result.exit_code == 0, f"exit={result.exit_code} output={result.output}"
+    assert captured.get("incremental") is True, (
+        f"--incremental must reach script backfill(); captured={captured}"
+    )
+    # incremental does NOT require force.
+    assert captured.get("force") in (False, None)

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -617,14 +617,24 @@ def test_cli_thematic_backfill_incremental_advances_pg_ohlcv(
     # covers it. (codex iter-2: don't freeze a module the CLI never reuses.)
     today = date.today()
 
-    # An existing parquet cache with OLD history, plus the registries the
-    # mirror reads. Built so the incremental window (today-5..today) is a
-    # genuine gap relative to what is already in the cache + PG.
-    old_panel = _build_ohlcv_panel(symbols, n_days=10)  # dates in 2024-10
+    # An existing parquet cache whose high-water mark is INSIDE the incremental
+    # window (gap guard satisfied), with dates distinct from the recent fetch
+    # window. The dual-write mirrors only the freshly fetched frame, so the
+    # seed rows never reach PG — PG advances by exactly the recent window.
+    seed_dates = [today - timedelta(days=d) for d in (5, 4, 3)]
+    seed_rows = [
+        {
+            "symbol": s, "date": d, "open": 50.0, "high": 50.5, "low": 49.5,
+            "close": 50.0, "volume": 1_000_000,
+            "fetched_at": pd.Timestamp.now(tz="UTC"), "yfinance_version": "seed",
+        }
+        for s in symbols
+        for d in seed_dates
+    ]
     cache = tmp_path / "cache"
     cache.mkdir()
     panel_path = cache / "thematic_universe.parquet"
-    old_panel.to_parquet(panel_path)
+    pd.DataFrame(seed_rows).to_parquet(panel_path)
     tr = cache / "tr.parquet"
     sr = cache / "sr.parquet"
     yaml_path = tmp_path / "universe.yaml"

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -608,7 +608,14 @@ def test_cli_thematic_backfill_incremental_advances_pg_ohlcv(
     from rainier.cli import cli
 
     symbols = ["AAA", "BBB", "CCC"]
-    today = date(2026, 5, 29)
+    # Derive `today` from the REAL clock. The CLI loads the backfill script as a
+    # FRESH module instance (importlib.util.module_from_spec), so a monkeypatch
+    # of any pre-imported module's date.today() would NOT reach it — the CLI
+    # always uses the real date.today(). Building the synthetic recent window
+    # relative to the real today keeps this test clock-independent: whatever
+    # incremental window backfill() computes (today-5..today), our stub panel
+    # covers it. (codex iter-2: don't freeze a module the CLI never reuses.)
+    today = date.today()
 
     # An existing parquet cache with OLD history, plus the registries the
     # mirror reads. Built so the incremental window (today-5..today) is a
@@ -623,7 +630,9 @@ def test_cli_thematic_backfill_incremental_advances_pg_ohlcv(
     yaml_path = tmp_path / "universe.yaml"
     _write_universe_yaml(yaml_path, symbols)
 
-    # Recent-window rows the incremental fetch should pick up.
+    # Recent-window rows the incremental fetch should pick up. All within
+    # backfill()'s window (today-INCREMENTAL_WINDOW_DAYS .. today), so the
+    # windowed stub returns them regardless of what real date the CLI sees.
     recent_dates = [today - timedelta(days=2), today - timedelta(days=1), today]
     recent_rows = []
     for s_idx, sym in enumerate(symbols):
@@ -633,29 +642,12 @@ def test_cli_thematic_backfill_incremental_advances_pg_ohlcv(
                 {
                     "symbol": sym, "date": d, "open": close, "high": close * 1.01,
                     "low": close * 0.99, "close": close, "volume": 2_000_000,
-                    "fetched_at": pd.Timestamp("2026-05-29T16:30:00Z"),
+                    "fetched_at": pd.Timestamp.now(tz="UTC"),
                     "yfinance_version": "stub-test",
                 }
             )
     recent_panel = pd.DataFrame(recent_rows)
     _patch_yfinance(monkeypatch, recent_panel)
-
-    # Pin "today" so the incremental window is deterministic. backfill() takes a
-    # `today` kwarg; the CLI doesn't forward it, so freeze date.today() at the
-    # source the script reads (scripts/backfill_thematic_universe.date.today).
-    import importlib
-
-    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
-    if str(scripts_dir) not in sys.path:
-        sys.path.insert(0, str(scripts_dir))
-    bf_mod = importlib.import_module("backfill_thematic_universe")
-
-    class _FrozenDate(bf_mod.date):  # type: ignore[misc, valid-type]
-        @classmethod
-        def today(cls):
-            return today
-
-    monkeypatch.setattr(bf_mod, "date", _FrozenDate)
 
     # PG starts with zero OHLCV rows.
     assert _count(migrated_engine, "thematic_ohlcv") == 0

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -544,6 +544,178 @@ def test_labels_dual_write_handles_null_complete_through(
 
 
 # ---------------------------------------------------------------------------
+# thematic backfill --incremental (CLI surface) -> market.thematic_ohlcv MUST
+# advance. Regression for the daily-cron mirror gap: the CLI subcommand
+# `thematic backfill --incremental` (cli.py:thematic_backfill) must forward
+# yaml_path into module.backfill(...) so _dual_write_pg mirrors the freshly
+# fetched OHLCV into Neon. Before the fix the CLI omitted yaml_path, so the
+# cron-wired `thematic backfill --incremental` advanced ONLY the parquet and
+# left market.thematic_ohlcv STALE (live catch-up 2026-05-30: features/labels
+# reached today but thematic_ohlcv was stuck days behind). The worker's
+# module-level dual-write tests pass yaml_path explicitly, so they could not
+# catch this — the broken seam was the CLI command, which this test drives.
+# ---------------------------------------------------------------------------
+
+
+def _patch_yfinance(monkeypatch, panel: pd.DataFrame) -> None:
+    """Make the real ``_yfinance_fetch`` offline by stubbing ``yf.download``.
+
+    The CLI ``thematic backfill`` command resolves its fetcher internally
+    (no fetch_fn injection point), so to exercise the real CLI seam we stub
+    the network call one layer down. ``_yfinance_fetch`` bumps ``end`` by +1
+    day (exclusive end) and slices [start, end); we honor that window here so
+    the incremental path's recent-window resolution is exercised end to end.
+    """
+    import types
+
+    def fake_download(sym, start=None, end=None, **kwargs):
+        start_d = pd.to_datetime(start).date()
+        end_d = pd.to_datetime(end).date()  # already +1 (exclusive) from caller
+        sub = panel.loc[
+            (panel["symbol"] == sym)
+            & (panel["date"] >= start_d)
+            & (panel["date"] < end_d),
+            ["date", "open", "high", "low", "close", "volume"],
+        ].copy()
+        if sub.empty:
+            return pd.DataFrame()
+        # _yfinance_fetch expects yfinance's capitalized columns + a DatetimeIndex.
+        sub = sub.rename(
+            columns={
+                "date": "Date",
+                "open": "Open",
+                "high": "High",
+                "low": "Low",
+                "close": "Close",
+                "volume": "Volume",
+            }
+        )
+        sub = sub.set_index("Date")
+        return sub
+
+    fake_yf = types.SimpleNamespace(download=fake_download, __version__="stub-test")
+    monkeypatch.setitem(sys.modules, "yfinance", fake_yf)
+
+
+@pytest.mark.requires_postgres
+def test_cli_thematic_backfill_incremental_advances_pg_ohlcv(
+    migrated_engine, tmp_path, database_url, monkeypatch
+):
+    """`thematic backfill --incremental` (CLI) must ADVANCE market.thematic_ohlcv
+    in Postgres, not just the parquet — proves the daily cron keeps Neon's raw
+    OHLCV fresh. This is the load-bearing assertion for the daily-cron wire.
+    """
+    from rainier.cli import cli
+
+    symbols = ["AAA", "BBB", "CCC"]
+    today = date(2026, 5, 29)
+
+    # An existing parquet cache with OLD history, plus the registries the
+    # mirror reads. Built so the incremental window (today-5..today) is a
+    # genuine gap relative to what is already in the cache + PG.
+    old_panel = _build_ohlcv_panel(symbols, n_days=10)  # dates in 2024-10
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    panel_path = cache / "thematic_universe.parquet"
+    old_panel.to_parquet(panel_path)
+    tr = cache / "tr.parquet"
+    sr = cache / "sr.parquet"
+    yaml_path = tmp_path / "universe.yaml"
+    _write_universe_yaml(yaml_path, symbols)
+
+    # Recent-window rows the incremental fetch should pick up.
+    recent_dates = [today - timedelta(days=2), today - timedelta(days=1), today]
+    recent_rows = []
+    for s_idx, sym in enumerate(symbols):
+        for j, d in enumerate(recent_dates):
+            close = 200.0 + s_idx * 10 + j
+            recent_rows.append(
+                {
+                    "symbol": sym, "date": d, "open": close, "high": close * 1.01,
+                    "low": close * 0.99, "close": close, "volume": 2_000_000,
+                    "fetched_at": pd.Timestamp("2026-05-29T16:30:00Z"),
+                    "yfinance_version": "stub-test",
+                }
+            )
+    recent_panel = pd.DataFrame(recent_rows)
+    _patch_yfinance(monkeypatch, recent_panel)
+
+    # Pin "today" so the incremental window is deterministic. backfill() takes a
+    # `today` kwarg; the CLI doesn't forward it, so freeze date.today() at the
+    # source the script reads (scripts/backfill_thematic_universe.date.today).
+    import importlib
+
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    bf_mod = importlib.import_module("backfill_thematic_universe")
+
+    class _FrozenDate(bf_mod.date):  # type: ignore[misc, valid-type]
+        @classmethod
+        def today(cls):
+            return today
+
+    monkeypatch.setattr(bf_mod, "date", _FrozenDate)
+
+    # PG starts with zero OHLCV rows.
+    assert _count(migrated_engine, "thematic_ohlcv") == 0
+
+    res = CliRunner().invoke(
+        cli,
+        [
+            "thematic", "backfill", "--incremental",
+            "--yaml", str(yaml_path),
+            "--out", str(panel_path),
+            "--ticker-registry", str(tr),
+            "--sector-registry", str(sr),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+
+    # The recent window landed in PG (3 symbols x 3 recent dates = 9 rows).
+    pg_after = _count(migrated_engine, "thematic_ohlcv")
+    assert pg_after == len(symbols) * len(recent_dates), (
+        f"market.thematic_ohlcv must ADVANCE on the incremental CLI path; "
+        f"got {pg_after} rows, expected {len(symbols) * len(recent_dates)}. "
+        f"output:\n{res.output}"
+    )
+    # Registries mirrored too (the daily cron keeps the FK parents fresh).
+    assert _count(migrated_engine, "tickers") == len(symbols)
+    assert _count(migrated_engine, "sectors") == 1
+
+    # max(date) advanced to today -> run-daily's stale-OHLCV guard passes.
+    with migrated_engine.connect() as conn:
+        max_date = conn.execute(
+            text("SELECT max(date) FROM market.thematic_ohlcv")
+        ).scalar_one()
+        sample_close = conn.execute(
+            text(
+                "SELECT close FROM market.thematic_ohlcv "
+                "WHERE symbol='AAA' AND date=:d"
+            ),
+            {"d": today},
+        ).scalar_one()
+    assert max_date == today, "thematic_ohlcv must reach today's date"
+    assert sample_close == pytest.approx(202.0), "today's AAA close mirrored to PG"
+
+    # Idempotent: a second incremental run over the same window adds no rows.
+    res2 = CliRunner().invoke(
+        cli,
+        [
+            "thematic", "backfill", "--incremental",
+            "--yaml", str(yaml_path),
+            "--out", str(panel_path),
+            "--ticker-registry", str(tr),
+            "--sector-registry", str(sr),
+        ],
+    )
+    assert res2.exit_code == 0, res2.output
+    assert _count(migrated_engine, "thematic_ohlcv") == pg_after, (
+        "re-running incremental must be idempotent (UPSERT, no duplicate rows)"
+    )
+
+
+# ---------------------------------------------------------------------------
 # DATABASE_URL-unset skip path — NO Postgres needed
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `rainier thematic backfill --incremental` (in-place (symbol,date) upsert into thematic_universe.parquet, last-5-day window, idempotent; mirrors the breadth `backfill-ohlcv --incremental` twin) so the thematic OHLCV cache refreshes daily without --force sibling cohorts.
- Forward `yaml_path` so the incremental backfill ALSO mirrors `market.thematic_ohlcv` (+ ticker/sector registries) to the Neon canonical store — closes the gap where Neon thematic_ohlcv stayed stale while features/labels advanced.
- Wire config/cron.yaml: `thematic-ranks-daily` = `thematic backfill --incremental && thematic run-daily`, `enabled: true`; `market-breadth-daily` `enabled: true` (matches the live crontab). This makes the daily producer crons keep Neon fresh and closes the ETF-freshness axis of the parked empty-render alert.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 9) — codex caught + fixed 5 real [P1]s in the incremental path: thematic_ohlcv not mirrored to PG (yaml_path omitted); shallow-history cache → Layer A no-data sentinel; outage gate (thin cache on yfinance failure); gap-too-large corrupting rel_20/vol_20; off-by-one + recovery FileExistsError. Each with a regression test (incl. a Postgres-container test proving --incremental advances market.thematic_ohlcv).

## Deferred (P2, documented)
- Per-symbol gap high-water marks; gap-guard boundary one day stricter than necessary (fail-safe); `run-daily`/`market-breadth-daily` use calendar today() with no --asof so market holidays fire false Discord alerts (pre-existing cron-semantics, own fix).

## Test plan
- [ ] CI green
- [ ] after merge: coord pulls, `jobs sync` (thematic-ranks-daily → ACTIVE), re-runs catch-up so Neon thematic_ohlcv reaches latest