### PR TITLE
fix: retire fengshen-publish crons — disable etf-dashboard-publish, strip publish tail from market-breadth-daily

### DIFF
--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -124,19 +124,19 @@ jobs:
   # pre-close compute pass — or this job would need to render the latest
   # available asof — for today's data to be ready at 12:40 PT.
   #
-  # Until that's reconciled, this job will hit the empty-render guard on
-  # weekdays and fire a Discord alert (loud-fail, not silent corruption).
-  # Operator decision: keep `enabled: true` so the empty-render alert
-  # surfaces the data-readiness gap; flip to `false` to suppress alerts
-  # during the transition. Fixing the timing belongs to a follow-up PR that
-  # owns the pre-close compute path; this PR only ships the publish chain.
+  # RETIRED 2026-06-03 (retire-fengshen-dashboar-aec0): fengshen's PG-backed
+  # /trading is now the canonical source, so this pure git-push-HTML publisher
+  # is dead weight (and caused daily "target working tree dirty" failures). The
+  # ETF PG write it depended on lives in `thematic-ranks-daily`, which STAYS
+  # enabled — so disabling this loses no market.* data. scripts/publish-etf-
+  # dashboard.sh is left on disk (unreferenced) for a later cleanup.
   - name: etf-dashboard-publish
-    description: "Render ETF ranks HTML + publish to fengshen.dev/trading/etf-ranks/"
+    description: "RETIRED — legacy ETF ranks publish to fengshen-site (PG write lives in thematic-ranks-daily)"
     schedule: "40 12 * * 1-5"   # 12:40 PST, Mon-Fri (20 min pre-close)
     command: "scripts/publish-etf-dashboard.sh"
     log: "data/etf-dashboard.log"
     discord_on_failure: true
-    enabled: true
+    enabled: false
 
   # S&P 500 breadth-webpage child series — daily OHLCV refresh.
   # docs/DESIGN-market-breadth-webpage.md §3.2.
@@ -164,31 +164,22 @@ jobs:
   # seeded (breadth dashboard is live). On a fresh host, run the one-shot seed
   # first or flip this back to `enabled: false` until the seed completes.
   - name: market-breadth-daily
-    description: "Refresh sp500 OHLCV + compute breadth indicators + render & publish market-breadth dashboard"
+    description: "Refresh sp500 OHLCV + compute breadth indicators (writes market.breadth_indicator_daily)"
     schedule: "45 12 * * 1-5"   # 12:45 PST Mon-Fri (15 min pre-close)
-    # Schedule rationale: `etf-dashboard-publish` runs at 12:40 PT and also
-    # invokes `scripts/publish-dashboard.sh` against the SAME fengshen-site
-    # checkout. If the two publishers raced, the second would see a dirty
-    # tree (publish-dashboard.sh:75 bails with "target working tree dirty
-    # — refusing to publish") and fire a spurious Discord alert. Staggering
-    # by 5 minutes gives the ETF publish chain time to commit + push before
-    # this job's `cd "$TARGET_DIR"` step runs.
+    # This job is COMPUTE-ONLY since 2026-06-03 (retire-fengshen-dashboar-aec0):
+    # the `&& scripts/publish-market-breadth.sh` tail was dropped because
+    # fengshen's PG-backed /trading is now the canonical source and no longer
+    # reads git-pushed HTML. The two compute steps are KEPT — they write
+    # market.breadth_indicator_daily, which fengshen reads.
     #
-    # Full chain (DESIGN-market-breadth-webpage.md §6):
+    # Compute chain (DESIGN-market-breadth-webpage.md §6, publish step retired):
     #   1. yfinance incremental refresh -> data/cache/sp500_universe.parquet
-    #   2. indicator recompute          -> data/cache/sp500_breadth_daily.parquet
-    #   3. render + publish             -> fengshen.dev/trading/market-breadth/
+    #   2. indicator recompute          -> market.breadth_indicator_daily
     #
     # `&&` enforces serial execution and propagates the first non-zero exit
     # to cron-wrapper.sh, which fires the Discord alert (discord_on_failure
-    # below). Render is gated behind compute so today's bar is always
-    # reflected in the published HTML; publish step is byte-stable (no-op
-    # commit when the rendered HTML matches what's already deployed).
-    #
-    # The publish-market-breadth.sh chain-wrapper exists to keep `%` chars
-    # off the crontab (cron treats `%` as a stdin marker); compute the
-    # rendered-at HH:MM inside the script.
-    command: "uv run rainier market-breadth backfill-ohlcv --incremental && uv run rainier market-breadth compute-indicators && scripts/publish-market-breadth.sh"
+    # below).
+    command: "uv run rainier market-breadth backfill-ohlcv --incremental && uv run rainier market-breadth compute-indicators"
     log: "data/market-breadth.log"
     discord_on_failure: true
     enabled: true

