### PR TITLE
feat(dualwrite): loud PG-MIRROR-FAILURE diagnostic + always-yield guard

### DIFF
--- a/src/rainier/db/dualwrite.py
+++ b/src/rainier/db/dualwrite.py
@@ -69,11 +69,11 @@ _PASSWORD_KV_RE = re.compile(
     r"""(?P<key>\b(?:password|pwd)\b)   # password / pwd, word-bounded
         (?P<sep>['"]?\s*[:=]\s*)        # optional key-closing quote + : or = sep
         (?:
-            (?P<sq>')[^']*(?P=sq)       # single-quoted value: stop only at the
-                                         #   matching ' (a " inside is part of it)
-          | (?P<dq>")[^"]*(?P=dq)       # double-quoted value: stop only at the
-                                         #   matching " (a ' inside is part of it)
-          | [^'"\s,;]*                  # unquoted value: stop at ws/sep
+            (?P<sq>')(?:\\.|[^'\\])*(?P=sq)  # single-quoted: consume \-escapes so
+                                              #   an escaped \' inside stays part of
+                                              #   the secret; stop at the real close
+          | (?P<dq>")(?:\\.|[^"\\])*(?P=dq)  # double-quoted: same, for \" (JSON)
+          | [^'"\s,;]*                       # unquoted value: stop at ws/sep
         )
     """,
     re.IGNORECASE | re.VERBOSE,

--- a/src/rainier/db/dualwrite.py
+++ b/src/rainier/db/dualwrite.py
@@ -123,6 +123,12 @@ def _redact_host(database_url: str) -> str:
     try:
         db = url.database or ""
         host = url.host or ""
+        # An unescaped '@' in the password (e.g. postgresql://u:pa@ss@db/prod)
+        # makes make_url parse the host as `ss@db` — a password fragment bled into
+        # the host field. Any '@' in the host means the parse was ambiguous and
+        # creds may be embedded; refuse to render it (never leak to cron logs).
+        if "@" in host:
+            return "<unparseable>"
         # A "socket" host is a filesystem path (leading '/'), or it lives in the
         # `host` query param (libpq Unix-socket convention SQLAlchemy passes
         # through). Prefer the query-param socket dir when present.

--- a/src/rainier/db/dualwrite.py
+++ b/src/rainier/db/dualwrite.py
@@ -55,11 +55,12 @@ _DESIGN_DOC = "docs/DESIGN-rainier-postgres-canonical-store.md"
 
 # Drop a `<scheme>://<userinfo>@` segment, with OR without a `:password` part, so
 # neither the password NOR the username survives. Scheme allows `+driver` forms
-# (e.g. postgresql+psycopg). userinfo is everything up to the first '@' that is
-# not itself a scheme/host separator; we match conservatively (no '/' or '@' in
-# userinfo) to avoid eating the host.
+# (e.g. postgresql+psycopg). userinfo runs up to the LAST '@' before the host —
+# greedy `[^/\s]*@` so an unescaped '@' INSIDE the password (e.g.
+# `postgresql://u:pa@ss@db/prod`) is consumed too (the userinfo ends at the final
+# '@' before the path/host); `[^/\s]` keeps us from crossing into the path.
 _URL_USERINFO_RE = re.compile(
-    r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]*://)(?P<userinfo>[^/@\s]+)@"
+    r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]*://)(?P<userinfo>[^/\s]*@)"
 )
 # password=<v> / pwd=<v>, optionally quoted (key/value connect-arg + JSON-ish).
 # Two alternatives for the value so a QUOTED secret with embedded whitespace /

--- a/src/rainier/db/dualwrite.py
+++ b/src/rainier/db/dualwrite.py
@@ -161,7 +161,15 @@ def _scrub_credentials(text: str, database_url: str | None = None) -> str:
             if ui:
                 literals.add(ui)
             try:
-                parsed_host = make_url(database_url).host or ""
+                parsed = make_url(database_url)
+                parsed_host = parsed.host or ""
+                # Parsed username/password — auth errors echo these standalone,
+                # e.g. `password authentication failed for user "bob"`, with no URL
+                # or `password=` form for the other rules to catch. Min length 2
+                # avoids pathological 1-char redaction across unrelated text.
+                for cred in (parsed.username, parsed.password):
+                    if cred and len(cred) >= 2:
+                        literals.add(cred)
             except Exception:
                 parsed_host = ""
             if "@" in parsed_host:

