### PR TITLE
feat(db): realign stock_prices stock_id->symbol via in-place ALTER (migration 0006)

### DIFF
--- a/migrations/0006_stock_prices_symbol_key.sql
+++ b/migrations/0006_stock_prices_symbol_key.sql
@@ -184,7 +184,25 @@ END
 $$;
 
 -- 6c. Drop the standalone stock_id index (auto-name ix_stock_prices_stock_id).
-DROP INDEX IF EXISTS ix_stock_prices_stock_id;
+--     Qualify to the resolved `stock_prices` schema: an unqualified DROP INDEX
+--     resolves through the search_path, so on a re-run (after the target index
+--     is gone) it could otherwise drop a same-named index in a later-path schema
+--     (e.g. public). DROP the one in the SAME schema as our target table only.
+DO $$
+DECLARE
+    target_schema text;
+BEGIN
+    SELECT n.nspname INTO target_schema
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE c.oid = to_regclass('stock_prices');
+    IF target_schema IS NOT NULL THEN
+        EXECUTE format(
+            'DROP INDEX IF EXISTS %I.ix_stock_prices_stock_id', target_schema
+        );
+    END IF;
+END
+$$;
 
 -- 6d. Drop the stock_id column (CASCADE on the column itself is unnecessary —
 --     its FK/unique/index are already gone above; any leftover dependent object

--- a/migrations/0006_stock_prices_symbol_key.sql
+++ b/migrations/0006_stock_prices_symbol_key.sql
@@ -1,0 +1,180 @@
+-- Migration 0006 — realign `stock_prices` to symbol-keyed (in-place ALTER).
+--
+-- The `StockPrice` ORM (core/models.py) is symbol-keyed:
+--   symbol VARCHAR(10) NOT NULL FK->stocks.symbol, index on symbol,
+--   UNIQUE(symbol, date) = uq_stock_price_symbol_date, PK (id, date).
+-- The live `stock_prices` table is still the OLD stock_id-keyed shape:
+--   stock_id INTEGER FK->stocks.id, UNIQUE(stock_id, date) = uq_stock_price_date,
+--   index ix_stock_prices_stock_id, PK (id, date). `create_all` never ALTERs an
+--   existing table, so this drift was never migrated.
+--
+-- This realigns the table IN PLACE — NOT drop+recreate. Plain `ALTER TABLE`
+-- works on a Timescale hypertable; recreating risks chunk/sequence/dependency
+-- drift + catalog churn, and `create_hypertable` does NOT need re-running for an
+-- in-place ALTER (the hypertable identity is preserved across ALTERs).
+--
+-- Steps (each guarded by a catalog check so a re-apply — including AFTER stock_id
+-- is already gone — is a clean no-op):
+--   1. ADD COLUMN symbol (nullable first).
+--   2. Backfill symbol from stocks via stock_id (guarded: only if stock_id still
+--      exists; after it's dropped, the backfill is skipped).
+--   3. SET symbol NOT NULL.
+--   4. Add FK symbol->stocks(symbol).
+--   5. Add UNIQUE(symbol, date) uq_stock_price_symbol_date + index on symbol.
+--   6. Drop the old stock_id FK / uq_stock_price_date / stock_id index / stock_id
+--      column.
+--
+-- Timescale uniqueness rule: every unique index / PK on the hypertable MUST
+-- include the partition column `date`. UNIQUE(symbol, date) ✓ and PK(id, date) ✓
+-- are preserved; NEVER UNIQUE(symbol) or PK(id) alone.
+--
+-- `date TIMESTAMPTZ NOT NULL`, the `id` BIGINT sequence/default, and PK(id, date)
+-- are all preserved unchanged.
+--
+-- Apply with (legacy local-TimescaleDB engine — NOT Neon, see memory
+-- project_two_database_url_engines):
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0006_stock_prices_symbol_key.sql
+--
+-- Idempotent: re-applying is safe. market.* and all other public tables are
+-- untouched.
+
+BEGIN;
+
+-- 1. ADD COLUMN symbol (nullable while we backfill).
+ALTER TABLE stock_prices ADD COLUMN IF NOT EXISTS symbol VARCHAR(10);
+
+-- 2. Backfill symbol from stocks via the old stock_id join — ONLY if stock_id
+--    still exists (a re-run after stock_id was dropped skips this cleanly).
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'stock_prices'
+          AND column_name = 'stock_id'
+    ) THEN
+        UPDATE stock_prices sp
+           SET symbol = s.symbol
+          FROM stocks s
+         WHERE sp.stock_id = s.id
+           AND sp.symbol IS NULL;
+    END IF;
+END
+$$;
+
+-- 3. SET symbol NOT NULL (idempotent: SET NOT NULL on an already-NOT-NULL column
+--    is a no-op; guard avoids re-issuing the catalog rewrite needlessly and
+--    keeps the intent explicit). Any NULL here means a stock_prices row whose
+--    stock_id had no matching stocks row — that surfaces as an error, which is
+--    correct (the FK below would reject it anyway).
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'stock_prices'
+          AND column_name = 'symbol'
+          AND is_nullable = 'YES'
+    ) THEN
+        ALTER TABLE stock_prices ALTER COLUMN symbol SET NOT NULL;
+    END IF;
+END
+$$;
+
+-- 4. Add FK symbol -> stocks(symbol) (discover by referenced column, not name,
+--    so a pre-existing equivalent FK under any name is treated as present).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid = con.conrelid
+         WHERE rel.relname = 'stock_prices'
+           AND con.contype = 'f'
+           AND con.conkey = (
+               SELECT array_agg(attnum)
+                 FROM pg_attribute
+                WHERE attrelid = rel.oid AND attname = 'symbol'
+           )
+    ) THEN
+        ALTER TABLE stock_prices
+            ADD CONSTRAINT fk_stock_prices_symbol
+            FOREIGN KEY (symbol) REFERENCES stocks (symbol);
+    END IF;
+END
+$$;
+
+-- 5. Add UNIQUE(symbol, date) uq_stock_price_symbol_date + index on symbol.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid = con.conrelid
+         WHERE rel.relname = 'stock_prices'
+           AND con.conname = 'uq_stock_price_symbol_date'
+    ) THEN
+        ALTER TABLE stock_prices
+            ADD CONSTRAINT uq_stock_price_symbol_date UNIQUE (symbol, date);
+    END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS ix_stock_prices_symbol ON stock_prices (symbol);
+
+-- 6a. Drop the old stock_id FK (discover its name from the catalog by referenced
+--     column — auto-name was stock_prices_stock_id_fkey).
+DO $$
+DECLARE
+    fk_name text;
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'stock_prices'
+          AND column_name = 'stock_id'
+    ) THEN
+        FOR fk_name IN
+            SELECT con.conname
+              FROM pg_constraint con
+              JOIN pg_class rel ON rel.oid = con.conrelid
+             WHERE rel.relname = 'stock_prices'
+               AND con.contype = 'f'
+               AND con.conkey = (
+                   SELECT array_agg(attnum)
+                     FROM pg_attribute
+                    WHERE attrelid = rel.oid AND attname = 'stock_id'
+               )
+        LOOP
+            EXECUTE format('ALTER TABLE stock_prices DROP CONSTRAINT %I', fk_name);
+        END LOOP;
+    END IF;
+END
+$$;
+
+-- 6b. Drop the old uq_stock_price_date unique (on (stock_id, date)).
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid = con.conrelid
+         WHERE rel.relname = 'stock_prices'
+           AND con.conname = 'uq_stock_price_date'
+    ) THEN
+        ALTER TABLE stock_prices DROP CONSTRAINT uq_stock_price_date;
+    END IF;
+END
+$$;
+
+-- 6c. Drop the standalone stock_id index (auto-name ix_stock_prices_stock_id).
+DROP INDEX IF EXISTS ix_stock_prices_stock_id;
+
+-- 6d. Drop the stock_id column (CASCADE on the column itself is unnecessary —
+--     its FK/unique/index are already gone above; any leftover dependent object
+--     would be the unique we dropped).
+ALTER TABLE stock_prices DROP COLUMN IF EXISTS stock_id;
+
+COMMIT;
+
+-- Downgrade lives in migrations/0006_stock_prices_symbol_key_downgrade.sql.

--- a/migrations/0006_stock_prices_symbol_key.sql
+++ b/migrations/0006_stock_prices_symbol_key.sql
@@ -89,7 +89,9 @@ BEGIN
         SELECT 1
           FROM pg_constraint con
           JOIN pg_class rel ON rel.oid = con.conrelid
+          JOIN pg_namespace ns ON ns.oid = rel.relnamespace
          WHERE rel.relname = 'stock_prices'