--- a/tests/test_cron_config.py
+++ b/tests/test_cron_config.py
@@ -1,0 +1,82 @@
+"""Cron-config invariants for config/cron.yaml.
+
+These assert the fengshen-publish retirement (task retire-fengshen-dashboar-aec0):
+the legacy git-push-HTML publish steps are retired while every market.* PG-write
+step is preserved. fengshen's PG-backed /trading is now the canonical source, so
+no enabled cron job may invoke a publish-*dashboard*.sh / publish-market-breadth.sh
+script (those git-push rendered HTML into the fengshen-site checkout and caused the
+daily "target working tree dirty" publish failures).
+
+Deterministic: parses the committed YAML with yaml.safe_load — no network, no cron
+install.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CRON_PATH = ROOT / "config" / "cron.yaml"
+
+# Any script that git-pushes rendered HTML into the fengshen-site checkout. None
+# of these may appear in an *enabled* job's command after the retirement.
+PUBLISH_SCRIPT_RE = re.compile(r"publish-(?:[a-z-]*dashboard|market-breadth)\.sh")
+
+
+@pytest.fixture(scope="module")
+def jobs() -> dict[str, dict]:
+    """Return {job_name: job_dict} parsed from the committed cron.yaml."""
+    data = yaml.safe_load(CRON_PATH.read_text())
+    return {job["name"]: job for job in data["jobs"]}
+
+
+def test_etf_dashboard_publish_disabled(jobs: dict[str, dict]) -> None:
+    """The pure-publish ETF job is retired (its PG write lives in thematic-ranks-daily)."""
+    assert jobs["etf-dashboard-publish"]["enabled"] is False
+
+
+def test_market_breadth_keeps_compute_drops_publish(jobs: dict[str, dict]) -> None:
+    """market-breadth-daily stays enabled and keeps both PG-write compute steps,
+    but no longer invokes the publish-market-breadth.sh tail."""
+    job = jobs["market-breadth-daily"]
+    assert job["enabled"] is True
+    cmd = job["command"]
+    assert "backfill-ohlcv" in cmd
+    assert "compute-indicators" in cmd
+    assert "publish-market-breadth.sh" not in cmd
+    assert not PUBLISH_SCRIPT_RE.search(cmd)
+
+
+def test_no_enabled_job_publishes_to_fengshen(jobs: dict[str, dict]) -> None:
+    """Net invariant: zero enabled jobs git-push HTML to fengshen-site."""
+    offenders = [
+        name
+        for name, job in jobs.items()
+        if job.get("enabled") and PUBLISH_SCRIPT_RE.search(job.get("command", ""))
+    ]
+    assert offenders == [], f"enabled jobs still invoke a fengshen publish script: {offenders}"
+
+
+def test_trading_dashboard_stays_disabled(jobs: dict[str, dict]) -> None:
+    """The combined-dashboard publisher was already disabled; verify it wasn't flipped on."""
+    assert jobs["trading-dashboard"]["enabled"] is False
+
+
+def test_pg_write_jobs_preserved(jobs: dict[str, dict]) -> None:
+    """The market.* PG-write producers fengshen reads from stay enabled + intact."""
+    thematic = jobs["thematic-ranks-daily"]
+    assert thematic["enabled"] is True
+    assert "thematic backfill" in thematic["command"]
+    assert "run-daily" in thematic["command"]
+
+    names = jobs["etf-names-refresh"]
+    assert names["enabled"] is True
+    assert "backfill-names" in names["command"]
+
+    breadth = jobs["market-breadth-daily"]
+    assert "backfill-ohlcv" in breadth["command"]
+    assert "compute-indicators" in breadth["command"]


### PR DESCRIPTION
## Summary
- Disable `etf-dashboard-publish` cron (`enabled: false`) — pure publish-to-fengshen; its ETF PG write lives in `thematic-ranks-daily`, which stays enabled.
- Strip the `&& scripts/publish-market-breadth.sh` tail off `market-breadth-daily` while KEEPING its PG-write compute steps (`backfill-ohlcv --incremental && compute-indicators` → `market.breadth_indicator_daily`, which fengshen reads). Description updated to "compute only".
- Net: zero git-pushes to fengshen-site; all `market.*` PG writes preserved. Also stops the daily "target working tree dirty" publish failures. `trading-dashboard` confirmed still `enabled: false`; `thematic-ranks-daily` + `etf-names-refresh` unchanged.

## Review
- /review: PASS (2 consecutive clean rounds).
- codex review (3 rounds): raised one **[P1]** — now that fengshen `/trading` reads PG canonically, a *silent* PG-mirror failure (`mirror_guard` exits 0 by design, DESIGN-mirror-guard-loud-on-failure.md) yields a green cron + stale page + no alert. **Operator-reviewed and ACCEPTED as out-of-scope for this config-only retirement** (2026-06-04): net-neutral on the failure mechanism — the old parquet-based publish path also exited 0 on a silent PG failure — and codex's proposed fix (make the mirror fatal) would reverse the intentional `mirror_guard` exit-0 contract. **Deferred to P2 follow-up `breadth-pg-mirror-alert-b8cc`** (add a loud Discord alert on mirror failure, keeping exit 0).

## Test plan
- [x] 5 new deterministic cron-config tests pass (`tests/test_cron_config.py`); full scheduler+cron suite 30 passed; ruff clean.
- [ ] CI green

Deferred [P1]: PG-mirror fail-loud observability → `breadth-pg-mirror-alert-b8cc` (P2).