### PR TITLE
feat(thematic): backfill --force --adopt (atomic cohort→canonical bridge) + gc-cohorts

### DIFF
--- a/scripts/backfill_thematic_universe.py
+++ b/scripts/backfill_thematic_universe.py
@@ -520,6 +520,7 @@ def backfill(
     end: str,
     out_path: Path,
     force: bool = False,
+    adopt: bool = False,
     dry_run: bool = False,
     incremental: bool = False,
     fetch_fn: Callable[[Iterable[str], str, str], dict[str, pd.DataFrame]]
@@ -539,6 +540,15 @@ def backfill(
       * **One-shot** (default): full ``start``..``end`` fetch. Refuses to
         overwrite an existing cache unless ``force=True`` (which writes a dated
         sibling cohort, never in place — revision-immutability).
+      * **Adopt** (``force=True, adopt=True``): the sanctioned cohort ->
+        canonical bridge. Runs the same clean full fetch + validation as
+        ``--force``, but instead of leaving the fresh data in a dated sibling
+        cohort, it ATOMICALLY replaces the (stale) canonical ``out_path`` with
+        it via ``os.replace`` — no orphan sibling, no manual ``mv``. This is the
+        one-command self-heal for a stale canonical: the canonical parquet AND
+        (when ``yaml_path`` is set) Neon ``market.thematic_ohlcv`` both end up
+        current. ``adopt`` requires ``force`` and is a modifier of the force
+        fetch path, not a bypass of the overwrite guard.
       * **Incremental** (``incremental=True``): the daily-cron refresh path
         that mirrors the breadth twin (``market-breadth backfill-ohlcv
         --incremental``). ``start``/``end`` are ignored; the window is the last
@@ -595,11 +605,11 @@ def backfill(
                         f"{gap_days} calendar days behind today={today_d}, but "
                         f"the incremental window is only {INCREMENTAL_WINDOW_DAYS} "
                         f"days. Refreshing would leave a hole in the series and "
-                        f"produce wrong rel_20/vol_20 ranks. Run the full-history "
-                        f"seed instead:\n"
-                        f"  python scripts/backfill_thematic_universe.py "
-                        f"--start 2024-10-01 --end {today_d} --force\n"
-                        f"then move the new cohort into place."
+                        f"produce wrong rel_20/vol_20 ranks. Self-heal the "
+                        f"canonical with the sanctioned adopt bridge (atomic "
+                        f"in-place replace + Neon mirror, no manual mv):\n"
+                        f"  uv run rainier thematic backfill --force --adopt "
+                        f"--start 2024-10-01 --end {today_d} --out {out_path}"
                     )
 
     if dry_run:
@@ -684,11 +694,23 @@ def backfill(
         merged = _upsert_in_place(df, out_path)
         _write_parquet_atomic(merged, target)
     else:
-        target = (
-            _cohort_path(out_path, fetched_at)
-            if (out_path.exists() and force)
-            else out_path
-        )
+        # --force on an existing canonical normally writes a dated SIBLING
+        # cohort (revision-immutability). --adopt instead replaces the canonical
+        # in place: _write_parquet_atomic writes to a .tmp sibling, fsyncs, then
+        # os.replace's onto out_path — so the canonical is never partial and no
+        # orphan cohort is left behind. The validation/coverage gate above has
+        # already run, so a provider outage aborts BEFORE this write and the
+        # prior good canonical stays intact.
+        #
+        #   force+adopt+exists -> out_path (atomic replace, no sibling)
+        #   force+exists       -> dated sibling cohort
+        #   else               -> out_path (fresh write)
+        if force and adopt:
+            target = out_path
+        elif out_path.exists() and force:
+            target = _cohort_path(out_path, fetched_at)
+        else:
+            target = out_path
         _write_parquet_atomic(df, target)
 
     # Phase 2 dual-write: mirror into market.* AFTER the parquet write (parquet
@@ -705,6 +727,82 @@ def backfill(
         )
 
     return target
+
+
+# ---------------------------------------------------------------------------
+# gc-cohorts — reap orphan sibling cohorts (cleanup; this task)
+# ---------------------------------------------------------------------------
+#
+# --force (without --adopt) writes dated sibling cohorts next to the canonical
+# parquet, and the cron's refresh path can leave a thematic_universe_refresh
+# sibling. These accumulate and never get reaped. gc_cohorts keeps the
+# canonical + the N most-recent cohorts and reaps the rest. Mirrors `fleet gc`'s
+# surface-then-apply ethos: dry-run lists by default, --apply deletes. The
+# canonical out_path is NEVER a deletion candidate.
+#
+#   data/cache/
+#     thematic_universe.parquet                     <- canonical (never deleted)
+#     thematic_universe_20260501_010101_000001.parquet  <- cohort (gc candidate)
+#     thematic_universe_refresh.parquet             <- refresh sibling (candidate)
+
+
+def _orphan_cohort_paths(out_path: Path) -> list[Path]:
+    """Return sibling cohort parquets next to ``out_path``, EXCLUDING the
+    canonical itself. Matches ``<stem>_*<suffix>`` (dated cohorts +
+    ``<stem>_refresh<suffix>``)."""
+    out_path = Path(out_path)
+    parent = out_path.parent
+    stem = out_path.stem
+    suffix = out_path.suffix
+    candidates: list[Path] = []
+    for p in parent.glob(f"{stem}_*{suffix}"):
+        if p == out_path:
+            continue
+        candidates.append(p)
+    return candidates
+
+
+def gc_cohorts(
+    out_path: Path,
+    keep: int = 2,
+    apply: bool = False,
+) -> dict[str, list[Path]]:
+    """Reap orphan sibling cohort parquets next to the canonical ``out_path``.
+
+    Keeps the canonical (``out_path``) plus the ``keep`` most-recent sibling
+    cohorts (ranked by mtime, newest first); everything older is a deletion
+    candidate. Dry-run by default (``apply=False``) — it only computes the plan.
+    ``apply=True`` deletes the candidates. The canonical is NEVER a candidate,
+    regardless of ``keep`` (``keep=0`` still preserves the canonical).
+
+    Returns a dict with:
+      * ``keep``: cohorts retained (newest ``keep``),
+      * ``delete``: cohorts that would be / were reaped,
+      * ``deleted``: cohorts actually unlinked (empty unless ``apply=True``).
+    """
+    out_path = Path(out_path)
+    cohorts = _orphan_cohort_paths(out_path)
+    # Newest first by mtime; stable tiebreak on name so the plan is deterministic
+    # when two cohorts share an mtime (e.g. test fixtures).
+    cohorts.sort(key=lambda p: (p.stat().st_mtime, p.name), reverse=True)
+
+    keep_n = max(0, int(keep))
+    kept = cohorts[:keep_n]
+    to_delete = cohorts[keep_n:]
+
+    deleted: list[Path] = []
+    if apply:
+        for p in to_delete:
+            # Defensive: never unlink the canonical even if it somehow matched.
+            if p == out_path:
+                continue
+            try:
+                p.unlink()
+                deleted.append(p)
+            except OSError:
+                pass
+
+    return {"keep": kept, "delete": to_delete, "deleted": deleted}
 
 
 # ---------------------------------------------------------------------------
@@ -739,6 +837,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--force",
         action="store_true",
         help="When the cache exists, write a timestamped sibling cohort.",
+    )
+    p.add_argument(
+        "--adopt",
+        "--in-place",
+        dest="adopt",
+        action="store_true",
+        help=(
+            "With --force: atomically replace the (stale) canonical --out with "
+            "the fresh cohort in place (no orphan sibling, no manual mv). The "
+            "sanctioned cohort -> canonical bridge."
+        ),
     )
     p.add_argument(
         "--incremental",
@@ -797,6 +906,7 @@ def main(argv: list[str] | None = None) -> int:
         end=ns.end,
         out_path=out_path,
         force=ns.force,
+        adopt=ns.adopt,
         incremental=ns.incremental,
         dry_run=ns.dry_run,
         allow_empty=allow_empty,

--- a/scripts/backfill_thematic_universe.py
+++ b/scripts/backfill_thematic_universe.py
@@ -796,7 +796,7 @@ def gc_cohorts(
     out_path: Path,
     keep: int = 2,
     apply: bool = False,
-) -> dict[str, list[Path]]:
+) -> dict[str, list]:
     """Reap orphan sibling cohort parquets next to the canonical ``out_path``.
 
     Keeps the canonical (``out_path``) plus the ``keep`` most-recent sibling
@@ -808,7 +808,10 @@ def gc_cohorts(
     Returns a dict with:
       * ``keep``: cohorts retained (newest ``keep``),
       * ``delete``: cohorts that would be / were reaped,
-      * ``deleted``: cohorts actually unlinked (empty unless ``apply=True``).
+      * ``deleted``: cohorts actually unlinked (empty unless ``apply=True``),
+      * ``failed``: ``(path, error)`` tuples for candidates that could NOT be
+        unlinked (permission/locked-file). Non-empty means gc did NOT fully
+        complete; the CLI surfaces this as a non-zero exit.
     """
     out_path = Path(out_path)
     cohorts = _orphan_cohort_paths(out_path)
@@ -821,6 +824,7 @@ def gc_cohorts(
     to_delete = cohorts[keep_n:]
 
     deleted: list[Path] = []
+    failed: list[tuple[Path, str]] = []
     if apply:
         for p in to_delete:
             # Defensive: never unlink the canonical even if it somehow matched.
@@ -829,10 +833,18 @@ def gc_cohorts(
             try:
                 p.unlink()
                 deleted.append(p)
-            except OSError:
-                pass
+            except OSError as exc:
+                # Don't swallow: a permission/locked-file failure must surface so
+                # automation + operators don't believe gc completed when an
+                # orphan is still on disk. (codex review iter-2 [P2].)
+                failed.append((p, str(exc)))
 
-    return {"keep": kept, "delete": to_delete, "deleted": deleted}
+    return {
+        "keep": kept,
+        "delete": to_delete,
+        "deleted": deleted,
+        "failed": failed,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -923,6 +935,21 @@ def main(argv: list[str] | None = None) -> int:
         symbols = [s.strip() for s in ns.symbols.split(",") if s.strip()]
     else:
         symbols = load_symbols_from_yaml(Path(ns.yaml))
+
+    # --adopt replaces the canonical IN PLACE; an ad-hoc --symbols subset would
+    # therefore clobber the full-universe canonical with only that subset.
+    # Refuse it — adopt must run over the full universe (YAML), the same set the
+    # canonical is supposed to hold. (codex review iter-2 [P2].)
+    if ns.adopt and ns.symbols:
+        print(
+            "error: --adopt replaces the canonical --out in place and must run "
+            "over the FULL universe (from --yaml), not an ad-hoc --symbols "
+            "subset (that would shrink the canonical to the subset). Drop "
+            "--symbols, or use --force without --adopt to write a sibling "
+            "cohort for the subset.",
+            file=sys.stderr,
+        )
+        return 2
     allow_empty = [s.strip() for s in ns.allow_empty.split(",") if s.strip()]
     allow_gaps = [s.strip() for s in ns.allow_gaps.split(",") if s.strip()]
     out_path = Path(ns.out)

--- a/scripts/backfill_thematic_universe.py
+++ b/scripts/backfill_thematic_universe.py
@@ -220,6 +220,15 @@ def _write_parquet_atomic(df: pd.DataFrame, out_path: Path) -> None:
     table = pa.Table.from_pandas(df, schema=schema, preserve_index=False)
     try:
         pq.write_table(table, tmp, compression="snappy")
+        # fsync the tmp file before the atomic rename so a crash/power-loss
+        # between write and replace can't leave a torn canonical: the bytes are
+        # durable on disk before os.replace flips the name. (The dir entry rename
+        # itself is atomic on a POSIX same-filesystem replace.)
+        fd = os.open(tmp, os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
         os.replace(tmp, out_path)
     finally:
         if tmp.exists():

--- a/scripts/backfill_thematic_universe.py
+++ b/scripts/backfill_thematic_universe.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
@@ -753,21 +754,41 @@ def backfill(
 #     thematic_universe.parquet                     <- canonical (never deleted)
 #     thematic_universe_20260501_010101_000001.parquet  <- cohort (gc candidate)
 #     thematic_universe_refresh.parquet             <- refresh sibling (candidate)
+#     thematic_universe_log.parquet                 <- snapshot-universe log (SPARED)
+#     thematic_universe_names.parquet               <- any other sibling (SPARED)
 
 
 def _orphan_cohort_paths(out_path: Path) -> list[Path]:
     """Return sibling cohort parquets next to ``out_path``, EXCLUDING the
-    canonical itself. Matches ``<stem>_*<suffix>`` (dated cohorts +
-    ``<stem>_refresh<suffix>``)."""
+    canonical itself.
+
+    A blanket ``<stem>_*<suffix>`` glob is UNSAFE: the default cache dir also
+    holds ``thematic_universe_log.parquet`` (the universe-change log written by
+    ``thematic snapshot-universe``), which shares the ``thematic_universe_``
+    prefix but is a persistent, load-bearing file — never a cohort. (codex
+    review iter-1 [P1].) So we match ONLY:
+      * timestamped cohorts ``<stem>_YYYYMMDD_HHMMSS_ffffff[_N]<suffix>`` as
+        written by ``_cohort_path`` (``%Y%m%d_%H%M%S_%f`` + optional collision
+        ``_N`` suffix), and
+      * the exact ``<stem>_refresh<suffix>`` sibling the cron refresh path may
+        leave behind.
+    Any other ``<stem>_*`` sibling (e.g. ``_log``) is left untouched.
+    """
     out_path = Path(out_path)
     parent = out_path.parent
-    stem = out_path.stem
-    suffix = out_path.suffix
+    stem = re.escape(out_path.stem)
+    suffix = re.escape(out_path.suffix)
+    # YYYYMMDD_HHMMSS_ffffff with an optional _N collision-avoidance suffix.
+    cohort_re = re.compile(
+        rf"^{stem}_\d{{8}}_\d{{6}}_\d+(?:_\d+)?{suffix}$"
+    )
+    refresh_re = re.compile(rf"^{stem}_refresh{suffix}$")
     candidates: list[Path] = []
-    for p in parent.glob(f"{stem}_*{suffix}"):
+    for p in parent.glob(f"{out_path.stem}_*{out_path.suffix}"):
         if p == out_path:
             continue
-        candidates.append(p)
+        if cohort_re.match(p.name) or refresh_re.match(p.name):
+            candidates.append(p)
     return candidates
 
 

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3551,12 +3551,22 @@ def thematic_gc_cohorts(out_path: str, keep: int, apply: bool) -> None:
     kept = plan["keep"]
     if apply:
         deleted = plan["deleted"]
+        failed = plan.get("failed", [])
         click.echo(
             f"gc-cohorts: deleted {len(deleted)} orphan cohort(s); "
             f"kept canonical {canonical.name} + {len(kept)} latest."
         )
         for p in deleted:
             click.echo(f"  deleted {p}")
+        # Surface unlink failures as a hard error so automation/operators don't
+        # think gc completed when an orphan is still on disk (codex iter-2 [P2]).
+        if failed:
+            for p, err in failed:
+                click.echo(f"  FAILED to delete {p}: {err}", err=True)
+            raise click.ClickException(
+                f"gc-cohorts: {len(failed)} orphan cohort(s) could not be "
+                f"deleted (see above). Resolve the error and re-run --apply."
+            )
     else:
         click.echo(
             f"DRY-RUN gc-cohorts: would delete {len(candidates)} orphan "

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3331,6 +3331,19 @@ def thematic() -> None:
     help="When the cache exists, write a timestamped sibling cohort.",
 )
 @click.option(
+    "--adopt",
+    "--in-place",
+    "adopt",
+    is_flag=True,
+    default=False,
+    help=(
+        "With --force: atomically replace the (stale) canonical --out with the "
+        "fresh cohort in place (no orphan sibling, no manual mv) AND mirror the "
+        "fresh OHLCV + registries to Neon. The sanctioned cohort -> canonical "
+        "bridge for a stale-canonical self-heal."
+    ),
+)
+@click.option(
     "--incremental",
     is_flag=True,
     default=False,
@@ -3381,6 +3394,7 @@ def thematic_backfill(
     end: str | None,
     out_path: str,
     force: bool,
+    adopt: bool,
     incremental: bool,
     dry_run: bool,
     allow_empty: str,
@@ -3430,6 +3444,7 @@ def thematic_backfill(
         end=end_eff,
         out_path=Path(out_path),
         force=force,
+        adopt=adopt,
         incremental=incremental,
         dry_run=dry_run,
         allow_empty=[s.strip() for s in allow_empty.split(",") if s.strip()],
@@ -3461,7 +3476,14 @@ def thematic_backfill(
         return
 
     written_path = result
-    mode = "incremental" if incremental else "one-shot"
+    if incremental:
+        mode = "incremental"
+    elif force and adopt:
+        mode = "adopt (canonical replaced in place)"
+    elif force:
+        mode = "force (sibling cohort)"
+    else:
+        mode = "one-shot"
     click.echo(f"wrote OHLCV cache ({mode}) -> {written_path}")
 
     # Seed registries with the just-fetched universe. Idempotent — re-running
@@ -3475,6 +3497,76 @@ def thematic_backfill(
     )
     click.echo(f"seeded ticker registry  -> {ticker_registry}")
     click.echo(f"seeded sector registry  -> {sector_registry}")
+
+
+@thematic.command("gc-cohorts")
+@click.option(
+    "--out",
+    "out_path",
+    type=click.Path(),
+    default="data/cache/thematic_universe.parquet",
+    show_default=True,
+    help="Canonical parquet path; siblings next to it are gc candidates.",
+)
+@click.option(
+    "--keep",
+    type=int,
+    default=2,
+    show_default=True,
+    help="Number of most-recent sibling cohorts to retain (newest by mtime).",
+)
+@click.option(
+    "--apply",
+    is_flag=True,
+    default=False,
+    help="Delete the reap candidates. Without this, dry-run lists them only.",
+)
+def thematic_gc_cohorts(out_path: str, keep: int, apply: bool) -> None:
+    """Reap orphan sibling cohort parquets, keeping canonical + N latest.
+
+    ``--force`` (without ``--adopt``) writes dated sibling cohorts next to the
+    canonical ``thematic_universe.parquet``; these accumulate. This reaps them,
+    keeping the canonical (NEVER deleted) plus the ``--keep`` most-recent
+    cohorts. Dry-run by default — pass ``--apply`` to delete. Mirrors
+    ``fleet gc``'s surface-then-apply ethos.
+    """
+    import importlib.util
+
+    root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "backfill_thematic_universe",
+        root / "scripts" / "backfill_thematic_universe.py",
+    )
+    if spec is None or spec.loader is None:
+        raise click.ClickException(
+            "could not load scripts/backfill_thematic_universe.py"
+        )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    canonical = Path(out_path)
+    plan = module.gc_cohorts(out_path=canonical, keep=keep, apply=apply)
+
+    candidates = plan["delete"]
+    kept = plan["keep"]
+    if apply:
+        deleted = plan["deleted"]
+        click.echo(
+            f"gc-cohorts: deleted {len(deleted)} orphan cohort(s); "
+            f"kept canonical {canonical.name} + {len(kept)} latest."
+        )
+        for p in deleted:
+            click.echo(f"  deleted {p}")
+    else:
+        click.echo(
+            f"DRY-RUN gc-cohorts: would delete {len(candidates)} orphan "
+            f"cohort(s); would keep canonical {canonical.name} + {len(kept)} "
+            f"latest. Re-run with --apply to delete."
+        )
+        for p in candidates:
+            click.echo(f"  would delete {p}")
+    for p in kept:
+        click.echo(f"  keep {p}")
 
 
 @thematic.command("backfill-names")
@@ -3983,13 +4075,11 @@ def _check_ohlcv_freshness(
     if panel_max < asof_dt:
         raise click.ClickException(
             f"OHLCV cache stale: max(date)={panel_max} < asof={asof_dt}. "
-            f"Refresh with:\n"
-            f"  1. uv run python scripts/backfill_thematic_universe.py "
-            f"--start 2024-10-01 --end {asof_dt} --force\n"
-            f"  2. mv $(ls -t {Path(ohlcv_path).parent}/"
-            f"{Path(ohlcv_path).stem}_*{Path(ohlcv_path).suffix} | head -1) "
-            f"{ohlcv_path}\n"
-            f"  3. uv run rainier thematic run-daily  # retry"
+            f"Self-heal the canonical with the sanctioned adopt bridge "
+            f"(atomic in-place replace + Neon mirror, no manual mv):\n"
+            f"  1. uv run rainier thematic backfill --force --adopt "
+            f"--start 2024-10-01 --end {asof_dt} --out {ohlcv_path}\n"
+            f"  2. uv run rainier thematic run-daily  # retry"
         )
 
     # Shallow-history guard: Layer A's longest lookback is the 20-trading-day
@@ -4003,21 +4093,20 @@ def _check_ohlcv_freshness(
     if distinct_dates < MIN_HISTORY_TRADING_DAYS:
         # The shallow cache already exists (--incremental created it), so the
         # seed must replace it: the one-shot backfill refuses to overwrite
-        # without --force, and --force writes a sibling cohort that must be
-        # moved into place (revision-immutability) — same flow as the stale
-        # branch above (codex iter-5).
+        # without --force. --force --adopt does the full re-fetch then atomically
+        # replaces the shallow canonical in place (+ mirrors Neon) — the
+        # sanctioned bridge, no manual mv (revision-immutability preserved by the
+        # atomic os.replace inside backfill()).
         raise click.ClickException(
             f"OHLCV cache too shallow: only {distinct_dates} trading day(s) "
             f"<= asof={asof_dt}; Layer A needs >= {MIN_HISTORY_TRADING_DAYS} "
             f"(rel_20/vol_20 windows) or every rank is the no-data sentinel. "
             f"The --incremental refresh only fetches a few days and is NOT a "
-            f"substitute for the full-history seed. Replace the shallow cache:\n"
-            f"  1. uv run python scripts/backfill_thematic_universe.py "
-            f"--start 2024-10-01 --end {asof_dt} --force\n"
-            f"  2. mv $(ls -t {Path(ohlcv_path).parent}/"
-            f"{Path(ohlcv_path).stem}_*{Path(ohlcv_path).suffix} | head -1) "
-            f"{ohlcv_path}\n"
-            f"  3. uv run rainier thematic run-daily  # retry"
+            f"substitute for the full-history seed. Replace the shallow cache "
+            f"with the sanctioned adopt bridge (no manual mv):\n"
+            f"  1. uv run rainier thematic backfill --force --adopt "
+            f"--start 2024-10-01 --end {asof_dt} --out {ohlcv_path}\n"
+            f"  2. uv run rainier thematic run-daily  # retry"
         )
 
     expected_syms = {sym for syms in spec.sectors.values() for sym in syms}

--- a/tests/research/test_backfill_thematic_universe.py
+++ b/tests/research/test_backfill_thematic_universe.py
@@ -609,6 +609,264 @@ def test_incremental_outage_aborts_before_write(backfill_mod, tmp_path):
     assert today not in set(pd.to_datetime(after["date"]).dt.date)
 
 
+# ---------------------------------------------------------------------------
+# --adopt — sanctioned cohort -> canonical bridge (this task)
+#
+# `backfill(force=True, adopt=True)` over an EXISTING canonical replaces the
+# stale canonical atomically (os.replace) with the freshly fetched cohort and
+# leaves NO orphan sibling. This is the one-command self-heal for a stale
+# canonical, replacing the unsanctioned manual `mv cohort -> canonical`.
+# ---------------------------------------------------------------------------
+
+
+def test_adopt_replaces_canonical_atomically(backfill_mod, tmp_path):
+    """force+adopt over an existing canonical advances max(date) and writes
+    IN PLACE onto the canonical path — no sibling cohort left behind."""
+    from datetime import date, timedelta
+
+    out = tmp_path / "thematic_universe.parquet"
+    # Seed a STALE canonical: full-history fetch anchored at an old window.
+    old = date(2026, 5, 1)
+    old_dates = [old - timedelta(days=d) for d in (4, 3, 2, 1, 0)]
+    backfill_mod.backfill(
+        symbols=["XLK", "SMH"],
+        start=min(old_dates).isoformat(),
+        end=max(old_dates).isoformat(),
+        out_path=out,
+        force=False,
+        fetch_fn=_windowed_fetch_factory(old_dates),
+        min_coverage=0.0,
+    )
+    stale_max = pd.to_datetime(pd.read_parquet(out)["date"]).dt.date.max()
+
+    # Fresh full fetch that reaches a newer high-water mark.
+    fresh = date(2026, 5, 29)
+    fresh_dates = [fresh - timedelta(days=d) for d in (4, 3, 2, 1, 0)]
+    result = backfill_mod.backfill(
+        symbols=["XLK", "SMH"],
+        start=min(fresh_dates).isoformat(),
+        end=max(fresh_dates).isoformat(),
+        out_path=out,
+        force=True,
+        adopt=True,
+        fetch_fn=_windowed_fetch_factory(fresh_dates),
+        min_coverage=0.0,
+    )
+
+    # Wrote onto the canonical path itself, not a sibling.
+    assert result == out
+    siblings = [
+        p
+        for p in tmp_path.glob("thematic_universe_*.parquet")
+        if p != out
+    ]
+    assert siblings == [], f"adopt must leave no orphan cohort, found {siblings}"
+    # Canonical advanced to the fresh cohort.
+    new_max = pd.to_datetime(pd.read_parquet(out)["date"]).dt.date.max()
+    assert new_max > stale_max
+    assert new_max == fresh
+    # No tmp leak.
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_adopt_then_incremental_is_clean_noop(backfill_mod, tmp_path):
+    """After adopt brings the canonical current, a subsequent --incremental over
+    the same recent window adds no new rows and never trips the gap guard —
+    proving the daily cron self-heals."""
+    from datetime import date, timedelta
+
+    out = tmp_path / "thematic_universe.parquet"
+    fresh = date(2026, 5, 29)
+    fresh_dates = [fresh - timedelta(days=d) for d in (2, 1, 0)]
+
+    # Seed a stale canonical then adopt a fresh cohort over it.
+    stale = date(2026, 5, 1)
+    stale_dates = [stale - timedelta(days=d) for d in (1, 0)]
+    backfill_mod.backfill(
+        symbols=["XLK"],
+        start=min(stale_dates).isoformat(),
+        end=max(stale_dates).isoformat(),
+        out_path=out,
+        force=False,
+        fetch_fn=_windowed_fetch_factory(stale_dates),
+        min_coverage=0.0,
+    )
+    backfill_mod.backfill(
+        symbols=["XLK"],
+        start=min(fresh_dates).isoformat(),
+        end=max(fresh_dates).isoformat(),
+        out_path=out,
+        force=True,
+        adopt=True,
+        fetch_fn=_windowed_fetch_factory(fresh_dates),
+        min_coverage=0.0,
+    )
+    rows_after_adopt = len(pd.read_parquet(out))
+
+    # Incremental over the same fresh window is a clean no-op (no gap, no dups).
+    backfill_mod.backfill(
+        symbols=["XLK"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        incremental=True,
+        fetch_fn=_windowed_fetch_factory(fresh_dates),
+        today=fresh,
+        min_coverage=0.0,
+    )
+    df = pd.read_parquet(out)
+    assert len(df) == rows_after_adopt
+    assert not df.duplicated(subset=["symbol", "date"]).any()
+
+
+def test_adopt_on_missing_canonical_writes_in_place(backfill_mod, tmp_path):
+    """force+adopt with no pre-existing canonical just writes the canonical
+    path directly (no sibling) — fresh-host safety net."""
+    out = tmp_path / "thematic_universe.parquet"
+    result = backfill_mod.backfill(
+        symbols=["XLK", "SMH"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=True,
+        adopt=True,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+    assert result == out
+    assert out.exists()
+    assert [p for p in tmp_path.glob("thematic_universe_*.parquet") if p != out] == []
+
+
+def test_adopt_requires_force(backfill_mod, tmp_path):
+    """adopt without force on an existing canonical still refuses the clobber —
+    adopt is a modifier of the --force fetch path, not a bypass of the guard."""
+    out = tmp_path / "thematic_universe.parquet"
+    backfill_mod.backfill(
+        symbols=["XLK"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=False,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+    with pytest.raises(FileExistsError):
+        backfill_mod.backfill(
+            symbols=["XLK"],
+            start="2024-10-01",
+            end="2024-10-08",
+            out_path=out,
+            force=False,
+            adopt=True,
+            fetch_fn=_stub_fetch,
+            min_coverage=0.0,
+        )
+
+
+def test_adopt_outage_does_not_clobber_canonical(backfill_mod, tmp_path):
+    """A provider outage on a force+adopt run must abort BEFORE the os.replace,
+    leaving the prior good canonical intact (no partial/empty canonical)."""
+    out = tmp_path / "thematic_universe.parquet"
+    backfill_mod.backfill(
+        symbols=["XLK", "SMH", "XLE", "XLF"],
+        start="2024-10-01",
+        end="2024-10-08",
+        out_path=out,
+        force=False,
+        fetch_fn=_stub_fetch,
+        min_coverage=0.0,
+    )
+    good_rows = len(pd.read_parquet(out))
+
+    def _outage_fetch(symbols, start, end):
+        cols = ["date", "open", "high", "low", "close", "volume"]
+        return {s: pd.DataFrame(columns=cols) for s in symbols}
+
+    with pytest.raises(ValueError):
+        backfill_mod.backfill(
+            symbols=["XLK", "SMH", "XLE", "XLF"],
+            start="2024-10-01",
+            end="2024-10-08",
+            out_path=out,
+            force=True,
+            adopt=True,
+            fetch_fn=_outage_fetch,
+            # default min_coverage trips the Tier-1 empty gate.
+        )
+    assert len(pd.read_parquet(out)) == good_rows
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+# ---------------------------------------------------------------------------
+# gc_cohorts — reap orphan sibling cohorts, keep canonical + N latest
+# ---------------------------------------------------------------------------
+
+
+def _touch_cohort(tmp_path, name, mtime):
+    p = tmp_path / name
+    p.write_bytes(b"x")
+    os = __import__("os")
+    os.utime(p, (mtime, mtime))
+    return p
+
+
+def test_gc_cohorts_dry_run_lists_without_deleting(backfill_mod, tmp_path):
+    canonical = tmp_path / "thematic_universe.parquet"
+    canonical.write_bytes(b"canonical")
+    c1 = _touch_cohort(tmp_path, "thematic_universe_20260501_010101_000001.parquet", 100)
+    c2 = _touch_cohort(tmp_path, "thematic_universe_20260502_010101_000001.parquet", 200)
+    c3 = _touch_cohort(tmp_path, "thematic_universe_20260503_010101_000001.parquet", 300)
+
+    plan = backfill_mod.gc_cohorts(out_path=canonical, keep=1, apply=False)
+
+    # Nothing deleted in dry-run.
+    assert c1.exists() and c2.exists() and c3.exists()
+    assert canonical.exists()
+    # Plan reaps the 2 oldest, keeps the newest cohort.
+    assert set(plan["delete"]) == {c1, c2}
+    assert c3 in plan["keep"]
+    assert canonical not in plan["delete"]
+
+
+def test_gc_cohorts_apply_deletes_old_keeps_canonical_and_latest(backfill_mod, tmp_path):
+    canonical = tmp_path / "thematic_universe.parquet"
+    canonical.write_bytes(b"canonical")
+    c1 = _touch_cohort(tmp_path, "thematic_universe_20260501_010101_000001.parquet", 100)
+    c2 = _touch_cohort(tmp_path, "thematic_universe_20260502_010101_000001.parquet", 200)
+    c3 = _touch_cohort(tmp_path, "thematic_universe_20260503_010101_000001.parquet", 300)
+    refresh = _touch_cohort(tmp_path, "thematic_universe_refresh.parquet", 50)
+
+    deleted = backfill_mod.gc_cohorts(out_path=canonical, keep=2, apply=True)
+
+    # Canonical NEVER touched.
+    assert canonical.exists()
+    # Two most-recent cohorts kept; older cohort + refresh sibling reaped.
+    assert c2.exists() and c3.exists()
+    assert not c1.exists()
+    assert not refresh.exists()
+    assert set(deleted["deleted"]) == {c1, refresh}
+
+
+def test_gc_cohorts_never_deletes_canonical(backfill_mod, tmp_path):
+    canonical = tmp_path / "thematic_universe.parquet"
+    canonical.write_bytes(b"canonical")
+    # keep=0 is the most aggressive setting; canonical must still survive.
+    c1 = _touch_cohort(tmp_path, "thematic_universe_20260501_010101_000001.parquet", 100)
+    deleted = backfill_mod.gc_cohorts(out_path=canonical, keep=0, apply=True)
+    assert canonical.exists()
+    assert not c1.exists()
+    assert canonical not in deleted["deleted"]
+
+
+def test_gc_cohorts_no_cohorts_is_empty_plan(backfill_mod, tmp_path):
+    canonical = tmp_path / "thematic_universe.parquet"
+    canonical.write_bytes(b"canonical")
+    plan = backfill_mod.gc_cohorts(out_path=canonical, keep=2, apply=False)
+    assert plan["delete"] == []
+    assert canonical.exists()
+
+
 def test_incremental_gap_too_large_aborts(backfill_mod, tmp_path):
     """If the existing cache's high-water mark is older than the incremental
     window can bridge, the refresh must fail loud rather than stitch a gapped

--- a/tests/research/test_backfill_thematic_universe.py
+++ b/tests/research/test_backfill_thematic_universe.py
@@ -914,6 +914,50 @@ def test_gc_cohorts_matches_collision_suffixed_cohort(backfill_mod, tmp_path):
     assert bumped in plan["delete"]
 
 
+def test_gc_cohorts_apply_surfaces_unlink_failure(backfill_mod, tmp_path, monkeypatch):
+    """An unlink failure in --apply must be surfaced in `failed`, not swallowed
+    — automation must not believe gc completed with an orphan still on disk.
+    (codex review iter-2 [P2].)"""
+    canonical = tmp_path / "thematic_universe.parquet"
+    canonical.write_bytes(b"canonical")
+    cohort = _touch_cohort(
+        tmp_path, "thematic_universe_20260501_010101_000001.parquet", 100
+    )
+
+    def _boom(self):
+        raise PermissionError("locked")
+
+    monkeypatch.setattr(Path, "unlink", _boom)
+    plan = backfill_mod.gc_cohorts(out_path=canonical, keep=0, apply=True)
+    assert plan["deleted"] == []
+    assert len(plan["failed"]) == 1
+    assert plan["failed"][0][0] == cohort
+    assert "locked" in plan["failed"][0][1]
+    # The cohort is still on disk (the failure was real, not swallowed).
+    assert cohort.exists()
+
+
+def test_adopt_rejects_adhoc_symbol_subset(backfill_mod, tmp_path):
+    """`--adopt` over an ad-hoc `--symbols` subset must be refused: replacing
+    the full-universe canonical with a subset would silently shrink it.
+    (codex review iter-2 [P2].)"""
+    out = tmp_path / "thematic_universe.parquet"
+    rc = backfill_mod.main(
+        [
+            "--symbols", "XLK,SMH",
+            "--start", "2024-10-01",
+            "--end", "2024-10-08",
+            "--out", str(out),
+            "--force",
+            "--adopt",
+        ]
+    )
+    assert rc == 2
+    # Refused before any write — no canonical, no sibling created.
+    assert not out.exists()
+    assert list(tmp_path.glob("thematic_universe*.parquet")) == []
+
+
 def test_incremental_gap_too_large_aborts(backfill_mod, tmp_path):
     """If the existing cache's high-water mark is older than the incremental
     window can bridge, the refresh must fail loud rather than stitch a gapped

--- a/tests/research/test_backfill_thematic_universe.py
+++ b/tests/research/test_backfill_thematic_universe.py
@@ -867,6 +867,53 @@ def test_gc_cohorts_no_cohorts_is_empty_plan(backfill_mod, tmp_path):
     assert canonical.exists()
 
 
+def test_gc_cohorts_spares_universe_log_and_other_prefix_siblings(
+    backfill_mod, tmp_path
+):
+    """The gc glob must match ONLY timestamped cohorts + the exact _refresh
+    sibling — NOT every `thematic_universe_*` sibling. In particular the
+    persistent `thematic_universe_log.parquet` (the snapshot-universe change
+    log) shares the prefix but is load-bearing and must NEVER be reaped, even
+    with keep=0 --apply. (codex review iter-1 [P1] — data loss.)"""
+    canonical = tmp_path / "thematic_universe.parquet"
+    canonical.write_bytes(b"canonical")
+    # Real timestamped cohort (gc candidate).
+    cohort = _touch_cohort(
+        tmp_path, "thematic_universe_20260501_010101_000001.parquet", 100
+    )
+    # Prefix-sharing non-cohorts that MUST be spared.
+    log = tmp_path / "thematic_universe_log.parquet"
+    log.write_bytes(b"universe change log")
+    names = tmp_path / "thematic_universe_names.parquet"
+    names.write_bytes(b"names")
+
+    # Plan must list only the real cohort.
+    plan = backfill_mod.gc_cohorts(out_path=canonical, keep=0, apply=False)
+    assert set(plan["delete"]) == {cohort}
+    assert log not in plan["delete"]
+    assert names not in plan["delete"]
+
+    # Apply with the most aggressive keep=0 — log + names survive, cohort gone.
+    deleted = backfill_mod.gc_cohorts(out_path=canonical, keep=0, apply=True)
+    assert log.exists()
+    assert names.exists()
+    assert canonical.exists()
+    assert not cohort.exists()
+    assert set(deleted["deleted"]) == {cohort}
+
+
+def test_gc_cohorts_matches_collision_suffixed_cohort(backfill_mod, tmp_path):
+    """`_cohort_path` appends a `_N` collision suffix when two cohorts share a
+    microsecond stamp; gc must still recognize those as cohorts."""
+    canonical = tmp_path / "thematic_universe.parquet"
+    canonical.write_bytes(b"canonical")
+    bumped = _touch_cohort(
+        tmp_path, "thematic_universe_20260501_010101_000001_3.parquet", 100
+    )
+    plan = backfill_mod.gc_cohorts(out_path=canonical, keep=0, apply=False)
+    assert bumped in plan["delete"]
+
+
 def test_incremental_gap_too_large_aborts(backfill_mod, tmp_path):
     """If the existing cache's high-water mark is older than the incremental
     window can bridge, the refresh must fail loud rather than stitch a gapped

--- a/tests/research/test_thematic_run_daily.py
+++ b/tests/research/test_thematic_run_daily.py
@@ -459,18 +459,20 @@ def test_run_daily_stale_ohlcv_surfaces_diagnostic(fake_cache):
     assert "stale" in result.output.lower(), (
         f"diagnostic should mention 'stale'; got: {result.output!r}"
     )
-    assert "backfill_thematic_universe" in result.output, (
+    assert "thematic backfill" in result.output, (
         f"diagnostic should name the next-step backfill command; got: {result.output!r}"
     )
-    # codex iter-3 [P1]: the recovery flow must account for backfill's
-    # revision-immutability (--force writes a sibling cohort, not in-place).
-    # Diagnostic must include the cohort-swap step (--force then mv).
-    assert "--force" in result.output, (
-        f"diagnostic must mention --force (sibling cohort flow); "
+    # The recovery flow now points at the sanctioned `--force --adopt` bridge
+    # (atomic in-place canonical replace + Neon mirror) instead of the old
+    # manual `mv cohort -> canonical` swap (revision-immutability preserved by
+    # the atomic os.replace inside backfill()).
+    assert "--force --adopt" in result.output, (
+        f"diagnostic must mention the --force --adopt bridge; "
         f"got: {result.output!r}"
     )
-    assert " mv " in result.output, (
-        f"diagnostic must include cohort-swap mv step; got: {result.output!r}"
+    assert " mv " not in result.output, (
+        f"diagnostic must NOT tell the operator to manually mv (unsanctioned "
+        f"cache mutation); got: {result.output!r}"
     )
 
 
@@ -527,8 +529,12 @@ def test_check_freshness_rejects_shallow_history():
         _check_ohlcv_freshness(panel, asof, "data/cache/thematic_universe.parquet", spec)
     msg = str(exc.value)
     assert "shallow" in msg.lower(), f"diagnostic must say 'shallow'; got: {msg!r}"
-    assert "backfill_thematic_universe" in msg, (
-        f"diagnostic must name the full-history seed command; got: {msg!r}"
+    assert "thematic backfill --force --adopt" in msg, (
+        f"diagnostic must name the sanctioned full-history adopt bridge; "
+        f"got: {msg!r}"
+    )
+    assert " mv " not in msg, (
+        f"diagnostic must NOT tell the operator to manually mv; got: {msg!r}"
     )
 
 

--- a/tests/test_cli/test_thematic_cohort_adopt_gc.py
+++ b/tests/test_cli/test_thematic_cohort_adopt_gc.py
@@ -1,0 +1,150 @@
+"""CLI wiring tests for the sanctioned cohort->canonical bridge.
+
+Covers:
+  * `thematic backfill --adopt` exposes the flag and passes adopt=True (with
+    force=True) through to the script's backfill().
+  * `thematic gc-cohorts` reaps orphan sibling cohorts, keeps canonical + N
+    latest, dry-runs by default, --apply deletes, never touches canonical.
+
+The adopt fetch/replace semantics are unit-tested in
+tests/research/test_backfill_thematic_universe.py; here we verify the CLI
+surface + the gc command wiring.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from click.testing import CliRunner
+
+# ---------------------------------------------------------------------------
+# backfill --adopt
+# ---------------------------------------------------------------------------
+
+
+def test_adopt_flag_in_help():
+    from rainier.cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["thematic", "backfill", "--help"])
+    assert result.exit_code == 0
+    assert "--adopt" in result.output
+
+
+def test_adopt_passes_through_to_script(monkeypatch, tmp_path):
+    """`thematic backfill --force --adopt` reaches script backfill() with
+    adopt=True and force=True."""
+    import importlib.util as _ilu
+
+    import rainier.cli as cli_mod
+
+    yaml_path = tmp_path / "thematic_universe.yaml"
+    yaml_path.write_text(
+        "version: 1\n"
+        "schema: thematic_universe.v1\n"
+        "asof_seeded: 2024-10-01\n"
+        "universe:\n"
+        "  test_sector:\n"
+        "    - XLK\n"
+        "    - SMH\n"
+    )
+    out_path = tmp_path / "thematic_universe.parquet"
+
+    captured: dict[str, object] = {}
+
+    def _fake_backfill(**kwargs):
+        captured.update(kwargs)
+        return Path(kwargs["out_path"])
+
+    orig_module_from_spec = _ilu.module_from_spec
+
+    def _patched_module_from_spec(spec):
+        mod = orig_module_from_spec(spec)
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+        mod.backfill = _fake_backfill  # type: ignore[attr-defined]
+        spec.loader.exec_module = lambda _m: None  # type: ignore[assignment]
+        return mod
+
+    monkeypatch.setattr(_ilu, "module_from_spec", _patched_module_from_spec)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        [
+            "thematic",
+            "backfill",
+            "--force",
+            "--adopt",
+            "--yaml",
+            str(yaml_path),
+            "--out",
+            str(out_path),
+            "--ticker-registry",
+            str(tmp_path / "ticker_registry.parquet"),
+            "--sector-registry",
+            str(tmp_path / "sector_registry.parquet"),
+        ],
+    )
+    assert result.exit_code == 0, f"exit={result.exit_code} output={result.output}"
+    assert captured.get("adopt") is True, f"captured={captured}"
+    assert captured.get("force") is True
+
+
+# ---------------------------------------------------------------------------
+# gc-cohorts
+# ---------------------------------------------------------------------------
+
+
+def _touch(p: Path, mtime: int) -> Path:
+    p.write_bytes(b"x")
+    os.utime(p, (mtime, mtime))
+    return p
+
+
+def test_gc_cohorts_in_help():
+    from rainier.cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["thematic", "gc-cohorts", "--help"])
+    assert result.exit_code == 0
+    assert "--apply" in result.output
+    assert "--keep" in result.output
+
+
+def test_gc_cohorts_dry_run_default_lists_no_delete(tmp_path):
+    from rainier.cli import cli
+
+    canonical = tmp_path / "thematic_universe.parquet"
+    _touch(canonical, 1000)
+    c1 = _touch(tmp_path / "thematic_universe_20260501_010101_000001.parquet", 100)
+    c2 = _touch(tmp_path / "thematic_universe_20260502_010101_000001.parquet", 200)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["thematic", "gc-cohorts", "--out", str(canonical), "--keep", "1"]
+    )
+    assert result.exit_code == 0, result.output
+    # Default is dry-run: nothing deleted.
+    assert c1.exists() and c2.exists() and canonical.exists()
+    assert "DRY-RUN" in result.output or "dry-run" in result.output
+
+
+def test_gc_cohorts_apply_deletes_keeps_canonical(tmp_path):
+    from rainier.cli import cli
+
+    canonical = tmp_path / "thematic_universe.parquet"
+    _touch(canonical, 1000)
+    c1 = _touch(tmp_path / "thematic_universe_20260501_010101_000001.parquet", 100)
+    c2 = _touch(tmp_path / "thematic_universe_20260502_010101_000001.parquet", 200)
+    c3 = _touch(tmp_path / "thematic_universe_20260503_010101_000001.parquet", 300)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["thematic", "gc-cohorts", "--out", str(canonical), "--keep", "2", "--apply"],
+    )
+    assert result.exit_code == 0, result.output
+    assert canonical.exists()  # NEVER deleted
+    assert c2.exists() and c3.exists()  # 2 latest kept
+    assert not c1.exists()  # oldest reaped

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -258,6 +258,66 @@ def test_backfill_dual_write_idempotent(migrated_engine, tmp_path, database_url)
 
 
 @pytest.mark.requires_postgres
+def test_adopt_mirrors_ohlcv_to_pg_and_replaces_canonical(
+    migrated_engine, tmp_path, database_url
+):
+    """`backfill(force=True, adopt=True)` over a stale canonical advances the
+    canonical parquet IN PLACE (no orphan sibling) AND mirrors the fresh OHLCV
+    into market.thematic_ohlcv — one command leaves BOTH current."""
+    backfill = _import_backfill()
+    symbols = ["AAA", "BBB"]
+    yaml_path = tmp_path / "universe.yaml"
+    _write_universe_yaml(yaml_path, symbols)
+    out_path = tmp_path / "thematic_universe.parquet"
+
+    def _fetch_for(panel):
+        def fake_fetch(syms, start, end):
+            return {
+                s: panel.loc[
+                    panel["symbol"] == s,
+                    ["date", "open", "high", "low", "close", "volume"],
+                ].reset_index(drop=True)
+                for s in syms
+            }
+
+        return fake_fetch
+
+    # Seed a stale canonical (older dates).
+    stale_panel = _build_ohlcv_panel(symbols, n_days=10)
+    backfill.backfill(
+        symbols=symbols, start="2024-10-01", end="2024-10-31",
+        out_path=out_path, fetch_fn=_fetch_for(stale_panel), yaml_path=yaml_path,
+        min_coverage=0.0,
+        ticker_registry_path=tmp_path / "tr.parquet",
+        sector_registry_path=tmp_path / "sr.parquet",
+    )
+    stale_max = pd.to_datetime(pd.read_parquet(out_path)["date"]).dt.date.max()
+
+    # Fresh full fetch with MORE days -> later high-water mark.
+    fresh_panel = _build_ohlcv_panel(symbols, n_days=30)
+    written = backfill.backfill(
+        symbols=symbols, start="2024-10-01", end="2024-10-31",
+        out_path=out_path, force=True, adopt=True,
+        fetch_fn=_fetch_for(fresh_panel), yaml_path=yaml_path,
+        min_coverage=0.0,
+        ticker_registry_path=tmp_path / "tr.parquet",
+        sector_registry_path=tmp_path / "sr.parquet",
+    )
+
+    # Canonical replaced in place, no orphan sibling.
+    assert Path(written) == out_path
+    siblings = [
+        p for p in tmp_path.glob("thematic_universe_*.parquet") if p != out_path
+    ]
+    assert siblings == [], f"adopt left orphan cohort: {siblings}"
+    canon = pd.read_parquet(out_path)
+    assert pd.to_datetime(canon["date"]).dt.date.max() > stale_max
+
+    # PG thematic_ohlcv mirrors the fresh canonical exactly.
+    assert _count(migrated_engine, "thematic_ohlcv") == len(canon)
+
+
+@pytest.mark.requires_postgres
 def test_backfill_and_compute_share_stable_ids_across_yaml_reorder(
     migrated_engine, tmp_path, database_url
 ):


### PR DESCRIPTION
## Summary
- `rainier thematic backfill --force --adopt` (alias --in-place): after a clean full fetch+validate, atomically os.replace's the fresh cohort onto the canonical thematic_universe.parquet (fsync before rename; outage aborts BEFORE the replace so the prior canonical survives) AND mirrors thematic_ohlcv + registries to Neon. One command brings canonical + Postgres current → the daily thematic cron self-heals from a stale canonical (no more manual `mv`, no gap-guard dead-end).
- `rainier thematic gc-cohorts [--apply] [--keep N]`: reaps orphan timestamped sibling cohorts + the _refresh sibling, keeps the canonical + N latest, dry-run by default, NEVER deletes the canonical.
- Stale/shallow diagnostics now point at `--force --adopt` instead of a manual mv.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 3) — caught a data-loss [P1] (gc-cohorts glob matched the persistent thematic_universe_log.parquet change-log → narrowed to an anchored timestamped-cohort regex + == canonical guard), a missing fsync-before-replace, and 2 P2s (subset-adopt rejected; gc unlink failures surfaced not swallowed). Each with regression tests.

## Context
- Closes the tool gap found during the 2026-05-30 Neon cutover: a stale canonical (beyond the --incremental window) had no sanctioned bridge. After merge the coord runs `thematic backfill --force --adopt` to bring the canonical to latest → verify-coverage green + daily cron self-heals; then gc-cohorts reaps the orphan cohorts left from the cutover.

## Test plan
- [ ] CI green
- [ ] after merge: coord runs --adopt to bridge canonical + verify-coverage all match