### PR TITLE
fix(qu100): schema-drift detector + regression tests + local stocks repair script

### DIFF
--- a/docs/HOTFIX-qu100-local-stocks-repair.md
+++ b/docs/HOTFIX-qu100-local-stocks-repair.md
@@ -37,8 +37,13 @@ notification: 400`) — secondary alerting bug (see Follow-ups).
 Idempotent, non-destructive (`stocks` is empty): `ADD COLUMN IF NOT EXISTS` the
 6 missing columns matching `core/models.py` Stock, set defaults/`NOT NULL` with
 guarded backfills, `symbol SET NOT NULL`, add the ORM's `ix_stocks_symbol`
-lookup index (the unique `stocks_symbol_key` already exists). Run inside one
-transaction. **Run only against `$LEGACY_DATABASE_URL`, never Neon.**
+lookup index (the unique `stocks_symbol_key` already exists). The observed stub
+**retained** `id`'s `nextval('stocks_id_seq')` default and `stocks_symbol_key`,
+and **no table FK-references `stocks`** — but the script also guards the `id`
+autoincrement default idempotently (restores a sequence only if missing) so a
+variant stub created as a plain `id INTEGER PRIMARY KEY` is also fully repaired
+(otherwise inserts would fail next on a NULL `id`). Run inside one transaction.
+**Run only against `$LEGACY_DATABASE_URL`, never Neon.**
 
 ### 2. Recreate the dropped `stock_prices`
 `uv run rainier db init` — `create_all` recreates the missing table (additive;

--- a/docs/HOTFIX-qu100-local-stocks-repair.md
+++ b/docs/HOTFIX-qu100-local-stocks-repair.md
@@ -1,0 +1,74 @@
+# HOTFIX — QU100 0-record P0: local `stocks` stub + drift detector
+
+- **Severity:** P0 — QU100 morning scrape (2026-06-03 08:45 PT) persisted **0 records**; pipeline silently broken.
+- **Scope:** local TimescaleDB (`$LEGACY_DATABASE_URL`, default `localhost:5432/rainier`). Neon (`$DATABASE_URL`) unaffected.
+- **Branch:** `hotfix/repair-local-stocks-schema`.
+
+## Diagnosis (evidence)
+
+`data/qu-scrape.log` for the 08:45 run: Chrome connected, login OK, data fetched
+(`qu100_data_date=2026-06-03`), then **persist failed** —
+`(psycopg2.errors.UndefinedColumn) column "name" of relation "stocks" does not
+exist` on `INSERT INTO stocks (symbol, name, sector, industry, is_active)` →
+`records_created=0`. **The scrape itself worked; only the DB write failed.**
+
+Live local schema (introspected 2026-06-03):
+
+| Table | State | ORM expects |
+|---|---|---|
+| `stocks` | **stub: `id`, `symbol` only, 0 rows** | 8 cols (`name`,`sector`,`industry`,`is_active`,`created_at`,`updated_at`) |
+| `stock_prices` | **dropped (does not exist)** | symbol-keyed hypertable |
+| `money_flow_snapshots` | intact, **8,300 rows** | — (QU100 history safe) |
+
+**Root cause:** the stock-prices migration work's *pre-fix* test fixtures ran
+against the shared local DB and clobbered `public` — codex iter-2 on that PR
+(#119) was exactly *"teardown used `DROP TABLE … CASCADE` on shared public
+tables"*. That left `stocks` a 2-col stub and `stock_prices` gone. The isolation
+fix shipped in #119 (throwaway schema), so it **won't recur** — but the local DB
+is already damaged. `db init` (`create_all`) is additive only and cannot repair
+an existing stubbed table, so the drift was invisible until the scrape failed.
+
+Why it was silent: the failure Discord alert **400'd** (`Failed to send Discord
+notification: 400`) — secondary alerting bug (see Follow-ups).
+
+## Fix
+
+### 1. Restore `stocks` — `scripts/repair_local_stocks_schema.sql`
+Idempotent, non-destructive (`stocks` is empty): `ADD COLUMN IF NOT EXISTS` the
+6 missing columns matching `core/models.py` Stock, set defaults/`NOT NULL` with
+guarded backfills, `symbol SET NOT NULL`, add the ORM's `ix_stocks_symbol`
+lookup index (the unique `stocks_symbol_key` already exists). Run inside one
+transaction. **Run only against `$LEGACY_DATABASE_URL`, never Neon.**
+
+### 2. Recreate the dropped `stock_prices`
+`uv run rainier db init` — `create_all` recreates the missing table (additive;
+won't touch the now-repaired `stocks` or the intact tables), `_create_hypertables`
+restores the hypertable. Yields the current symbol-keyed shape.
+
+### 3. Backfill today's data
+`uv run rainier scrape qu --session morning --cdp http://127.0.0.1:9222` →
+expect `records_created: 200` ×2, 0 errors. Re-runnable (snapshot table keyed on
+`captured_at`).
+
+## Regression guard — `core/schema_check.py` + `tests/test_schema_check.py`
+
+`check_schema_drift(engine)` compares `Base.metadata` to the live schema and
+returns `missing table:` / `missing column:` findings — drift `db init` can't
+see. Tests (`requires_postgres`) prove it flags the exact incident: fresh
+`create_all` → no drift; `stocks` missing `name` → flagged; `stock_prices`
+dropped → flagged; full 6-col stub → all reported. Verified: 4 passed against an
+isolated DB.
+
+## Rollback
+
+The repair only ADDs columns to an empty table; to undo, `ALTER TABLE stocks
+DROP COLUMN …` the 6 added columns (no data loss — table was empty). `db init`
+and the re-scrape are additive/idempotent.
+
+## Follow-ups (not in this hotfix)
+
+- **P1:** wire `check_schema_drift` into a `rainier db check` command + the scrape
+  preflight so drift fails loudly (would have caught this at 08:45).
+- **P1/P2:** fix the Discord failure-webhook (returning 400 → alerts silently lost).
+- Confirm no other shared-DB tables were stubbed beyond `stocks`/`stock_prices`
+  (introspection showed the rest intact).

