### PR TITLE
fix(db): split legacy engine onto LEGACY_DATABASE_URL (P0 QU100 restore)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Database — canonical-store (Postgres on Neon prod, local docker in dev).
-# Use the psycopg3 driver explicitly so SQLAlchemy picks the new db/ engine,
-# not legacy psycopg2. The legacy core/database.py path also reads this var.
+# Consumed ONLY by the new db/ engine (market.* schema) + alembic migrations,
+# which read DATABASE_URL directly from the environment. Use the psycopg3
+# driver explicitly so SQLAlchemy picks the new db/ engine, not legacy psycopg2.
 #
 #   local (docker-compose up):  postgresql+psycopg://rainier:rainier_dev@localhost:5432/rainier
 #   neon (prod):                postgresql+psycopg://USER:PASS@HOST/dbname?sslmode=require
@@ -10,6 +11,14 @@
 #   uv run rainier db migrate
 #   uv run rainier db migrate --downgrade base
 DATABASE_URL=postgresql+psycopg://rainier:rainier_dev@localhost:5432/rainier
+
+# Legacy DB — public-schema ORM + TimescaleDB hypertables (money_flow_snapshots,
+# QU scraper persist, thesis, screener, dashboard, ML feature store, backtests).
+# The legacy core/database.py singleton engine binds to THIS var, not
+# DATABASE_URL — keeping the legacy family on local TimescaleDB while
+# DATABASE_URL points at Neon. Defaults to the local DSN; set only if your
+# local DSN differs.
+LEGACY_DATABASE_URL=postgresql://rainier:rainier_dev@localhost:5432/rainier
 
 # Optional: an isolated test DB for pytest tests/test_db_migrations.py
 # when pg_config/initdb aren't on PATH (i.e., pytest-postgresql can't run).

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -344,7 +344,13 @@ class Settings(BaseSettings):
     )
 
     # Secrets from .env
+    # Canonical-store DSN (Neon in prod). Config-layer mirror of DATABASE_URL;
+    # NOT read by any engine after the legacy split — db/engine.py reads
+    # os.environ["DATABASE_URL"] directly. Kept for backward-compat / --config echo.
     database_url: str = "postgresql://rainier:rainier_dev@localhost:5432/rainier"
+    # Legacy public-schema ORM + TimescaleDB hypertables (local TimescaleDB).
+    # The core/database.py singleton engine binds to this (env LEGACY_DATABASE_URL).
+    legacy_database_url: str = "postgresql://rainier:rainier_dev@localhost:5432/rainier"
     qu_username: str = ""
     qu_password: str = ""
     openai_api_key: str = ""