+           AND ns.nspname = current_schema()
            AND con.contype = 'f'
            AND con.conkey = (
                SELECT array_agg(attnum)
@@ -111,7 +113,9 @@ BEGIN
         SELECT 1
           FROM pg_constraint con
           JOIN pg_class rel ON rel.oid = con.conrelid
+          JOIN pg_namespace ns ON ns.oid = rel.relnamespace
          WHERE rel.relname = 'stock_prices'
+           AND ns.nspname = current_schema()
            AND con.conname = 'uq_stock_price_symbol_date'
     ) THEN
         ALTER TABLE stock_prices
@@ -138,7 +142,9 @@ BEGIN
             SELECT con.conname
               FROM pg_constraint con
               JOIN pg_class rel ON rel.oid = con.conrelid
+              JOIN pg_namespace ns ON ns.oid = rel.relnamespace
              WHERE rel.relname = 'stock_prices'
+               AND ns.nspname = current_schema()
                AND con.contype = 'f'
                AND con.conkey = (
                    SELECT array_agg(attnum)
@@ -159,7 +165,9 @@ BEGIN
         SELECT 1
           FROM pg_constraint con
           JOIN pg_class rel ON rel.oid = con.conrelid
+          JOIN pg_namespace ns ON ns.oid = rel.relnamespace
          WHERE rel.relname = 'stock_prices'
+           AND ns.nspname = current_schema()
            AND con.conname = 'uq_stock_price_date'
     ) THEN
         ALTER TABLE stock_prices DROP CONSTRAINT uq_stock_price_date;

--- a/migrations/0006_stock_prices_symbol_key.sql
+++ b/migrations/0006_stock_prices_symbol_key.sql
@@ -48,9 +48,19 @@ ALTER TABLE stock_prices ADD COLUMN IF NOT EXISTS symbol VARCHAR(10);
 DO $$
 BEGIN
     IF EXISTS (
+        -- Resolve the schema of the table that the UNQUALIFIED `stock_prices`
+        -- actually binds to (the first schema on the search_path that contains
+        -- it). Comparing to `current_schema()` would be WRONG when the path's
+        -- first schema lacks `stock_prices` (e.g. `"$user", public`): the ALTER
+        -- below hits `public.stock_prices` but `current_schema()` is `$user`, so
+        -- the guard would skip the backfill while DROP COLUMN still runs.
         SELECT 1 FROM information_schema.columns
-        WHERE table_schema = current_schema()
-          AND table_name = 'stock_prices'
+        WHERE (table_schema, table_name) = (
+                  SELECT n.nspname, c.relname
+                    FROM pg_class c
+                    JOIN pg_namespace n ON n.oid = c.relnamespace
+                   WHERE c.oid = to_regclass('stock_prices')
+              )
           AND column_name = 'stock_id'
     ) THEN
         UPDATE stock_prices sp
@@ -71,8 +81,12 @@ DO $$
 BEGIN
     IF EXISTS (
         SELECT 1 FROM information_schema.columns
-        WHERE table_schema = current_schema()
-          AND table_name = 'stock_prices'
+        WHERE (table_schema, table_name) = (
+                  SELECT n.nspname, c.relname
+                    FROM pg_class c
+                    JOIN pg_namespace n ON n.oid = c.relnamespace
+                   WHERE c.oid = to_regclass('stock_prices')
+              )
           AND column_name = 'symbol'
           AND is_nullable = 'YES'
     ) THEN
@@ -89,9 +103,7 @@ BEGIN
         SELECT 1
           FROM pg_constraint con
           JOIN pg_class rel ON rel.oid = con.conrelid