--- a/src/rainier/db/dualwrite.py
+++ b/src/rainier/db/dualwrite.py
@@ -69,9 +69,11 @@ _PASSWORD_KV_RE = re.compile(
     r"""(?P<key>\b(?:password|pwd)\b)   # password / pwd, word-bounded
         (?P<sep>['"]?\s*[:=]\s*)        # optional key-closing quote + : or = sep
         (?:
-            (?P<quote>['"])[^'"]*(?P=quote)  # quoted value: everything up to the
-                                              #   matching closing quote (ws ok)
-          | [^'"\s,;]*                        # unquoted value: stop at ws/sep
+            (?P<sq>')[^']*(?P=sq)       # single-quoted value: stop only at the
+                                         #   matching ' (a " inside is part of it)
+          | (?P<dq>")[^"]*(?P=dq)       # double-quoted value: stop only at the
+                                         #   matching " (a ' inside is part of it)
+          | [^'"\s,;]*                  # unquoted value: stop at ws/sep
         )
     """,
     re.IGNORECASE | re.VERBOSE,
@@ -91,7 +93,7 @@ def _scrub_credentials(text: str) -> str:
     def _kv_repl(m: re.Match[str]) -> str:
         # Re-wrap with the captured quote when the value was quoted, so the
         # output stays well-formed (password='***'); bare *** when unquoted.
-        quote = m.group("quote") or ""
+        quote = m.group("sq") or m.group("dq") or ""
         return f"{m.group('key')}{m.group('sep')}{quote}***{quote}"
 
     try:

--- a/src/rainier/db/dualwrite.py
+++ b/src/rainier/db/dualwrite.py
@@ -102,6 +102,29 @@ def _raw_userinfo(database_url: str) -> str | None:
         return None
 
 
+def _raw_password_token(database_url: str) -> str | None:
+    """Return the RAW ``user:password`` token of a DATABASE_URL that has NO ``@``
+    separator (a malformed URL like ``postgresql://user:secret host/db``).
+
+    ``make_url`` then raises a ``ValueError`` whose text echoes a credential
+    fragment (``invalid literal ... 'secret host'``) — and ``_raw_userinfo``
+    (which requires an ``@``) misses it. We grab everything between ``://`` and
+    the first ``/`` and require a ``:`` (the user:pass separator) so we only
+    redact a genuine credential token, never a bare host. Returns None otherwise.
+    Never raises.
+    """
+    try:
+        if "@" in database_url:  # the @-form is handled by _raw_userinfo
+            return None
+        m = re.match(r"[a-zA-Z][a-zA-Z0-9+.\-]*://(?P<token>[^/]*)", database_url)
+        if not m:
+            return None
+        token = m.group("token")
+        return token if token and ":" in token else None
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
 def _scrub_credentials(text: str, database_url: str | None = None) -> str:
     """Strip credentials from arbitrary error text. Bounded scope (design §3.2):
 
@@ -143,6 +166,14 @@ def _scrub_credentials(text: str, database_url: str | None = None) -> str:
                 parsed_host = ""
             if "@" in parsed_host:
                 literals.add(parsed_host)
+            # No-'@' malformed form: a ValueError echoes the user:pass token (or
+            # just its password half, e.g. 'secret host'); redact both literals.
+            token = _raw_password_token(database_url)
+            if token:
+                literals.add(token)
+                _, _, pwd = token.partition(":")
+                if pwd:
+                    literals.add(pwd)
             for literal in sorted(literals, key=len, reverse=True):
                 out = out.replace(literal, "***")
         return out

--- a/src/rainier/db/dualwrite.py
+++ b/src/rainier/db/dualwrite.py
@@ -81,15 +81,43 @@ _PASSWORD_KV_RE = re.compile(
 )
 
 
-def _scrub_credentials(text: str) -> str:
+def _raw_userinfo(database_url: str) -> str | None:
+    """Return the RAW userinfo substring of a DATABASE_URL — everything between
+    ``://`` and the LAST ``@`` before the host/path — without parsing.
+
+    Used as a defense-in-depth literal to scrub from arbitrary error text:
+    ``make_url`` mis-parses an unescaped ``@`` in the password (it splits at the
+    FIRST ``@``), so ``url.password`` alone misses the suffix. The raw substring
+    captures the WHOLE secret (``u:pa@ss``) regardless of how a driver later
+    echoes a fragment of it (e.g. ``failed to resolve host 'ss@db'``). Returns
+    None when there is no userinfo (no ``@`` before the path). Never raises.
+    """
+    try:
+        m = re.match(r"[a-zA-Z][a-zA-Z0-9+.\-]*://(?P<userinfo>[^/\s]*)@", database_url)
+        if not m:
+            return None
+        ui = m.group("userinfo")
+        return ui or None
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def _scrub_credentials(text: str, database_url: str | None = None) -> str:
     """Strip credentials from arbitrary error text. Bounded scope (design §3.2):
 
       1. URL-shaped creds: ``<scheme>://<userinfo>@`` -> ``<scheme>://@`` (with or
          without a ``:password`` — the username never survives either way).
       2. key/value forms: ``password=<v>`` / ``pwd=<v>`` (quoted or not,
          case-insensitive) -> ``password=***``.
+      3. (defense-in-depth) when ``database_url`` is supplied, any LITERAL
+         occurrence of its raw userinfo substring AND of the mis-parsed host (the
+         ``make_url`` host when it carries an embedded ``@``, e.g. ``'ss@db'`` from
+         ``u:pa@ss@db``) is redacted — covers a driver echoing a credential
+         fragment that forms 1-2 miss. Only these specific, env-derived literals
+         are touched (no short ``@``-split pieces), so unrelated text is never
+         over-scrubbed.
 
-    Anything outside these two forms is left untouched. Never raises.
+    Anything outside these forms is left untouched. Never raises.
     """
     def _kv_repl(m: re.Match[str]) -> str:
         # Re-wrap with the captured quote when the value was quoted, so the
@@ -100,6 +128,23 @@ def _scrub_credentials(text: str) -> str:
     try:
         out = _URL_USERINFO_RE.sub(r"\g<scheme>@", text)
         out = _PASSWORD_KV_RE.sub(_kv_repl, out)
+        # Defense-in-depth literal scrub of our own env's credentials. Redact the
+        # raw userinfo (full secret-as-typed) and the mis-parsed '@'-bearing host
+        # (the password suffix a driver may echo as the "host"). Both are long,
+        # env-specific literals — never short fragments — longest-first.
+        if database_url:
+            literals = set()
+            ui = _raw_userinfo(database_url)
+            if ui:
+                literals.add(ui)
+            try:
+                parsed_host = make_url(database_url).host or ""
+            except Exception:
+                parsed_host = ""
+            if "@" in parsed_host:
+                literals.add(parsed_host)
+            for literal in sorted(literals, key=len, reverse=True):
+                out = out.replace(literal, "***")
         return out
     except Exception:  # pragma: no cover - defensive; regex on str cannot raise
         return text
@@ -170,8 +215,9 @@ def _emit_mirror_failure(writer_name: str, exc: BaseException) -> None:
     ``_redact_host`` and the error message is credential-scrubbed via
     ``_scrub_credentials`` before printing.
     """
-    host = _redact_host(os.environ.get("DATABASE_URL", ""))
-    message = _scrub_credentials(str(exc))
+    database_url = os.environ.get("DATABASE_URL", "")
+    host = _redact_host(database_url)
+    message = _scrub_credentials(str(exc), database_url)
     print(
         f"PG-MIRROR-FAILURE: {writer_name} dual-write FAILED — NOT written to {host}\n"
         f"  error: {type(exc).__name__}: {message}\n"

--- a/src/rainier/db/dualwrite.py
+++ b/src/rainier/db/dualwrite.py
@@ -62,12 +62,17 @@ _URL_USERINFO_RE = re.compile(
     r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]*://)(?P<userinfo>[^/@\s]+)@"
 )
 # password=<v> / pwd=<v>, optionally quoted (key/value connect-arg + JSON-ish).
+# Two alternatives for the value so a QUOTED secret with embedded whitespace /
+# separators (e.g. password='foo bar') is consumed WHOLE — an unquoted class that
+# stops at whitespace would leave the tail of the secret in the scrubbed text.
 _PASSWORD_KV_RE = re.compile(
     r"""(?P<key>\b(?:password|pwd)\b)   # password / pwd, word-bounded
         (?P<sep>['"]?\s*[:=]\s*)        # optional key-closing quote + : or = sep
-        (?P<quote>['"]?)                # optional value-opening quote
-        [^'"\s,;]*                      # the secret value (no quote/ws/sep)
-        (?P=quote)                      # matching value-closing quote
+        (?:
+            (?P<quote>['"])[^'"]*(?P=quote)  # quoted value: everything up to the
+                                              #   matching closing quote (ws ok)
+          | [^'"\s,;]*                        # unquoted value: stop at ws/sep
+        )
     """,
     re.IGNORECASE | re.VERBOSE,
 )
