### PR TITLE
test: consolidate Playwright scraper mocks into conftest (slim R5)

### DIFF
--- a/tests/test_scrapers/conftest.py
+++ b/tests/test_scrapers/conftest.py
@@ -1,0 +1,95 @@
+"""Shared Playwright mock helpers for QUScraper unit tests.
+
+Consolidates the copy-pasted ``_make_mock_page`` / ``_make_scraper`` helpers
+that previously lived in each ``test_scrapers/*.py`` file (R5 of the slim
+audit). These are module-level helper functions rather than pytest fixtures:
+the call sites invoke them imperatively mid-test (often more than once, with
+per-test URL/title overrides), which fits a plain factory better than a
+fixture.
+
+Behavior is the union of the prior per-file variants, gated by keyword args so
+each call site keeps its exact previous semantics:
+
+  - ``make_mock_page`` always returns ``(page, page_url)``; callers that only
+    want the page unpack ``page, _``.
+  - ``query_selector_returns_element`` toggles the default ``query_selector``
+    result (element vs ``None``) — cdp_auth's flow needs ``None``.
+  - ``titles`` supports the CF-recovery multi-call title sequence; otherwise a
+    single ``title`` is returned on every call.
+  - ``make_scraper`` takes ``is_cdp`` (and an optional pre-built browser) so the
+    CDP-vs-launch distinction each file encoded as a default is explicit.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+from rainier.scrapers.qu.scraper import QUScraper
+
+
+def make_mock_page(
+    url: str = "https://www.quantunicorn.com/products#qu100",
+    title: str = "QU100",
+    titles: list[str] | None = None,
+    query_selector_returns_element: bool = True,
+):
+    """Create a mock Playwright Page; returns ``(page, page_url)``.
+
+    ``page.url`` is a property backed by the mutable ``page_url`` dict so tests
+    (and ``goto``) can change it mid-flow. When ``titles`` is given, successive
+    ``.title()`` calls walk that list and then repeat the last entry (so e.g.
+    ``["Just a moment...", "QuantUnicorn"]`` returns the CF page first and
+    clears on every later check).
+    """
+    page = AsyncMock()
+    page_url = {"value": url}
+    type(page).url = PropertyMock(side_effect=lambda: page_url["value"])
+
+    if titles is not None:
+        title_idx = {"n": 0}
+
+        async def fake_title():
+            idx = min(title_idx["n"], len(titles) - 1)
+            title_idx["n"] += 1
+            return titles[idx]
+
+        page.title = AsyncMock(side_effect=fake_title)
+    else:
+        page.title = AsyncMock(return_value=title)
+
+    page.context = AsyncMock()
+    page.context.add_cookies = AsyncMock()
+
+    query_default = AsyncMock() if query_selector_returns_element else None
+    page.query_selector = AsyncMock(return_value=query_default)
+    page.wait_for_selector = AsyncMock(return_value=AsyncMock())
+    page.wait_for_load_state = AsyncMock()
+    # CF-challenge wait — harmless extra mock for flows that never await it.
+    page.wait_for_function = AsyncMock()
+    page.goto = AsyncMock(side_effect=lambda u, **kw: page_url.update(value=u))
+
+    return page, page_url
+
+
+def make_scraper(mock_browser: MagicMock | None = None, is_cdp: bool = False) -> QUScraper:
+    """Create a QUScraper with a mocked browser and patched settings.
+
+    When ``mock_browser`` is omitted, a ``MagicMock`` with ``_is_cdp=is_cdp`` is
+    used. Settings are patched in-place so no real config file is read.
+    """
+    if mock_browser is None:
+        mock_browser = MagicMock()
+        mock_browser._is_cdp = is_cdp
+
+    with patch("rainier.scrapers.qu.scraper.get_settings") as mock_settings:
+        qu_config = MagicMock()
+        qu_config.url = "https://www.quantunicorn.com/products#qu100"
+        qu_config.login_url = "https://www.quantunicorn.com/signin"
+        qu_config.session_file = "./data/auth/qu_session.json"
+        qu_config.session_ttl_hours = 12
+        qu_config.timeout_ms = 30000
+        qu_config.backfill_delay_seconds = 2.0
+        mock_settings.return_value.scraping.quantunicorn = qu_config
+        scraper = QUScraper(mock_browser)
+
+    return scraper

--- a/tests/test_scrapers/test_cdp_auth.py
+++ b/tests/test_scrapers/test_cdp_auth.py
@@ -8,12 +8,13 @@ are mocked — no real browser needed.
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from rainier.scrapers.qu import selectors as sel
-from rainier.scrapers.qu.scraper import QUScraper
+
+from .conftest import make_mock_page, make_scraper
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -21,52 +22,13 @@ from rainier.scrapers.qu.scraper import QUScraper
 
 
 def _make_mock_page(url="https://www.quantunicorn.com/products#qu100", title="QU100"):
-    """Create a mock Playwright Page with sensible defaults."""
-    page = AsyncMock()
-    # page.url is a property (not a coroutine), use a mutable container
-    # so tests can change it mid-flow via side_effect on goto/click
-    page_url = {"value": url}
-    type(page).url = PropertyMock(side_effect=lambda: page_url["value"])
-
-    page.title = AsyncMock(return_value=title)
-    page.context = AsyncMock()
-    page.context.add_cookies = AsyncMock()
-
-    # query_selector returns None by default (no element found)
-    page.query_selector = AsyncMock(return_value=None)
-    # wait_for_selector returns a mock element by default
-    page.wait_for_selector = AsyncMock(return_value=AsyncMock())
-    page.wait_for_load_state = AsyncMock()
-    # wait_for_function (CF challenge wait) — defaults to clean return so
-    # title==challenge tests don't accidentally hit the timeout branch.
-    page.wait_for_function = AsyncMock()
-
-    def set_url(new_url, **kwargs):
-        page_url["value"] = new_url
-
-    page.goto = AsyncMock(side_effect=lambda url, **kw: set_url(url))
-
-    return page, page_url
+    # This flow needs query_selector to default to None ("no element found").
+    return make_mock_page(url=url, title=title, query_selector_returns_element=False)
 
 
 def _make_scraper(mock_browser=None):
-    """Create a QUScraper with mocked browser and settings."""
-    if mock_browser is None:
-        mock_browser = MagicMock()
-        mock_browser._is_cdp = True
-
-    with patch("rainier.scrapers.qu.scraper.get_settings") as mock_settings:
-        qu_config = MagicMock()
-        qu_config.url = "https://www.quantunicorn.com/products#qu100"
-        qu_config.login_url = "https://www.quantunicorn.com/signin"
-        qu_config.session_file = "./data/auth/qu_session.json"
-        qu_config.session_ttl_hours = 12
-        qu_config.timeout_ms = 30000
-        qu_config.backfill_delay_seconds = 2.0
-        mock_settings.return_value.scraping.quantunicorn = qu_config
-        scraper = QUScraper(mock_browser)
-
-    return scraper
+    # CDP mode by default for this file's auth-flow tests.
+    return make_scraper(mock_browser=mock_browser, is_cdp=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scrapers/test_cdp_cf_recovery.py
+++ b/tests/test_scrapers/test_cdp_cf_recovery.py
@@ -15,61 +15,16 @@ Test matrix:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from rainier.scrapers.qu.scraper import QUScraper
-
-
-def _make_mock_page(
-    url: str = "https://www.quantunicorn.com/products#qu100",
-    titles: list[str] | None = None,
-):
-    """Mock Page where successive .title() calls return entries from `titles`.
-
-    On the (n+1)th call, the last value is repeated — so a list of
-    ["Just a moment...", "QuantUnicorn"] gives the CF page first and
-    every subsequent title check resolves cleanly.
-    """
-    page = AsyncMock()
-    page_url = {"value": url}
-    type(page).url = PropertyMock(side_effect=lambda: page_url["value"])
-
-    titles = titles or ["QU100"]
-    title_idx = {"n": 0}
-
-    async def fake_title():
-        idx = min(title_idx["n"], len(titles) - 1)
-        title_idx["n"] += 1
-        return titles[idx]
-
-    page.title = AsyncMock(side_effect=fake_title)
-    page.context = AsyncMock()
-    page.context.add_cookies = AsyncMock()
-    # Table query: return a truthy element so the post-CF path early-returns
-    # at "table already loaded".
-    page.query_selector = AsyncMock(return_value=AsyncMock())
-    page.wait_for_selector = AsyncMock(return_value=AsyncMock())
-    page.wait_for_load_state = AsyncMock()
-    page.wait_for_function = AsyncMock()
-    page.goto = AsyncMock(side_effect=lambda u, **kw: page_url.update(value=u))
-    return page, page_url
+from .conftest import make_mock_page as _make_mock_page
+from .conftest import make_scraper
 
 
 def _make_scraper():
-    mock_browser = MagicMock()
-    mock_browser._is_cdp = True
-    with patch("rainier.scrapers.qu.scraper.get_settings") as mock_settings:
-        qu_config = MagicMock()
-        qu_config.url = "https://www.quantunicorn.com/products#qu100"
-        qu_config.login_url = "https://www.quantunicorn.com/signin"
-        qu_config.session_file = "./data/auth/qu_session.json"
-        qu_config.session_ttl_hours = 12
-        qu_config.timeout_ms = 30000
-        qu_config.backfill_delay_seconds = 2.0
-        mock_settings.return_value.scraping.quantunicorn = qu_config
-        return QUScraper(mock_browser)
+    return make_scraper(is_cdp=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scrapers/test_qu_api_retry.py
+++ b/tests/test_scrapers/test_qu_api_retry.py
@@ -13,29 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rainier.scrapers.qu.scraper import QUScraper
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_scraper(is_cdp: bool = False) -> QUScraper:
-    mock_browser = MagicMock()
-    mock_browser._is_cdp = is_cdp
-
-    with patch("rainier.scrapers.qu.scraper.get_settings") as mock_settings:
-        qu_config = MagicMock()
-        qu_config.url = "https://www.quantunicorn.com/products#qu100"
-        qu_config.login_url = "https://www.quantunicorn.com/signin"
-        qu_config.session_file = "./data/auth/qu_session.json"
-        qu_config.session_ttl_hours = 12
-        qu_config.timeout_ms = 30000
-        qu_config.backfill_delay_seconds = 2.0
-        mock_settings.return_value.scraping.quantunicorn = qu_config
-        scraper = QUScraper(mock_browser)
-    return scraper
-
+from .conftest import make_scraper as _make_scraper
 
 # ---------------------------------------------------------------------------
 # Unit tests on QUScraper._fetch_qu_api

--- a/tests/test_scrapers/test_scraper_in_page_fetch.py
+++ b/tests/test_scrapers/test_scraper_in_page_fetch.py
@@ -16,12 +16,15 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from rainier.scrapers.qu import selectors as sel
 from rainier.scrapers.qu.scraper import QUScraper
+
+from .conftest import make_mock_page
+from .conftest import make_scraper as _make_scraper
 
 FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures"
 
@@ -36,35 +39,10 @@ def _load_fixture(name: str) -> dict:
 
 
 def _make_mock_page(url: str = "https://www.quantunicorn.com/products#qu100") -> MagicMock:
-    page = AsyncMock()
-    page_url = {"value": url}
-    type(page).url = PropertyMock(side_effect=lambda: page_url["value"])
-    page.title = AsyncMock(return_value="QU100")
-    page.context = AsyncMock()
-    page.context.add_cookies = AsyncMock()
-    page.query_selector = AsyncMock(return_value=AsyncMock())
-    page.wait_for_selector = AsyncMock(return_value=AsyncMock())
-    page.wait_for_load_state = AsyncMock()
-    page.goto = AsyncMock(side_effect=lambda u, **kw: page_url.update(value=u))
+    # This file's call sites want only the page; the shared helper returns
+    # ``(page, page_url)`` — drop the page_url here to keep call sites unchanged.
+    page, _ = make_mock_page(url=url)
     return page
-
-
-def _make_scraper(mock_browser: MagicMock | None = None) -> QUScraper:
-    if mock_browser is None:
-        mock_browser = MagicMock()
-        mock_browser._is_cdp = False
-
-    with patch("rainier.scrapers.qu.scraper.get_settings") as mock_settings:
-        qu_config = MagicMock()
-        qu_config.url = "https://www.quantunicorn.com/products#qu100"
-        qu_config.login_url = "https://www.quantunicorn.com/signin"
-        qu_config.session_file = "./data/auth/qu_session.json"
-        qu_config.session_ttl_hours = 12
-        qu_config.timeout_ms = 30000
-        qu_config.backfill_delay_seconds = 2.0
-        mock_settings.return_value.scraping.quantunicorn = qu_config
-        scraper = QUScraper(mock_browser)
-    return scraper
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scrapers/test_verify_session.py
+++ b/tests/test_scrapers/test_verify_session.py
@@ -16,43 +16,12 @@ These tests pin the new behavior:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from rainier.scrapers.qu.scraper import QUScraper
-
-
-def _make_mock_page(url: str = "https://www.quantunicorn.com/products#qu100"):
-    """Mock Playwright Page that lets tests mutate `.url` mid-flow."""
-    page = AsyncMock()
-    page_url = {"value": url}
-    type(page).url = PropertyMock(side_effect=lambda: page_url["value"])
-    page.title = AsyncMock(return_value="QU100")
-    page.context = AsyncMock()
-    page.context.add_cookies = AsyncMock()
-    page.query_selector = AsyncMock(return_value=AsyncMock())
-    page.wait_for_selector = AsyncMock(return_value=AsyncMock())
-    page.wait_for_load_state = AsyncMock()
-    page.goto = AsyncMock(side_effect=lambda u, **kw: page_url.update(value=u))
-    return page, page_url
-
-
-def _make_scraper():
-    """QUScraper with mocked browser + settings; launch mode (not CDP)."""
-    mock_browser = MagicMock()
-    mock_browser._is_cdp = False
-    with patch("rainier.scrapers.qu.scraper.get_settings") as mock_settings:
-        qu_config = MagicMock()
-        qu_config.url = "https://www.quantunicorn.com/products#qu100"
-        qu_config.login_url = "https://www.quantunicorn.com/signin"
-        qu_config.session_file = "./data/auth/qu_session.json"
-        qu_config.session_ttl_hours = 12
-        qu_config.timeout_ms = 30000
-        qu_config.backfill_delay_seconds = 2.0
-        mock_settings.return_value.scraping.quantunicorn = qu_config
-        return QUScraper(mock_browser)
-
+from .conftest import make_mock_page as _make_mock_page
+from .conftest import make_scraper as _make_scraper
 
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Slim audit R5: extract shared `make_scraper`/`make_mock_page` into `tests/test_scrapers/conftest.py`; update 5 scraper test files to use them. Net -158 test LOC. The divergent `fake_goto`/`fake_fetch` closures were left in place (not force-merged). Behavior-preserving.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 2)
- Verified point-by-point: per-file is_cdp defaults, query_selector/return-shape/title variants all preserved; no assertion weakened; 1344 passed / 154 skipped (matches baseline); out-of-scope test_db_* fake_fetch untouched.

## Parent
- docs/DESIGN-rainier-slim-audit.md (PR #120)

## Test plan
- [ ] CI green (1344 passed locally)