-          JOIN pg_namespace ns ON ns.oid = rel.relnamespace
-         WHERE rel.relname = 'stock_prices'
-           AND ns.nspname = current_schema()
+         WHERE rel.oid = to_regclass('stock_prices')
            AND con.contype = 'f'
            AND con.conkey = (
                SELECT array_agg(attnum)
@@ -112,10 +124,7 @@ BEGIN
     IF NOT EXISTS (
         SELECT 1
           FROM pg_constraint con
-          JOIN pg_class rel ON rel.oid = con.conrelid
-          JOIN pg_namespace ns ON ns.oid = rel.relnamespace
-         WHERE rel.relname = 'stock_prices'
-           AND ns.nspname = current_schema()
+         WHERE con.conrelid = to_regclass('stock_prices')
            AND con.conname = 'uq_stock_price_symbol_date'
     ) THEN
         ALTER TABLE stock_prices
@@ -134,17 +143,19 @@ DECLARE
 BEGIN
     IF EXISTS (
         SELECT 1 FROM information_schema.columns
-        WHERE table_schema = current_schema()
-          AND table_name = 'stock_prices'
+        WHERE (table_schema, table_name) = (
+                  SELECT n.nspname, c.relname
+                    FROM pg_class c
+                    JOIN pg_namespace n ON n.oid = c.relnamespace
+                   WHERE c.oid = to_regclass('stock_prices')
+              )
           AND column_name = 'stock_id'
     ) THEN
         FOR fk_name IN
             SELECT con.conname
               FROM pg_constraint con
               JOIN pg_class rel ON rel.oid = con.conrelid
-              JOIN pg_namespace ns ON ns.oid = rel.relnamespace
-             WHERE rel.relname = 'stock_prices'
-               AND ns.nspname = current_schema()
+             WHERE rel.oid = to_regclass('stock_prices')
                AND con.contype = 'f'
                AND con.conkey = (
                    SELECT array_agg(attnum)
@@ -164,10 +175,7 @@ BEGIN
     IF EXISTS (
         SELECT 1
           FROM pg_constraint con
-          JOIN pg_class rel ON rel.oid = con.conrelid
-          JOIN pg_namespace ns ON ns.oid = rel.relnamespace
-         WHERE rel.relname = 'stock_prices'
-           AND ns.nspname = current_schema()
+         WHERE con.conrelid = to_regclass('stock_prices')
            AND con.conname = 'uq_stock_price_date'
     ) THEN
         ALTER TABLE stock_prices DROP CONSTRAINT uq_stock_price_date;

--- a/migrations/0006_stock_prices_symbol_key_downgrade.sql
+++ b/migrations/0006_stock_prices_symbol_key_downgrade.sql
@@ -31,9 +31,16 @@ ALTER TABLE stock_prices ADD COLUMN IF NOT EXISTS stock_id INTEGER;
 DO $$
 BEGIN
     IF EXISTS (
+        -- Resolve the schema of the table the UNQUALIFIED `stock_prices` binds
+        -- to (mirror of the up migration; `current_schema()` is wrong when the
+        -- search_path's first schema doesn't contain the table).
         SELECT 1 FROM information_schema.columns
-        WHERE table_schema = current_schema()
-          AND table_name = 'stock_prices'
+        WHERE (table_schema, table_name) = (
+                  SELECT n.nspname, c.relname
+                    FROM pg_class c
+                    JOIN pg_namespace n ON n.oid = c.relnamespace
+                   WHERE c.oid = to_regclass('stock_prices')
+              )
           AND column_name = 'symbol'
     ) THEN
         UPDATE stock_prices sp
@@ -65,8 +72,12 @@ DO $$
 BEGIN
     IF EXISTS (
         SELECT 1 FROM information_schema.columns
-        WHERE table_schema = current_schema()
-          AND table_name = 'stock_prices'
+        WHERE (table_schema, table_name) = (
+                  SELECT n.nspname, c.relname
+                    FROM pg_class c
+                    JOIN pg_namespace n ON n.oid = c.relnamespace
+                   WHERE c.oid = to_regclass('stock_prices')
+              )
           AND column_name = 'stock_id'
           AND is_nullable = 'YES'
     ) THEN
@@ -83,17 +94,19 @@ DECLARE
 BEGIN
     IF EXISTS (
         SELECT 1 FROM information_schema.columns
-        WHERE table_schema = current_schema()
-          AND table_name = 'stock_prices'
+        WHERE (table_schema, table_name) = (
+                  SELECT n.nspname, c.relname
+                    FROM pg_class c
+                    JOIN pg_namespace n ON n.oid = c.relnamespace
+                   WHERE c.oid = to_regclass('stock_prices')
+              )
           AND column_name = 'symbol'
     ) THEN
         FOR fk_name IN
             SELECT con.conname
               FROM pg_constraint con
               JOIN pg_class rel ON rel.oid = con.conrelid
-              JOIN pg_namespace ns ON ns.oid = rel.relnamespace
-             WHERE rel.relname = 'stock_prices'
-               AND ns.nspname = current_schema()
+             WHERE rel.oid = to_regclass('stock_prices')
                AND con.contype = 'f'
                AND con.conkey = (
                    SELECT array_agg(attnum)
@@ -113,10 +126,7 @@ BEGIN
     IF EXISTS (
         SELECT 1
           FROM pg_constraint con
-          JOIN pg_class rel ON rel.oid = con.conrelid
-          JOIN pg_namespace ns ON ns.oid = rel.relnamespace
-         WHERE rel.relname = 'stock_prices'
-           AND ns.nspname = current_schema()
+         WHERE con.conrelid = to_regclass('stock_prices')
            AND con.conname = 'uq_stock_price_symbol_date'
     ) THEN
         ALTER TABLE stock_prices DROP CONSTRAINT uq_stock_price_symbol_date;
@@ -135,9 +145,7 @@ BEGIN
         SELECT 1
           FROM pg_constraint con
           JOIN pg_class rel ON rel.oid = con.conrelid
-          JOIN pg_namespace ns ON ns.oid = rel.relnamespace
-         WHERE rel.relname = 'stock_prices'
-           AND ns.nspname = current_schema()
+         WHERE rel.oid = to_regclass('stock_prices')
            AND con.contype = 'f'
            AND con.conkey = (
                SELECT array_agg(attnum)
@@ -158,10 +166,7 @@ BEGIN
     IF NOT EXISTS (
         SELECT 1
           FROM pg_constraint con
-          JOIN pg_class rel ON rel.oid = con.conrelid
-          JOIN pg_namespace ns ON ns.oid = rel.relnamespace
-         WHERE rel.relname = 'stock_prices'
-           AND ns.nspname = current_schema()
+         WHERE con.conrelid = to_regclass('stock_prices')
            AND con.conname = 'uq_stock_price_date'
     ) THEN
         ALTER TABLE stock_prices

--- a/migrations/0006_stock_prices_symbol_key_downgrade.sql
+++ b/migrations/0006_stock_prices_symbol_key_downgrade.sql
@@ -134,8 +134,25 @@ BEGIN
 END
 $$;
 
--- 5c. Drop the symbol index.
-DROP INDEX IF EXISTS ix_stock_prices_symbol;
+-- 5c. Drop the symbol index. Qualify to the resolved `stock_prices` schema so an
+--     idempotent re-run (after the target index is gone) cannot resolve the
+--     unqualified name through the search_path and drop a same-named index in a
+--     later-path schema (e.g. public). Mirror of the up migration's 6c.
+DO $$
+DECLARE
+    target_schema text;
+BEGIN
+    SELECT n.nspname INTO target_schema
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE c.oid = to_regclass('stock_prices');
+    IF target_schema IS NOT NULL THEN
+        EXECUTE format(
+            'DROP INDEX IF EXISTS %I.ix_stock_prices_symbol', target_schema
+        );
+    END IF;
+END
+$$;
 
 -- 6a. Add stock_id FK -> stocks(id) (discover by referenced column so a
 --     pre-existing equivalent FK is treated as present).

--- a/migrations/0006_stock_prices_symbol_key_downgrade.sql
+++ b/migrations/0006_stock_prices_symbol_key_downgrade.sql
@@ -91,7 +91,9 @@ BEGIN
             SELECT con.conname
               FROM pg_constraint con
               JOIN pg_class rel ON rel.oid = con.conrelid
+              JOIN pg_namespace ns ON ns.oid = rel.relnamespace
              WHERE rel.relname = 'stock_prices'
+               AND ns.nspname = current_schema()
                AND con.contype = 'f'
                AND con.conkey = (
                    SELECT array_agg(attnum)
@@ -112,7 +114,9 @@ BEGIN
         SELECT 1
           FROM pg_constraint con
           JOIN pg_class rel ON rel.oid = con.conrelid
+          JOIN pg_namespace ns ON ns.oid = rel.relnamespace
          WHERE rel.relname = 'stock_prices'
+           AND ns.nspname = current_schema()
            AND con.conname = 'uq_stock_price_symbol_date'
     ) THEN
         ALTER TABLE stock_prices DROP CONSTRAINT uq_stock_price_symbol_date;
@@ -131,7 +135,9 @@ BEGIN
         SELECT 1
           FROM pg_constraint con
           JOIN pg_class rel ON rel.oid = con.conrelid
+          JOIN pg_namespace ns ON ns.oid = rel.relnamespace
          WHERE rel.relname = 'stock_prices'
+           AND ns.nspname = current_schema()
            AND con.contype = 'f'
            AND con.conkey = (
                SELECT array_agg(attnum)
@@ -153,7 +159,9 @@ BEGIN
         SELECT 1
           FROM pg_constraint con
           JOIN pg_class rel ON rel.oid = con.conrelid
+          JOIN pg_namespace ns ON ns.oid = rel.relnamespace
          WHERE rel.relname = 'stock_prices'
+           AND ns.nspname = current_schema()
            AND con.conname = 'uq_stock_price_date'
     ) THEN
         ALTER TABLE stock_prices

--- a/migrations/0006_stock_prices_symbol_key_downgrade.sql
+++ b/migrations/0006_stock_prices_symbol_key_downgrade.sql
@@ -1,0 +1,171 @@
+-- Migration 0006 DOWNGRADE — reverses 0006_stock_prices_symbol_key.sql.
+--
+-- Restores the OLD stock_id-keyed `stock_prices` shape IN PLACE (NOT
+-- drop+recreate), data-preserving and symmetric to the up migration:
+--   1. ADD COLUMN stock_id (nullable while we backfill).
+--   2. Backfill stock_id from stocks via the symbol join (guarded: only if
+--      symbol still exists).
+--   3. Assert no NULL stock_id (a NULL means a row whose symbol had no stocks
+--      match — refuse to drop symbol and lose the key).
+--   4. SET stock_id NOT NULL (restore the old non-null FK shape).
+--   5. Drop the symbol FK / uq_stock_price_symbol_date / symbol index.
+--   6. Add stock_id FK -> stocks(id) + UNIQUE(stock_id, date) uq_stock_price_date
+--      + the standalone ix_stock_prices_stock_id index.
+--   7. Drop the symbol column.
+--
+-- PK(id, date), `date TIMESTAMPTZ NOT NULL`, the `id` sequence/default, and the
+-- hypertable identity are all preserved. market.* and other public tables are
+-- untouched.
+--
+-- Apply with:
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0006_stock_prices_symbol_key_downgrade.sql
+--
+-- Idempotent: re-applying is safe (guards check catalog state throughout).
+
+BEGIN;
+
+-- 1. ADD COLUMN stock_id (nullable while we backfill).
+ALTER TABLE stock_prices ADD COLUMN IF NOT EXISTS stock_id INTEGER;
+
+-- 2. Backfill stock_id from stocks via symbol — ONLY if symbol still exists.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'stock_prices'
+          AND column_name = 'symbol'
+    ) THEN
+        UPDATE stock_prices sp
+           SET stock_id = s.id
+          FROM stocks s
+         WHERE sp.symbol = s.symbol
+           AND sp.stock_id IS NULL;
+    END IF;
+END
+$$;
+
+-- 3. Assert no NULL stock_id remains (only meaningful when rows exist + a symbol
+--    failed to resolve). Refuse the downgrade rather than silently lose the key.
+DO $$
+DECLARE
+    n_null bigint;
+BEGIN
+    SELECT count(*) INTO n_null FROM stock_prices WHERE stock_id IS NULL;
+    IF n_null > 0 THEN
+        RAISE EXCEPTION
+            'downgrade 0006: % stock_prices rows have NULL stock_id (symbol did not resolve to a stocks row); aborting to avoid data loss',
+            n_null;
+    END IF;
+END
+$$;
+
+-- 4. SET stock_id NOT NULL (restore the old non-null FK shape).
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'stock_prices'
+          AND column_name = 'stock_id'
+          AND is_nullable = 'YES'
+    ) THEN
+        ALTER TABLE stock_prices ALTER COLUMN stock_id SET NOT NULL;
+    END IF;
+END
+$$;
+
+-- 5a. Drop the symbol FK (discover by referenced column — up-migration named it
+--     fk_stock_prices_symbol, but match by conkey for robustness).
+DO $$
+DECLARE
+    fk_name text;
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'stock_prices'
+          AND column_name = 'symbol'
+    ) THEN
+        FOR fk_name IN
+            SELECT con.conname
+              FROM pg_constraint con
+              JOIN pg_class rel ON rel.oid = con.conrelid
+             WHERE rel.relname = 'stock_prices'
+               AND con.contype = 'f'
+               AND con.conkey = (
+                   SELECT array_agg(attnum)
+                     FROM pg_attribute
+                    WHERE attrelid = rel.oid AND attname = 'symbol'
+               )
+        LOOP
+            EXECUTE format('ALTER TABLE stock_prices DROP CONSTRAINT %I', fk_name);
+        END LOOP;
+    END IF;
+END
+$$;
+
+-- 5b. Drop the uq_stock_price_symbol_date unique.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid = con.conrelid
+         WHERE rel.relname = 'stock_prices'
+           AND con.conname = 'uq_stock_price_symbol_date'
+    ) THEN
+        ALTER TABLE stock_prices DROP CONSTRAINT uq_stock_price_symbol_date;
+    END IF;
+END
+$$;
+
+-- 5c. Drop the symbol index.
+DROP INDEX IF EXISTS ix_stock_prices_symbol;
+
+-- 6a. Add stock_id FK -> stocks(id) (discover by referenced column so a
+--     pre-existing equivalent FK is treated as present).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid = con.conrelid
+         WHERE rel.relname = 'stock_prices'
+           AND con.contype = 'f'
+           AND con.conkey = (
+               SELECT array_agg(attnum)
+                 FROM pg_attribute
+                WHERE attrelid = rel.oid AND attname = 'stock_id'
+           )
+    ) THEN
+        ALTER TABLE stock_prices
+            ADD CONSTRAINT stock_prices_stock_id_fkey
+            FOREIGN KEY (stock_id) REFERENCES stocks (id);
+    END IF;
+END
+$$;
+
+-- 6b. Add UNIQUE(stock_id, date) uq_stock_price_date.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid = con.conrelid
+         WHERE rel.relname = 'stock_prices'
+           AND con.conname = 'uq_stock_price_date'
+    ) THEN
+        ALTER TABLE stock_prices
+            ADD CONSTRAINT uq_stock_price_date UNIQUE (stock_id, date);
+    END IF;
+END
+$$;
+
+-- 6c. Restore the standalone stock_id index for true symmetry.
+CREATE INDEX IF NOT EXISTS ix_stock_prices_stock_id ON stock_prices (stock_id);
+
+-- 7. Drop the symbol column.
+ALTER TABLE stock_prices DROP COLUMN IF EXISTS symbol;
+
+COMMIT;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ asyncio_mode = "auto"
 markers = [
     "llm_integration: real-LLM end-to-end (skipped unless RAINIER_LLM_INTEGRATION_TEST=1)",
     "requires_postgres: tests that need a live Postgres DB",
+    "requires_timescaledb: tests that need the timescaledb extension (hypertable catalog asserts)",
     "slow: spawns subprocesses or takes >1s (selectable with -m slow / -m 'not slow')",
 ]
 

