### PR TITLE
docs: fix CLAUDE.md ORM table count (10→19) + dashboard status (slim R8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Rainier — trading analysis platform combining futures price action (Xiaojiang 
 ```
 src/rainier/
 ├── core/           types.py (shared dataclasses), protocols.py (boundary contracts),
-│                   config.py (unified Pydantic), models.py (10 ORM tables), database.py (singleton + TimescaleDB)
+│                   config.py (unified Pydantic), models.py (19 ORM tables), database.py (singleton + TimescaleDB)
 ├── data/           provider.py (protocol), csv_provider.py, yfinance_provider.py
 ├── analysis/       analyzer.py (orchestrator), pivots.py, pinbar.py, sr_horizontal.py, sr_diagonal.py, bias.py, inside_bar.py
 ├── features/       extractor.py (AnalysisResult→ML features), labels.py (TradeRecord→training labels)
@@ -24,7 +24,7 @@ src/rainier/
 ├── scheduler/      jobs.py (cron.yaml → system crontab), service.py (APScheduler for scraping)
 ├── pipeline/       post_scrape.py (shared screen→persist→LLM thesis→Discord, used by cron CLI + scheduler)
 ├── trader/         (Phase 3 placeholder — IB TWS execution)
-└── dashboard/      (placeholder — Streamlit)
+└── dashboard/      app.py, render_etf.py, render_combined.py, data.py, actions.py (ETF + combined dashboards)
 ```
 
 ## Commands


### PR DESCRIPTION
## Summary
- Slim audit R8 (docs-only): CLAUDE.md ORM table count corrected 10→19 (verified: `grep -c __tablename__ core/models.py` == 19); `dashboard/` re-described from "(placeholder)" to its real files (it's fully built — render_etf.py ~949 LOC); `trader/` remains the only Phase-3 placeholder.
- Note: the 57 untracked docs/*.md live in the main checkout (another working tree), not this worktree, so tracking them is a separate operator action (gitignore already covers the .html companions).

## Review
- /review: passed (claude rounds: 1)
- codex review: passed (codex rounds: 2)

## Parent
- docs/DESIGN-rainier-slim-audit.md (PR #120)

## Test plan
- [ ] CI green (docs-only; ruff clean locally)