--- a/scripts/repair_local_stocks_schema.sql
+++ b/scripts/repair_local_stocks_schema.sql
@@ -1,0 +1,70 @@
+-- repair_local_stocks_schema.sql
+-- ONE-OFF LOCAL REPAIR — not a numbered migration (the damage is local-DB only,
+-- caused by the stock-prices migration's pre-fix test fixtures clobbering the
+-- shared public schema; the isolation fix already shipped in PR #119).
+--
+-- Target: $LEGACY_DATABASE_URL (default local TimescaleDB localhost:5432/rainier).
+-- Do NOT run against Neon ($DATABASE_URL) — that store is unaffected.
+--
+-- Problem: public.stocks was reduced to a 2-column stub (id, symbol; 0 rows),
+-- so the QU100 scraper's `INSERT INTO stocks (symbol, name, sector, industry,
+-- is_active)` fails with `column "name" ... does not exist` and persists 0 rows.
+-- The actual QU100 history (money_flow_snapshots, 8300 rows) is intact.
+--
+-- This script restores stocks to the ORM shape (core/models.py:99 Stock).
+-- Idempotent: ADD COLUMN IF NOT EXISTS + guarded NOT NULL/DEFAULT, safe to
+-- re-run. Non-destructive: stocks is empty (0 rows) so backfill UPDATEs are
+-- no-ops; no existing data is touched.
+--
+-- Current stub state (verified 2026-06-03):
+--   columns: id INTEGER (PK stocks_pkey, NOT NULL), symbol VARCHAR(10) NULLABLE
+--   unique:  stocks_symbol_key on (symbol)   <- already present, FK-target ready
+--   missing: name, sector, industry, is_active, created_at, updated_at
+--
+-- ORM target (core/models.py Stock):
+--   name VARCHAR(255) NULL | sector VARCHAR(100) NULL | industry VARCHAR(200) NULL
+--   is_active BOOLEAN NOT NULL server_default true
+--   created_at TIMESTAMPTZ NOT NULL server_default now()
+--   updated_at TIMESTAMPTZ NOT NULL server_default now() (onupdate now() is ORM-side)
+--   symbol VARCHAR(10) NOT NULL unique index
+
+BEGIN;
+
+-- 1. add the missing columns (nullable first; defaults/NOT NULL applied below)
+ALTER TABLE stocks
+    ADD COLUMN IF NOT EXISTS name       VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS sector     VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS industry   VARCHAR(200),
+    ADD COLUMN IF NOT EXISTS is_active  BOOLEAN,
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;
+
+-- 2. is_active: default true, backfill any NULLs (0 rows), enforce NOT NULL
+ALTER TABLE stocks ALTER COLUMN is_active SET DEFAULT true;
+UPDATE stocks SET is_active = true WHERE is_active IS NULL;
+ALTER TABLE stocks ALTER COLUMN is_active SET NOT NULL;
+
+-- 3. created_at / updated_at: default now(), backfill NULLs, enforce NOT NULL
+ALTER TABLE stocks ALTER COLUMN created_at SET DEFAULT now();
+UPDATE stocks SET created_at = now() WHERE created_at IS NULL;
+ALTER TABLE stocks ALTER COLUMN created_at SET NOT NULL;
+
+ALTER TABLE stocks ALTER COLUMN updated_at SET DEFAULT now();
+UPDATE stocks SET updated_at = now() WHERE updated_at IS NULL;
+ALTER TABLE stocks ALTER COLUMN updated_at SET NOT NULL;
+
+-- 4. symbol: ORM is NOT NULL (stub left it nullable); 0 rows so safe to enforce
+ALTER TABLE stocks ALTER COLUMN symbol SET NOT NULL;
+
+-- 5. ORM declares index=True on symbol (separate from the unique constraint
+--    stocks_symbol_key, which already exists). Add the plain lookup index for
+--    parity; harmless if a unique index already covers it.
+CREATE INDEX IF NOT EXISTS ix_stocks_symbol ON stocks (symbol);
+
+COMMIT;
+
+-- Post-repair verification (run separately, read-only):
+--   \d stocks            -> 8 columns, symbol NOT NULL, is_active/created_at/updated_at NOT NULL
+--   then: uv run rainier db init        (recreates the dropped stock_prices hypertable; idempotent)
+--   then: uv run rainier scrape qu --session morning --cdp http://127.0.0.1:9222
+--         -> expect "records_created: 200" (top100) + 200 (bottom100), 0 errors

--- a/scripts/repair_local_stocks_schema.sql
+++ b/scripts/repair_local_stocks_schema.sql
@@ -56,6 +56,25 @@ ALTER TABLE stocks ALTER COLUMN updated_at SET NOT NULL;
 -- 4. symbol: ORM is NOT NULL (stub left it nullable); 0 rows so safe to enforce
 ALTER TABLE stocks ALTER COLUMN symbol SET NOT NULL;
 
+-- 4b. id autoincrement default. The ORM declares id SERIAL (autoincrement) and
+--     all insert paths (scraper, Stock(...)) OMIT id, relying on a server
+--     default. The observed stub RETAINED nextval('stocks_id_seq'), but a
+--     variant stub created as a plain `id INTEGER PRIMARY KEY` would have no
+--     default and every insert would then fail on a NULL id. Guard
+--     idempotently: only act if the default is missing; harmless otherwise.
+DO $$
+BEGIN
+    IF (SELECT column_default
+          FROM information_schema.columns
+         WHERE table_name = 'stocks' AND column_name = 'id') IS NULL THEN
+        CREATE SEQUENCE IF NOT EXISTS stocks_id_seq OWNED BY stocks.id;
+        ALTER TABLE stocks ALTER COLUMN id SET DEFAULT nextval('stocks_id_seq');
+        -- advance past any existing ids (table is empty here -> next id = 1)
+        PERFORM setval('stocks_id_seq', COALESCE((SELECT MAX(id) FROM stocks), 0) + 1, false);
+    END IF;
+END
+$$;
+
 -- 5. ORM declares index=True on symbol (separate from the unique constraint
 --    stocks_symbol_key, which already exists). Add the plain lookup index for
 --    parity; harmless if a unique index already covers it.

--- a/src/rainier/core/schema_check.py
+++ b/src/rainier/core/schema_check.py
@@ -1,0 +1,49 @@
+"""Detect drift between the legacy ORM (``core/models.py`` Base) and a live DB.
+
+Motivation — the 2026-06-03 QU100 P0: the shared local ``stocks`` table was
+reduced to a 2-column stub (``id``, ``symbol``) by a buggy migration-test
+fixture. The QU scraper's ``INSERT INTO stocks (symbol, name, sector, ...)``
+then failed with ``column "name" ... does not exist`` and persisted 0 rows —
+silently, because the failure Discord alert also errored.
+
+``db init`` (``Base.metadata.create_all``) is **additive only**: it creates
+MISSING tables but never ALTERs an existing table to add columns, so a stubbed
+or drifted table is invisible to it. This module compares ``Base.metadata`` to
+the live schema and reports missing tables/columns so drift is caught loudly
+(e.g. a ``rainier db check`` preflight) instead of as a silent zero-row scrape.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import inspect
+from sqlalchemy.engine import Engine
+
+from rainier.core.models import Base
+
+
+def check_schema_drift(engine: Engine) -> list[str]:
+    """Compare the legacy ORM to ``engine``'s live schema.
+
+    Returns a list of human-readable findings, each one of:
+
+      * ``"missing table: <name>"``
+      * ``"missing column: <table>.<column>"``
+
+    An empty list means the live schema satisfies every ORM-declared table and
+    column. Extra (DB-only) tables/columns are intentionally NOT reported: the
+    ORM is the contract, and a shared instance may legitimately carry tables the
+    legacy models don't declare. Findings are ordered by ORM table-definition
+    order (tables before their columns) for stable output.
+    """
+    insp = inspect(engine)
+    existing_tables = set(insp.get_table_names())
+    findings: list[str] = []
+    for table_name, table in Base.metadata.tables.items():
+        if table_name not in existing_tables:
+            findings.append(f"missing table: {table_name}")
+            continue
+        live_cols = {col["name"] for col in insp.get_columns(table_name)}
+        for column in table.columns:
+            if column.name not in live_cols:
+                findings.append(f"missing column: {table_name}.{column.name}")
+    return findings

--- a/tests/test_schema_check.py
+++ b/tests/test_schema_check.py
@@ -58,18 +58,37 @@ def legacy_db_url(request):
 
 @pytest.fixture
 def legacy_engine(legacy_db_url):
-    """A legacy-ORM-initialized engine. Drops + create_all for a clean slate
-    (RAINIER_TEST_DATABASE_URL may point at a reused DB), tears down after."""
+    """A legacy-ORM-initialized engine on an ISOLATED throwaway database.
+
+    NEVER runs ``drop_all`` against the provided URL — that is exactly the
+    shared-DB clobbering this hotfix exists to prevent (and how the original
+    incident happened: the prior tests' ``RAINIER_TEST_DATABASE_URL`` pointed
+    at the live ``rainier`` DB). Instead we ``CREATE DATABASE`` a per-process
+    throwaway alongside it, ``create_all`` there, and ``DROP DATABASE`` it on
+    teardown — so even if the URL points at the live DB, its tables are
+    untouched.
+    """
+    from sqlalchemy.engine import make_url
+
     from rainier.core.models import Base
 
-    engine = create_engine(legacy_db_url)
-    Base.metadata.drop_all(engine)
+    base = make_url(legacy_db_url)
+    throwaway = f"schemacheck_test_{os.getpid()}"
+    # AUTOCOMMIT: CREATE/DROP DATABASE cannot run inside a transaction block.
+    admin = create_engine(legacy_db_url, isolation_level="AUTOCOMMIT")
+    with admin.connect() as conn:
+        conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{throwaway}"')
+        conn.exec_driver_sql(f'CREATE DATABASE "{throwaway}"')
+
+    engine = create_engine(base.set(database=throwaway))
     Base.metadata.create_all(engine)
     try:
         yield engine
     finally:
-        Base.metadata.drop_all(engine)
-        engine.dispose()
+        engine.dispose()  # release connections so DROP DATABASE can proceed
+        with admin.connect() as conn:
+            conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{throwaway}"')
+        admin.dispose()
 
 
 def test_fresh_create_all_has_no_drift(legacy_engine):

--- a/tests/test_schema_check.py
+++ b/tests/test_schema_check.py
@@ -77,6 +77,14 @@ def legacy_engine(legacy_db_url):
     # AUTOCOMMIT: CREATE/DROP DATABASE cannot run inside a transaction block.
     admin = create_engine(legacy_db_url, isolation_level="AUTOCOMMIT")
     with admin.connect() as conn:
+        # Managed/CI roles often lack CREATEDB. Skip gracefully rather than
+        # hard-failing setup when we can't isolate a throwaway database.
+        can_create = conn.exec_driver_sql(
+            "SELECT rolcreatedb OR rolsuper FROM pg_roles WHERE rolname = current_user"
+        ).scalar()
+        if not can_create:
+            admin.dispose()
+            pytest.skip("test role lacks CREATEDB; cannot isolate a throwaway database")
         conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{throwaway}"')
         conn.exec_driver_sql(f'CREATE DATABASE "{throwaway}"')
 

--- a/tests/test_schema_check.py
+++ b/tests/test_schema_check.py
@@ -1,0 +1,118 @@
+"""Regression tests for the schema-drift detector (``core/schema_check``).
+
+Guards the 2026-06-03 QU100 P0: the shared local ``stocks`` table was silently
+reduced to a 2-column stub (``id``, ``symbol``), so the scraper's
+``INSERT INTO stocks (symbol, name, ...)`` failed with ``column "name" ...
+does not exist`` and persisted 0 rows. ``db init`` couldn't detect it
+(``create_all`` is additive only). ``check_schema_drift`` makes such drift
+visible; these tests prove it flags exactly that incident.
+
+Gated on ``requires_postgres`` — needs a real Postgres to ``create_all`` the
+legacy ORM and introspect it (SQLite can't represent JSONB/TIMESTAMPTZ defs).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import create_engine, text
+
+pytestmark = pytest.mark.requires_postgres
+
+try:
+    from pytest_postgresql import factories as _pg_factories
+
+    _HAS_PYTEST_POSTGRESQL = True
+except ImportError:  # pragma: no cover
+    _HAS_PYTEST_POSTGRESQL = False
+
+
+def _local_pg_binary_available() -> bool:
+    import shutil
+
+    return shutil.which("pg_config") is not None and shutil.which("initdb") is not None
+
+
+if _HAS_PYTEST_POSTGRESQL and _local_pg_binary_available():
+    postgresql_proc = _pg_factories.postgresql_proc(port=None, unixsocketdir="/tmp")
+    postgresql = _pg_factories.postgresql("postgresql_proc")
+
+
+@pytest.fixture
+def legacy_db_url(request):
+    """Clean Postgres URL. RAINIER_TEST_DATABASE_URL -> pytest-postgresql -> skip."""
+    env_url = os.environ.get("RAINIER_TEST_DATABASE_URL")
+    if env_url:
+        return env_url
+    if not _HAS_PYTEST_POSTGRESQL:
+        pytest.skip("pytest-postgresql not installed")
+    if not _local_pg_binary_available():
+        pytest.skip("pg_config / initdb not on PATH; set RAINIER_TEST_DATABASE_URL")
+    pg = request.getfixturevalue("postgresql")
+    return (
+        f"postgresql+psycopg://{pg.info.user}@{pg.info.host}:{pg.info.port}"
+        f"/{pg.info.dbname}"
+    )
+
+
+@pytest.fixture
+def legacy_engine(legacy_db_url):
+    """A legacy-ORM-initialized engine. Drops + create_all for a clean slate
+    (RAINIER_TEST_DATABASE_URL may point at a reused DB), tears down after."""
+    from rainier.core.models import Base
+
+    engine = create_engine(legacy_db_url)
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def test_fresh_create_all_has_no_drift(legacy_engine):
+    """A freshly create_all'd legacy schema must report zero drift."""
+    from rainier.core.schema_check import check_schema_drift
+
+    assert check_schema_drift(legacy_engine) == []
+
+
+def test_detects_stub_stocks_missing_name(legacy_engine):
+    """THE regression for the 2026-06-03 QU100 P0: a ``stocks`` table missing
+    the ``name`` column (the exact stub state) must be flagged. Pre-detector
+    this drift was invisible and the scraper failed silently."""
+    from rainier.core.schema_check import check_schema_drift
+
+    with legacy_engine.begin() as conn:
+        conn.execute(text("ALTER TABLE stocks DROP COLUMN name"))
+
+    findings = check_schema_drift(legacy_engine)
+    assert "missing column: stocks.name" in findings
+
+
+def test_detects_dropped_table(legacy_engine):
+    """A wholly-dropped ORM table (e.g. the ``stock_prices`` the same incident
+    deleted) must be flagged as a missing table, not silently ignored."""
+    from rainier.core.schema_check import check_schema_drift
+
+    with legacy_engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS stock_prices CASCADE"))
+
+    findings = check_schema_drift(legacy_engine)
+    assert "missing table: stock_prices" in findings
+
+
+def test_multiple_stub_columns_all_reported(legacy_engine):
+    """The full stub (all 6 non-id/symbol columns dropped) reports each one,
+    so an operator sees the complete repair list, not just the first miss."""
+    from rainier.core.schema_check import check_schema_drift
+
+    with legacy_engine.begin() as conn:
+        for col in ("name", "sector", "industry", "is_active", "created_at", "updated_at"):
+            conn.execute(text(f"ALTER TABLE stocks DROP COLUMN {col}"))
+
+    findings = set(check_schema_drift(legacy_engine))
+    for col in ("name", "sector", "industry", "is_active", "created_at", "updated_at"):
+        assert f"missing column: stocks.{col}" in findings

--- a/tests/test_schema_check.py
+++ b/tests/test_schema_check.py
@@ -88,12 +88,18 @@ def legacy_engine(legacy_db_url):
         conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{throwaway}"')
         conn.exec_driver_sql(f'CREATE DATABASE "{throwaway}"')
 
-    engine = create_engine(base.set(database=throwaway))
-    Base.metadata.create_all(engine)
+    # create_engine + create_all are INSIDE the try so a failure there still
+    # drops the throwaway DB + disposes admin in finally (no leaked database /
+    # connection pool). pid-based naming + DROP IF EXISTS self-heals a prior
+    # same-pid crash leak on the next run.
+    engine = None
     try:
+        engine = create_engine(base.set(database=throwaway))
+        Base.metadata.create_all(engine)
         yield engine
     finally:
-        engine.dispose()  # release connections so DROP DATABASE can proceed
+        if engine is not None:
+            engine.dispose()  # release connections so DROP DATABASE can proceed
         with admin.connect() as conn:
             conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{throwaway}"')
         admin.dispose()


### PR DESCRIPTION
## Summary
Hotfix + permanent guard for the 2026-06-03 QU100 0-record P0 (a migration-test fixture clobbered the shared local DB: `stocks` → 2-col stub, `stock_prices` dropped, so the scraper persisted 0 records silently).

- **`src/rainier/core/schema_check.py`** — `check_schema_drift(engine)` compares the legacy ORM (`Base.metadata`) to the live schema, returning `missing table:` / `missing column:` findings that `db init` (additive-only `create_all`) can't detect. The permanent regression guard.
- **`tests/test_schema_check.py`** — 4 `requires_postgres` tests: fresh-create_all has no drift; stub `stocks` missing `name` is flagged (the exact incident); dropped `stock_prices` flagged; full 6-col stub all reported. Fixture isolates in a per-process throwaway DATABASE (never `drop_all`s the provided URL — that was the incident's own footgun), skips gracefully without CREATEDB.
- **`scripts/repair_local_stocks_schema.sql`** — idempotent, non-destructive repair restoring `stocks` to the ORM shape (incl. an `id`-sequence guard for variant stubs). One-off local repair (already applied to recover prod).
- **`docs/HOTFIX-qu100-local-stocks-repair.md`** — incident writeup + recovery + follow-ups.

## Review
- **codex review: passed** — 7 rounds; caught + fixed 2× P1 (drop_all-on-shared-DB → throwaway-DB isolation; missing `stocks.id` sequence guard) + 1 P2 (CREATEDB skip). Two consecutive clean.
- **/review: passed** — critical pass clean; specialist+adversarial pass found only P2/P3; fixed the one P2 (test-fixture leak: `create_engine`/`create_all` moved inside try/finally).

## Test plan
- [ ] CI green (4 schema-check tests skip without a CREATEDB-capable Postgres; pass against local TimescaleDB)
- [x] Repair script validated end-to-end against both documented + variant stubs; live DB recovered (200 records/day flowing)

## Follow-ups (not in this PR)
- Wire `check_schema_drift` into a `rainier db check` / scrape preflight (fail loud on drift)
- Fix the Discord failure-webhook 400 (why this P0 was silent)