--- a/tests/test_paper/conftest.py
+++ b/tests/test_paper/conftest.py
@@ -146,16 +146,43 @@ def _apply_sql(engine, path: Path) -> None:
         conn.execute(text(sql))
 
 
+# Disposable schema for the paper-tracker (0005) fixtures. Building the prereq
+# tables + 0005 migration inside a throwaway schema (instead of shared `public`)
+# gives each run a guaranteed-clean namespace (no residue collisions across tests
+# on a reused `RAINIER_TEST_DATABASE_URL`) AND lets teardown drop ONLY this schema
+# — never the real `public.*` ORM tables a reused DB may hold. `public` stays on
+# the search_path as a fallback so the timescaledb extension functions (installed
+# in `public`) stay resolvable. Mirrors the 0006 fixtures. The fixture exposes
+# `engine.rainier_schema` so schema-scoped inspector calls in the 0005 tests can
+# target the right namespace.
+_PAPER_SCHEMA = "rainier_paper_test"
+
+
 @pytest.fixture
 def pg_legacy_engine(request):
     """Ephemeral Postgres with prereq tables + the 0005 migration applied.
 
-    Also binds the legacy `core.database` singleton to it so production code
-    under test (ingest / fill / positions) hits this DB. Resets the singleton
-    before and after (PR #115 discipline).
+    Builds everything in a disposable schema (`_PAPER_SCHEMA`) so teardown drops
+    only that schema (never shared `public`) and each run starts clean. Also
+    binds the legacy `core.database` singleton to it so production code under
+    test (ingest / fill / positions) hits this DB. Resets the singleton before
+    and after (PR #115 discipline).
     """
     url = _resolve_pg_url(request)
-    engine = create_engine(url, future=True)
+    # search_path-free admin connection so DROP/CREATE SCHEMA targets the right
+    # namespace regardless of any pinned path.
+    admin = create_engine(url, future=True)
+    with admin.begin() as conn:
+        conn.execute(text(f"DROP SCHEMA IF EXISTS {_PAPER_SCHEMA} CASCADE"))
+        conn.execute(text(f"CREATE SCHEMA {_PAPER_SCHEMA}"))
+    admin.dispose()
+
+    engine = create_engine(
+        url,
+        future=True,
+        connect_args={"options": f"-csearch_path={_PAPER_SCHEMA},public"},
+    )
+    engine.rainier_schema = _PAPER_SCHEMA  # type: ignore[attr-defined]
     with engine.begin() as conn:
         conn.execute(text(_PREREQ_DDL))
     _apply_sql(engine, MIGRATION_UP)
@@ -171,21 +198,13 @@ def pg_legacy_engine(request):
         database._engine = None
         database._session_factory = None
         config._settings = None
-        # Drop the tables this fixture created so a reused
-        # `RAINIER_TEST_DATABASE_URL` leaves no `public.stock_prices`/`stocks`
-        # residue. Without this, the schema-isolated 0006 fixtures (which keep
-        # `public` on their search_path for the timescaledb extension) would see
-        # a second `public.stock_prices` and the migration's unscoped catalog
-        # DO-blocks could match both. No-op on a fresh ephemeral PG.
-        with engine.begin() as conn:
-            conn.execute(text("DROP TABLE IF EXISTS stock_prices CASCADE"))
-            conn.execute(text("DROP TABLE IF EXISTS paper_report_snapshot CASCADE"))
-            conn.execute(text("DROP TABLE IF EXISTS paper_skip CASCADE"))
-            conn.execute(text("DROP TABLE IF EXISTS paper_trade CASCADE"))
-            conn.execute(text("DROP TABLE IF EXISTS screened_stocks CASCADE"))
-            conn.execute(text("DROP TABLE IF EXISTS analysis_results CASCADE"))
-            conn.execute(text("DROP TABLE IF EXISTS stocks CASCADE"))
         engine.dispose()
+        # Drop ONLY the throwaway schema — never shared `public`. A reused
+        # `RAINIER_TEST_DATABASE_URL` keeps its real ORM tables intact.
+        admin = create_engine(url, future=True)
+        with admin.begin() as conn:
+            conn.execute(text(f"DROP SCHEMA IF EXISTS {_PAPER_SCHEMA} CASCADE"))
+        admin.dispose()
 
 
 @pytest.fixture

--- a/tests/test_paper/conftest.py
+++ b/tests/test_paper/conftest.py
@@ -171,6 +171,20 @@ def pg_legacy_engine(request):
         database._engine = None
         database._session_factory = None
         config._settings = None
+        # Drop the tables this fixture created so a reused
+        # `RAINIER_TEST_DATABASE_URL` leaves no `public.stock_prices`/`stocks`
+        # residue. Without this, the schema-isolated 0006 fixtures (which keep
+        # `public` on their search_path for the timescaledb extension) would see
+        # a second `public.stock_prices` and the migration's unscoped catalog
+        # DO-blocks could match both. No-op on a fresh ephemeral PG.
+        with engine.begin() as conn:
+            conn.execute(text("DROP TABLE IF EXISTS stock_prices CASCADE"))
+            conn.execute(text("DROP TABLE IF EXISTS paper_report_snapshot CASCADE"))
+            conn.execute(text("DROP TABLE IF EXISTS paper_skip CASCADE"))
+            conn.execute(text("DROP TABLE IF EXISTS paper_trade CASCADE"))
+            conn.execute(text("DROP TABLE IF EXISTS screened_stocks CASCADE"))
+            conn.execute(text("DROP TABLE IF EXISTS analysis_results CASCADE"))
+            conn.execute(text("DROP TABLE IF EXISTS stocks CASCADE"))
         engine.dispose()
 
 