@@ -83,9 +88,15 @@ def _scrub_credentials(text: str) -> str:
 
     Anything outside these two forms is left untouched. Never raises.
     """
+    def _kv_repl(m: re.Match[str]) -> str:
+        # Re-wrap with the captured quote when the value was quoted, so the
+        # output stays well-formed (password='***'); bare *** when unquoted.
+        quote = m.group("quote") or ""
+        return f"{m.group('key')}{m.group('sep')}{quote}***{quote}"
+
     try:
         out = _URL_USERINFO_RE.sub(r"\g<scheme>@", text)
-        out = _PASSWORD_KV_RE.sub(r"\g<key>\g<sep>\g<quote>***\g<quote>", out)
+        out = _PASSWORD_KV_RE.sub(_kv_repl, out)
         return out
     except Exception:  # pragma: no cover - defensive; regex on str cannot raise
         return text

--- a/src/rainier/db/dualwrite.py
+++ b/src/rainier/db/dualwrite.py
@@ -4,11 +4,12 @@ The dual-write posture is *additive and non-fatal*: parquet is the load-bearing
 output; the Postgres write is a mirror. Two ways PG can be unusable, both must
 leave the parquet pipeline whole (exit 0):
 
-  1. DATABASE_URL unset (local dev, CI without a DB) -> skip + warn.
+  1. DATABASE_URL unset (local dev, CI without a DB) -> skip + warn (quiet).
   2. DATABASE_URL set but PG is unreachable / unmigrated / missing migration
-     0002 -> the connect or upsert raises a SQLAlchemyError. We catch it, warn,
-     and continue. A flaky mirror DB must NOT abort `run-daily` (which would
-     otherwise crash after writing labels parquet but before rendering).
+     0002 -> the connect or upsert raises a SQLAlchemyError. We catch it, emit a
+     LOUD, greppable diagnostic (PG-MIRROR-FAILURE), and continue. A flaky mirror
+     DB must NOT abort `run-daily` (which would otherwise crash after writing
+     labels parquet but before rendering).
 
 ``mirror_guard`` centralizes BOTH so all call sites share identical behavior:
 
@@ -19,35 +20,164 @@ leave the parquet pipeline whole (exit 0):
             market_upsert(eng, ...)
     # engine disposed + SQLAlchemyError swallowed on the way out (rainier owns
     # the lifecycle of what it opens; a mirror failure is never fatal).
+
+Visibility design (docs/DESIGN-mirror-guard-loud-on-failure.md): a set-but-failing
+mirror emits a distinct ``PG-MIRROR-FAILURE`` block to stderr — host-redacted,
+credential-scrubbed, greppable in cron logs — while the benign DATABASE_URL-unset
+(or empty) skip stays quiet. The failure surfaces BEFORE *or* DURING the body:
+
+    ┌─ mirror_guard ────────────────────────────────────────────────┐
+    │ try:                                                           │
+    │   try: eng = pg_engine_or_skip()   # may raise BEFORE yield    │
+    │   except SQLAlchemyError: _emit(...); eng = None  ──┐          │
+    │   yield eng   # ALWAYS reached (None on failure) <──┘          │
+    │ except SQLAlchemyError: _emit(...)  # body (upsert) failure    │
+    │ finally: if eng: eng.dispose()      # cleanup, both paths      │
+    └────────────────────────────────────────────────────────────────┘
+
+Always reaching the ``yield`` fixes a latent fatal bug: a before-``yield``
+SQLAlchemyError used to escape as ``RuntimeError: generator didn't yield`` and
+abort the caller, contradicting the non-fatal contract.
 """
 
 from __future__ import annotations
 
 import contextlib
 import os
+import re
 import sys
 from collections.abc import Iterator
 
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Engine, make_url
 from sqlalchemy.exc import SQLAlchemyError
+
+_DESIGN_DOC = "docs/DESIGN-rainier-postgres-canonical-store.md"
+
+# Drop a `<scheme>://<userinfo>@` segment, with OR without a `:password` part, so
+# neither the password NOR the username survives. Scheme allows `+driver` forms
+# (e.g. postgresql+psycopg). userinfo is everything up to the first '@' that is
+# not itself a scheme/host separator; we match conservatively (no '/' or '@' in
+# userinfo) to avoid eating the host.
+_URL_USERINFO_RE = re.compile(
+    r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]*://)(?P<userinfo>[^/@\s]+)@"
+)
+# password=<v> / pwd=<v>, optionally quoted (key/value connect-arg + JSON-ish).
+_PASSWORD_KV_RE = re.compile(
+    r"""(?P<key>\b(?:password|pwd)\b)   # password / pwd, word-bounded
+        (?P<sep>['"]?\s*[:=]\s*)        # optional key-closing quote + : or = sep
+        (?P<quote>['"]?)                # optional value-opening quote
+        [^'"\s,;]*                      # the secret value (no quote/ws/sep)
+        (?P=quote)                      # matching value-closing quote
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _scrub_credentials(text: str) -> str:
+    """Strip credentials from arbitrary error text. Bounded scope (design §3.2):
+
+      1. URL-shaped creds: ``<scheme>://<userinfo>@`` -> ``<scheme>://@`` (with or
+         without a ``:password`` — the username never survives either way).
+      2. key/value forms: ``password=<v>`` / ``pwd=<v>`` (quoted or not,
+         case-insensitive) -> ``password=***``.
+
+    Anything outside these two forms is left untouched. Never raises.
+    """
+    try:
+        out = _URL_USERINFO_RE.sub(r"\g<scheme>@", text)
+        out = _PASSWORD_KV_RE.sub(r"\g<key>\g<sep>\g<quote>***\g<quote>", out)
+        return out
+    except Exception:  # pragma: no cover - defensive; regex on str cannot raise
+        return text
+
+
+def _redact_host(database_url: str) -> str:
+    """Render a credential-free host identifier from a DATABASE_URL.
+
+    Parses with SQLAlchemy's ``make_url`` and renders host/port/database only —
+    never username or password. Handles driver-prefixed URLs, IPv6 hosts,
+    percent-encoded passwords, and query-string options. For a host-less /
+    Unix-socket form, renders a MEANINGFUL identifier (the socket path from the
+    ``host`` query param or the URL host field, plus the db name) rather than a
+    bare ``/db``. On ANY parse failure, returns the literal ``"<unparseable>"``
+    (never echoes the raw URL — it carries creds). Never raises.
+    """
+    try:
+        url = make_url(database_url)
+    except Exception:
+        return "<unparseable>"
+
+    try:
+        db = url.database or ""
+        host = url.host or ""
+        # A "socket" host is a filesystem path (leading '/'), or it lives in the
+        # `host` query param (libpq Unix-socket convention SQLAlchemy passes
+        # through). Prefer the query-param socket dir when present.
+        query = url.query or {}
+        socket_q = query.get("host")
+        if isinstance(socket_q, (list, tuple)):
+            socket_q = socket_q[0] if socket_q else None
+
+        socket_path = None
+        if socket_q and str(socket_q).startswith("/"):
+            socket_path = str(socket_q)
+        elif host.startswith("/"):
+            socket_path = host
+
+        if socket_path:
+            # Meaningful socket identifier: socket path + db name when available.
+            return f"{socket_path}/{db}" if db else socket_path
+
+        if not host:
+            # No TCP host and no socket path — degenerate. Render whatever db we
+            # have rather than an empty string, but never an empty/misleading host.
+            return db or "<unparseable>"
+
+        # TCP host. IPv6 hosts already come back bracket-free from make_url; wrap
+        # them so the rendered form is unambiguous.
+        rendered_host = f"[{host}]" if ":" in host else host
+        if url.port:
+            rendered_host = f"{rendered_host}:{url.port}"
+        return f"{rendered_host}/{db}" if db else rendered_host
+    except Exception:  # pragma: no cover - defensive
+        return "<unparseable>"
+
+
+def _emit_mirror_failure(writer_name: str, exc: BaseException) -> None:
+    """Print the LOUD, greppable PG-MIRROR-FAILURE diagnostic to stderr.
+
+    Non-fatal: the caller swallows the error after this. Host is redacted via
+    ``_redact_host`` and the error message is credential-scrubbed via
+    ``_scrub_credentials`` before printing.
+    """
+    host = _redact_host(os.environ.get("DATABASE_URL", ""))
+    message = _scrub_credentials(str(exc))
+    print(
+        f"PG-MIRROR-FAILURE: {writer_name} dual-write FAILED — NOT written to {host}\n"
+        f"  error: {type(exc).__name__}: {message}\n"
+        f"  impact: NON-FATAL (parquet output is load-bearing and unaffected; exit 0)\n"
+        f"  fix: ensure the mirror DB is reachable and migrated to head\n"
+        f"       (see {_DESIGN_DOC})",
+        file=sys.stderr,
+    )
 
 
 def pg_engine_or_skip(writer_name: str) -> Engine | None:
     """Return a fresh Engine, or None (with a warning) when PG is unconfigured.
 