--- a/src/rainier/core/database.py
+++ b/src/rainier/core/database.py
@@ -26,7 +26,7 @@ def get_engine(settings: Settings | None = None) -> Engine:
         if settings is None:
             settings = get_settings()
         _engine = create_engine(
-            settings.database_url,
+            settings.legacy_database_url,
             echo=settings.database.echo,
             pool_size=settings.database.pool_size,
             pool_pre_ping=True,

--- a/src/rainier/scrapers/qu/coverage.py
+++ b/src/rainier/scrapers/qu/coverage.py
@@ -538,7 +538,7 @@ def _open_session(settings: Settings | None = None) -> Iterator[Session]:
     from sqlalchemy.orm import sessionmaker
 
     engine = create_engine(
-        settings.database_url,
+        settings.legacy_database_url,
         echo=settings.database.echo,
         pool_size=settings.database.pool_size,
         pool_pre_ping=True,

--- a/tests/test_legacy_db_url.py
+++ b/tests/test_legacy_db_url.py
@@ -96,8 +96,6 @@ def test_init_db_targets_legacy_engine(reset_db_singletons, monkeypatch):
 
     captured: dict[str, object] = {}
 
-    real_create_all = database.Base.metadata.create_all
-
     def _capture_create_all(engine, *args, **kwargs):
         captured["engine"] = engine
         # Don't actually create tables against a throwaway sqlite memory DB.
@@ -117,5 +115,3 @@ def test_init_db_targets_legacy_engine(reset_db_singletons, monkeypatch):
     assert "canonical" not in bound, (
         f"init_db wrongly targeted the canonical DATABASE_URL: {bound!r}"
     )
-    # sanity: real create_all still exists (we only patched the bound method)
-    assert real_create_all is not None

--- a/tests/test_legacy_db_url.py
+++ b/tests/test_legacy_db_url.py
@@ -1,0 +1,121 @@
+"""Tests for the LEGACY_DATABASE_URL split (P0 QU100 restore).
+
+Design: docs/DESIGN-legacy-database-url-split.md §5 (items 1, 3, 4, 6, 7).
+
+The legacy engine (``core/database.py`` singleton) must read
+``settings.legacy_database_url`` (env ``LEGACY_DATABASE_URL``, default local
+TimescaleDB) so ``DATABASE_URL`` can stay pointed at the canonical Neon store.
+``db/engine.py`` (canonical, ``DATABASE_URL``) is intentionally NOT touched here
+— it has its own coverage in ``tests/test_db_engine.py`` (design §5 item 2).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+LOCAL_DEFAULT = "postgresql://rainier:rainier_dev@localhost:5432/rainier"
+
+
+@pytest.fixture
+def reset_db_singletons(monkeypatch):
+    """Reset ALL caches that hide env changes (design §5 item 7).
+
+    Mutating ``LEGACY_DATABASE_URL``/``DATABASE_URL`` is useless if a cached
+    ``Settings`` (``core.config._settings``) or a cached engine/session-factory
+    (``core.database._engine`` / ``_session_factory``) survives across tests.
+    Reset all three before AND after each test so neither stale config nor a
+    pinned engine leaks in either direction.
+    """
+    from rainier.core import config, database
+
+    def _clear() -> None:
+        config._settings = None
+        database._engine = None
+        database._session_factory = None
+
+    _clear()
+    yield
+    _clear()
+
+
+def test_legacy_engine_uses_legacy_database_url(reset_db_singletons):
+    """§5.1 — legacy engine binds to ``legacy_database_url``, NOT ``database_url``."""
+    from rainier.core.config import Settings
+    from rainier.core.database import get_engine
+
+    settings = Settings(
+        database_url="sqlite:///file:canonical?mode=memory&cache=shared&uri=true",
+        legacy_database_url="sqlite:///file:legacy?mode=memory&cache=shared&uri=true",
+    )
+    engine = get_engine(settings)
+    bound = str(engine.url)
+    assert "legacy" in bound, f"legacy engine bound to wrong DB: {bound!r}"
+    assert "canonical" not in bound, (
+        f"legacy engine wrongly bound to the canonical database_url: {bound!r}"
+    )
+
+
+def test_default_fallback_to_local(reset_db_singletons, monkeypatch):
+    """§5.3 — with ``LEGACY_DATABASE_URL`` unset, default is the local DSN."""
+    from rainier.core.config import Settings
+
+    monkeypatch.delenv("LEGACY_DATABASE_URL", raising=False)
+    assert Settings().legacy_database_url == LOCAL_DEFAULT
+
+
+def test_uppercase_env_var_populates_field(reset_db_singletons, monkeypatch):
+    """§5.4 — uppercase ``LEGACY_DATABASE_URL`` env var maps to the field.
+
+    Locks down pydantic's case-insensitive env mapping for this P0 field; do
+    not assume the default silently masks a typo'd env name.
+    """
+    from rainier.core.config import Settings
+
+    sentinel = "postgresql://u:p@example.invalid:5432/legacy_sentinel"
+    monkeypatch.setenv("LEGACY_DATABASE_URL", sentinel)
+    assert Settings().legacy_database_url == sentinel
+
+
+def test_init_db_targets_legacy_engine(reset_db_singletons, monkeypatch):
+    """§5.6 — ``init_db()`` operates on the legacy engine (``get_engine()``),
+    never the canonical ``DATABASE_URL`` path.
+
+    We capture the engine handed to ``Base.metadata.create_all`` and assert it
+    is the legacy singleton bound to ``legacy_database_url``.
+    """
+    from rainier.core import database
+    from rainier.core.config import Settings
+
+    legacy_url = "sqlite:///file:initdb_legacy?mode=memory&cache=shared&uri=true"
+    settings = Settings(
+        database_url="postgresql://u:p@example.invalid/canonical",
+        legacy_database_url=legacy_url,
+    )
+    # Pin the settings the no-arg get_engine() will use.
+    monkeypatch.setattr(database, "get_settings", lambda: settings)
+
+    captured: dict[str, object] = {}
+
+    real_create_all = database.Base.metadata.create_all
+
+    def _capture_create_all(engine, *args, **kwargs):
+        captured["engine"] = engine
+        # Don't actually create tables against a throwaway sqlite memory DB.
+        return None
+
+    monkeypatch.setattr(database.Base.metadata, "create_all", _capture_create_all)
+    # Stub hypertable creation — TimescaleDB SQL isn't valid on sqlite.
+    monkeypatch.setattr(database, "_create_hypertables", lambda engine: None)
+
+    database.init_db()
+
+    assert "engine" in captured, "init_db did not call create_all"
+    bound = str(captured["engine"].url)  # type: ignore[union-attr]
+    assert "initdb_legacy" in bound, (
+        f"init_db targeted the wrong engine: {bound!r}"
+    )
+    assert "canonical" not in bound, (
+        f"init_db wrongly targeted the canonical DATABASE_URL: {bound!r}"
+    )
+    # sanity: real create_all still exists (we only patched the bound method)
+    assert real_create_all is not None

--- a/tests/test_scrapers/test_money_flow_coverage.py
+++ b/tests/test_scrapers/test_money_flow_coverage.py
@@ -478,14 +478,24 @@ def test_open_session_bypasses_engine_singleton(tmp_path, monkeypatch):
     monkeypatch.setattr(database, "_engine", sentinel)
     monkeypatch.setattr(database, "_session_factory", None)
 
-    staging_settings = Settings(database_url=f"sqlite:///{staging_db}")
+    # Coverage audits ``money_flow_snapshots`` (a legacy public-schema table),
+    # so the --config branch must bind to ``legacy_database_url``, NOT the
+    # canonical ``database_url`` (which now stays pointed at Neon). Set a
+    # distinct sentinel on ``database_url`` to prove we never bind to it.
+    staging_settings = Settings(
+        database_url="postgresql://u:p@example.invalid/canonical-must-not-bind",
+        legacy_database_url=f"sqlite:///{staging_db}",
+    )
 
     with coverage._open_session(staging_settings) as session:
         bound_url = str(session.get_bind().url)
 
     assert bound_url == f"sqlite:///{staging_db}", (
-        "config-scoped session bound to the wrong DB — singleton leaked through "
-        f"(got {bound_url!r})"
+        "config-scoped session bound to the wrong DB — should use "
+        f"legacy_database_url, not database_url (got {bound_url!r})"
+    )
+    assert "canonical-must-not-bind" not in bound_url, (
+        "coverage --config session wrongly bound to the canonical database_url"
     )
     # Sentinel singleton remains untouched (we never mutated it).
     assert database._engine is sentinel


### PR DESCRIPTION
## Summary
- P0: a single DATABASE_URL fed BOTH the legacy `core.database` engine (public-schema ORM tables incl. money_flow_snapshots) and the canonical `db.engine` (market.* only). Pointing it at Neon for the canonical-store pivot silently broke every legacy public-schema writer — all four QU100 cron slots failed with `UndefinedTable: money_flow_snapshots` (broken since Fri 2026-05-29; first weekday cron after the repoint).
- Fix (Option A): add `Settings.legacy_database_url` (env `LEGACY_DATABASE_URL`, default local TimescaleDB); retarget `core.database.get_engine` + the `coverage._open_session --config` branch to it. `DATABASE_URL`→Neon and the `db/engine.py`/`mirror_guard`/`market.*` path are untouched. Centralized in the two factories — no call-site churn.
- Tests: 8-item plan (design §5) incl. a singleton-reset fixture covering `core.config._settings`. Full suite 1265 passed, ruff clean.

Design: docs/DESIGN-legacy-database-url-split.md (codex-clean, 3 rounds) · Task plan: docs/TASK-PLAN-legacy-db-url-split-cb2f.md

## Operator transition (after merge — REQUIRED for QU100 to resume)
1. Ensure the local TimescaleDB (OrbStack) is running and holds the `public` tables (it did through 5/29).
2. Set `LEGACY_DATABASE_URL` in `.env` only if your local DSN differs from the default `postgresql://rainier:rainier_dev@localhost:5432/rainier`.
3. Leave `DATABASE_URL`=Neon (unchanged) so the market.* mirror keeps working.
4. Smoke: `uv run rainier scrape qu --session morning --cdp …` writes records again; `uv run rainier qu money-flow-coverage` runs clean.

## Review
- /review: passed (claude rounds: 1)
- codex review: passed (codex rounds: 2)

## Test plan
- [ ] CI green
- [ ] verify locally (smoke above)