@@ -227,6 +241,48 @@ CREATE TABLE IF NOT EXISTS stocks (
 """
 
 
+# Dedicated, disposable schema for the 0006 migration fixtures. Isolating these
+# fixtures in their own schema means the `DROP SCHEMA ... CASCADE` setup/teardown
+# can NEVER reach the shared `public` ORM tables — so pointing
+# `RAINIER_TEST_DATABASE_URL` at a reusable Postgres with the full schema is safe
+# (a CASCADE drop of `public.stocks` would otherwise strip FK constraints from
+# every sibling table that references it). Codex review P2.
+_MIG0006_SCHEMA = "rainier_mig0006_test"
+
+
+def _isolated_engine(url: str):
+    """Engine whose connections resolve names in the disposable 0006 test schema.
+
+    `search_path` puts `_MIG0006_SCHEMA` FIRST, so `create_all` / `init_db()` /
+    the migration's unqualified `stock_prices`/`stocks` all create and resolve
+    there (shadowing any `public` namesakes in a reused DB). `public` stays on
+    the path only as a fallback so the timescaledb extension functions
+    (`create_hypertable`, installed in `public`) remain resolvable. The schema is
+    (re)created fresh and dropped CASCADE around the fixture body — CASCADE is
+    scoped to throwaway objects only, never the shared `public` ORM tables.
+    """
+    engine = create_engine(
+        url,
+        future=True,
+        connect_args={"options": f"-csearch_path={_MIG0006_SCHEMA},public"},
+    )
+    # Recreate the schema fresh using a search_path-free connection so the DROP
+    # CASCADE targets the right schema regardless of the pinned path.
+    admin = create_engine(url, future=True)
+    with admin.begin() as conn:
+        conn.execute(text(f"DROP SCHEMA IF EXISTS {_MIG0006_SCHEMA} CASCADE"))
+        conn.execute(text(f"CREATE SCHEMA {_MIG0006_SCHEMA}"))
+    admin.dispose()
+    return engine
+
+
+def _drop_isolated_schema(url: str) -> None:
+    admin = create_engine(url, future=True)
+    with admin.begin() as conn:
+        conn.execute(text(f"DROP SCHEMA IF EXISTS {_MIG0006_SCHEMA} CASCADE"))
+    admin.dispose()
+
+
 def _has_timescaledb(engine) -> bool:
     """True if the connected Postgres has the timescaledb extension installed."""
     with engine.connect() as conn:
@@ -259,13 +315,10 @@ def pg_oldshape_engine(request):
     Exposes `engine.rainier_has_timescaledb` (bool) for tests to gate on.
     """
     url = _resolve_pg_url(request)
-    engine = create_engine(url, future=True)
+    # Isolated schema: setup/teardown CASCADE can't touch shared `public` tables.
+    engine = _isolated_engine(url)
     has_ts = _try_create_extension(engine)
-    # Drop first so a shared/reused DB (RAINIER_TEST_DATABASE_URL pointed at a
-    # persistent PG) starts clean each test; harmless on a fresh ephemeral PG.
     with engine.begin() as conn:
-        conn.execute(text("DROP TABLE IF EXISTS stock_prices CASCADE"))
-        conn.execute(text("DROP TABLE IF EXISTS stocks CASCADE"))
         conn.execute(text(_STOCKS_ONLY_DDL))
         conn.execute(text(_OLD_STOCK_PRICES_DDL))
     if has_ts:
@@ -280,10 +333,8 @@ def pg_oldshape_engine(request):
     try:
         yield engine
     finally:
-        with engine.begin() as conn:
-            conn.execute(text("DROP TABLE IF EXISTS stock_prices CASCADE"))
-            conn.execute(text("DROP TABLE IF EXISTS stocks CASCADE"))
         engine.dispose()
+        _drop_isolated_schema(url)
 
 
 @pytest.fixture
@@ -294,13 +345,10 @@ def pg_empty_engine(request):
     and resets it before/after (PR #115 discipline).
     """
     url = _resolve_pg_url(request)
-    engine = create_engine(url, future=True)
+    # Isolated, freshly-(re)created empty schema so init_db() exercises the create
+    # path; teardown CASCADE is scoped to this schema, never shared `public`.
+    engine = _isolated_engine(url)
     engine.rainier_has_timescaledb = _try_create_extension(engine)  # type: ignore[attr-defined]
-    # Start from a truly empty schema so init_db() exercises the create path
-    # (defensive against a reused persistent test DB; no-op on ephemeral PG).
-    with engine.begin() as conn:
-        conn.execute(text("DROP TABLE IF EXISTS stock_prices CASCADE"))
-        conn.execute(text("DROP TABLE IF EXISTS stocks CASCADE"))
 
     from rainier.core import config, database
 
@@ -314,3 +362,4 @@ def pg_empty_engine(request):
         database._session_factory = None
         config._settings = None
         engine.dispose()
+        _drop_isolated_schema(url)

--- a/tests/test_paper/conftest.py
+++ b/tests/test_paper/conftest.py
@@ -183,3 +183,134 @@ def pg_legacy_session(pg_legacy_engine):
     finally:
         sess.rollback()
         sess.close()
+
+
+# --------------------------------------------------------------------------
+# Migration 0006 (stock_prices stock_id -> symbol realign) fixtures.
+# --------------------------------------------------------------------------
+
+MIGRATION_0006_UP = REPO_ROOT / "migrations" / "0006_stock_prices_symbol_key.sql"
+MIGRATION_0006_DOWN = REPO_ROOT / "migrations" / "0006_stock_prices_symbol_key_downgrade.sql"
+
+# The OLD, stock_id-keyed `stock_prices` shape that migration 0006 realigns. The
+# baseline `_PREREQ_DDL` above already builds the NEW (symbol-keyed) shape, so the
+# 0006 migration tests need to start from the pre-migration drift instead.
+_OLD_STOCK_PRICES_DDL = """
+CREATE TABLE IF NOT EXISTS stock_prices (
+    id        BIGSERIAL,
+    stock_id  INTEGER NOT NULL REFERENCES stocks (id),
+    date      TIMESTAMP WITH TIME ZONE NOT NULL,
+    open      DOUBLE PRECISION,
+    high      DOUBLE PRECISION,
+    low       DOUBLE PRECISION,
+    close     DOUBLE PRECISION,
+    volume    BIGINT,
+    PRIMARY KEY (id, date),
+    CONSTRAINT uq_stock_price_date UNIQUE (stock_id, date)
+);
+CREATE INDEX IF NOT EXISTS ix_stock_prices_stock_id ON stock_prices (stock_id);
+"""
+
+# Only the FK-target `stocks` is needed for the 0006 tests (not the whole paper
+# prereq set / 0005 migration).
+_STOCKS_ONLY_DDL = """
+CREATE TABLE IF NOT EXISTS stocks (
+    id          SERIAL PRIMARY KEY,
+    symbol      VARCHAR(10) NOT NULL UNIQUE,
+    name        VARCHAR(255),
+    sector      VARCHAR(100),
+    industry    VARCHAR(200),
+    is_active   BOOLEAN DEFAULT TRUE,
+    created_at  TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at  TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+"""
+
+
+def _has_timescaledb(engine) -> bool:
+    """True if the connected Postgres has the timescaledb extension installed."""
+    with engine.connect() as conn:
+        return bool(
+            conn.execute(
+                text("SELECT 1 FROM pg_extension WHERE extname = 'timescaledb'")
+            ).scalar()
+        )
+
+
+def _try_create_extension(engine) -> bool:
+    """Best-effort `CREATE EXTENSION timescaledb`; returns whether it's present."""
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE"))
+    except Exception:
+        pass
+    return _has_timescaledb(engine)
+
+
+@pytest.fixture
+def pg_oldshape_engine(request):
+    """Ephemeral Postgres seeded with the OLD stock_id-keyed `stock_prices`.
+
+    Makes `stock_prices` a hypertable when the timescaledb extension is
+    available (so the in-place ALTER is exercised against a real hypertable);
+    falls back to a plain table otherwise (schema/idempotency/backfill checks
+    still run; the hypertable-catalog asserts are `requires_timescaledb`-gated).
+
+    Exposes `engine.rainier_has_timescaledb` (bool) for tests to gate on.
+    """
+    url = _resolve_pg_url(request)
+    engine = create_engine(url, future=True)
+    has_ts = _try_create_extension(engine)
+    # Drop first so a shared/reused DB (RAINIER_TEST_DATABASE_URL pointed at a
+    # persistent PG) starts clean each test; harmless on a fresh ephemeral PG.
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS stock_prices CASCADE"))
+        conn.execute(text("DROP TABLE IF EXISTS stocks CASCADE"))
+        conn.execute(text(_STOCKS_ONLY_DDL))
+        conn.execute(text(_OLD_STOCK_PRICES_DDL))
+    if has_ts:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "SELECT create_hypertable('stock_prices', 'date', "
+                    "migrate_data => true, if_not_exists => true)"
+                )
+            )
+    engine.rainier_has_timescaledb = has_ts  # type: ignore[attr-defined]
+    try:
+        yield engine
+    finally:
+        with engine.begin() as conn:
+            conn.execute(text("DROP TABLE IF EXISTS stock_prices CASCADE"))
+            conn.execute(text("DROP TABLE IF EXISTS stocks CASCADE"))
+        engine.dispose()
+
+
+@pytest.fixture
+def pg_empty_engine(request):
+    """Ephemeral Postgres with NOTHING created — for the fresh `init_db()` path.
+
+    Binds the legacy `core.database` singleton so `init_db()` targets this DB,
+    and resets it before/after (PR #115 discipline).
+    """
+    url = _resolve_pg_url(request)
+    engine = create_engine(url, future=True)
+    engine.rainier_has_timescaledb = _try_create_extension(engine)  # type: ignore[attr-defined]
+    # Start from a truly empty schema so init_db() exercises the create path
+    # (defensive against a reused persistent test DB; no-op on ephemeral PG).
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS stock_prices CASCADE"))
+        conn.execute(text("DROP TABLE IF EXISTS stocks CASCADE"))
+
+    from rainier.core import config, database
+
+    config._settings = None
+    database._engine = engine
+    database._session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+    try:
+        yield engine
+    finally:
+        database._engine = None
+        database._session_factory = None
+        config._settings = None
+        engine.dispose()

--- a/tests/test_paper/test_migrations.py
+++ b/tests/test_paper/test_migrations.py
@@ -124,7 +124,8 @@ def test_paper_trade_not_a_hypertable_marker():
 @pytest.mark.requires_postgres
 def test_a1_paper_trade_pg_shape(pg_legacy_engine):
     insp = inspect(pg_legacy_engine)
-    cols = {c["name"] for c in insp.get_columns("paper_trade")}
+    schema = pg_legacy_engine.rainier_schema
+    cols = {c["name"] for c in insp.get_columns("paper_trade", schema=schema)}
     assert {"price_basis", "time_stop_days", "planned_entry_price"} <= cols
     # NOT a hypertable — the timescaledb catalog has no entry (or the ext is
     # absent, which also proves not-a-hypertable).
@@ -148,10 +149,13 @@ def test_a1_paper_trade_pg_shape(pg_legacy_engine):
 @pytest.mark.requires_postgres
 def test_a3_a4_pg_objects_exist(pg_legacy_engine):
     insp = inspect(pg_legacy_engine)
-    tables = set(insp.get_table_names())
+    schema = pg_legacy_engine.rainier_schema
+    tables = set(insp.get_table_names(schema=schema))
     assert {"paper_trade", "paper_skip", "paper_report_snapshot"} <= tables
     payload_col = next(
-        c for c in insp.get_columns("paper_report_snapshot") if c["name"] == "payload"
+        c
+        for c in insp.get_columns("paper_report_snapshot", schema=schema)
+        if c["name"] == "payload"
     )
     assert "JSON" in str(payload_col["type"]).upper()
 
@@ -221,13 +225,14 @@ def test_a5_downgrade_reverses(pg_legacy_engine):
         conn.execute(text(down.read_text()))
 
     insp = inspect(pg_legacy_engine)
-    tables = set(insp.get_table_names())
+    schema = pg_legacy_engine.rainier_schema
+    tables = set(insp.get_table_names(schema=schema))
     assert "paper_trade" not in tables
     assert "paper_skip" not in tables
     assert "paper_report_snapshot" not in tables
     # FK targets survive.
     assert {"analysis_results", "screened_stocks"} <= tables
     # The four additive columns are gone; pattern_type survives.
-    scr_cols = {c["name"] for c in insp.get_columns("screened_stocks")}
+    scr_cols = {c["name"] for c in insp.get_columns("screened_stocks", schema=schema)}
     assert not ({"entry_price", "stop_loss", "target_price", "rr_ratio"} & scr_cols)
     assert "pattern_type" in scr_cols

--- a/tests/test_paper/test_stock_prices_migration.py
+++ b/tests/test_paper/test_stock_prices_migration.py
@@ -1,0 +1,371 @@
+"""Migration 0006 — realign `stock_prices` stock_id -> symbol (TASK-PLAN T1-T7).
+
+Lane split (TASK-PLAN §Tests):
+
+* Pure schema / idempotency / backfill checks run under `requires_postgres` on
+  plain Postgres.
+* Hypertable-catalog assertions (still-a-hypertable after the in-place ALTER)
+  are gated behind `requires_timescaledb` — they skip with a clear reason when
+  the test Postgres has no timescaledb extension (the ephemeral pytest-postgresql
+  build is plain PG).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import inspect, text
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UP = REPO_ROOT / "migrations" / "0006_stock_prices_symbol_key.sql"
+DOWN = REPO_ROOT / "migrations" / "0006_stock_prices_symbol_key_downgrade.sql"
+
+D = datetime(2026, 1, 5, tzinfo=timezone.utc)
+
+
+def _apply(engine, path: Path) -> None:
+    with engine.begin() as conn:
+        conn.execute(text(path.read_text()))
+
+
+def _seed_old_row(engine, *, stock_id: int, symbol: str, close: float) -> None:
+    with engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO stocks (id, symbol) VALUES (:i, :s) ON CONFLICT DO NOTHING"),
+            {"i": stock_id, "s": symbol},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO stock_prices (stock_id, date, open, high, low, close, volume) "
+                "VALUES (:i, :d, 100, 110, 95, :c, 1000)"
+            ),
+            {"i": stock_id, "d": D, "c": close},
+        )
+
+
+def _columns(engine) -> dict:
+    insp = inspect(engine)
+    return {c["name"]: c for c in insp.get_columns("stock_prices")}
+
+
+def _constraint_names(engine, contype: str | None = None) -> set[str]:
+    sql = (
+        "SELECT con.conname FROM pg_constraint con "
+        "JOIN pg_class rel ON rel.oid = con.conrelid "
+        "WHERE rel.relname = 'stock_prices'"
+    )
+    if contype:
+        sql += f" AND con.contype = '{contype}'"
+    with engine.connect() as conn:
+        return {r[0] for r in conn.execute(text(sql)).all()}
+
+
+def _index_names(engine) -> set[str]:
+    with engine.connect() as conn:
+        return {
+            r[0]
+            for r in conn.execute(
+                text("SELECT indexname FROM pg_indexes WHERE tablename = 'stock_prices'")
+            ).all()
+        }
+
+
+def _pk_columns(engine) -> list[str]:
+    return inspect(engine).get_pk_constraint("stock_prices")["constrained_columns"]
+
+
+def _is_hypertable(engine) -> bool:
+    with engine.connect() as conn:
+        return bool(
+            conn.execute(
+                text(
+                    "SELECT count(*) FROM timescaledb_information.hypertables "
+                    "WHERE hypertable_name = 'stock_prices'"
+                )
+            ).scalar()
+        )
+
+
+def _unique_index_columns(engine) -> list[list[str]]:
+    """Column lists of every UNIQUE index/constraint on stock_prices."""
+    sql = """
+        SELECT array_agg(a.attname ORDER BY k.ord) AS cols
+          FROM pg_index ix
+          JOIN pg_class t ON t.oid = ix.indrelid
+          JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE
+          JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+         WHERE t.relname = 'stock_prices' AND ix.indisunique
+         GROUP BY ix.indexrelid
+    """
+    with engine.connect() as conn:
+        return [list(r[0]) for r in conn.execute(text(sql)).all()]
+
+
+# ---------------------------------------------------------------------------
+# T1 — migration applies + schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_postgres
+def test_t1_schema_after_up(pg_oldshape_engine):
+    engine = pg_oldshape_engine
+    _apply(engine, UP)
+
+    cols = _columns(engine)
+    # symbol varchar(10) NOT NULL
+    assert "symbol" in cols
+    assert cols["symbol"]["nullable"] is False
+    assert "VARCHAR(10)" in str(cols["symbol"]["type"]).upper().replace(" ", "")
+    # stock_id gone
+    assert "stock_id" not in cols
+    # date still timestamptz NOT NULL
+    assert cols["date"]["nullable"] is False
+    assert "TIMESTAMP" in str(cols["date"]["type"]).upper()
+    # id default/sequence preserved (BIGINT autoincrement)
+    assert "nextval" in (cols["id"].get("default") or "")
+
+    # FK symbol -> stocks.symbol
+    fks = inspect(engine).get_foreign_keys("stock_prices")
+    sym_fk = [f for f in fks if f["constrained_columns"] == ["symbol"]]
+    assert sym_fk and sym_fk[0]["referred_table"] == "stocks"
+    assert sym_fk[0]["referred_columns"] == ["symbol"]
+    # no stock_id FK
+    assert not any(f["constrained_columns"] == ["stock_id"] for f in fks)
+
+    # uq_stock_price_symbol_date present; uq_stock_price_date gone
+    cons = _constraint_names(engine)
+    assert "uq_stock_price_symbol_date" in cons
+    assert "uq_stock_price_date" not in cons
+
+    # index on symbol; stock_id index gone
+    idxs = _index_names(engine)
+    assert "ix_stock_prices_symbol" in idxs
+    assert "ix_stock_prices_stock_id" not in idxs
+
+    # PK still (id, date)
+    assert _pk_columns(engine) == ["id", "date"]
+
+    # Timescale rule — no unique index omits `date`.
+    for col_list in _unique_index_columns(engine):
+        assert "date" in col_list, f"unique index {col_list} omits the partition column"
+
+
+@pytest.mark.requires_timescaledb
+def test_t1_still_hypertable_after_up(pg_oldshape_engine):
+    if not getattr(pg_oldshape_engine, "rainier_has_timescaledb", False):
+        pytest.skip("no timescaledb extension")
+    _apply(pg_oldshape_engine, UP)
+    assert _is_hypertable(pg_oldshape_engine)
+
+
+# ---------------------------------------------------------------------------
+# T2 — data preservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_postgres
+def test_t2_data_preserved(pg_oldshape_engine):
+    engine = pg_oldshape_engine
+    _seed_old_row(engine, stock_id=42, symbol="NVDA", close=120.85)
+    _apply(engine, UP)
+    with engine.connect() as conn:
+        row = conn.execute(
+            text("SELECT symbol, date, close, open, high, low, volume FROM stock_prices")
+        ).one()
+    assert row.symbol == "NVDA"
+    assert row.close == 120.85
+    assert row.open == 100 and row.high == 110 and row.low == 95 and row.volume == 1000
+    # FK satisfied (NVDA exists in stocks) — proven by the apply not failing.
+
+
+# ---------------------------------------------------------------------------
+# T3 — idempotent (re-apply + already-migrated no-op)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_postgres
+def test_t3_idempotent_double_apply(pg_oldshape_engine):
+    engine = pg_oldshape_engine
+    _seed_old_row(engine, stock_id=42, symbol="NVDA", close=120.85)
+    _apply(engine, UP)
+    # Second apply (stock_id already gone) is a clean no-op.
+    _apply(engine, UP)
+    cols = _columns(engine)
+    assert "stock_id" not in cols and cols["symbol"]["nullable"] is False
+    with engine.connect() as conn:
+        assert conn.execute(text("SELECT symbol FROM stock_prices")).scalar() == "NVDA"
+
+
+@pytest.mark.requires_postgres
+def test_t3_noop_on_fresh_symbol_keyed(pg_legacy_engine):
+    # pg_legacy_engine builds the ALREADY symbol-keyed stock_prices (the fresh
+    # `db init` shape). Applying 0006 must be a clean no-op.
+    _apply(pg_legacy_engine, UP)
+    cols = _columns(pg_legacy_engine)
+    assert "symbol" in cols and "stock_id" not in cols
+    assert "uq_stock_price_symbol_date" in _constraint_names(pg_legacy_engine)
+
+
+# ---------------------------------------------------------------------------
+# T4 — downgrade: symmetric + data-preserving
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_postgres
+def test_t4_downgrade_symmetric(pg_oldshape_engine):
+    engine = pg_oldshape_engine
+    _apply(engine, UP)
+    # Insert symbol-keyed rows post-migration.
+    with engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO stocks (id, symbol) VALUES (42, 'NVDA'), (7, 'TSLA')")
+        )
+        conn.execute(
+            text(
+                "INSERT INTO stock_prices (symbol, date, close) "
+                "VALUES ('NVDA', :d1, 120.85), ('TSLA', :d2, 250.5)"
+            ),
+            {"d1": D, "d2": datetime(2026, 1, 6, tzinfo=timezone.utc)},
+        )
+
+    _apply(engine, DOWN)
+
+    cols = _columns(engine)
+    # stock_id restored + NOT NULL; symbol gone.
+    assert "stock_id" in cols
+    assert cols["stock_id"]["nullable"] is False
+    assert "symbol" not in cols
+    # uq_stock_price_date restored; uq_stock_price_symbol_date gone.
+    cons = _constraint_names(engine)
+    assert "uq_stock_price_date" in cons
+    assert "uq_stock_price_symbol_date" not in cons
+    # stock_id index restored; symbol index gone.
+    idxs = _index_names(engine)
+    assert "ix_stock_prices_stock_id" in idxs
+    assert "ix_stock_prices_symbol" not in idxs
+    # stock_id FK restored.
+    fks = inspect(engine).get_foreign_keys("stock_prices")
+    assert any(
+        f["constrained_columns"] == ["stock_id"] and f["referred_table"] == "stocks"
+        for f in fks
+    )
+    # PK still (id, date).
+    assert _pk_columns(engine) == ["id", "date"]
+    # Rows survive with correct stock_id backfilled from symbol.
+    with engine.connect() as conn:
+        got = {
+            (r.stock_id, float(r.close))
+            for r in conn.execute(text("SELECT stock_id, close FROM stock_prices")).all()
+        }
+    assert got == {(42, 120.85), (7, 250.5)}
+
+
+@pytest.mark.requires_timescaledb
+def test_t4_downgrade_preserves_hypertable(pg_oldshape_engine):
+    if not getattr(pg_oldshape_engine, "rainier_has_timescaledb", False):
+        pytest.skip("no timescaledb extension")
+    _apply(pg_oldshape_engine, UP)
+    _apply(pg_oldshape_engine, DOWN)
+    assert _is_hypertable(pg_oldshape_engine)
+
+
+# ---------------------------------------------------------------------------
+# T5 — fresh db init
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_postgres
+def test_t5_fresh_db_init_symbol_keyed(pg_empty_engine):
+    from rainier.core.database import init_db
+
+    init_db()
+    cols = _columns(pg_empty_engine)
+    assert "symbol" in cols and "stock_id" not in cols
+    fks = inspect(pg_empty_engine).get_foreign_keys("stock_prices")
+    assert any(
+        f["constrained_columns"] == ["symbol"] and f["referred_columns"] == ["symbol"]
+        for f in fks
+    )
+    assert "uq_stock_price_symbol_date" in _constraint_names(pg_empty_engine)
+
+
+@pytest.mark.requires_timescaledb
+def test_t5_fresh_db_init_hypertable(pg_empty_engine):
+    if not getattr(pg_empty_engine, "rainier_has_timescaledb", False):
+        pytest.skip("no timescaledb extension")
+    from rainier.core.database import init_db
+
+    init_db()
+    assert _is_hypertable(pg_empty_engine)
+
+
+# ---------------------------------------------------------------------------
+# T6 — ingest smoke (regression for `column stock_prices.symbol does not exist`)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_postgres
+def test_t6_ingest_smoke(pg_legacy_session):
+    """With the symbol-keyed table, ingest_prices upserts a (symbol, date) row
+    and a re-run is a no-op. yfinance mocked (fetch_fn injected, no network)."""
+    from datetime import date
+
+    from rainier.core.models import StockPrice
+    from rainier.paper.ingest import ingest_prices
+
+    as_of = date(2026, 1, 9)  # Friday
+    target = date(2026, 1, 9)
+    bar = {
+        "date": target,
+        "open": 10.0,
+        "high": 11.0,
+        "low": 9.0,
+        "close": 10.5,
+        "volume": 1000,
+    }
+
+    def fetch_fn(syms, start, end):
+        return {s: [bar] for s in syms}
+
+    res = ingest_prices(["AAA"], as_of=as_of, fetch_fn=fetch_fn, window_days=5)
+    assert res["upserted"] >= 1
+    rows = (
+        pg_legacy_session.query(StockPrice)
+        .filter(StockPrice.symbol == "AAA")
+        .all()
+    )
+    assert len(rows) == 1 and rows[0].close == 10.5
+
+    # Re-run with the same single bar: idempotent on the (symbol, date) key — no
+    # NEW row is created (the design re-confirms in-window bars via upsert, so
+    # `upserted` may re-count the existing pair; the invariant is "no new rows").
+    ingest_prices(["AAA"], as_of=as_of, fetch_fn=fetch_fn, window_days=5)
+    rows2 = (
+        pg_legacy_session.query(StockPrice)
+        .filter(StockPrice.symbol == "AAA")
+        .all()
+    )
+    assert len(rows2) == 1 and rows2[0].close == 10.5
+
+
+# ---------------------------------------------------------------------------
+# T7 — no stock_id readers (static)
+# ---------------------------------------------------------------------------
+
+
+def test_t7_no_stock_id_readers():
+    """No src/ code references stock_prices.stock_id / StockPrice.stock_id."""
+    import re
+
+    src = REPO_ROOT / "src"
+    offenders: list[str] = []
+    # `StockPrice.stock_id` (ORM attr) or `stock_prices.stock_id` (raw SQL).
+    pat = re.compile(r"StockPrice\.stock_id|stock_prices\.stock_id")
+    for py in src.rglob("*.py"):
+        text_ = py.read_text()
+        for i, line in enumerate(text_.splitlines(), 1):
+            if pat.search(line):
+                offenders.append(f"{py.relative_to(REPO_ROOT)}:{i}: {line.strip()}")
+    assert not offenders, "stale stock_id readers:\n" + "\n".join(offenders)

--- a/tests/test_paper/test_stock_prices_migration.py
+++ b/tests/test_paper/test_stock_prices_migration.py
@@ -24,6 +24,18 @@ DOWN = REPO_ROOT / "migrations" / "0006_stock_prices_symbol_key_downgrade.sql"
 
 D = datetime(2026, 1, 5, tzinfo=timezone.utc)
 
+# Catalog/inspector lookups MUST scope to the engine's active schema. The 0006
+# fixtures (`pg_oldshape_engine` / `pg_empty_engine`) isolate every object in a
+# throwaway schema (conftest `_isolated_engine`), while `pg_legacy_engine` builds
+# in `public`. A reused `RAINIER_TEST_DATABASE_URL` may hold BOTH a
+# `public.stock_prices` and the isolated one, so an unscoped `relname =
+# 'stock_prices'` filter would match two rows. Resolving the schema from
+# `current_schema()` (which honors the engine's pinned search_path) targets the
+# right one for either fixture.
+def _schema(engine) -> str:
+    with engine.connect() as conn:
+        return conn.execute(text("SELECT current_schema()")).scalar()
+
 
 def _apply(engine, path: Path) -> None:
     with engine.begin() as conn:
@@ -45,21 +57,29 @@ def _seed_old_row(engine, *, stock_id: int, symbol: str, close: float) -> None:
         )
 
 
+def _fks(engine) -> list[dict]:
+    return inspect(engine).get_foreign_keys("stock_prices", schema=_schema(engine))
+
+
 def _columns(engine) -> dict:
     insp = inspect(engine)
-    return {c["name"]: c for c in insp.get_columns("stock_prices")}
+    return {
+        c["name"]: c
+        for c in insp.get_columns("stock_prices", schema=_schema(engine))
+    }
 
 
 def _constraint_names(engine, contype: str | None = None) -> set[str]:
     sql = (
         "SELECT con.conname FROM pg_constraint con "
         "JOIN pg_class rel ON rel.oid = con.conrelid "
-        "WHERE rel.relname = 'stock_prices'"
+        "JOIN pg_namespace ns ON ns.oid = rel.relnamespace "
+        "WHERE rel.relname = 'stock_prices' AND ns.nspname = :schema"
     )
     if contype:
         sql += f" AND con.contype = '{contype}'"
     with engine.connect() as conn:
-        return {r[0] for r in conn.execute(text(sql)).all()}
+        return {r[0] for r in conn.execute(text(sql), {"schema": _schema(engine)}).all()}
 
 
 def _index_names(engine) -> set[str]:
@@ -67,23 +87,32 @@ def _index_names(engine) -> set[str]:
         return {
             r[0]
             for r in conn.execute(
-                text("SELECT indexname FROM pg_indexes WHERE tablename = 'stock_prices'")
+                text(
+                    "SELECT indexname FROM pg_indexes "
+                    "WHERE tablename = 'stock_prices' AND schemaname = :schema"
+                ),
+                {"schema": _schema(engine)},
             ).all()
         }
 
 
 def _pk_columns(engine) -> list[str]:
-    return inspect(engine).get_pk_constraint("stock_prices")["constrained_columns"]
+    return inspect(engine).get_pk_constraint("stock_prices", schema=_schema(engine))[
+        "constrained_columns"
+    ]
 
 
 def _is_hypertable(engine) -> bool:
     with engine.connect() as conn:
+        schema = conn.execute(text("SELECT current_schema()")).scalar()
         return bool(
             conn.execute(
                 text(
                     "SELECT count(*) FROM timescaledb_information.hypertables "
-                    "WHERE hypertable_name = 'stock_prices'"
-                )
+                    "WHERE hypertable_name = 'stock_prices' "
+                    "AND hypertable_schema = :schema"
+                ),
+                {"schema": schema},
             ).scalar()
         )
 
@@ -94,13 +123,18 @@ def _unique_index_columns(engine) -> list[list[str]]:
         SELECT array_agg(a.attname ORDER BY k.ord) AS cols
           FROM pg_index ix
           JOIN pg_class t ON t.oid = ix.indrelid
+          JOIN pg_namespace ns ON ns.oid = t.relnamespace
           JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE
           JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
-         WHERE t.relname = 'stock_prices' AND ix.indisunique
+         WHERE t.relname = 'stock_prices' AND ns.nspname = :schema
+           AND ix.indisunique
          GROUP BY ix.indexrelid
     """
     with engine.connect() as conn:
-        return [list(r[0]) for r in conn.execute(text(sql)).all()]
+        return [
+            list(r[0])
+            for r in conn.execute(text(sql), {"schema": _schema(engine)}).all()
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -127,7 +161,7 @@ def test_t1_schema_after_up(pg_oldshape_engine):
     assert "nextval" in (cols["id"].get("default") or "")
 
     # FK symbol -> stocks.symbol
-    fks = inspect(engine).get_foreign_keys("stock_prices")
+    fks = _fks(engine)
     sym_fk = [f for f in fks if f["constrained_columns"] == ["symbol"]]
     assert sym_fk and sym_fk[0]["referred_table"] == "stocks"
     assert sym_fk[0]["referred_columns"] == ["symbol"]
@@ -246,7 +280,7 @@ def test_t4_downgrade_symmetric(pg_oldshape_engine):
     assert "ix_stock_prices_stock_id" in idxs
     assert "ix_stock_prices_symbol" not in idxs
     # stock_id FK restored.
-    fks = inspect(engine).get_foreign_keys("stock_prices")
+    fks = _fks(engine)
     assert any(
         f["constrained_columns"] == ["stock_id"] and f["referred_table"] == "stocks"
         for f in fks
@@ -283,7 +317,7 @@ def test_t5_fresh_db_init_symbol_keyed(pg_empty_engine):
     init_db()
     cols = _columns(pg_empty_engine)
     assert "symbol" in cols and "stock_id" not in cols
-    fks = inspect(pg_empty_engine).get_foreign_keys("stock_prices")
+    fks = _fks(pg_empty_engine)
     assert any(
         f["constrained_columns"] == ["symbol"] and f["referred_columns"] == ["symbol"]
         for f in fks

--- a/tests/test_paper/test_stock_prices_migration.py
+++ b/tests/test_paper/test_stock_prices_migration.py
@@ -102,6 +102,28 @@ def _pk_columns(engine) -> list[str]:
     ]
 
 
+def _public_stock_prices_exists(engine) -> bool:
+    """True if a `public.stock_prices` table exists.
+
+    The `pg_empty_engine` fixture runs `init_db()` inside a throwaway schema, but
+    `Base.metadata.create_all(checkfirst=True)` resolves table existence through
+    the connection search_path (`<schema>,public`). If a reused
+    `RAINIER_TEST_DATABASE_URL` already has the real `public.stock_prices`,
+    checkfirst sees it and SKIPS creating the isolated-schema copy — so the T5
+    fresh-init asserts cannot be exercised against that DB. Detect and skip
+    deterministically (CI runs against a clean Postgres where this is absent).
+    """
+    with engine.connect() as conn:
+        return bool(
+            conn.execute(
+                text(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = 'public' AND table_name = 'stock_prices'"
+                )
+            ).scalar()
+        )
+
+
 def _is_hypertable(engine) -> bool:
     with engine.connect() as conn:
         schema = conn.execute(text("SELECT current_schema()")).scalar()
@@ -312,6 +334,17 @@ def test_t4_downgrade_preserves_hypertable(pg_oldshape_engine):
 
 @pytest.mark.requires_postgres
 def test_t5_fresh_db_init_symbol_keyed(pg_empty_engine):
+    # `init_db()` -> `_create_hypertables()` runs an unconditional
+    # `CREATE EXTENSION IF NOT EXISTS timescaledb`, which RAISES (not skips) on a
+    # plain-PG install where the extension isn't available. The plain-Postgres
+    # lane therefore can't exercise `init_db()`; gate on the extension being
+    # present, same as the hypertable asserts. The schema-only shape is still
+    # covered by T3's `test_t3_noop_on_fresh_symbol_keyed` on plain PG.
+    if not getattr(pg_empty_engine, "rainier_has_timescaledb", False):
+        pytest.skip("init_db() requires the timescaledb extension")
+    if _public_stock_prices_exists(pg_empty_engine):
+        pytest.skip("public.stock_prices shadows create_all checkfirst (reused DB)")
+
     from rainier.core.database import init_db
 
     init_db()
@@ -329,6 +362,8 @@ def test_t5_fresh_db_init_symbol_keyed(pg_empty_engine):
 def test_t5_fresh_db_init_hypertable(pg_empty_engine):
     if not getattr(pg_empty_engine, "rainier_has_timescaledb", False):
         pytest.skip("no timescaledb extension")
+    if _public_stock_prices_exists(pg_empty_engine):
+        pytest.skip("public.stock_prices shadows create_all checkfirst (reused DB)")
     from rainier.core.database import init_db
 
     init_db()


### PR DESCRIPTION
## Summary
- New migration 0006 realigns the live `stock_prices` TimescaleDB hypertable from stock_id-keyed to symbol-keyed (in-place ALTER, guarded/idempotent, symmetric data-preserving downgrade). Unblocks the QU100 paper loop (`db ingest-prices` no longer crashes on missing `symbol`).
- Tests T1-T7 in tests/test_paper/ (schema, data-preservation, idempotency, downgrade, fresh-init, ingest smoke, static no-stock_id-readers); paper fixtures isolated in a throwaway schema.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 4)

## Operator action after merge
- Apply `migrations/0006_stock_prices_symbol_key.sql` to $LEGACY_DATABASE_URL (or `rainier db init` on a fresh DB).

## Test plan
- [ ] CI green
- [ ] migration applied to legacy DB