-    None means "DATABASE_URL is unset — skip the PG mirror". The caller must
-    have already done its parquet write so the pipeline stays whole.
+    None means "DATABASE_URL is unset (or empty) — skip the PG mirror". The
+    caller must have already done its parquet write so the pipeline stays whole.
 
-    NOTE: this only handles the *unset* case. A set-but-broken DATABASE_URL is
-    handled by ``mirror_guard``, which catches the SQLAlchemyError the upsert
-    raises. Prefer ``mirror_guard`` at call sites so broken-PG is non-fatal.
+    NOTE: this only handles the *unset/empty* case. A set-but-broken DATABASE_URL
+    is handled by ``mirror_guard``, which catches the SQLAlchemyError the engine
+    creation or upsert raises and emits the loud diagnostic. Prefer
+    ``mirror_guard`` at call sites so broken-PG is non-fatal.
     """
     if not os.environ.get("DATABASE_URL"):
         print(
             f"warning: DATABASE_URL not set — {writer_name} skipping the "
             f"Postgres dual-write (parquet output unaffected). Set DATABASE_URL "
-            f"to mirror into market.* (see "
-            f"docs/DESIGN-rainier-postgres-canonical-store.md).",
+            f"to mirror into market.* (see {_DESIGN_DOC}).",
             file=sys.stderr,
         )
         return None
@@ -62,25 +192,30 @@ def pg_engine_or_skip(writer_name: str) -> Engine | None:
 def mirror_guard(writer_name: str) -> Iterator[Engine | None]:
     """Context manager for an additive, non-fatal PG mirror write.
 
-    Yields a fresh Engine (or None when DATABASE_URL is unset). The caller runs
-    its ``market_upsert`` calls in the ``with`` body. On exit the engine is
-    disposed, and ANY ``SQLAlchemyError`` raised inside the body (PG down,
-    schema unmigrated, missing migration 0002, etc.) is caught, warned to
-    stderr, and swallowed — so a broken mirror DB never aborts the load-bearing
-    parquet pipeline. Non-SQLAlchemy errors (programmer bugs) propagate.
+    Yields a fresh Engine (or None when DATABASE_URL is unset/empty). The caller
+    runs its ``market_upsert`` calls in the ``with`` body. On exit the engine is
+    disposed, and ANY ``SQLAlchemyError`` raised — either BEFORE the yield (engine
+    creation: malformed/unreachable DATABASE_URL) or DURING the body (PG down,
+    schema unmigrated, missing migration 0002, etc.) — is caught, emitted as a
+    LOUD ``PG-MIRROR-FAILURE`` diagnostic to stderr, and swallowed, so a broken
+    mirror DB never aborts the load-bearing parquet pipeline. Non-SQLAlchemy
+    errors (programmer bugs) propagate.
+
+    The generator ALWAYS reaches ``yield``: an engine-creation failure emits the
+    diagnostic and yields ``None`` (caller takes its existing skip path), instead
+    of escaping as ``RuntimeError: generator didn't yield`` and aborting the
+    caller (the latent fatal bug this fixes).
     """
     eng: Engine | None = None
     try:
-        eng = pg_engine_or_skip(writer_name)
-        yield eng
-    except SQLAlchemyError as exc:
-        print(
-            f"warning: {writer_name} Postgres dual-write failed ({type(exc).__name__}: "
-            f"{exc}); parquet output is unaffected. Check the mirror DB is "
-            f"reachable and migrated to head "
-            f"(see docs/DESIGN-rainier-postgres-canonical-store.md).",
-            file=sys.stderr,
-        )
+        try:
+            eng = pg_engine_or_skip(writer_name)  # may raise BEFORE the yield
+        except SQLAlchemyError as exc:
+            _emit_mirror_failure(writer_name, exc)
+            eng = None  # …and fall through so we still yield
+        yield eng  # ALWAYS yields (None on engine-creation failure)
+    except SQLAlchemyError as exc:  # body (upsert) failure
+        _emit_mirror_failure(writer_name, exc)
     finally:
         if eng is not None:
             eng.dispose()

--- a/src/rainier/db/dualwrite.py
+++ b/src/rainier/db/dualwrite.py
@@ -221,7 +221,13 @@ def mirror_guard(writer_name: str) -> Iterator[Engine | None]:
     try:
         try:
             eng = pg_engine_or_skip(writer_name)  # may raise BEFORE the yield
-        except SQLAlchemyError as exc:
+        except (SQLAlchemyError, ValueError) as exc:
+            # SQLAlchemyError: unreachable/unmigrated PG. ValueError: a malformed
+            # DATABASE_URL whose make_url/create_engine parse fails (e.g. a
+            # non-numeric port → `int('notaport')`) raises a bare ValueError, not
+            # SQLAlchemyError. Both are mirror-config failures on a SET url, so
+            # both are non-fatal here (design §3.1). The BODY handler below stays
+            # SQLAlchemyError-only so a programmer-bug ValueError still propagates.
             _emit_mirror_failure(writer_name, exc)
             eng = None  # …and fall through so we still yield
         yield eng  # ALWAYS yields (None on engine-creation failure)

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -847,6 +847,27 @@ def test_mirror_guard_before_yield_failure_is_non_fatal(monkeypatch, capsys):
     assert "ArgumentError" in err
 
 
+def test_mirror_guard_malformed_port_valueerror_is_non_fatal(monkeypatch, capsys):
+    """codex iter-2 — a malformed DATABASE_URL with a non-numeric port makes
+    make_url/create_engine raise a bare ``ValueError`` (int('notaport')) BEFORE
+    the yield, not a SQLAlchemyError. That must still be non-fatal: emit the loud
+    diagnostic and yield None, not abort the caller (design §3.1 — any
+    engine-creation failure on a SET url is non-fatal)."""
+    from rainier.db.dualwrite import mirror_guard
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@host:notaport/db")
+
+    body_ran_with_none = False
+    # Must NOT escape as ValueError nor RuntimeError: generator didn't yield.
+    with mirror_guard("malformed-port-writer") as eng:
+        body_ran_with_none = eng is None
+
+    assert body_ran_with_none, "malformed-port URL must yield None, not abort"
+    err = capsys.readouterr().err
+    assert _SENTINEL in err, "malformed-port failure must emit loud diagnostic"
+    assert "ValueError" in err, "the bare ValueError class must be named"
+
+
 def test_mirror_guard_unset_stays_quiet(monkeypatch, capsys):
     """§4.3 — DATABASE_URL unset -> the benign skip warning, NO sentinel."""
     from rainier.db.dualwrite import mirror_guard

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -990,6 +990,19 @@ def test_scrub_credentials_url_and_keyvalue_forms():
         assert "baz" not in scrubbed, f"quoted secret leaked: {scrubbed!r}"
         assert "***" in scrubbed
 
+    # quoted value containing the OPPOSITE quote char must stop only at the
+    # matching closing quote (codex iter-3 regression: an either-quote class let
+    # `password="foo'bar"` leak the tail after ***).
+    for embedded_quote_form in [
+        "password=\"foo'bar\"",
+        "password='foo\"bar'",
+        "password='foo\"bar baz'",
+    ]:
+        scrubbed = _scrub_credentials(embedded_quote_form)
+        assert "foo" not in scrubbed, f"embedded-quote secret leaked: {scrubbed!r}"
+        assert "bar" not in scrubbed, f"embedded-quote secret leaked: {scrubbed!r}"
+        assert "***" in scrubbed
+
     # credential-free / malformed unchanged + no raise
     for clean in ["just an error message", "", "host=db port=5432", "no creds here"]:
         assert _scrub_credentials(clean) == clean

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -788,6 +788,244 @@ def test_mirror_guard_swallows_sqlalchemy_error(monkeypatch, capsys):
     assert issubclass(SQLAlchemyError, Exception)
 
 
+# ---------------------------------------------------------------------------
+# mirror_guard loud-on-failure diagnostic (design DESIGN-mirror-guard-loud-on-
+# failure.md §4, items 1-10). All assertions target STDERR specifically.
+# NO Postgres needed — these drive the guard + its helpers directly.
+# ---------------------------------------------------------------------------
+
+_SENTINEL = "PG-MIRROR-FAILURE"
+
+
+def test_mirror_guard_loud_on_body_failure(monkeypatch, capsys):
+    """§4.1 — DATABASE_URL set, body raises SQLAlchemyError -> loud diagnostic on
+    stderr with sentinel + redacted host + error class; no exception escapes;
+    password substring absent."""
+    from sqlalchemy.exc import OperationalError
+
+    from rainier.db.dualwrite import mirror_guard
+
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql+psycopg://bob:hunter2@db.example.com:5432/mirror"
+    )
+    with mirror_guard("unit-writer") as eng:
+        assert eng is not None, "engine object returned when URL is set"
+        raise OperationalError("boom", None, Exception("conn refused"))
+
+    err = capsys.readouterr().err
+    assert _SENTINEL in err, "loud sentinel must be on stderr"
+    assert "unit-writer" in err
+    assert "OperationalError" in err, "error class named"
+    assert "db.example.com" in err, "redacted host present"
+    assert "hunter2" not in err, "password must not leak"
+    assert "bob" not in err, "username must not leak"
+
+
+def test_mirror_guard_before_yield_failure_is_non_fatal(monkeypatch, capsys):
+    """§4.2 — engine creation raises SQLAlchemyError BEFORE the yield. Today this
+    escapes as `RuntimeError: generator didn't yield` and aborts the caller. The
+    fix must emit the loud diagnostic AND still yield None so the body runs."""
+    from sqlalchemy.exc import ArgumentError
+
+    import rainier.db.dualwrite as dw
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@host/db")
+
+    def boom(_writer):
+        raise ArgumentError("malformed URL")
+
+    monkeypatch.setattr(dw, "pg_engine_or_skip", boom)
+
+    body_ran_with_none = False
+    # Must NOT raise RuntimeError: generator didn't yield.
+    with dw.mirror_guard("before-yield-writer") as eng:
+        body_ran_with_none = eng is None
+
+    assert body_ran_with_none, "body must run with eng is None after engine-creation failure"
+    err = capsys.readouterr().err
+    assert _SENTINEL in err, "before-yield failure must still emit loud diagnostic"
+    assert "ArgumentError" in err
+
+
+def test_mirror_guard_unset_stays_quiet(monkeypatch, capsys):
+    """§4.3 — DATABASE_URL unset -> the benign skip warning, NO sentinel."""
+    from rainier.db.dualwrite import mirror_guard
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with mirror_guard("quiet-writer") as eng:
+        assert eng is None
+    err = capsys.readouterr().err
+    assert _SENTINEL not in err, "unset case must not emit the loud sentinel"
+    assert "database_url" in err.lower(), "benign skip warning preserved"
+
+
+def test_mirror_guard_success_is_silent(monkeypatch, capsys):
+    """§4.4 — set + body succeeds -> no sentinel."""
+    import rainier.db.dualwrite as dw
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@host/db")
+
+    class _FakeEngine:
+        def dispose(self):
+            pass
+
+    monkeypatch.setattr(dw, "pg_engine_or_skip", lambda _w: _FakeEngine())
+
+    with dw.mirror_guard("ok-writer") as eng:
+        assert eng is not None  # body succeeds, no raise
+
+    err = capsys.readouterr().err
+    assert _SENTINEL not in err, "successful mirror must be silent"
+
+
+def test_mirror_guard_non_sqlalchemy_error_propagates(monkeypatch):
+    """§4.5 — body raises ValueError (programmer bug) -> it escapes."""
+    from rainier.db.dualwrite import mirror_guard
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://nouser@127.0.0.1:1/nodb")
+    with pytest.raises(ValueError):
+        with mirror_guard("propagate-writer"):
+            raise ValueError("programmer bug must not be swallowed")
+
+
+@pytest.mark.parametrize(
+    ("url", "must_absent", "must_present"),
+    [
+        # credentialed (user:pass)
+        ("postgresql://bob:hunter2@db.example.com:5432/mirror", ["bob", "hunter2"], ["db.example.com"]),
+        # password-less userinfo — username must NOT survive
+        ("postgresql://bob@db.example.com/mirror", ["bob"], ["db.example.com"]),
+        # percent-encoded password
+        ("postgresql://bob:p%40ss%21@db.example.com/mirror", ["bob", "p@ss", "p%40ss"], ["db.example.com"]),
+        # IPv6 host
+        ("postgresql://bob:hunter2@[2001:db8::1]:5432/mirror", ["bob", "hunter2"], ["2001:db8::1"]),
+        # query-string options
+        ("postgresql://bob:hunter2@db.example.com/mirror?sslmode=require", ["bob", "hunter2"], ["db.example.com"]),
+        # driver-prefixed
+        ("postgresql+psycopg://bob:hunter2@db.example.com/mirror", ["bob", "hunter2"], ["db.example.com"]),
+    ],
+)
+def test_redact_host_never_leaks_creds(url, must_absent, must_present):
+    """§4.6 — _redact_host renders host/port/db only; neither username nor
+    password survives; never raises."""
+    from rainier.db.dualwrite import _redact_host
+
+    out = _redact_host(url)
+    for s in must_absent:
+        assert s not in out, f"{s!r} must not survive in {out!r}"
+    for s in must_present:
+        assert s in out, f"{s!r} should be in {out!r}"
+
+
+def test_redact_host_malformed_returns_unparseable():
+    """§4.6 — malformed URL -> '<unparseable>'; never raises."""
+    from rainier.db.dualwrite import _redact_host
+
+    for bad in ["not a url at all", "://://", "", "@@@", "postgres://:::"]:
+        out = _redact_host(bad)
+        assert out == "<unparseable>" or "<unparseable>" in out
+        # never echoes raw garbage credentials
+    assert _redact_host("postgresql://u:secret@") == "<unparseable>" or "secret" not in _redact_host(
+        "postgresql://u:secret@"
+    )
+
+
+def test_scrub_credentials_url_and_keyvalue_forms():
+    """§4.7 — _scrub_credentials drops URL userinfo (with/without password) and
+    password=/pwd= key-value forms; credential-free text unchanged; never
+    raises."""
+    from rainier.db.dualwrite import _scrub_credentials
+
+    # URL with user:pass embedded in arbitrary error text
+    t1 = "could not connect: postgresql://user:secret@host/db (timeout)"
+    s1 = _scrub_credentials(t1)
+    assert "secret" not in s1
+    assert "user" not in s1.replace("could not", "")  # the username 'user' is scrubbed
+    assert "postgresql://@host/db" in s1
+
+    # password-less userinfo — username must not survive
+    t2 = "url=postgresql://user@host/db here"
+    s2 = _scrub_credentials(t2)
+    assert "postgresql://@host/db" in s2
+
+    # key/value forms
+    assert "secret" not in _scrub_credentials("password=secret extra")
+    assert "secret" not in _scrub_credentials("'password': 'secret'")
+    assert "secret" not in _scrub_credentials("pwd=secret;host=x")
+    assert "secret" not in _scrub_credentials('"password": "secret"')
+
+    # credential-free / malformed unchanged + no raise
+    for clean in ["just an error message", "", "host=db port=5432", "no creds here"]:
+        assert _scrub_credentials(clean) == clean
+
+
+def test_diagnostic_scrubs_credential_in_error_message(monkeypatch, capsys):
+    """§4.7 end-to-end — when the raised SQLAlchemyError's MESSAGE itself carries
+    a credentialed URL, the printed diagnostic must be scrubbed."""
+    from sqlalchemy.exc import OperationalError
+
+    from rainier.db.dualwrite import mirror_guard
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://safe@host/db")
+    with mirror_guard("scrub-writer"):
+        raise OperationalError(
+            "FATAL: password authentication failed for postgresql://admin:topsecret@host/db",
+            None,
+            Exception("auth"),
+        )
+    err = capsys.readouterr().err
+    assert _SENTINEL in err
+    assert "topsecret" not in err, "credential in error message must be scrubbed"
+    assert "admin" not in err, "username in error message must be scrubbed"
+
+
+def test_mirror_guard_disposes_engine_on_caught_error(monkeypatch, capsys):
+    """§4.8 — dispose() runs even when the body raises SQLAlchemyError."""
+    import rainier.db.dualwrite as dw
+    from sqlalchemy.exc import OperationalError
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@host/db")
+
+    disposed = {"called": False}
+
+    class _FakeEngine:
+        def dispose(self):
+            disposed["called"] = True
+
+    monkeypatch.setattr(dw, "pg_engine_or_skip", lambda _w: _FakeEngine())
+
+    with dw.mirror_guard("dispose-writer"):
+        raise OperationalError("boom", None, Exception("x"))
+
+    assert disposed["called"], "engine must be disposed on the caught-error path"
+    assert _SENTINEL in capsys.readouterr().err
+
+
+def test_mirror_guard_empty_database_url_stays_quiet(monkeypatch, capsys):
+    """§4.9 — DATABASE_URL='' (empty) is treated as unset -> quiet skip, no
+    sentinel (pins the empty=unset decision)."""
+    from rainier.db.dualwrite import mirror_guard
+
+    monkeypatch.setenv("DATABASE_URL", "")
+    with mirror_guard("empty-writer") as eng:
+        assert eng is None
+    err = capsys.readouterr().err
+    assert _SENTINEL not in err, "empty DATABASE_URL must stay quiet"
+
+
+def test_redact_host_socket_renders_meaningfully():
+    """§4.10 — a host-less / socket URL must render the socket path (and db when
+    available), not a bare db name, and leak no creds."""
+    from rainier.db.dualwrite import _redact_host
+
+    url = "postgresql://bob:hunter2@/mirror?host=/var/run/postgresql"
+    out = _redact_host(url)
+    assert "/var/run/postgresql" in out, f"socket path must appear in {out!r}"
+    assert out != "mirror", "bare db name is not a meaningful host"
+    assert "hunter2" not in out
+    assert "bob" not in out
+
+
 def test_compute_skips_pg_when_database_url_unset(tmp_path, monkeypatch):
     """thematic compute with DATABASE_URL unset still writes parquet, exit 0."""
     monkeypatch.delenv("DATABASE_URL", raising=False)

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -951,6 +951,23 @@ def test_redact_host_malformed_returns_unparseable():
     )
 
 
+def test_redact_host_unescaped_at_in_password_does_not_leak():
+    """codex iter-5 — an unescaped '@' in the password (e.g.
+    postgresql://u:pa@ss@db/prod) makes make_url parse host as `ss@db`, leaking
+    the password fragment `ss`. _redact_host must treat an '@'-bearing host as
+    unparseable, never rendering it."""
+    from rainier.db.dualwrite import _redact_host
+
+    for url in [
+        "postgresql://u:pa@ss@db/prod",
+        "postgresql://user:p@ssw0rd@host:5432/db",
+        "postgresql+psycopg://u:a@b@c/d",
+    ]:
+        out = _redact_host(url)
+        assert out == "<unparseable>", f"@-in-password host must be unparseable, got {out!r}"
+        assert "ss" not in out and "ssw0rd" not in out
+
+
 def test_scrub_credentials_url_and_keyvalue_forms():
     """§4.7 — _scrub_credentials drops URL userinfo (with/without password) and
     password=/pwd= key-value forms; credential-free text unchanged; never

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -986,6 +986,15 @@ def test_scrub_credentials_url_and_keyvalue_forms():
     s2 = _scrub_credentials(t2)
     assert "postgresql://@host/db" in s2
 
+    # unescaped '@' INSIDE the password — the WHOLE userinfo (both @s) must go,
+    # not just up to the first '@' (codex iter-6 regression: an old class that
+    # stopped at the first '@' left the `ss@db` password fragment behind).
+    t3 = "could not connect: postgresql://u:pa@ss@db/prod (timeout)"
+    s3 = _scrub_credentials(t3)
+    assert "pa" not in s3, f"password fragment leaked: {s3!r}"
+    assert "ss" not in s3, f"password fragment leaked: {s3!r}"
+    assert "postgresql://@db/prod" in s3
+
     # key/value forms
     assert "secret" not in _scrub_credentials("password=secret extra")
     assert "secret" not in _scrub_credentials("'password': 'secret'")

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -1048,6 +1048,50 @@ def test_scrub_credentials_url_and_keyvalue_forms():
         assert _scrub_credentials(clean) == clean
 
 
+def test_scrub_credentials_redacts_misparsed_host_fragment():
+    """codex iter-7 — an unescaped '@' in the password makes make_url parse the
+    host as a password suffix (e.g. `ss@db` from `u:pa@ss@db`). A driver that
+    echoes that mis-parsed host as bare text (`failed to resolve host 'ss@db'`)
+    is neither URL-shaped nor `password=` form, so forms 1-2 miss it. The
+    env-derived literal scrub (form 3) must redact it — without over-scrubbing
+    short fragments out of unrelated words."""
+    from rainier.db.dualwrite import _scrub_credentials
+
+    url = "postgresql://u:pa@ss@db/prod"
+    err = "could not translate host name: failed to resolve host 'ss@db'"
+    out = _scrub_credentials(err, url)
+    assert "ss@db" not in out, f"mis-parsed host fragment leaked: {out!r}"
+    assert "***" in out
+
+    # the full raw userinfo (secret-as-typed) is also redacted from error text
+    out2 = _scrub_credentials("connect args: u:pa@ss = bad", url)
+    assert "pa@ss" not in out2, f"raw userinfo leaked: {out2!r}"
+
+    # over-scrub guard: the short 'ss' piece must NOT be redacted out of unrelated
+    # words (we only redact the full env-derived literals, never short fragments).
+    out3 = _scrub_credentials("address lookup failed for the database", url)
+    assert out3 == "address lookup failed for the database"
+
+
+def test_diagnostic_scrubs_misparsed_host_end_to_end(monkeypatch, capsys):
+    """codex iter-7 end-to-end — the printed PG-MIRROR-FAILURE diagnostic must not
+    leak the mis-parsed-host password fragment when the error text echoes it."""
+    from sqlalchemy.exc import OperationalError
+
+    from rainier.db.dualwrite import mirror_guard
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:pa@ss@db/prod")
+    with mirror_guard("misparse-writer"):
+        raise OperationalError(
+            "could not translate host name: failed to resolve host 'ss@db'",
+            None,
+            Exception("dns"),
+        )
+    err = capsys.readouterr().err
+    assert _SENTINEL in err
+    assert "ss@db" not in err, "mis-parsed host password fragment must be scrubbed"
+
+
 def test_diagnostic_scrubs_credential_in_error_message(monkeypatch, capsys):
     """§4.7 end-to-end — when the raised SQLAlchemyError's MESSAGE itself carries
     a credentialed URL, the printed diagnostic must be scrubbed."""

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -1073,6 +1073,42 @@ def test_scrub_credentials_redacts_misparsed_host_fragment():
     assert out3 == "address lookup failed for the database"
 
 
+def test_scrub_credentials_redacts_no_at_malformed_token():
+    """codex iter-8 — a malformed DATABASE_URL with NO '@' (e.g.
+    `postgresql://user:secret host/db`) makes make_url raise a ValueError whose
+    text echoes the credential token (`invalid literal ... 'secret host'`).
+    _raw_userinfo requires an '@' so it misses this; form 3 must derive the
+    user:pass token (and its password half) and redact it — without over-scrubbing
+    when the credential word appears in unrelated text under a different URL."""
+    from rainier.db.dualwrite import _scrub_credentials
+
+    url = "postgresql://user:secret host/db"
+    err = "invalid literal for int() with base 10: 'secret host'"
+    out = _scrub_credentials(err, url)
+    assert "secret host" not in out, f"no-@ credential token leaked: {out!r}"
+    assert "secret" not in out, f"password fragment leaked: {out!r}"
+    assert "***" in out
+
+    # over-scrub guard: the same word under a DIFFERENT url is NOT redacted.
+    out2 = _scrub_credentials("the secret sauce", "postgresql://u:p@host/db")
+    assert out2 == "the secret sauce"
+
+
+def test_diagnostic_scrubs_no_at_malformed_end_to_end(monkeypatch, capsys):
+    """codex iter-8 end-to-end — the printed diagnostic must not leak the
+    credential token from a no-'@' malformed URL's ValueError."""
+    from rainier.db.dualwrite import mirror_guard
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:secret host/db")
+    # The malformed URL makes pg_engine_or_skip raise ValueError before yield;
+    # the guard must emit a scrubbed diagnostic and stay non-fatal.
+    with mirror_guard("no-at-writer") as eng:
+        assert eng is None
+    err = capsys.readouterr().err
+    assert _SENTINEL in err
+    assert "secret host" not in err, "no-@ credential token must be scrubbed"
+
+
 def test_diagnostic_scrubs_misparsed_host_end_to_end(monkeypatch, capsys):
     """codex iter-7 end-to-end — the printed PG-MIRROR-FAILURE diagnostic must not
     leak the mis-parsed-host password fragment when the error text echoes it."""

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -1003,6 +1003,20 @@ def test_scrub_credentials_url_and_keyvalue_forms():
         assert "bar" not in scrubbed, f"embedded-quote secret leaked: {scrubbed!r}"
         assert "***" in scrubbed
 
+    # backslash-ESCAPED quote inside the value (JSON-serialized connect args) must
+    # be consumed as part of the secret (codex iter-4 regression: a quoted branch
+    # that stopped at the escaped quote leaked the tail `bar`).
+    for escaped_quote_form in [
+        '"password": "foo\\"bar"',
+        "'password': 'foo\\'bar'",
+        '"password": "foo\\"bar baz"',
+    ]:
+        scrubbed = _scrub_credentials(escaped_quote_form)
+        assert "foo" not in scrubbed, f"escaped-quote secret leaked: {scrubbed!r}"
+        assert "bar" not in scrubbed, f"escaped-quote secret leaked: {scrubbed!r}"
+        assert "baz" not in scrubbed, f"escaped-quote secret leaked: {scrubbed!r}"
+        assert "***" in scrubbed
+
     # credential-free / malformed unchanged + no raise
     for clean in ["just an error message", "", "host=db port=5432", "no creds here"]:
         assert _scrub_credentials(clean) == clean

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -981,8 +981,9 @@ def test_diagnostic_scrubs_credential_in_error_message(monkeypatch, capsys):
 
 def test_mirror_guard_disposes_engine_on_caught_error(monkeypatch, capsys):
     """§4.8 — dispose() runs even when the body raises SQLAlchemyError."""
-    import rainier.db.dualwrite as dw
     from sqlalchemy.exc import OperationalError
+
+    import rainier.db.dualwrite as dw
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@host/db")
 

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -1094,6 +1094,48 @@ def test_scrub_credentials_redacts_no_at_malformed_token():
     assert out2 == "the secret sauce"
 
 
+def test_scrub_credentials_redacts_standalone_username_and_password():
+    """codex iter-9 — auth errors echo the username/password STANDALONE, e.g.
+    `password authentication failed for user "bob"`, with no URL or `password=`
+    form. Form 3 must redact the parsed username and (URL-decoded) password from
+    the env, with a min-length guard so 1-char creds don't over-scrub."""
+    from rainier.db.dualwrite import _scrub_credentials
+
+    url = "postgresql://bob:hunter2@db.example.com/mirror"
+    assert "bob" not in _scrub_credentials(
+        'password authentication failed for user "bob"', url
+    )
+    assert "hunter2" not in _scrub_credentials('FATAL: password "hunter2" rejected', url)
+
+    # URL-decoded password (make_url decodes %40 -> @) is redacted too.
+    url_pct = "postgresql://bob:p%40ss@db/mirror"
+    assert "p@ss" not in _scrub_credentials("auth failed for p@ss", url_pct)
+
+    # over-scrub guard: a 1-char username must NOT be redacted out of unrelated
+    # text (min length 2).
+    url_short = "postgresql://u:p@host/db"
+    assert _scrub_credentials("user u connected to unit", url_short) == (
+        "user u connected to unit"
+    )
+
+
+def test_diagnostic_scrubs_standalone_username_end_to_end(monkeypatch, capsys):
+    """codex iter-9 end-to-end — the printed diagnostic must not leak the parsed
+    DATABASE_URL username on a typical auth-failure message."""
+    from sqlalchemy.exc import OperationalError
+
+    from rainier.db.dualwrite import mirror_guard
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://bob:hunter2@db.example.com/mirror")
+    with mirror_guard("auth-writer"):
+        raise OperationalError(
+            'FATAL: password authentication failed for user "bob"', None, Exception("auth")
+        )
+    err = capsys.readouterr().err
+    assert _SENTINEL in err
+    assert "bob" not in err, "standalone username must be scrubbed"
+
+
 def test_diagnostic_scrubs_no_at_malformed_end_to_end(monkeypatch, capsys):
     """codex iter-8 end-to-end — the printed diagnostic must not leak the
     credential token from a no-'@' malformed URL's ValueError."""

--- a/tests/test_db_dual_write.py
+++ b/tests/test_db_dual_write.py
@@ -954,6 +954,21 @@ def test_scrub_credentials_url_and_keyvalue_forms():
     assert "secret" not in _scrub_credentials("pwd=secret;host=x")
     assert "secret" not in _scrub_credentials('"password": "secret"')
 
+    # quoted value with embedded whitespace / separators must be consumed WHOLE
+    # (codex iter-1 regression: the value class used to stop at the first space,
+    # leaving the secret tail behind as `password=***'foo bar'`).
+    for whitespace_form in [
+        "password='foo bar'",
+        'password="foo bar"',
+        "password='foo,bar;baz'",
+        "'password': 'foo bar baz'",
+    ]:
+        scrubbed = _scrub_credentials(whitespace_form)
+        assert "foo" not in scrubbed, f"quoted secret leaked: {scrubbed!r}"
+        assert "bar" not in scrubbed, f"quoted secret leaked: {scrubbed!r}"
+        assert "baz" not in scrubbed, f"quoted secret leaked: {scrubbed!r}"
+        assert "***" in scrubbed
+
     # credential-free / malformed unchanged + no raise
     for clean in ["just an error message", "", "host=db port=5432", "no creds here"]:
         assert _scrub_credentials(clean) == clean


### PR DESCRIPTION
## Summary
- mirror_guard (src/rainier/db/dualwrite.py): emit a loud, greppable `PG-MIRROR-FAILURE:` stderr diagnostic when DATABASE_URL is set but the PG dual-write fails, while staying non-fatal (parquet load-bearing, exit 0). Unset/empty DATABASE_URL stay quiet.
- Fixes a latent fatal path: a before-`yield` SQLAlchemyError (engine creation / malformed URL) previously escaped as `RuntimeError: generator did't yield` and aborted the caller; the generator now always yields None on that path.
- Adds `_redact_host` + `_scrub_credentials` (bounded, credential-safe, never-raise) and a stderr diagnostic emitter; public API unchanged, no call-site edits.
- Tests: 10-item stderr-targeted plan per docs/DESIGN-mirror-guard-loud-on-failure.md §4. Full suite 1268 passed, ruff clean.

Design: docs/DESIGN-mirror-guard-loud-on-failure.md (codex-clean, 10 design-review rounds) · Task plan: docs/TASK-PLAN-mirror-guard-loud-on-fai-20c1.md

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 11) — 9 credential-leak/contract fixes + 2 clean confirms

## Test plan
- [ ] CI green
- [ ] verify locally