### PR TITLE
feat(paper): QU100-LLM feedback loop Phase 2 — calibration block + weekly lessons + discover_time_stop

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -168,7 +168,9 @@ llm_thesis:
   enabled: true
   model: "claude-sonnet-4-6"
   max_usd_per_scan: 1.0
-  prompt_version: "v1"
+  # v2: D7a calibration block. This runtime value is what builds the Tier-1
+  # cache key (not prompt.PROMPT_VERSION) — keep it == the module constant.
+  prompt_version: "v2"
   enabled_sessions:
     - afternoon
     - close

--- a/migrations/0007_paper_calibration.sql
+++ b/migrations/0007_paper_calibration.sql
@@ -1,0 +1,36 @@
+-- Migration 0007 — QU100 paper-trade calibration block (Phase 2, D7a)
+--
+-- Adds (on the LEGACY local-TimescaleDB engine — NOT Neon, see memory
+-- project_two_database_url_engines):
+--   * paper_calibration — one bounded calibration payload per as-of date.
+--     Written by the daily eval job AFTER run_paper_daily_report
+--     (scheduler/service.py). Read by build_user_message() to inject the
+--     calibration section into the LLM thesis prompt.
+--
+--     Plain Postgres table (NOT a hypertable): tiny row count (one row per
+--     trading day), keyed UNIQUE(as_of_date) so a same-day re-run upserts.
+--     The HEADLINE stats inside `payload` are the UNBIASED ThesisEvaluation
+--     fixed-horizon (1d/5d/10d) numbers (survivorship-free); the realized
+--     paper-trade record (K=10 closed + MTM-including-open) is labeled
+--     supplementary context. The compute lives in paper/calibration.py.
+--
+-- Apply with (POST-#115 the legacy public-schema tables live on
+-- LEGACY_DATABASE_URL, NOT DATABASE_URL which now points at Neon):
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0007_paper_calibration.sql
+--
+-- Idempotent: re-applying is safe (IF NOT EXISTS throughout). market.* and
+-- every other public table are untouched.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS paper_calibration (
+    id          BIGSERIAL PRIMARY KEY,
+    as_of_date  DATE NOT NULL,
+    payload     JSONB NOT NULL,
+    created_at  TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT uq_paper_calibration_as_of_date UNIQUE (as_of_date)
+);
+
+COMMIT;
+
+-- Downgrade lives in migrations/0007_paper_calibration_downgrade.sql.

--- a/migrations/0007_paper_calibration_downgrade.sql
+++ b/migrations/0007_paper_calibration_downgrade.sql
@@ -1,0 +1,15 @@
+-- Migration 0007 DOWNGRADE — reverses 0007_paper_calibration.sql.
+--
+-- Drops EXACTLY: paper_calibration (+ its unique constraint). market.* and
+-- every other public table are untouched.
+--
+-- Apply with:
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0007_paper_calibration_downgrade.sql
+--
+-- Idempotent: re-applying is safe (IF EXISTS).
+
+BEGIN;
+
+DROP TABLE IF EXISTS paper_calibration;
+
+COMMIT;

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -303,7 +303,12 @@ class LLMThesisConfig(BaseModel):
     enabled: bool = True
     model: str = "claude-sonnet-4-6"
     max_usd_per_scan: float = 1.0
-    prompt_version: str = "v1"
+    # Bumped v1->v2 with the D7a calibration block. The Tier-1 cache key is built
+    # from THIS runtime value (service.generate_thesis reads
+    # settings.llm_thesis.prompt_version), so it must track prompt.PROMPT_VERSION
+    # — the module constant alone never busts the cache. Keep the two in lockstep
+    # (test_prompt_version_config_tracks_module guards the invariant).
+    prompt_version: str = "v2"
     enabled_sessions: list[str] = Field(
         default_factory=lambda: ["afternoon", "close"]
     )

--- a/src/rainier/core/models.py
+++ b/src/rainier/core/models.py
@@ -730,6 +730,34 @@ class PaperReportSnapshot(Base):
     )
 
 
+class PaperCalibration(Base):
+    """Bounded calibration block injected into the LLM thesis prompt (D7a).
+
+    One row per as-of date, written by the daily eval job AFTER the paper
+    daily report. `payload` is a bounded JSONB blob whose HEADLINE stats are
+    the UNBIASED `ThesisEvaluation` fixed-horizon (1d/5d/10d) close-to-close
+    numbers (survivorship-free), with the realized paper-trade record (last
+    K=10 closed + MTM-including-open) carried as labeled supplementary
+    context. `build_user_message()` reads the latest row and renders it into
+    the prompt so the LLM sees how its prior calls actually graded out.
+
+    Plain Postgres, tiny row count (one per trading day). NOT a hypertable.
+    """
+
+    __tablename__ = "paper_calibration"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    as_of_date: Mapped[date] = mapped_column(Date, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint("as_of_date", name="uq_paper_calibration_as_of_date"),
+    )
+
+
 # Tables to convert to TimescaleDB hypertables
 HYPERTABLES = {
     "money_flow_snapshots": "captured_at",

--- a/src/rainier/llm_thesis/prompt.py
+++ b/src/rainier/llm_thesis/prompt.py
@@ -7,7 +7,11 @@ historical replay / A/B comparison.
 
 from __future__ import annotations
 
-PROMPT_VERSION = "v1"
+# v2 (Phase 2, D7a): adds the calibration section to the user message. The
+# calibration text is INVISIBLE to compute_input_hash (it hashes only the
+# EvidencePack + image), so the Tier-1 cache — keyed on prompt_version — would
+# otherwise serve a pre-calibration thesis. Bumping the version busts Tier-1.
+PROMPT_VERSION = "v2"
 
 OUTPUT_SCHEMA = """{
   "verdict": "setup_long" | "watch" | "no_setup",
@@ -86,11 +90,18 @@ def build_user_message(
     session_name: str,
     candidate_summary: str,
     signal_renders: list[str],
+    calibration_section: str = "",
 ) -> str:
     """Stitch the per-call evidence into the user-side prompt.
 
     `signal_renders` is the list of `signal.render_for_prompt(value)` strings for
     every enabled signal that produced a non-None value. Order is REGISTRY order.
+
+    `calibration_section` (D7a) is a bounded, pre-rendered block describing how
+    prior theses graded out (unbiased fixed-horizon headline + labeled realized
+    supplementary). Empty string = nothing to inject (Phase-0 / fresh DB). NOTE:
+    this text does NOT enter `compute_input_hash` (Tier-2), so PROMPT_VERSION is
+    bumped to bust the Tier-1 cache whenever this block's shape changes.
     """
     body = (
         f"Symbol: {symbol}\n"
@@ -103,5 +114,7 @@ def build_user_message(
         body += "\n".join(f"- {s}" for s in signal_renders)
     else:
         body += "(no signals produced non-None values)"
+    if calibration_section:
+        body += f"\n\n{calibration_section}"
     body += "\n\nProduce the JSON object now."
     return body

--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -917,14 +917,25 @@ def _day_k_exit_return(
         key=lambda r: r[0],
     )
     if exit_day == k:
-        # Locate the k-th priced (non-NULL-OHLC) session and resolve the level.
+        # Locate the k-th priced (non-NULL-OHLC) session and resolve the level
+        # with evaluate_exit's exact precedence (exit.py): an OPEN that already
+        # gapped through a level fills AT THE OPEN before any intraday high/low
+        # is consulted; only then do intraday touches apply (same-bar SL+TP ->
+        # stop, F3 downward bias).
         session_n = 0
-        for _d, _o, high, low, _c in bars:
+        for _d, open_px, high, low, _c in bars:
             if high is None or low is None:
                 continue
             session_n += 1
             if session_n == k:
-                # Conservative: stop takes priority on a same-bar SL+TP hit.
+                # Open-gap fills first (at the open). stop_loss < target_price,
+                # so at most one applies.
+                if open_px is not None and open_px <= stop_loss:
+                    return (open_px - entry_price) / entry_price
+                if open_px is not None and open_px >= target_price:
+                    return (open_px - entry_price) / entry_price
+                # No open-gap: intraday touches. Stop takes priority on a
+                # same-bar SL+TP hit.
                 if low <= stop_loss:
                     return (stop_loss - entry_price) / entry_price
                 if high >= target_price:

--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -878,6 +878,64 @@ def _sl_tp_exit_day(
     return None
 
 
+def _day_k_exit_return(
+    price_rows: list[tuple[Any, float | None, float | None, float | None, float | None]],
+    entry_date: date,
+    entry_price: float,
+    stop_loss: float,
+    target_price: float,
+    k: int,
+    *,
+    as_of: date,
+) -> float | None:
+    """Return realized under a ``time_stop_days=k`` policy, MATCHING evaluate_exit's
+    same-session priority (codex iter-4 [P2]).
+
+    evaluate_exit checks SL/TP BEFORE the time-stop on the same session, so a
+    trade whose day-k bar touches stop/target exits at that LEVEL, not the day-k
+    close. We therefore:
+      * if SL/TP fires on a session < k → return None (caller already excludes
+        these from candidate k's survivor cohort);
+      * if SL/TP fires exactly on session k → score the LEVEL return (stop_loss
+        or target_price), conservatively resolving a same-bar SL+TP hit to the
+        stop (the F3 downward-bias convention evaluate_exit uses);
+      * otherwise (survives past k) → score the day-k close return.
+
+    None when the curve hasn't matured to day k (as-of guard).
+    """
+    exit_day = _sl_tp_exit_day(
+        price_rows, entry_date, stop_loss, target_price, as_of=as_of
+    )
+    if exit_day is not None and exit_day < k:
+        return None  # exited before k — not in candidate k's cohort
+    bars = sorted(
+        (
+            (_as_date_local(d), o, h, lo, c)
+            for (d, o, h, lo, c) in price_rows
+            if entry_date <= _as_date_local(d) <= as_of
+        ),
+        key=lambda r: r[0],
+    )
+    if exit_day == k:
+        # Locate the k-th priced (non-NULL-OHLC) session and resolve the level.
+        session_n = 0
+        for _d, _o, high, low, _c in bars:
+            if high is None or low is None:
+                continue
+            session_n += 1
+            if session_n == k:
+                # Conservative: stop takes priority on a same-bar SL+TP hit.
+                if low <= stop_loss:
+                    return (stop_loss - entry_price) / entry_price
+                if high >= target_price:
+                    return (target_price - entry_price) / entry_price
+                break
+    curve = _return_by_holding_day(price_rows, entry_date, entry_price, as_of=as_of)
+    if len(curve) < k:
+        return None
+    return curve[k - 1]
+
+
 def _sharpe_like(returns: list[float]) -> float | None:
     """Risk-adjusted objective (design ★): mean / population-std of the by-day
     returns at candidate `k`. NOT mean return — the gate is return PER UNIT of
@@ -997,20 +1055,19 @@ def discover_time_stop(
         cohort_returns: list[float] = []
         survivors = 0
         for t in trades:
-            exit_day = _sl_tp_exit_day(
-                t["price_rows"], t["entry_date"], t["stop_loss"],
-                t["target_price"], as_of=anchor,
+            # Score with evaluate_exit's same-session SL/TP-before-time-stop
+            # priority (codex iter-4 [P2]): a day-k bar that touches stop/target
+            # exits at that LEVEL, not the day-k close. Returns None when the
+            # trade exited strictly before k (excluded from candidate k's
+            # survivor cohort) or hasn't matured to day k (as-of guard).
+            ret_k = _day_k_exit_return(
+                t["price_rows"], t["entry_date"], t["entry_price"],
+                t["stop_loss"], t["target_price"], k, as_of=anchor,
             )
-            # Excluded from candidate k if it SL/TP-exited strictly BEFORE day k.
-            if exit_day is not None and exit_day < k:
+            if ret_k is None:
                 continue
-            curve = _return_by_holding_day(
-                t["price_rows"], t["entry_date"], t["entry_price"], as_of=anchor
-            )
-            if len(curve) < k:
-                continue  # not matured to day k yet (as-of guard)
             survivors += 1
-            cohort_returns.append(curve[k - 1])
+            cohort_returns.append(ret_k)
         if survivors < min_survivors:
             continue
         obj = _sharpe_like(cohort_returns)

--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -809,6 +809,17 @@ TIME_STOP_SUBJECT = "paper_time_stop"
 TIME_STOP_STABLE_RUNS = 2
 
 
+def _is_priced_session(high: Any, low: Any, close: Any) -> bool:
+    """A bar counts as ONE holding session iff its high, low AND close are all
+    present (codex iter-6 [P2]). Unifying the rule across _return_by_holding_day
+    and _sl_tp_exit_day keeps session numbering identical between the exit-day
+    detector and the return curve — otherwise a partial OHLC bar (e.g. high/low
+    present but close NULL) would advance one helper's counter but not the
+    other's, shifting the k-th session and mis-scoring the candidate horizon.
+    (open may be NULL — evaluate_exit simply skips the open-gap check then.)"""
+    return high is not None and low is not None and close is not None
+
+
 def _return_by_holding_day(
     price_rows: list[tuple[Any, float | None, float | None, float | None, float | None]],
     entry_date: date,
@@ -818,7 +829,8 @@ def _return_by_holding_day(
 ) -> list[float]:
     """Reconstruct the close-to-entry return at each holding day (entry day =
     day 1), from entry_date forward, using only bars in [entry_date, as_of]
-    (as-of guard — no hindsight). NULL-close days are skipped (no phantom day).
+    (as-of guard — no hindsight). Partial-OHLC days are skipped (no phantom day)
+    using the SAME predicate as _sl_tp_exit_day so session numbers stay aligned.
 
     Returns a list where index i = return_pct after holding through the (i+1)th
     priced session.
@@ -832,8 +844,8 @@ def _return_by_holding_day(
         key=lambda r: r[0],
     )
     out: list[float] = []
-    for _d, _o, _h, _lo, close in bars:
-        if close is None:
+    for _d, _o, high, low, close in bars:
+        if not _is_priced_session(high, low, close):
             continue
         out.append((float(close) - entry_price) / entry_price)
     return out
@@ -858,7 +870,8 @@ def _sl_tp_exit_day(
     candidate `k`: a trade exiting before day `k` is excluded from candidate `k`.
 
     Mirrors evaluate_exit's level rules (low<=stop, high>=target) walking
-    priced sessions; NULL-OHLC days are skipped and do not advance the counter.
+    priced sessions; partial-OHLC days are skipped (same _is_priced_session
+    predicate as the return curve) and do not advance the counter.
     """
     bars = sorted(
         (
@@ -869,8 +882,8 @@ def _sl_tp_exit_day(
         key=lambda r: r[0],
     )
     session_n = 0
-    for _d, _o, high, low, _c in bars:
-        if high is None or low is None:
+    for _d, _o, high, low, close in bars:
+        if not _is_priced_session(high, low, close):
             continue
         session_n += 1
         if low <= stop_loss or high >= target_price:
@@ -923,8 +936,8 @@ def _day_k_exit_return(
         # is consulted; only then do intraday touches apply (same-bar SL+TP ->
         # stop, F3 downward bias).
         session_n = 0
-        for _d, open_px, high, low, _c in bars:
-            if high is None or low is None:
+        for _d, open_px, high, low, close in bars:
+            if not _is_priced_session(high, low, close):
                 continue
             session_n += 1
             if session_n == k:

--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -809,15 +809,17 @@ TIME_STOP_SUBJECT = "paper_time_stop"
 TIME_STOP_STABLE_RUNS = 2
 
 
-def _is_priced_session(high: Any, low: Any, close: Any) -> bool:
-    """A bar counts as ONE holding session iff its high, low AND close are all
-    present (codex iter-6 [P2]). Unifying the rule across _return_by_holding_day
-    and _sl_tp_exit_day keeps session numbering identical between the exit-day
-    detector and the return curve — otherwise a partial OHLC bar (e.g. high/low
-    present but close NULL) would advance one helper's counter but not the
-    other's, shifting the k-th session and mis-scoring the candidate horizon.
-    (open may be NULL — evaluate_exit simply skips the open-gap check then.)"""
-    return high is not None and low is not None and close is not None
+def _is_priced_session(high: Any, low: Any) -> bool:
+    """A bar counts as ONE holding session iff its high AND low are present —
+    EXACTLY evaluate_exit's rule (exit.py: it skips only when high/low is None
+    and advances the session counter on everything else, regardless of close).
+    Unifying on this single predicate across _return_by_holding_day,
+    _sl_tp_exit_day and _day_k_exit_return keeps session numbering identical to
+    the production exit engine even on partial-OHLC bars (codex iter-6/iter-7
+    [P2]). close is NOT required to count — a NULL-close session still counts;
+    the return curve falls back to entry_price (0%) for it, matching the
+    evaluate_exit time-stop close fallback (exit.py:129)."""
+    return high is not None and low is not None
 
 
 def _return_by_holding_day(
@@ -829,8 +831,11 @@ def _return_by_holding_day(
 ) -> list[float]:
     """Reconstruct the close-to-entry return at each holding day (entry day =
     day 1), from entry_date forward, using only bars in [entry_date, as_of]
-    (as-of guard — no hindsight). Partial-OHLC days are skipped (no phantom day)
-    using the SAME predicate as _sl_tp_exit_day so session numbers stay aligned.
+    (as-of guard — no hindsight). Sessions are counted on high/low presence
+    (same _is_priced_session predicate as _sl_tp_exit_day, mirroring
+    evaluate_exit). A counted session whose close is NULL contributes a 0%
+    (entry_price fallback) return — exactly evaluate_exit's missing-close
+    time-stop behaviour (exit.py:129) — so session numbers stay aligned.
 
     Returns a list where index i = return_pct after holding through the (i+1)th
     priced session.
@@ -845,9 +850,12 @@ def _return_by_holding_day(
     )
     out: list[float] = []
     for _d, _o, high, low, close in bars:
-        if not _is_priced_session(high, low, close):
+        if not _is_priced_session(high, low):
             continue
-        out.append((float(close) - entry_price) / entry_price)
+        # Missing close on a counted session → entry_price fallback (0% return),
+        # matching evaluate_exit's time-stop close handling.
+        px = float(close) if close is not None else entry_price
+        out.append((px - entry_price) / entry_price)
     return out
 
 
@@ -882,8 +890,8 @@ def _sl_tp_exit_day(
         key=lambda r: r[0],
     )
     session_n = 0
-    for _d, _o, high, low, close in bars:
-        if not _is_priced_session(high, low, close):
+    for _d, _o, high, low, _close in bars:
+        if not _is_priced_session(high, low):
             continue
         session_n += 1
         if low <= stop_loss or high >= target_price:
@@ -936,8 +944,8 @@ def _day_k_exit_return(
         # is consulted; only then do intraday touches apply (same-bar SL+TP ->
         # stop, F3 downward bias).
         session_n = 0
-        for _d, open_px, high, low, close in bars:
-            if not _is_priced_session(high, low, close):
+        for _d, open_px, high, low, _close in bars:
+            if not _is_priced_session(high, low):
                 continue
             session_n += 1
             if session_n == k:

--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -67,6 +67,12 @@ INSIGHT_KINDS: tuple[str, ...] = (
     "calibration_off",
     "prompt_regression",
     "new_pattern_discovered",
+    # Phase 2 (D6): the learned force-exit horizon discovered by
+    # discover_time_stop. Recommend-only — action set_learned_time_stop_days.
+    "time_stop_discovered",
+    # Phase 2 (D7c): weekly human-readable lessons from the paper-trade record.
+    # info/noop — feedable into the prompt later.
+    "paper_lessons",
 )
 
 SEVERITIES: tuple[str, ...] = ("info", "warn", "critical")
@@ -792,6 +798,377 @@ def check_prompt_regression(
 
 
 # ---------------------------------------------------------------------------
+# D6 — discover_time_stop (learn the force-exit horizon; recommend-only)
+# ---------------------------------------------------------------------------
+
+# Subject is fixed so re-emission UPSERTs onto one pending row (stability is
+# tracked in evidence across weekly runs, not via duplicate rows).
+TIME_STOP_SUBJECT = "paper_time_stop"
+# A chosen `k` must repeat across this many consecutive weekly runs before the
+# action flips from recommend-only (noop) to executable (set_learned_time_stop_days).
+TIME_STOP_STABLE_RUNS = 2
+
+
+def _return_by_holding_day(
+    price_rows: list[tuple[Any, float | None, float | None, float | None, float | None]],
+    entry_date: date,
+    entry_price: float,
+    *,
+    as_of: date,
+) -> list[float]:
+    """Reconstruct the close-to-entry return at each holding day (entry day =
+    day 1), from entry_date forward, using only bars in [entry_date, as_of]
+    (as-of guard — no hindsight). NULL-close days are skipped (no phantom day).
+
+    Returns a list where index i = return_pct after holding through the (i+1)th
+    priced session.
+    """
+    bars = sorted(
+        (
+            (_as_date_local(d), o, h, lo, c)
+            for (d, o, h, lo, c) in price_rows
+            if entry_date <= _as_date_local(d) <= as_of
+        ),
+        key=lambda r: r[0],
+    )
+    out: list[float] = []
+    for _d, _o, _h, _lo, close in bars:
+        if close is None:
+            continue
+        out.append((float(close) - entry_price) / entry_price)
+    return out
+
+
+def _as_date_local(d: Any) -> date:
+    if isinstance(d, datetime):
+        return d.date()
+    return d
+
+
+def _sl_tp_exit_day(
+    price_rows: list[tuple[Any, float | None, float | None, float | None, float | None]],
+    entry_date: date,
+    stop_loss: float,
+    target_price: float,
+    *,
+    as_of: date,
+) -> int | None:
+    """The 1-based holding day a trade SL/TP-exits, or None if it never does
+    within [entry_date, as_of]. Used to build the SURVIVOR cohort for each
+    candidate `k`: a trade exiting before day `k` is excluded from candidate `k`.
+
+    Mirrors evaluate_exit's level rules (low<=stop, high>=target) walking
+    priced sessions; NULL-OHLC days are skipped and do not advance the counter.
+    """
+    bars = sorted(
+        (
+            (_as_date_local(d), o, h, lo, c)
+            for (d, o, h, lo, c) in price_rows
+            if entry_date <= _as_date_local(d) <= as_of
+        ),
+        key=lambda r: r[0],
+    )
+    session_n = 0
+    for _d, _o, high, low, _c in bars:
+        if high is None or low is None:
+            continue
+        session_n += 1
+        if low <= stop_loss or high >= target_price:
+            return session_n
+    return None
+
+
+def _sharpe_like(returns: list[float]) -> float | None:
+    """Risk-adjusted objective (design ★): mean / population-std of the by-day
+    returns at candidate `k`. NOT mean return — the gate is return PER UNIT of
+    dispersion, so a high-mean/high-variance `k` can lose to a lower-mean/tight
+    one. None when undefined (n<2 or zero dispersion)."""
+    n = len(returns)
+    if n < 2:
+        return None
+    mean = sum(returns) / n
+    var = sum((r - mean) ** 2 for r in returns) / n
+    std = var ** 0.5
+    if std == 0:
+        return None
+    return mean / std
+
+
+def _load_time_stop_trades(
+    as_of: date,
+) -> list[dict[str, Any]]:
+    """Pull each paper position's (entry, levels, entry-forward price rows) for
+    the curve reconstruction. Only filled positions (entry_date set) qualify."""
+    from rainier.core.models import PaperTrade, StockPrice
+    from rainier.paper.ingest import canonical_instant
+
+    trades: list[dict[str, Any]] = []
+    with get_session() as session:
+        positions = session.execute(
+            select(PaperTrade).where(PaperTrade.entry_date.isnot(None))
+        ).scalars().all()
+        meta = [
+            {
+                "id": p.id,
+                "symbol": p.symbol,
+                "entry_date": _as_date_local(p.entry_date),
+                "entry_price": p.entry_price,
+                "stop_loss": p.stop_loss,
+                "target_price": p.target_price,
+            }
+            for p in positions
+            if p.entry_price is not None
+        ]
+        for m in meta:
+            rows = session.execute(
+                select(
+                    StockPrice.date,
+                    StockPrice.open,
+                    StockPrice.high,
+                    StockPrice.low,
+                    StockPrice.close,
+                ).where(
+                    StockPrice.symbol == m["symbol"],
+                    StockPrice.date >= canonical_instant(m["entry_date"]),
+                    StockPrice.date <= canonical_instant(as_of),
+                )
+            ).all()
+            m["price_rows"] = [tuple(r) for r in rows]
+            trades.append(m)
+    return trades
+
+
+def _prior_time_stop_evidence(db_session=None) -> dict[str, Any] | None:
+    """The evidence dict of the current pending time_stop_discovered insight (if
+    any), so we can read the prior chosen_k + stable_run_count to enforce the
+    ≥2-run stability gate."""
+
+    def _do(session):
+        row = (
+            session.query(ResearchInsight)
+            .filter(
+                ResearchInsight.kind == "time_stop_discovered",
+                ResearchInsight.subject == TIME_STOP_SUBJECT,
+                ResearchInsight.status == "pending",
+            )
+            .first()
+        )
+        return dict(row.evidence) if row is not None and row.evidence else None
+
+    if db_session is not None:
+        return _do(db_session)
+    with get_session() as session:
+        return _do(session)
+
+
+def discover_time_stop(
+    *,
+    eval_date: date | None = None,
+    candidate_ks: tuple[int, ...] = (3, 5, 8, 10, 15),
+    min_survivors: int = 5,
+    db_session=None,
+) -> list[ResearchInsight]:
+    """Learn the force-exit horizon `k` from realized paper positions (D6).
+
+    For each candidate `k`:
+      * reconstruct each trade's return-by-holding-day curve from stock_prices
+        (entry-day forward, as-of capped — no hindsight);
+      * include a trade in candidate `k`'s cohort ONLY if it SURVIVED to day `k`
+        (did not SL/TP-exit before day `k` — survivor cohort);
+      * require >= `min_survivors` matured survivors at day `k` (min-sample gate
+        is PER candidate `k`, not total trades);
+      * score the cohort's day-`k` returns by the RISK-ADJUSTED objective
+        (Sharpe-like mean/std — NOT mean return).
+    Pick the `k` maximizing the risk-adjusted objective.
+
+    RECOMMEND-ONLY until the chosen `k` is stable across >= TIME_STOP_STABLE_RUNS
+    consecutive weekly runs: while unstable the emitted action is `noop`; once
+    stable it flips to `set_learned_time_stop_days` (still operator-approvable —
+    never auto-applied here). Emits one `time_stop_discovered` insight or [].
+    """
+    anchor = eval_date if eval_date is not None else date.today()
+    trades = _load_time_stop_trades(anchor)
+    if not trades:
+        return []
+
+    # Score each candidate k over its survivor cohort.
+    scored: dict[int, dict[str, Any]] = {}
+    for k in candidate_ks:
+        cohort_returns: list[float] = []
+        survivors = 0
+        for t in trades:
+            exit_day = _sl_tp_exit_day(
+                t["price_rows"], t["entry_date"], t["stop_loss"],
+                t["target_price"], as_of=anchor,
+            )
+            # Excluded from candidate k if it SL/TP-exited strictly BEFORE day k.
+            if exit_day is not None and exit_day < k:
+                continue
+            curve = _return_by_holding_day(
+                t["price_rows"], t["entry_date"], t["entry_price"], as_of=anchor
+            )
+            if len(curve) < k:
+                continue  # not matured to day k yet (as-of guard)
+            survivors += 1
+            cohort_returns.append(curve[k - 1])
+        if survivors < min_survivors:
+            continue
+        obj = _sharpe_like(cohort_returns)
+        if obj is None:
+            continue
+        mean_ret = sum(cohort_returns) / len(cohort_returns)
+        scored[k] = {
+            "survivors": survivors,
+            "objective": obj,
+            "mean_return": mean_ret,
+        }
+
+    if not scored:
+        return []
+
+    chosen_k = max(scored, key=lambda k: scored[k]["objective"])
+
+    # Stability gate: compare to the prior pending insight's chosen_k.
+    prior = _prior_time_stop_evidence(db_session=db_session)
+    prior_k = prior.get("chosen_k") if prior else None
+    prior_runs = int(prior.get("stable_run_count", 0)) if prior else 0
+    stable_run_count = (prior_runs + 1) if prior_k == chosen_k else 1
+    is_stable = stable_run_count >= TIME_STOP_STABLE_RUNS
+
+    if is_stable:
+        action = {
+            "kind": "set_learned_time_stop_days",
+            "target": str(chosen_k),
+            "params": {"k": chosen_k},
+        }
+        severity = "warn"
+    else:
+        # Recommend-only — observed but not yet stable enough to apply.
+        action = {"kind": "noop", "target": str(chosen_k), "params": {}}
+        severity = "info"
+
+    evidence = {
+        "chosen_k": chosen_k,
+        "stable_run_count": stable_run_count,
+        "stable": is_stable,
+        "min_survivors": min_survivors,
+        "candidate_ks": list(candidate_ks),
+        "per_k": {str(k): v for k, v in sorted(scored.items())},
+    }
+    rationale = (
+        f"Risk-adjusted force-exit horizon k={chosen_k} "
+        f"(objective {scored[chosen_k]['objective']:.3f}, "
+        f"{scored[chosen_k]['survivors']} survivors, mean "
+        f"{scored[chosen_k]['mean_return']:+.2%}). "
+        + (
+            "Stable across "
+            f"{stable_run_count} consecutive runs — recommend adopting "
+            "learned_time_stop_days (future fills only)."
+            if is_stable
+            else f"Observed run {stable_run_count}/{TIME_STOP_STABLE_RUNS} — "
+            "recommend-only until stable across consecutive runs."
+        )
+    )
+    return [
+        emit_insight(
+            kind="time_stop_discovered",
+            subject=TIME_STOP_SUBJECT,
+            severity=severity,
+            evidence=evidence,
+            action=action,
+            rationale=rationale,
+            db_session=db_session,
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# D7c — weekly paper-trade lessons (human-readable; info/noop)
+# ---------------------------------------------------------------------------
+
+PAPER_LESSONS_SUBJECT = "paper_pnl"
+
+
+def check_paper_lessons(
+    *,
+    eval_date: date | None = None,
+    days: int = 30,
+    db_session=None,
+) -> list[ResearchInsight]:
+    """Read the closed paper-trade record over the rolling window and emit a
+    human-readable `paper_lessons` insight (info, action=noop) — D7c.
+
+    Summarizes realized win-rate, exit-reason mix, and the best/worst closed
+    trade so the operator (and later the prompt) can see what the paper book
+    actually did. No weight-tuning here (that is D7b, deferred)."""
+    from rainier.core.models import PaperTrade
+
+    anchor = eval_date if eval_date is not None else date.today()
+    cutoff = anchor - timedelta(days=days)
+
+    with get_session() as session:
+        closed = session.execute(
+            select(PaperTrade).where(
+                PaperTrade.status == "closed",
+                PaperTrade.exit_date.isnot(None),
+                PaperTrade.exit_date >= cutoff,
+                PaperTrade.exit_date <= anchor,
+            )
+        ).scalars().all()
+        rows = [
+            {
+                "symbol": p.symbol,
+                "exit_reason": p.exit_reason,
+                "return_pct": float(p.return_pct) if p.return_pct is not None else 0.0,
+                "pnl": float(p.pnl) if p.pnl is not None else 0.0,
+            }
+            for p in closed
+        ]
+
+    if not rows:
+        return []
+
+    n = len(rows)
+    wins = sum(1 for r in rows if r["return_pct"] > 0)
+    reason_mix: dict[str, int] = {}
+    for r in rows:
+        reason_mix[r["exit_reason"] or "unknown"] = (
+            reason_mix.get(r["exit_reason"] or "unknown", 0) + 1
+        )
+    total_pnl = sum(r["pnl"] for r in rows)
+    best = max(rows, key=lambda r: r["return_pct"])
+    worst = min(rows, key=lambda r: r["return_pct"])
+
+    evidence = {
+        "days": days,
+        "n_closed": n,
+        "win_rate": wins / n,
+        "exit_reason_mix": reason_mix,
+        "total_realized_pnl": round(total_pnl, 2),
+        "best": {"symbol": best["symbol"], "return_pct": round(best["return_pct"], 4)},
+        "worst": {"symbol": worst["symbol"], "return_pct": round(worst["return_pct"], 4)},
+    }
+    mix_str = ", ".join(f"{kk}:{vv}" for kk, vv in sorted(reason_mix.items()))
+    rationale = (
+        f"Paper book closed {n} trades over {days}d: win-rate {wins / n:.0%}, "
+        f"realized ${total_pnl:,.2f}. Exit mix [{mix_str}]. "
+        f"Best {best['symbol']} {best['return_pct']:+.2%}; "
+        f"worst {worst['symbol']} {worst['return_pct']:+.2%}."
+    )
+    return [
+        emit_insight(
+            kind="paper_lessons",
+            subject=PAPER_LESSONS_SUBJECT,
+            severity="info",
+            evidence=evidence,
+            action={"kind": "noop", "target": PAPER_LESSONS_SUBJECT, "params": {}},
+            rationale=rationale,
+            db_session=db_session,
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Top-level orchestrator
 # ---------------------------------------------------------------------------
 
@@ -815,6 +1192,9 @@ def run_research(
         ("calibration_off", check_calibration_off),
         ("new_pattern_discovered", check_new_pattern_discovered),
         ("prompt_regression", check_prompt_regression),
+        # Phase 2 (D6 / D7c): learn the force-exit horizon + weekly paper lessons.
+        ("time_stop_discovered", discover_time_stop),
+        ("paper_lessons", check_paper_lessons),
     ]
     for name, fn in checks:
         try:
@@ -830,6 +1210,9 @@ def run_research(
                 kwargs["horizon"] = horizon
             elif name == "verdict_drift":
                 kwargs["horizon"] = horizon
+            elif name == "paper_lessons":
+                kwargs["days"] = days
+            # discover_time_stop takes only eval_date (+ its own defaults).
             insights = fn(**kwargs)
             out.extend(insights)
             log.info(
@@ -968,6 +1351,39 @@ def _scale_signal_weight(
     }
 
 
+def _set_learned_time_stop_days(
+    target: str, params: dict, settings_path: Path
+) -> dict[str, Any]:
+    """Set llm_thesis.learned_time_stop_days to the discovered horizon `k` (D6).
+
+    The chosen `k` comes from `params['k']` (preferred) or, failing that, the
+    `target` string. Mutates the EXISTING `LLMThesisConfig.learned_time_stop_days`
+    field (core/config.py) — never re-creates it. Only FUTURE fills snapshot the
+    new value at fill time (positions.py); already-open positions keep their
+    prior NULL/value (future-fills-only invariant). `None`/unparseable clears it
+    (back to no time-exit).
+    """
+    raw = (params or {}).get("k", target)
+    new_value: int | None
+    try:
+        new_value = int(raw) if raw is not None and str(raw) != "" else None
+        if new_value is not None and new_value < 1:
+            new_value = None
+    except (TypeError, ValueError):
+        new_value = None
+
+    yaml, data = _load_yaml_round_trip(settings_path)
+    section = data.setdefault("llm_thesis", {})
+    old = section.get("learned_time_stop_days")
+    section["learned_time_stop_days"] = new_value
+    _atomic_write_yaml(yaml, data, settings_path)
+    return {
+        "field": "learned_time_stop_days",
+        "old_value": old,
+        "new_value": new_value,
+    }
+
+
 def _noop(target: str, params: dict, settings_path: Path) -> dict[str, Any]:
     """Info-only insight — no config change."""
     return {"noop": True, "target": target}
@@ -978,6 +1394,7 @@ ACTION_EXECUTORS: dict[str, Callable[[str, dict, Path], dict[str, Any]]] = {
     "bump_prompt_version": _bump_prompt_version,
     "raise_signal_weight": _raise_signal_weight,
     "lower_signal_weight": _lower_signal_weight,
+    "set_learned_time_stop_days": _set_learned_time_stop_days,
     "noop": _noop,
 }
 

--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -1028,11 +1028,26 @@ def discover_time_stop(
 
     chosen_k = max(scored, key=lambda k: scored[k]["objective"])
 
-    # Stability gate: compare to the prior pending insight's chosen_k.
+    # Stability gate: compare to the prior pending insight's chosen_k. Count
+    # only DISTINCT weekly observations — a retry/replay on the same eval_date
+    # must not advance the counter (codex iter-1 [P2]): otherwise re-running the
+    # job twice for one date would flip noop -> set_learned_time_stop_days
+    # without a genuinely new week of data. We key idempotency on the prior
+    # run's recorded eval_date.
     prior = _prior_time_stop_evidence(db_session=db_session)
     prior_k = prior.get("chosen_k") if prior else None
     prior_runs = int(prior.get("stable_run_count", 0)) if prior else 0
-    stable_run_count = (prior_runs + 1) if prior_k == chosen_k else 1
+    prior_run_date = prior.get("last_run_date") if prior else None
+    anchor_iso = anchor.isoformat()
+    if prior_k != chosen_k:
+        # Different pick — stability resets.
+        stable_run_count = 1
+    elif prior_run_date == anchor_iso:
+        # Same pick, SAME eval_date (retry/replay) — hold the count steady.
+        stable_run_count = max(prior_runs, 1)
+    else:
+        # Same pick, a new distinct observation date — advance.
+        stable_run_count = prior_runs + 1
     is_stable = stable_run_count >= TIME_STOP_STABLE_RUNS
 
     if is_stable:
@@ -1051,6 +1066,9 @@ def discover_time_stop(
         "chosen_k": chosen_k,
         "stable_run_count": stable_run_count,
         "stable": is_stable,
+        # Record the run's logical date so a same-date retry is idempotent
+        # against the stability counter (codex iter-1 [P2]).
+        "last_run_date": anchor_iso,
         "min_survivors": min_survivors,
         "candidate_ks": list(candidate_ks),
         "per_k": {str(k): v for k, v in sorted(scored.items())},

--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -1042,11 +1042,17 @@ def discover_time_stop(
     if prior_k != chosen_k:
         # Different pick — stability resets.
         stable_run_count = 1
-    elif prior_run_date == anchor_iso:
-        # Same pick, SAME eval_date (retry/replay) — hold the count steady.
+    elif prior_run_date is not None and anchor_iso <= prior_run_date:
+        # Same pick, but this run is NOT strictly forward of the prior recorded
+        # observation — a same-date retry OR an out-of-order older replay (codex
+        # iter-2 [P2]). Hold the count steady so neither can flip the action to
+        # executable without two genuinely forward consecutive runs. Preserve the
+        # prior recorded date so a later legitimate run still advances from it.
         stable_run_count = max(prior_runs, 1)
+        anchor_iso = str(prior_run_date)
     else:
-        # Same pick, a new distinct observation date — advance.
+        # Same pick, a new distinct observation date strictly after the prior —
+        # advance.
         stable_run_count = prior_runs + 1
     is_stable = stable_run_count >= TIME_STOP_STABLE_RUNS
 

--- a/src/rainier/llm_thesis/service.py
+++ b/src/rainier/llm_thesis/service.py
@@ -364,8 +364,12 @@ async def generate_thesis(
             render_calibration_section,
         )
 
+        # strict_before: a scan on day D must only see calibration from a PRIOR
+        # day. Day D's own paper_calibration row is written end-of-day D (after
+        # that day's eval/paper outcomes), so a same-day rerun / replay must not
+        # inject it — that would leak same-day hindsight (codex iter-3 [P2]).
         calibration_section = render_calibration_section(
-            load_latest_calibration(scan_date)
+            load_latest_calibration(scan_date, strict_before=True)
         )
     except Exception:
         log.warning("thesis_calibration_load_failed symbol=%s", symbol, exc_info=True)

--- a/src/rainier/llm_thesis/service.py
+++ b/src/rainier/llm_thesis/service.py
@@ -352,12 +352,31 @@ async def generate_thesis(
     input_hash = compute_input_hash(pack, image_bytes)
 
     candidate_summary = json.dumps(pack.candidate, sort_keys=True, default=str)
+    # D7a: inject the calibration section (how prior theses graded out). Loaded
+    # best-effort from the latest persisted PaperCalibration row; a failure or a
+    # missing row (Phase-0 / fresh DB) yields no section. This text is invisible
+    # to compute_input_hash, so PROMPT_VERSION ("v2") is what busts the Tier-1
+    # cache — see prompt.py.
+    calibration_section = ""
+    try:
+        from rainier.paper.calibration import (
+            load_latest_calibration,
+            render_calibration_section,
+        )
+
+        calibration_section = render_calibration_section(
+            load_latest_calibration(scan_date)
+        )
+    except Exception:
+        log.warning("thesis_calibration_load_failed symbol=%s", symbol, exc_info=True)
+
     user_prompt = build_user_message(
         symbol=symbol,
         scan_date=pack.scan_date,
         session_name=session_name,
         candidate_summary=candidate_summary,
         signal_renders=renders,
+        calibration_section=calibration_section,
     )
 
     last_error: str | None = None

--- a/src/rainier/paper/calibration.py
+++ b/src/rainier/paper/calibration.py
@@ -1,0 +1,319 @@
+"""Calibration block for the LLM thesis prompt (design D7a).
+
+WHAT THIS IS
+------------
+Each day, after the paper-book report runs, we compute a small "here is how
+your prior calls actually graded out" block and feed it back into tomorrow's
+thesis prompt. The goal is to let the LLM self-correct (e.g. "my high-confidence
+setup_long calls only hit 40% at 5d — tighten up").
+
+THE TRAP THIS AVOIDS (realization asymmetry, D7a2)
+--------------------------------------------------
+The paper book holds winners indefinitely but realizes losers fast (stop-loss
+fires early). So a "win-rate over *closed* paper trades" is survivorship-skewed
+upward — the open winners aren't in the denominator yet. Using that as the
+headline would teach the LLM the wrong lesson.
+
+So the HEADLINE is the UNBIASED `ThesisEvaluation` fixed-horizon stats: every
+graded thesis is held to a fixed 1d/5d/10d close-to-close horizon regardless of
+the paper-book's hold policy. Every thesis matures; nothing survives by staying
+open. The realized paper record (last K=10 closed + mark-to-market INCLUDING
+open) is carried only as clearly-labeled *supplementary* context.
+
+  ┌─────────────────────────────────────────────────────────────┐
+  │ HEADLINE  (unbiased — ThesisEvaluation fixed-horizon)         │
+  │   win-rate + avg return by verdict, by confidence bucket,     │
+  │   for each of 1d / 5d / 10d                                   │
+  ├─────────────────────────────────────────────────────────────┤
+  │ SUPPLEMENTARY  (labeled realized-closed — survivorship-prone) │
+  │   last K=10 closed paper trades (symbol, reason, return)      │
+  │   + mark-to-market INCLUDING open positions                   │
+  └─────────────────────────────────────────────────────────────┘
+
+The compute reads from the LEGACY local-TimescaleDB engine only
+(`core.database.get_session`): `thesis_evaluations` + `paper_trade`.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import Any
+
+from sqlalchemy import select
+
+from rainier.core.database import get_session
+from rainier.core.models import PaperCalibration, PaperTrade, ThesisEvaluation
+
+log = logging.getLogger(__name__)
+
+# Horizons the headline reports, in display order.
+HORIZONS: tuple[str, ...] = ("1d", "5d", "10d")
+# Rolling window for the unbiased headline aggregation.
+HEADLINE_WINDOW_DAYS = 60
+# Number of recent closed paper trades shown as supplementary context.
+CLOSED_SAMPLE_K = 10
+# Confidence buckets (llm_confidence 1-10) for the headline breakdown.
+_CONF_BUCKETS: tuple[tuple[str, int, int], ...] = (
+    ("low (1-4)", 1, 4),
+    ("mid (5-7)", 5, 7),
+    ("high (8-10)", 8, 10),
+)
+
+
+def _hit(verdict: str, return_pct: float) -> bool:
+    """Direction-aware hit: setup_long hits on a gain; watch/no_setup hit on a
+    flat-or-loss (the LLM was right NOT to buy). Mirrors eval/research."""
+    if verdict == "setup_long":
+        return return_pct > 0
+    if verdict in ("watch", "no_setup"):
+        return return_pct <= 0
+    return False
+
+
+def _agg(returns: list[float], hits: list[bool]) -> dict[str, Any]:
+    n = len(returns)
+    return {
+        "n": n,
+        "win_rate": (sum(1 for h in hits if h) / n) if n else None,
+        "avg_return_pct": (sum(returns) / n) if n else None,
+    }
+
+
+def _conf_bucket(conf: int | None) -> str | None:
+    if conf is None:
+        return None
+    for label, lo, hi in _CONF_BUCKETS:
+        if lo <= conf <= hi:
+            return label
+    return None
+
+
+def _headline_for_horizon(rows: list[tuple[str, int | None, float]]) -> dict[str, Any]:
+    """rows = (verdict, llm_confidence, return_pct) for one horizon."""
+    by_verdict: dict[str, tuple[list[float], list[bool]]] = {}
+    by_bucket: dict[str, tuple[list[float], list[bool]]] = {}
+    all_returns: list[float] = []
+    all_hits: list[bool] = []
+    for verdict, conf, ret in rows:
+        hit = _hit(verdict, ret)
+        all_returns.append(ret)
+        all_hits.append(hit)
+        vr, vh = by_verdict.setdefault(verdict, ([], []))
+        vr.append(ret)
+        vh.append(hit)
+        bucket = _conf_bucket(conf)
+        if bucket is not None:
+            br, bh = by_bucket.setdefault(bucket, ([], []))
+            br.append(ret)
+            bh.append(hit)
+    return {
+        "overall": _agg(all_returns, all_hits),
+        "by_verdict": {
+            v: _agg(r, h) for v, (r, h) in sorted(by_verdict.items())
+        },
+        "by_confidence_bucket": {
+            b: _agg(r, h) for b, (r, h) in by_bucket.items()
+        },
+    }
+
+
+def compute_calibration_payload(
+    as_of: date, *, window_days: int = HEADLINE_WINDOW_DAYS, k: int = CLOSED_SAMPLE_K
+) -> dict[str, Any]:
+    """Build the bounded calibration payload (design D7a).
+
+    HEADLINE (unbiased): per-horizon win-rate + avg return, broken down by
+    verdict and by confidence bucket, over the rolling `window_days` of
+    `thesis_evaluations` (scan_date <= as_of).
+
+    SUPPLEMENTARY (labeled realized): the last `k` closed paper trades and the
+    mark-to-market-including-open dollar figure.
+    """
+    cutoff = as_of - timedelta(days=window_days)
+
+    with get_session() as session:
+        # --- HEADLINE: unbiased fixed-horizon thesis evaluations. ---
+        eval_rows = session.execute(
+            select(
+                ThesisEvaluation.horizon,
+                ThesisEvaluation.verdict,
+                ThesisEvaluation.llm_confidence,
+                ThesisEvaluation.return_pct,
+            ).where(
+                ThesisEvaluation.scan_date >= cutoff,
+                ThesisEvaluation.scan_date <= as_of,
+            )
+        ).all()
+
+        # --- SUPPLEMENTARY: last K closed paper trades + MTM-including-open. ---
+        closed = session.execute(
+            select(PaperTrade)
+            .where(
+                PaperTrade.status == "closed",
+                PaperTrade.exit_date.isnot(None),
+                PaperTrade.exit_date <= as_of,
+            )
+            .order_by(PaperTrade.exit_date.desc(), PaperTrade.id.desc())
+            .limit(k)
+        ).scalars().all()
+
+    by_horizon: dict[str, list[tuple[str, int | None, float]]] = {}
+    for horizon, verdict, conf, ret in eval_rows:
+        by_horizon.setdefault(str(horizon), []).append(
+            (str(verdict or ""), conf, float(ret))
+        )
+    headline = {
+        h: _headline_for_horizon(by_horizon.get(h, []))
+        for h in HORIZONS
+        if h in by_horizon
+    }
+
+    realized_pnl = 0.0
+    closed_sample: list[dict[str, Any]] = []
+    closed_wins = 0
+    for p in closed:
+        if p.pnl is not None:
+            realized_pnl += float(p.pnl)
+        if p.return_pct is not None and p.return_pct > 0:
+            closed_wins += 1
+        closed_sample.append(
+            {
+                "symbol": p.symbol,
+                "outcome": "win" if (p.return_pct or 0) > 0 else "loss",
+                "exit_reason": p.exit_reason,
+                "return_pct": (
+                    round(float(p.return_pct), 4) if p.return_pct is not None else None
+                ),
+            }
+        )
+
+    # MTM-including-open comes from the daily report payload (realized + open
+    # MTM), the canonical realization-asymmetry-corrected figure. Imported
+    # lazily to avoid a module-load cycle (report imports nothing from here).
+    from rainier.paper.report import compute_daily_payload
+
+    daily = compute_daily_payload(as_of)
+
+    return {
+        "as_of_date": as_of.isoformat(),
+        "window_days": window_days,
+        # HEADLINE — unbiased, survivorship-free.
+        "headline_fixed_horizon": headline,
+        # SUPPLEMENTARY — realized paper record, explicitly labeled survivorship-
+        # prone so neither a renderer nor a reader mistakes it for the headline.
+        "supplementary_realized": {
+            "label": "realized-closed (survivorship-prone — NOT the headline)",
+            "n_closed_sample": len(closed_sample),
+            "closed_win_rate": (
+                (closed_wins / len(closed_sample)) if closed_sample else None
+            ),
+            "recent_closed": closed_sample,
+            "realized_pnl_usd": round(realized_pnl, 2),
+            "mtm_including_open_pnl_usd": daily.get("mtm_including_open_pnl"),
+        },
+    }
+
+
+def persist_calibration(as_of: date, payload: dict[str, Any]) -> None:
+    """Upsert one (as_of_date) calibration row (idempotent per day)."""
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    with get_session() as session:
+        stmt = (
+            pg_insert(PaperCalibration)
+            .values(as_of_date=as_of, payload=payload)
+            .on_conflict_do_update(
+                constraint="uq_paper_calibration_as_of_date",
+                set_={"payload": payload},
+            )
+        )
+        session.execute(stmt)
+
+
+def load_latest_calibration(as_of: date | None = None) -> dict[str, Any] | None:
+    """Return the most recent calibration payload at-or-before ``as_of``.
+
+    Used by ``build_user_message`` to inject the calibration section. Returns
+    None when no calibration row exists yet (Phase-0 days / fresh DB) — the
+    prompt then renders no section.
+    """
+    with get_session() as session:
+        q = select(PaperCalibration.payload).order_by(
+            PaperCalibration.as_of_date.desc()
+        )
+        if as_of is not None:
+            q = q.where(PaperCalibration.as_of_date <= as_of)
+        row = session.execute(q.limit(1)).first()
+    return dict(row[0]) if row is not None else None
+
+
+def _fmt_pct(v: float | None) -> str:
+    return f"{v:+.2%}" if v is not None else "n/a"
+
+
+def _fmt_rate(v: float | None) -> str:
+    return f"{v:.0%}" if v is not None else "n/a"
+
+
+def render_calibration_section(payload: dict[str, Any] | None) -> str:
+    """Render the calibration payload into a bounded prompt section.
+
+    Returns "" when there's nothing to show, so the caller can append
+    unconditionally. The HEADLINE is the unbiased fixed-horizon stats; the
+    realized paper record is rendered under an explicit "supplementary /
+    survivorship-prone" label so the LLM never reads it as the primary signal.
+    """
+    if not payload:
+        return ""
+    headline = payload.get("headline_fixed_horizon") or {}
+    supp = payload.get("supplementary_realized") or {}
+    if not headline and not supp:
+        return ""
+
+    lines: list[str] = [
+        "--- Calibration (how prior calls graded out) ---",
+        "HEADLINE = unbiased fixed-horizon outcomes (every thesis matures at a "
+        "fixed 1d/5d/10d close — survivorship-free). Treat this as primary.",
+    ]
+    for horizon in HORIZONS:
+        block = headline.get(horizon)
+        if not block:
+            continue
+        overall = block.get("overall", {})
+        lines.append(
+            f"[{horizon}] overall: win-rate {_fmt_rate(overall.get('win_rate'))}, "
+            f"avg {_fmt_pct(overall.get('avg_return_pct'))} (n={overall.get('n', 0)})"
+        )
+        by_verdict = block.get("by_verdict", {})
+        for verdict, agg in by_verdict.items():
+            lines.append(
+                f"    {verdict}: win-rate {_fmt_rate(agg.get('win_rate'))}, "
+                f"avg {_fmt_pct(agg.get('avg_return_pct'))} (n={agg.get('n', 0)})"
+            )
+        by_bucket = block.get("by_confidence_bucket", {})
+        for bucket, agg in by_bucket.items():
+            lines.append(
+                f"    conf {bucket}: win-rate {_fmt_rate(agg.get('win_rate'))}, "
+                f"avg {_fmt_pct(agg.get('avg_return_pct'))} (n={agg.get('n', 0)})"
+            )
+
+    if supp:
+        lines.append(
+            f"SUPPLEMENTARY ({supp.get('label', 'realized-closed')}) — context "
+            "only, do NOT treat as the headline:"
+        )
+        recent = supp.get("recent_closed", [])
+        if recent:
+            rendered = ", ".join(
+                f"{r['symbol']} {r['outcome']}({r.get('exit_reason') or '?'} "
+                f"{_fmt_pct(r.get('return_pct'))})"
+                for r in recent
+            )
+            lines.append(f"    last {len(recent)} closed: {rendered}")
+        lines.append(
+            f"    realized $P&L (closed): "
+            f"${supp.get('realized_pnl_usd', 0):,.2f} · MTM incl. open: "
+            f"${supp.get('mtm_including_open_pnl_usd') or 0:,.2f}"
+        )
+    return "\n".join(lines)

--- a/src/rainier/paper/calibration.py
+++ b/src/rainier/paper/calibration.py
@@ -146,9 +146,17 @@ def compute_calibration_payload(
             )
         ).all()
 
-        # --- SUPPLEMENTARY: last K closed paper trades + MTM-including-open. ---
+        # --- SUPPLEMENTARY: last K closed paper trades + MTM-including-open.
+        # Select scalar columns (not full ORM rows) so nothing is read after the
+        # session closes — matches the codebase's materialize-inside-the-block
+        # convention (report.py / positions.py).
         closed = session.execute(
-            select(PaperTrade)
+            select(
+                PaperTrade.symbol,
+                PaperTrade.exit_reason,
+                PaperTrade.return_pct,
+                PaperTrade.pnl,
+            )
             .where(
                 PaperTrade.status == "closed",
                 PaperTrade.exit_date.isnot(None),
@@ -156,7 +164,7 @@ def compute_calibration_payload(
             )
             .order_by(PaperTrade.exit_date.desc(), PaperTrade.id.desc())
             .limit(k)
-        ).scalars().all()
+        ).all()
 
     by_horizon: dict[str, list[tuple[str, int | None, float]]] = {}
     for horizon, verdict, conf, ret in eval_rows:
@@ -172,18 +180,18 @@ def compute_calibration_payload(
     realized_pnl = 0.0
     closed_sample: list[dict[str, Any]] = []
     closed_wins = 0
-    for p in closed:
-        if p.pnl is not None:
-            realized_pnl += float(p.pnl)
-        if p.return_pct is not None and p.return_pct > 0:
+    for symbol, exit_reason, return_pct, pnl in closed:
+        if pnl is not None:
+            realized_pnl += float(pnl)
+        if return_pct is not None and return_pct > 0:
             closed_wins += 1
         closed_sample.append(
             {
-                "symbol": p.symbol,
-                "outcome": "win" if (p.return_pct or 0) > 0 else "loss",
-                "exit_reason": p.exit_reason,
+                "symbol": symbol,
+                "outcome": "win" if (return_pct or 0) > 0 else "loss",
+                "exit_reason": exit_reason,
                 "return_pct": (
-                    round(float(p.return_pct), 4) if p.return_pct is not None else None
+                    round(float(return_pct), 4) if return_pct is not None else None
                 ),
             }
         )

--- a/src/rainier/paper/calibration.py
+++ b/src/rainier/paper/calibration.py
@@ -177,12 +177,16 @@ def compute_calibration_payload(
         if h in by_horizon
     }
 
-    realized_pnl = 0.0
+    # NOTE: this sum is over the last-K SAMPLE only (the query is .limit(k)).
+    # It is NOT the book's total realized P&L — that comes from the daily
+    # payload below. Surfaced as a clearly sample-scoped field so the renderer
+    # never pairs it with all-book MTM (codex iter-1 [P2]).
+    sample_realized_pnl = 0.0
     closed_sample: list[dict[str, Any]] = []
     closed_wins = 0
     for symbol, exit_reason, return_pct, pnl in closed:
         if pnl is not None:
-            realized_pnl += float(pnl)
+            sample_realized_pnl += float(pnl)
         if return_pct is not None and return_pct > 0:
             closed_wins += 1
         closed_sample.append(
@@ -217,7 +221,11 @@ def compute_calibration_payload(
                 (closed_wins / len(closed_sample)) if closed_sample else None
             ),
             "recent_closed": closed_sample,
-            "realized_pnl_usd": round(realized_pnl, 2),
+            # P&L summed over the last-K SAMPLE shown above — NOT the book total.
+            "sample_realized_pnl_usd": round(sample_realized_pnl, 2),
+            # The BOOK-TOTAL realized P&L (all closed, as-of capped) from the
+            # daily payload — the figure that correctly pairs with MTM-incl-open.
+            "realized_pnl_usd": daily.get("realized_pnl"),
             "mtm_including_open_pnl_usd": daily.get("mtm_including_open_pnl"),
         },
     }
@@ -320,8 +328,8 @@ def render_calibration_section(payload: dict[str, Any] | None) -> str:
             )
             lines.append(f"    last {len(recent)} closed: {rendered}")
         lines.append(
-            f"    realized $P&L (closed): "
-            f"${supp.get('realized_pnl_usd', 0):,.2f} · MTM incl. open: "
+            f"    realized $P&L (all closed): "
+            f"${supp.get('realized_pnl_usd') or 0:,.2f} · MTM incl. open: "
             f"${supp.get('mtm_including_open_pnl_usd') or 0:,.2f}"
         )
     return "\n".join(lines)

--- a/src/rainier/paper/calibration.py
+++ b/src/rainier/paper/calibration.py
@@ -37,7 +37,7 @@ The compute reads from the LEGACY local-TimescaleDB engine only
 from __future__ import annotations
 
 import logging
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any
 
 from sqlalchemy import select
@@ -59,6 +59,13 @@ _CONF_BUCKETS: tuple[tuple[str, int, int], ...] = (
     ("mid (5-7)", 5, 7),
     ("high (8-10)", 8, 10),
 )
+
+
+def _as_date_local(d: Any) -> date:
+    """Coerce a datetime/date column value to a plain date for comparison."""
+    if isinstance(d, datetime):
+        return d.date()
+    return d
 
 
 def _hit(verdict: str, return_pct: float) -> bool:
@@ -132,6 +139,22 @@ def compute_calibration_payload(
     """
     cutoff = as_of - timedelta(days=window_days)
 
+    # Per-horizon maturity ceiling (codex iter-2 [P2]): a thesis only counts in
+    # the headline once its fixed horizon has actually elapsed by `as_of`. In
+    # forward operation that's automatic, but a historical replay/backfill
+    # (run_daily_eval --eval-date <past>) runs after later-dated rows already
+    # exist, so a `scan_date <= as_of` filter alone would pull in e.g. a 10d row
+    # for a thesis scanned the day before `as_of` — leaking future outcomes into
+    # the calibration row. A row at `horizon` is mature iff its scan_date is on
+    # or before the date `_HORIZON_DAYS[horizon]` trading days before `as_of`.
+    from rainier.llm_thesis.eval import _HORIZON_DAYS, _trading_days_back
+
+    horizon_ceiling: dict[str, date] = {
+        h: _trading_days_back(as_of, _HORIZON_DAYS[h])
+        for h in HORIZONS
+        if h in _HORIZON_DAYS
+    }
+
     with get_session() as session:
         # --- HEADLINE: unbiased fixed-horizon thesis evaluations. ---
         eval_rows = session.execute(
@@ -140,6 +163,7 @@ def compute_calibration_payload(
                 ThesisEvaluation.verdict,
                 ThesisEvaluation.llm_confidence,
                 ThesisEvaluation.return_pct,
+                ThesisEvaluation.scan_date,
             ).where(
                 ThesisEvaluation.scan_date >= cutoff,
                 ThesisEvaluation.scan_date <= as_of,
@@ -167,8 +191,13 @@ def compute_calibration_payload(
         ).all()
 
     by_horizon: dict[str, list[tuple[str, int | None, float]]] = {}
-    for horizon, verdict, conf, ret in eval_rows:
-        by_horizon.setdefault(str(horizon), []).append(
+    for horizon, verdict, conf, ret, row_scan in eval_rows:
+        h = str(horizon)
+        ceiling = horizon_ceiling.get(h)
+        # Drop rows whose horizon hadn't matured by as_of (replay hindsight guard).
+        if ceiling is not None and _as_date_local(row_scan) > ceiling:
+            continue
+        by_horizon.setdefault(h, []).append(
             (str(verdict or ""), conf, float(ret))
         )
     headline = {

--- a/src/rainier/paper/calibration.py
+++ b/src/rainier/paper/calibration.py
@@ -276,11 +276,24 @@ def persist_calibration(as_of: date, payload: dict[str, Any]) -> None:
         session.execute(stmt)
 
 
-def load_latest_calibration(as_of: date | None = None) -> dict[str, Any] | None:
-    """Return the most recent calibration payload at-or-before ``as_of``.
+def load_latest_calibration(
+    as_of: date | None = None, *, strict_before: bool = False
+) -> dict[str, Any] | None:
+    """Return the most recent calibration payload relative to ``as_of``.
 
-    Used by ``build_user_message`` to inject the calibration section. Returns
-    None when no calibration row exists yet (Phase-0 days / fresh DB) — the
+    With ``strict_before=False`` (default, generic loader) the bound is
+    at-or-before ``as_of``. With ``strict_before=True`` it is STRICTLY before
+    ``as_of`` — the no-hindsight contract for the prompt-injection path
+    (codex iter-3 [P2]).
+
+    The thesis prompt for a scan on day D must only ever see calibration
+    computed on a PRIOR day: day D's own ``paper_calibration`` row is written
+    by ``run_daily_eval`` at end-of-day D (after that day's eval + paper-book
+    outcomes), so injecting it into a same-day scan rerun / historical replay
+    would leak same-day hindsight into the prompt. ``generate_thesis`` therefore
+    passes ``strict_before=True``.
+
+    Returns None when no eligible row exists yet (Phase-0 days / fresh DB) — the
     prompt then renders no section.
     """
     with get_session() as session:
@@ -288,7 +301,10 @@ def load_latest_calibration(as_of: date | None = None) -> dict[str, Any] | None:
             PaperCalibration.as_of_date.desc()
         )
         if as_of is not None:
-            q = q.where(PaperCalibration.as_of_date <= as_of)
+            if strict_before:
+                q = q.where(PaperCalibration.as_of_date < as_of)
+            else:
+                q = q.where(PaperCalibration.as_of_date <= as_of)
         row = session.execute(q.limit(1)).first()
     return dict(row[0]) if row is not None else None
 

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -209,6 +209,15 @@ async def run_daily_eval(eval_date_iso: str | None = None) -> None:
     except Exception as exc:
         log.error("daily_paper_report_failed", error=str(exc))
 
+    # Step (vi): D7a calibration block — compute the unbiased fixed-horizon
+    # headline + labeled realized supplementary and persist it for tomorrow's
+    # thesis prompt. Runs AFTER the daily report (it reuses the report's
+    # MTM-including-open figure). Non-fatal.
+    try:
+        await asyncio.to_thread(run_paper_calibration, eval_date)
+    except Exception as exc:
+        log.error("daily_paper_calibration_failed", error=str(exc))
+
 
 def run_paper_daily_steps(eval_date) -> None:
     """Paper steps (i)-(iii): ingest (active ∪ screened) → fill → update.
@@ -245,6 +254,22 @@ def run_paper_daily_report(eval_date, discord_config) -> None:
     payload = compute_daily_payload(eval_date)
     persist_daily_snapshot(eval_date, payload)
     send_daily_paper_report(payload, discord_config)
+
+
+def run_paper_calibration(eval_date) -> None:
+    """Paper step (vi): compute the D7a calibration payload → persist it.
+
+    The persisted row feeds ``build_user_message`` on the next scan. Headline =
+    unbiased fixed-horizon thesis stats; realized paper record is labeled
+    supplementary. Idempotent per as-of date.
+    """
+    from rainier.paper.calibration import (
+        compute_calibration_payload,
+        persist_calibration,
+    )
+
+    payload = compute_calibration_payload(eval_date)
+    persist_calibration(eval_date, payload)
 
 
 async def run_research_job(eval_date_iso: str | None = None) -> None:

--- a/tests/test_llm_thesis/test_calibration.py
+++ b/tests/test_llm_thesis/test_calibration.py
@@ -146,6 +146,18 @@ def test_prompt_version_bumped_for_calibration():
     assert PROMPT_VERSION != "v1"
 
 
+def test_prompt_version_config_tracks_module():
+    # codex iter-1 [P2->P1]: the RUNTIME Tier-1 key is built from
+    # settings.llm_thesis.prompt_version (service.generate_thesis), NOT the
+    # prompt.PROMPT_VERSION module constant. If the config default lags the
+    # module constant, the "bump busts Tier-1" mechanism silently no-ops —
+    # calibrated prompts get served from / recorded as the stale version. Guard
+    # the two in lockstep so the cache-bust actually fires in production.
+    from rainier.core.config import LLMThesisConfig
+
+    assert LLMThesisConfig().prompt_version == PROMPT_VERSION
+
+
 def test_input_hash_unaffected_by_calibration_text():
     # compute_input_hash hashes only EvidencePack + image bytes; the calibration
     # section lives in the prompt text, NOT the pack — so it can never enter the

--- a/tests/test_llm_thesis/test_calibration.py
+++ b/tests/test_llm_thesis/test_calibration.py
@@ -1,0 +1,165 @@
+"""Phase 2 D7a — calibration block in the thesis prompt.
+
+Covers:
+  * the HEADLINE = unbiased fixed-horizon ThesisEvaluation stats (NOT realized-
+    paper-only) with by-verdict + by-confidence-bucket breakdown;
+  * the K=10 closed paper trades are rendered as LABELED supplementary context
+    (realized-closed) alongside MTM-including-open — never as the headline;
+  * the calibration text is injected into build_user_message;
+  * bumping PROMPT_VERSION busts the Tier-1 cache key while compute_input_hash
+    (Tier-2) is unaffected by the calibration text.
+"""
+
+from __future__ import annotations
+
+from rainier.llm_thesis.prompt import PROMPT_VERSION, build_user_message
+from rainier.llm_thesis.schemas import EvidencePack, compute_input_hash
+from rainier.paper.calibration import (
+    _headline_for_horizon,
+    render_calibration_section,
+)
+
+# ---------------------------------------------------------------------------
+# headline aggregation — unbiased fixed-horizon stats
+# ---------------------------------------------------------------------------
+
+
+def test_headline_breaks_down_by_verdict_and_confidence():
+    # (verdict, llm_confidence, return_pct)
+    rows = [
+        ("setup_long", 9, 0.05),   # high-conf win
+        ("setup_long", 8, -0.02),  # high-conf loss
+        ("setup_long", 5, 0.01),   # mid-conf win
+        ("watch", 3, -0.01),       # low-conf, correctly didn't buy → hit
+    ]
+    h = _headline_for_horizon(rows)
+    assert h["overall"]["n"] == 4
+    # setup_long: 2 of 3 are gains → win-rate 2/3.
+    sl = h["by_verdict"]["setup_long"]
+    assert sl["n"] == 3
+    assert abs(sl["win_rate"] - 2 / 3) < 1e-9
+    # watch with a loss is a HIT (right not to buy).
+    assert h["by_verdict"]["watch"]["win_rate"] == 1.0
+    # Confidence buckets present.
+    assert "high (8-10)" in h["by_confidence_bucket"]
+    assert h["by_confidence_bucket"]["high (8-10)"]["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# render — headline is primary, realized record is labeled supplementary
+# ---------------------------------------------------------------------------
+
+
+def _sample_payload():
+    return {
+        "as_of_date": "2026-02-02",
+        "window_days": 60,
+        "headline_fixed_horizon": {
+            "5d": {
+                "overall": {"n": 10, "win_rate": 0.6, "avg_return_pct": 0.012},
+                "by_verdict": {
+                    "setup_long": {"n": 8, "win_rate": 0.5, "avg_return_pct": 0.01}
+                },
+                "by_confidence_bucket": {
+                    "high (8-10)": {"n": 4, "win_rate": 0.25, "avg_return_pct": -0.01}
+                },
+            }
+        },
+        "supplementary_realized": {
+            "label": "realized-closed (survivorship-prone — NOT the headline)",
+            "n_closed_sample": 2,
+            "closed_win_rate": 1.0,
+            "recent_closed": [
+                {"symbol": "AAA", "outcome": "win", "exit_reason": "target",
+                 "return_pct": 0.08},
+                {"symbol": "BBB", "outcome": "win", "exit_reason": "time_stop",
+                 "return_pct": 0.03},
+            ],
+            "realized_pnl_usd": 110.0,
+            "mtm_including_open_pnl_usd": -25.0,
+        },
+    }
+
+
+def test_render_headline_is_unbiased_and_supplementary_is_labeled():
+    text = render_calibration_section(_sample_payload())
+    # Headline framing present, primary.
+    assert "HEADLINE" in text
+    assert "unbiased fixed-horizon" in text
+    assert "[5d] overall: win-rate 60%" in text
+    assert "setup_long: win-rate 50%" in text
+    assert "conf high (8-10): win-rate 25%" in text
+    # The realized record is labeled supplementary / survivorship-prone — never
+    # surfaced as the headline.
+    assert "SUPPLEMENTARY" in text
+    assert "survivorship-prone" in text
+    assert "AAA win(target" in text
+    # MTM-including-open carried.
+    assert "MTM incl. open: $-25.00" in text
+
+
+def test_render_empty_payload_is_blank():
+    assert render_calibration_section(None) == ""
+    assert render_calibration_section({}) == ""
+
+
+# ---------------------------------------------------------------------------
+# prompt injection
+# ---------------------------------------------------------------------------
+
+
+def test_build_user_message_injects_calibration():
+    section = render_calibration_section(_sample_payload())
+    msg = build_user_message(
+        symbol="AAA",
+        scan_date="2026-02-03",
+        session_name="close",
+        candidate_summary="{}",
+        signal_renders=["rank up"],
+        calibration_section=section,
+    )
+    assert "HEADLINE" in msg
+    assert msg.strip().endswith("Produce the JSON object now.")
+
+
+def test_build_user_message_without_calibration_is_unchanged_tail():
+    msg = build_user_message(
+        symbol="AAA",
+        scan_date="2026-02-03",
+        session_name="close",
+        candidate_summary="{}",
+        signal_renders=["rank up"],
+    )
+    assert "Calibration" not in msg
+    assert "HEADLINE" not in msg
+
+
+# ---------------------------------------------------------------------------
+# cache correctness — PROMPT_VERSION busts Tier-1; input_hash unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_version_bumped_for_calibration():
+    # The Tier-1 key (date, symbol, prompt_version, session, model) includes
+    # prompt_version. Shipping the calibration block bumped it past v1 so the
+    # cache cannot serve a pre-calibration thesis.
+    assert PROMPT_VERSION != "v1"
+
+
+def test_input_hash_unaffected_by_calibration_text():
+    # compute_input_hash hashes only EvidencePack + image bytes; the calibration
+    # section lives in the prompt text, NOT the pack — so it can never enter the
+    # Tier-2 input_hash. Two identical packs hash identically regardless of any
+    # calibration block rendered into the prompt.
+    pack = EvidencePack(
+        symbol="AAA",
+        scan_date="2026-02-03",
+        session_name="close",
+        candidate={"rank": 5},
+        signals={"rank_trajectory": {"value": 1}},
+    )
+    h1 = compute_input_hash(pack, b"img")
+    h2 = compute_input_hash(pack, b"img")
+    assert h1 == h2
+    # The EvidencePack has no field that the calibration text could perturb.
+    assert "calibration" not in pack.model_dump()

--- a/tests/test_llm_thesis/test_discover_time_stop.py
+++ b/tests/test_llm_thesis/test_discover_time_stop.py
@@ -1,0 +1,298 @@
+"""Phase 2 D6 — discover_time_stop (learn the force-exit horizon).
+
+Deterministic: fixture price curves + monkeypatched DB loaders (no network, no
+Postgres). Asserts the four design invariants:
+  * risk-adjusted (Sharpe-like) objective-max k can DIFFER from mean-return-max k;
+  * survivor cohort — a trade SL/TP-exiting before day k is excluded from k;
+  * as-of ceiling — reconstruction never uses prices past the analysis date;
+  * recommend-only (noop) until k stable across >= 2 consecutive runs, then the
+    action flips to set_learned_time_stop_days.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from rainier.llm_thesis.research import (
+    TIME_STOP_STABLE_RUNS,
+    _return_by_holding_day,
+    _sharpe_like,
+    _sl_tp_exit_day,
+    discover_time_stop,
+)
+from tests.test_research_helpers import MemSession  # type: ignore
+
+
+def _bars(entry: date, closes, *, highs=None, lows=None, opens=None):
+    """Build (date, open, high, low, close) tuples one per consecutive day."""
+    rows = []
+    for i, c in enumerate(closes):
+        d = entry + timedelta(days=i)
+        rows.append(
+            (
+                d,
+                (opens[i] if opens else c),
+                (highs[i] if highs else c),
+                (lows[i] if lows else c),
+                c,
+            )
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_return_by_holding_day_as_of_guard():
+    entry = date(2026, 1, 1)
+    rows = _bars(entry, [100, 102, 104, 110])  # day1..day4
+    # As-of caps at day 3 (2026-01-03): the 110 (day 4) must be excluded.
+    curve = _return_by_holding_day(
+        rows, entry, 100.0, as_of=date(2026, 1, 3)
+    )
+    assert len(curve) == 3
+    assert curve[0] == 0.0
+    assert abs(curve[2] - 0.04) < 1e-9
+    # No hindsight: the day-4 +10% return never appears.
+    assert all(abs(x - 0.10) > 1e-9 for x in curve)
+
+
+def test_return_by_holding_day_skips_null_close():
+    entry = date(2026, 1, 1)
+    rows = [
+        (entry, 100, 100, 100, 100.0),
+        (entry + timedelta(days=1), None, None, None, None),  # no-data day
+        (entry + timedelta(days=2), 105, 105, 105, 105.0),
+    ]
+    curve = _return_by_holding_day(rows, entry, 100.0, as_of=entry + timedelta(days=2))
+    # NULL day skipped → only two priced sessions.
+    assert len(curve) == 2
+    assert abs(curve[1] - 0.05) < 1e-9
+
+
+def test_sl_tp_exit_day_excludes_pre_k_exit():
+    entry = date(2026, 1, 1)
+    # Day 2 low gaps to the stop (90) → exits on holding-day 2.
+    rows = _bars(
+        entry,
+        closes=[100, 92, 95],
+        highs=[101, 95, 96],
+        lows=[99, 90, 94],
+    )
+    assert _sl_tp_exit_day(rows, entry, stop_loss=90.0, target_price=120.0,
+                           as_of=date(2026, 1, 3)) == 2
+    # Never hits → None.
+    rows2 = _bars(entry, closes=[100, 101, 102])
+    assert _sl_tp_exit_day(rows2, entry, 80.0, 130.0, as_of=date(2026, 1, 3)) is None
+
+
+def test_sharpe_like_prefers_low_variance():
+    # Same mean (0.04) but tighter dispersion scores higher.
+    tight = [0.03, 0.04, 0.05]
+    wide = [-0.06, 0.04, 0.14]
+    assert _sharpe_like(tight) > _sharpe_like(wide)
+    assert _sharpe_like([0.05]) is None  # n<2 undefined
+    assert _sharpe_like([0.05, 0.05]) is None  # zero dispersion undefined
+
+
+# ---------------------------------------------------------------------------
+# discover_time_stop — risk-adjusted choice differs from mean-return-max
+# ---------------------------------------------------------------------------
+
+
+def _trade(symbol, entry, closes, *, stop=1.0, target=1e9):
+    """A trade whose curve is `closes` (entry_price=closes[0])."""
+    return {
+        "id": hash(symbol) & 0xFFFF,
+        "symbol": symbol,
+        "entry_date": entry,
+        "entry_price": float(closes[0]),
+        "stop_loss": float(stop),
+        "target_price": float(target),
+        "price_rows": _bars(entry, [float(c) for c in closes]),
+    }
+
+
+def test_risk_adjusted_max_differs_from_mean_return_max():
+    """k=10 has the highest MEAN return but blows up the variance; k=5 wins on
+    the risk-adjusted objective. Proves the objective is NOT mean-return-max."""
+    entry = date(2026, 1, 1)
+    # Build 6 trades. Each has 10 priced days. At day5 the cohort is tight and
+    # mildly positive; at day10 it is higher-mean but wildly dispersed.
+    day5 = [0.02, 0.03, 0.02, 0.03, 0.02, 0.03]  # mean .025, tight
+    day10 = [0.30, -0.20, 0.35, -0.25, 0.40, 0.20]  # mean ~.133, very wide
+    trades = []
+    for i in range(6):
+        closes = [100.0]
+        # days 2..5 ramp linearly to the day5 return
+        for d in range(1, 5):
+            closes.append(100.0 * (1 + day5[i] * d / 4))
+        # days 6..10 ramp to the day10 return
+        for d in range(5, 10):
+            frac = (d - 4) / 5
+            closes.append(100.0 * (1 + day5[i] + (day10[i] - day5[i]) * frac))
+        trades.append(_trade(f"S{i}", entry, closes))
+
+    as_of = entry + timedelta(days=9)
+    with patch(
+        "rainier.llm_thesis.research._load_time_stop_trades", return_value=trades
+    ), patch(
+        "rainier.llm_thesis.research._prior_time_stop_evidence", return_value=None
+    ):
+        sess = MemSession()
+        out = discover_time_stop(
+            eval_date=as_of, candidate_ks=(5, 10), min_survivors=3, db_session=sess
+        )
+    assert len(out) == 1
+    ev = out[0].evidence
+    # Mean-return-max would pick k=10; the risk-adjusted objective picks k=5.
+    per_k = ev["per_k"]
+    assert per_k["10"]["mean_return"] > per_k["5"]["mean_return"]
+    assert ev["chosen_k"] == 5
+
+
+def test_survivor_cohort_excludes_pre_k_exit():
+    """A trade that stops out at day 2 is excluded from candidate k=5's cohort
+    (survivor cohort), so it can't pad the min-survivors count or skew the
+    objective."""
+    entry = date(2026, 1, 1)
+    as_of = entry + timedelta(days=6)
+    # Varied day-5 returns so the cohort has non-zero dispersion (Sharpe-like
+    # objective is defined).
+    survivor_day5_close = [104, 105, 103, 106]
+    survivors = [
+        _trade(f"W{i}", entry, [100, 101, 102, 103, c, c], stop=80.0)
+        for i, c in enumerate(survivor_day5_close)
+    ]
+    # One early-stopper: day-2 low pierces 90.
+    stopper = {
+        "id": 999, "symbol": "EARLY", "entry_date": entry,
+        "entry_price": 100.0, "stop_loss": 90.0, "target_price": 1e9,
+        "price_rows": _bars(
+            entry, closes=[100, 88, 88, 88, 88, 88],
+            highs=[101, 95, 95, 95, 95, 95], lows=[99, 85, 85, 85, 85, 85],
+        ),
+    }
+    trades = survivors + [stopper]
+    with patch(
+        "rainier.llm_thesis.research._load_time_stop_trades", return_value=trades
+    ), patch(
+        "rainier.llm_thesis.research._prior_time_stop_evidence", return_value=None
+    ):
+        sess = MemSession()
+        out = discover_time_stop(
+            eval_date=as_of, candidate_ks=(5,), min_survivors=4, db_session=sess
+        )
+    assert len(out) == 1
+    # Only the 4 survivors counted at k=5 (the stopper excluded).
+    assert out[0].evidence["per_k"]["5"]["survivors"] == 4
+
+
+def test_min_survivors_gate_per_candidate_k():
+    """min_survivors is enforced PER candidate k: k=10 has too few matured
+    survivors and is dropped even though k=5 qualifies."""
+    entry = date(2026, 1, 1)
+    # 5 trades priced through day 5 only (none mature to day 10). Varied day-5
+    # closes give the cohort non-zero dispersion.
+    day5 = [104, 105, 103, 106, 102]
+    trades = [
+        _trade(f"T{i}", entry, [100, 101, 102, 103, c], stop=80.0)
+        for i, c in enumerate(day5)
+    ]
+    as_of = entry + timedelta(days=4)
+    with patch(
+        "rainier.llm_thesis.research._load_time_stop_trades", return_value=trades
+    ), patch(
+        "rainier.llm_thesis.research._prior_time_stop_evidence", return_value=None
+    ):
+        sess = MemSession()
+        out = discover_time_stop(
+            eval_date=as_of, candidate_ks=(5, 10), min_survivors=5, db_session=sess
+        )
+    assert len(out) == 1
+    per_k = out[0].evidence["per_k"]
+    assert "5" in per_k and "10" not in per_k
+    assert out[0].evidence["chosen_k"] == 5
+
+
+# ---------------------------------------------------------------------------
+# recommend-only until stable across >= 2 runs
+# ---------------------------------------------------------------------------
+
+
+def _stable_trades():
+    entry = date(2026, 1, 1)
+    # Varied day-5 closes → non-zero dispersion so the objective is defined.
+    day5 = [104, 105, 103, 106, 102]
+    return [
+        _trade(f"R{i}", entry, [100, 101, 102, 103, c, c], stop=80.0)
+        for i, c in enumerate(day5)
+    ], entry + timedelta(days=5)
+
+
+def test_recommend_only_first_run_is_noop():
+    trades, as_of = _stable_trades()
+    with patch(
+        "rainier.llm_thesis.research._load_time_stop_trades", return_value=trades
+    ), patch(
+        "rainier.llm_thesis.research._prior_time_stop_evidence", return_value=None
+    ):
+        sess = MemSession()
+        out = discover_time_stop(
+            eval_date=as_of, candidate_ks=(5,), min_survivors=5, db_session=sess
+        )
+    ins = out[0]
+    assert ins.evidence["stable_run_count"] == 1
+    assert ins.evidence["stable"] is False
+    assert ins.action["kind"] == "noop"
+    assert ins.severity == "info"
+
+
+def test_flips_to_executable_when_stable():
+    trades, as_of = _stable_trades()
+    chosen = 5
+    prior = {"chosen_k": chosen, "stable_run_count": TIME_STOP_STABLE_RUNS - 1}
+    with patch(
+        "rainier.llm_thesis.research._load_time_stop_trades", return_value=trades
+    ), patch(
+        "rainier.llm_thesis.research._prior_time_stop_evidence", return_value=prior
+    ):
+        sess = MemSession()
+        out = discover_time_stop(
+            eval_date=as_of, candidate_ks=(5,), min_survivors=5, db_session=sess
+        )
+    ins = out[0]
+    assert ins.evidence["chosen_k"] == chosen
+    assert ins.evidence["stable_run_count"] == TIME_STOP_STABLE_RUNS
+    assert ins.evidence["stable"] is True
+    assert ins.action == {
+        "kind": "set_learned_time_stop_days",
+        "target": str(chosen),
+        "params": {"k": chosen},
+    }
+
+
+def test_stability_resets_when_chosen_k_changes():
+    trades, as_of = _stable_trades()  # this run picks k=5
+    prior = {"chosen_k": 8, "stable_run_count": 5}  # prior pick was different
+    with patch(
+        "rainier.llm_thesis.research._load_time_stop_trades", return_value=trades
+    ), patch(
+        "rainier.llm_thesis.research._prior_time_stop_evidence", return_value=prior
+    ):
+        sess = MemSession()
+        out = discover_time_stop(
+            eval_date=as_of, candidate_ks=(5,), min_survivors=5, db_session=sess
+        )
+    assert out[0].evidence["stable_run_count"] == 1
+    assert out[0].action["kind"] == "noop"
+
+
+def test_no_trades_emits_nothing():
+    with patch(
+        "rainier.llm_thesis.research._load_time_stop_trades", return_value=[]
+    ):
+        assert discover_time_stop(eval_date=date(2026, 1, 1)) == []

--- a/tests/test_llm_thesis/test_discover_time_stop.py
+++ b/tests/test_llm_thesis/test_discover_time_stop.py
@@ -291,6 +291,61 @@ def test_stability_resets_when_chosen_k_changes():
     assert out[0].action["kind"] == "noop"
 
 
+def test_same_eval_date_retry_does_not_advance_stability():
+    # codex iter-1 [P2]: a retry/replay of the weekly job on the SAME eval_date
+    # must not increment the stability counter — only a genuinely new weekly
+    # observation (a later eval_date) does. Otherwise re-running once flips the
+    # action to executable without a new week of data.
+    trades, as_of = _stable_trades()  # picks k=5
+    chosen = 5
+    # Prior pending row was already recorded for THIS same eval_date at count 1.
+    prior = {
+        "chosen_k": chosen,
+        "stable_run_count": 1,
+        "last_run_date": as_of.isoformat(),
+    }
+    with patch(
+        "rainier.llm_thesis.research._load_time_stop_trades", return_value=trades
+    ), patch(
+        "rainier.llm_thesis.research._prior_time_stop_evidence", return_value=prior
+    ):
+        sess = MemSession()
+        out = discover_time_stop(
+            eval_date=as_of, candidate_ks=(5,), min_survivors=5, db_session=sess
+        )
+    ins = out[0]
+    # Held steady at 1 (not advanced to 2), so it stays recommend-only.
+    assert ins.evidence["stable_run_count"] == 1
+    assert ins.evidence["stable"] is False
+    assert ins.action["kind"] == "noop"
+
+
+def test_distinct_later_eval_date_advances_stability():
+    # The complement: same chosen_k but a LATER eval_date is a real new
+    # observation — the counter advances and (at the threshold) flips executable.
+    trades, as_of = _stable_trades()  # picks k=5
+    chosen = 5
+    earlier = (as_of - timedelta(days=7)).isoformat()
+    prior = {
+        "chosen_k": chosen,
+        "stable_run_count": TIME_STOP_STABLE_RUNS - 1,
+        "last_run_date": earlier,
+    }
+    with patch(
+        "rainier.llm_thesis.research._load_time_stop_trades", return_value=trades
+    ), patch(
+        "rainier.llm_thesis.research._prior_time_stop_evidence", return_value=prior
+    ):
+        sess = MemSession()
+        out = discover_time_stop(
+            eval_date=as_of, candidate_ks=(5,), min_survivors=5, db_session=sess
+        )
+    ins = out[0]
+    assert ins.evidence["stable_run_count"] == TIME_STOP_STABLE_RUNS
+    assert ins.evidence["stable"] is True
+    assert ins.action["kind"] == "set_learned_time_stop_days"
+
+
 def test_no_trades_emits_nothing():
     with patch(
         "rainier.llm_thesis.research._load_time_stop_trades", return_value=[]

--- a/tests/test_llm_thesis/test_discover_time_stop.py
+++ b/tests/test_llm_thesis/test_discover_time_stop.py
@@ -74,27 +74,43 @@ def test_return_by_holding_day_skips_null_close():
     assert abs(curve[1] - 0.05) < 1e-9
 
 
-def test_partial_ohlc_bar_skipped_consistently_in_both_helpers():
-    # codex iter-6 [P2]: a partial-OHLC bar (high/low present, close NULL) must
-    # NOT advance the session counter in EITHER helper — otherwise _sl_tp_exit_day
-    # and _return_by_holding_day would number sessions differently and shift the
-    # k-th session. With the shared _is_priced_session predicate both skip it.
+def test_partial_ohlc_bar_counts_matching_evaluate_exit():
+    # codex iter-7 [P2]: evaluate_exit (exit.py) skips a bar ONLY when high/low
+    # is None and advances the session counter on everything else regardless of
+    # close; a NULL-close counted session uses entry_price (0% return) for the
+    # time-stop. The discovery helpers must match: a high/low-present-but-close-
+    # NULL bar COUNTS as a session, and its return-curve entry is 0%.
     entry = date(2026, 1, 1)
     rows = [
         (entry, 100, 100, 100, 100.0),                       # session 1
-        (entry + timedelta(days=1), 80, 130, 70, None),      # partial: close NULL
-        (entry + timedelta(days=2), 105, 105, 105, 105.0),   # session 2
+        (entry + timedelta(days=1), 100, 130, 70, None),     # session 2: close NULL
+        (entry + timedelta(days=2), 105, 105, 105, 105.0),   # session 3
     ]
     as_of = entry + timedelta(days=2)
-    # Return curve: the partial bar is skipped → two priced sessions.
+    # Return curve: the close-NULL bar COUNTS (0% via entry_price fallback).
     curve = _return_by_holding_day(rows, entry, 100.0, as_of=as_of)
+    assert len(curve) == 3
+    assert curve[0] == 0.0
+    assert curve[1] == 0.0          # entry_price fallback for the NULL close
+    assert abs(curve[2] - 0.05) < 1e-9
+    # Exit-day detector: the counted session-2 low (70) pierces a 75 stop → the
+    # exit registers on session 2 (the bar is NOT skipped), matching production.
+    assert _sl_tp_exit_day(rows, entry, stop_loss=75.0, target_price=200.0,
+                           as_of=as_of) == 2
+
+
+def test_all_none_ohlc_bar_is_skipped():
+    # A truly empty bar (all OHLC None — a no-data day) is skipped in both
+    # helpers, since high/low are absent (matches evaluate_exit exit.py:100).
+    entry = date(2026, 1, 1)
+    rows = [
+        (entry, 100, 100, 100, 100.0),
+        (entry + timedelta(days=1), None, None, None, None),  # no-data day
+        (entry + timedelta(days=2), 105, 105, 105, 105.0),
+    ]
+    curve = _return_by_holding_day(rows, entry, 100.0, as_of=entry + timedelta(days=2))
     assert len(curve) == 2
     assert abs(curve[1] - 0.05) < 1e-9
-    # Exit-day detector: the partial bar's 70 low / 130 high must NOT register an
-    # exit (it's skipped), so with a stop=75/target=125 the only real touch would
-    # be on a counted session — here none, so None.
-    assert _sl_tp_exit_day(rows, entry, stop_loss=75.0, target_price=125.0,
-                           as_of=as_of) is None
 
 
 def test_sl_tp_exit_day_excludes_pre_k_exit():

--- a/tests/test_llm_thesis/test_discover_time_stop.py
+++ b/tests/test_llm_thesis/test_discover_time_stop.py
@@ -74,6 +74,29 @@ def test_return_by_holding_day_skips_null_close():
     assert abs(curve[1] - 0.05) < 1e-9
 
 
+def test_partial_ohlc_bar_skipped_consistently_in_both_helpers():
+    # codex iter-6 [P2]: a partial-OHLC bar (high/low present, close NULL) must
+    # NOT advance the session counter in EITHER helper — otherwise _sl_tp_exit_day
+    # and _return_by_holding_day would number sessions differently and shift the
+    # k-th session. With the shared _is_priced_session predicate both skip it.
+    entry = date(2026, 1, 1)
+    rows = [
+        (entry, 100, 100, 100, 100.0),                       # session 1
+        (entry + timedelta(days=1), 80, 130, 70, None),      # partial: close NULL
+        (entry + timedelta(days=2), 105, 105, 105, 105.0),   # session 2
+    ]
+    as_of = entry + timedelta(days=2)
+    # Return curve: the partial bar is skipped → two priced sessions.
+    curve = _return_by_holding_day(rows, entry, 100.0, as_of=as_of)
+    assert len(curve) == 2
+    assert abs(curve[1] - 0.05) < 1e-9
+    # Exit-day detector: the partial bar's 70 low / 130 high must NOT register an
+    # exit (it's skipped), so with a stop=75/target=125 the only real touch would
+    # be on a counted session — here none, so None.
+    assert _sl_tp_exit_day(rows, entry, stop_loss=75.0, target_price=125.0,
+                           as_of=as_of) is None
+
+
 def test_sl_tp_exit_day_excludes_pre_k_exit():
     entry = date(2026, 1, 1)
     # Day 2 low gaps to the stop (90) → exits on holding-day 2.

--- a/tests/test_llm_thesis/test_discover_time_stop.py
+++ b/tests/test_llm_thesis/test_discover_time_stop.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 from rainier.llm_thesis.research import (
     TIME_STOP_STABLE_RUNS,
+    _day_k_exit_return,
     _return_by_holding_day,
     _sharpe_like,
     _sl_tp_exit_day,
@@ -87,6 +88,68 @@ def test_sl_tp_exit_day_excludes_pre_k_exit():
     # Never hits → None.
     rows2 = _bars(entry, closes=[100, 101, 102])
     assert _sl_tp_exit_day(rows2, entry, 80.0, 130.0, as_of=date(2026, 1, 3)) is None
+
+
+def test_day_k_exit_return_uses_level_on_day_k_touch():
+    # codex iter-4 [P2]: evaluate_exit checks SL/TP BEFORE the time-stop on the
+    # same session, so a day-k bar that touches the target exits at the target
+    # LEVEL — not the (flat) day-k close. The scorer must match that priority.
+    entry = date(2026, 1, 1)
+    # Day 3 (k=3): high reaches the 120 target intraday but closes flat at 100.
+    rows = _bars(
+        entry,
+        closes=[100, 100, 100],
+        highs=[100, 100, 120],   # day-3 high touches target
+        lows=[100, 100, 100],
+    )
+    r = _day_k_exit_return(
+        rows, entry, 100.0, stop_loss=80.0, target_price=120.0, k=3,
+        as_of=date(2026, 1, 3),
+    )
+    # +20% target return, NOT the 0% flat close.
+    assert abs(r - 0.20) < 1e-9
+
+
+def test_day_k_exit_return_same_bar_resolves_to_stop():
+    # Same-bar SL+TP on day k resolves conservatively to the stop (F3 downward
+    # bias, matching evaluate_exit).
+    entry = date(2026, 1, 1)
+    rows = _bars(
+        entry,
+        closes=[100, 100, 100],
+        highs=[100, 100, 120],   # touches target
+        lows=[100, 100, 80],     # AND touches stop on the same day-3 bar
+    )
+    r = _day_k_exit_return(
+        rows, entry, 100.0, stop_loss=80.0, target_price=120.0, k=3,
+        as_of=date(2026, 1, 3),
+    )
+    assert abs(r - (-0.20)) < 1e-9  # -20% stop, not +20% target
+
+
+def test_day_k_exit_return_survives_past_k_uses_close():
+    # No SL/TP touch through day k → score the day-k close return.
+    entry = date(2026, 1, 1)
+    rows = _bars(entry, closes=[100, 102, 105])
+    r = _day_k_exit_return(
+        rows, entry, 100.0, stop_loss=80.0, target_price=200.0, k=3,
+        as_of=date(2026, 1, 3),
+    )
+    assert abs(r - 0.05) < 1e-9
+
+
+def test_day_k_exit_return_excludes_pre_k_exit():
+    # Exits before k → None (caller drops from candidate k's cohort).
+    entry = date(2026, 1, 1)
+    rows = _bars(
+        entry, closes=[100, 92, 95],
+        highs=[101, 95, 96], lows=[99, 90, 94],  # day-2 low pierces 90 stop
+    )
+    r = _day_k_exit_return(
+        rows, entry, 100.0, stop_loss=90.0, target_price=120.0, k=3,
+        as_of=date(2026, 1, 3),
+    )
+    assert r is None
 
 
 def test_sharpe_like_prefers_low_variance():

--- a/tests/test_llm_thesis/test_discover_time_stop.py
+++ b/tests/test_llm_thesis/test_discover_time_stop.py
@@ -127,6 +127,42 @@ def test_day_k_exit_return_same_bar_resolves_to_stop():
     assert abs(r - (-0.20)) < 1e-9  # -20% stop, not +20% target
 
 
+def test_day_k_exit_return_gap_up_open_through_target_fills_at_open():
+    # codex iter-5 [P2]: a day-k OPEN that gaps above the target fills AT THE
+    # OPEN (evaluate_exit precedence), even if the bar later trades down through
+    # the stop. So the return is the open's +25%, not the 120 target level.
+    entry = date(2026, 1, 1)
+    rows = _bars(
+        entry,
+        closes=[100, 100, 100],
+        opens=[100, 100, 125],   # day-3 gaps up through the 120 target
+        highs=[100, 100, 125],
+        lows=[100, 100, 79],     # ...and later trades down through the 80 stop
+    )
+    r = _day_k_exit_return(
+        rows, entry, 100.0, stop_loss=80.0, target_price=120.0, k=3,
+        as_of=date(2026, 1, 3),
+    )
+    assert abs(r - 0.25) < 1e-9  # target exit @ open, not the stop or 120 level
+
+
+def test_day_k_exit_return_gap_down_open_through_stop_fills_at_open():
+    # Symmetric: a day-k open gapping below the stop fills at the open.
+    entry = date(2026, 1, 1)
+    rows = _bars(
+        entry,
+        closes=[100, 100, 100],
+        opens=[100, 100, 75],    # day-3 gaps down through the 80 stop
+        highs=[100, 100, 100],
+        lows=[100, 100, 75],
+    )
+    r = _day_k_exit_return(
+        rows, entry, 100.0, stop_loss=80.0, target_price=120.0, k=3,
+        as_of=date(2026, 1, 3),
+    )
+    assert abs(r - (-0.25)) < 1e-9  # stop exit @ open (-25%), not the 80 level
+
+
 def test_day_k_exit_return_survives_past_k_uses_close():
     # No SL/TP touch through day k → score the day-k close return.
     entry = date(2026, 1, 1)

--- a/tests/test_llm_thesis/test_discover_time_stop.py
+++ b/tests/test_llm_thesis/test_discover_time_stop.py
@@ -346,6 +346,37 @@ def test_distinct_later_eval_date_advances_stability():
     assert ins.action["kind"] == "set_learned_time_stop_days"
 
 
+def test_older_eval_date_replay_does_not_advance_stability():
+    # codex iter-2 [P2]: a manual replay with an OLDER eval_date than the prior
+    # recorded run must not be treated as a new forward observation — otherwise
+    # an out-of-order backfill could flip noop -> executable without two forward
+    # consecutive runs. The counter holds steady and the recorded date is kept.
+    trades, as_of = _stable_trades()  # picks k=5
+    chosen = 5
+    newer = (as_of + timedelta(days=7)).isoformat()  # prior run was LATER
+    prior = {
+        "chosen_k": chosen,
+        "stable_run_count": TIME_STOP_STABLE_RUNS - 1,
+        "last_run_date": newer,
+    }
+    with patch(
+        "rainier.llm_thesis.research._load_time_stop_trades", return_value=trades
+    ), patch(
+        "rainier.llm_thesis.research._prior_time_stop_evidence", return_value=prior
+    ):
+        sess = MemSession()
+        out = discover_time_stop(
+            eval_date=as_of, candidate_ks=(5,), min_survivors=5, db_session=sess
+        )
+    ins = out[0]
+    # Held steady — not advanced to the threshold — so stays recommend-only.
+    assert ins.evidence["stable_run_count"] == TIME_STOP_STABLE_RUNS - 1
+    assert ins.evidence["stable"] is False
+    assert ins.action["kind"] == "noop"
+    # The later prior date is preserved (not clobbered by the older replay).
+    assert ins.evidence["last_run_date"] == newer
+
+
 def test_no_trades_emits_nothing():
     with patch(
         "rainier.llm_thesis.research._load_time_stop_trades", return_value=[]

--- a/tests/test_llm_thesis/test_research.py
+++ b/tests/test_llm_thesis/test_research.py
@@ -280,6 +280,9 @@ def test_insight_kinds_and_severities_are_complete():
         "calibration_off",
         "prompt_regression",
         "new_pattern_discovered",
+        # Phase 2 (D6 / D7c).
+        "time_stop_discovered",
+        "paper_lessons",
     }
     assert set(SEVERITIES) == {"info", "warn", "critical"}
 
@@ -708,7 +711,7 @@ def test_check_prompt_regression_no_emit_when_single_prompt():
 
 def test_run_research_runs_all_checks_and_collects_emissions():
     """Each individual check is patched to emit a single insight; the
-    orchestrator should collect 6 total."""
+    orchestrator should collect 8 total (6 PR3 + 2 Phase-2)."""
     sentinel_rows: list[Any] = []
 
     def _fake(name):
@@ -755,10 +758,18 @@ def test_run_research_runs_all_checks_and_collects_emissions():
             "rainier.llm_thesis.research.check_prompt_regression",
             side_effect=_fake("prompt_regression"),
         ),
+        patch(
+            "rainier.llm_thesis.research.discover_time_stop",
+            side_effect=_fake("time_stop_discovered"),
+        ),
+        patch(
+            "rainier.llm_thesis.research.check_paper_lessons",
+            side_effect=_fake("paper_lessons"),
+        ),
     ):
         out = run_research(eval_date=date(2026, 5, 7))
 
-    assert len(out) == 6
+    assert len(out) == 8
     assert {r.kind for r in out} == set(INSIGHT_KINDS)
 
 
@@ -791,6 +802,12 @@ def test_run_research_isolates_failures():
         ),
         patch(
             "rainier.llm_thesis.research.check_prompt_regression", side_effect=_ok
+        ),
+        patch(
+            "rainier.llm_thesis.research.discover_time_stop", side_effect=_ok
+        ),
+        patch(
+            "rainier.llm_thesis.research.check_paper_lessons", side_effect=_ok
         ),
     ):
         out = run_research(eval_date=date(2026, 5, 7))

--- a/tests/test_llm_thesis/test_yaml_mutation.py
+++ b/tests/test_llm_thesis/test_yaml_mutation.py
@@ -19,6 +19,7 @@ from rainier.llm_thesis.research import (
     _increment_prompt_version,
     _lower_signal_weight,
     _raise_signal_weight,
+    _set_learned_time_stop_days,
     apply_action,
 )
 
@@ -205,6 +206,52 @@ def test_signal_weight_clamps_at_five(settings_path: Path):
         "rank_trajectory", {"factor": 100.0}, settings_path
     )
     assert diff["new_value"] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# set_learned_time_stop_days (D6) — mutates the EXISTING config field
+# ---------------------------------------------------------------------------
+
+
+def test_set_learned_time_stop_days_from_params_k(settings_path: Path):
+    diff = _set_learned_time_stop_days("5", {"k": 5}, settings_path)
+    assert diff == {
+        "field": "learned_time_stop_days",
+        "old_value": None,  # SAMPLE_YAML has no key yet
+        "new_value": 5,
+    }
+    text = settings_path.read_text()
+    assert "learned_time_stop_days: 5" in text
+    # Mutates llm_thesis (the existing field's section), not a new top-level key.
+    thesis_section = text.split("llm_thesis:")[1]
+    assert "learned_time_stop_days: 5" in thesis_section
+
+
+def test_set_learned_time_stop_days_falls_back_to_target(settings_path: Path):
+    diff = _set_learned_time_stop_days("8", {}, settings_path)
+    assert diff["new_value"] == 8
+
+
+def test_set_learned_time_stop_days_clears_on_none(settings_path: Path):
+    # First set it, then clear with an empty/invalid value.
+    _set_learned_time_stop_days("5", {"k": 5}, settings_path)
+    diff = _set_learned_time_stop_days("", {"k": None}, settings_path)
+    assert diff["old_value"] == 5
+    assert diff["new_value"] is None
+
+
+def test_set_learned_time_stop_days_rejects_below_one(settings_path: Path):
+    diff = _set_learned_time_stop_days("0", {"k": 0}, settings_path)
+    assert diff["new_value"] is None  # k<1 is meaningless → cleared
+
+
+def test_apply_action_set_learned_time_stop_dispatches(settings_path: Path):
+    diff = apply_action(
+        {"kind": "set_learned_time_stop_days", "target": "7", "params": {"k": 7}},
+        settings_path,
+    )
+    assert diff["field"] == "learned_time_stop_days"
+    assert diff["new_value"] == 7
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_paper/conftest.py
+++ b/tests/test_paper/conftest.py
@@ -22,6 +22,10 @@ from sqlalchemy.orm import sessionmaker
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MIGRATION_UP = REPO_ROOT / "migrations" / "0005_paper_tracker.sql"
 MIGRATION_DOWN = REPO_ROOT / "migrations" / "0005_paper_tracker_downgrade.sql"
+# Phase 2 (D7a): paper_calibration. Applied on top of 0005 in the same throwaway
+# schema so calibration compute/persist tests have the table.
+MIGRATION_0007_UP = REPO_ROOT / "migrations" / "0007_paper_calibration.sql"
+MIGRATION_0007_DOWN = REPO_ROOT / "migrations" / "0007_paper_calibration_downgrade.sql"
 
 # Minimal DDL for the FK-target tables the paper migration references. The real
 # schema lives in migrations/0001-0004; for an isolated paper-tracker test DB we
@@ -99,6 +103,26 @@ CREATE TABLE IF NOT EXISTS stock_prices (
     volume  BIGINT,
     PRIMARY KEY (id, date),
     CONSTRAINT uq_stock_price_symbol_date UNIQUE (symbol, date)
+);
+
+-- Mirror the ThesisEvaluation ORM (models.py) enough for the D7a calibration
+-- headline compute (reads horizon/verdict/llm_confidence/return_pct/scan_date).
+CREATE TABLE IF NOT EXISTS thesis_evaluations (
+    id                 SERIAL PRIMARY KEY,
+    thesis_id          INTEGER NOT NULL REFERENCES analysis_results (id),
+    screened_record_id INTEGER REFERENCES screened_stocks (id),
+    evaluated_at       TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    horizon            VARCHAR(8) NOT NULL,
+    scan_date          DATE NOT NULL,
+    symbol             VARCHAR(10) NOT NULL,
+    verdict            VARCHAR(20) NOT NULL,
+    llm_confidence     INTEGER,
+    entry_price        DOUBLE PRECISION NOT NULL,
+    exit_price         DOUBLE PRECISION NOT NULL,
+    return_pct         DOUBLE PRECISION NOT NULL,
+    hit                BOOLEAN NOT NULL,
+    signals_used       VARCHAR(50)[],
+    notes              TEXT
 );
 """
 
@@ -186,6 +210,7 @@ def pg_legacy_engine(request):
     with engine.begin() as conn:
         conn.execute(text(_PREREQ_DDL))
     _apply_sql(engine, MIGRATION_UP)
+    _apply_sql(engine, MIGRATION_0007_UP)  # D7a paper_calibration
 
     from rainier.core import config, database
 

--- a/tests/test_paper/test_calibration_db.py
+++ b/tests/test_paper/test_calibration_db.py
@@ -63,13 +63,15 @@ def _add_closed_trade(session, tid, symbol, *, exit_date, return_pct, pnl,
 
 def test_headline_is_unbiased_fixed_horizon(pg_legacy_session):
     s = pg_legacy_session
-    # Three 5d theses: 2 setup_long wins + 1 loss.
+    # Three 5d theses: 2 setup_long wins + 1 loss. scan_date is the 5d maturity
+    # ceiling for AS_OF (2026-02-03 = 5 trading days before 2026-02-10) so the
+    # rows are validly matured-by-as_of and pass the hindsight guard.
     _add_eval(s, 1, horizon="5d", verdict="setup_long", conf=9, ret=0.05,
-              scan_date=date(2026, 2, 5))
+              scan_date=date(2026, 2, 3))
     _add_eval(s, 2, horizon="5d", verdict="setup_long", conf=8, ret=0.03,
-              scan_date=date(2026, 2, 5))
+              scan_date=date(2026, 2, 3))
     _add_eval(s, 3, horizon="5d", verdict="setup_long", conf=4, ret=-0.02,
-              scan_date=date(2026, 2, 5))
+              scan_date=date(2026, 2, 3))
 
     payload = compute_calibration_payload(AS_OF)
     h5 = payload["headline_fixed_horizon"]["5d"]
@@ -78,6 +80,26 @@ def test_headline_is_unbiased_fixed_horizon(pg_legacy_session):
     assert abs(h5["overall"]["win_rate"] - 2 / 3) < 1e-9
     # The supplementary realized record exists and is labeled survivorship-prone.
     assert "survivorship-prone" in payload["supplementary_realized"]["label"]
+
+
+def test_headline_excludes_immature_horizon_rows_on_replay(pg_legacy_session):
+    # codex iter-2 [P2]: when run_daily_eval is replayed for a PAST as_of after
+    # later-dated rows exist, a 10d eval row for a thesis scanned just before
+    # as_of has NOT actually matured by as_of — including it leaks future
+    # outcomes. The headline must drop rows whose horizon hadn't elapsed by as_of.
+    s = pg_legacy_session
+    # 10d ceiling for AS_OF (2026-02-10) is 2026-01-27 (10 trading days back).
+    # Mature: scanned on/before the ceiling. Immature: scanned after it.
+    _add_eval(s, 1, horizon="10d", verdict="setup_long", conf=8, ret=0.05,
+              scan_date=date(2026, 1, 26))   # mature → counted
+    _add_eval(s, 2, horizon="10d", verdict="setup_long", conf=8, ret=0.99,
+              scan_date=date(2026, 2, 9))    # immature (future outcome) → dropped
+
+    payload = compute_calibration_payload(AS_OF)
+    h10 = payload["headline_fixed_horizon"]["10d"]
+    # Only the matured row is counted; the hindsight-laden 0.99 row is excluded.
+    assert h10["overall"]["n"] == 1
+    assert abs(h10["overall"]["avg_return_pct"] - 0.05) < 1e-9
 
 
 def test_supplementary_last_k_closed_and_mtm(pg_legacy_session):

--- a/tests/test_paper/test_calibration_db.py
+++ b/tests/test_paper/test_calibration_db.py
@@ -153,3 +153,24 @@ def test_load_latest_picks_most_recent_on_or_before(pg_legacy_session):
     assert got["tag"] == "old"
     got2 = load_latest_calibration(date(2026, 2, 9))
     assert got2["tag"] == "new"
+
+
+def test_load_latest_strict_before_excludes_same_day(pg_legacy_session):
+    # codex iter-3 [P2]: the prompt-injection path (generate_thesis) loads with
+    # strict_before=True so a scan on day D never sees day D's own calibration
+    # row (written end-of-day D, after that day's eval/paper outcomes). That row
+    # must not leak same-day hindsight into a same-day rerun / historical replay.
+    s = pg_legacy_session  # noqa: F841
+    persist_calibration(date(2026, 2, 5), {"as_of_date": "2026-02-05", "tag": "prior"})
+    persist_calibration(date(2026, 2, 9), {"as_of_date": "2026-02-09", "tag": "today"})
+
+    # Default (generic loader) includes the same-day row.
+    incl = load_latest_calibration(date(2026, 2, 9))
+    assert incl["tag"] == "today"
+
+    # strict_before: same-day row is excluded; falls back to the prior day.
+    strict = load_latest_calibration(date(2026, 2, 9), strict_before=True)
+    assert strict["tag"] == "prior"
+
+    # No prior row at all under strict → None (Phase-0 behaviour).
+    assert load_latest_calibration(date(2026, 2, 5), strict_before=True) is None

--- a/tests/test_paper/test_calibration_db.py
+++ b/tests/test_paper/test_calibration_db.py
@@ -1,0 +1,126 @@
+"""Phase 2 D7a — calibration compute/persist against a real DB (Postgres).
+
+Postgres-only: paper_calibration uses JSONB + ON CONFLICT ON CONSTRAINT, and
+the headline reads the thesis_evaluations ARRAY-bearing table. Skips cleanly
+when no Postgres is reachable (CI provides one).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import select, text
+
+from rainier.core.models import PaperCalibration, PaperTrade
+from rainier.paper.calibration import (
+    compute_calibration_payload,
+    load_latest_calibration,
+    persist_calibration,
+)
+
+pytestmark = pytest.mark.requires_postgres
+
+AS_OF = date(2026, 2, 10)
+
+
+def _seed_thesis(session, tid):
+    session.execute(
+        text("INSERT INTO analysis_results (id, llm_model, prompt_template) "
+             "VALUES (:i,'m','t') ON CONFLICT DO NOTHING"),
+        {"i": tid},
+    )
+
+
+def _add_eval(session, tid, *, horizon, verdict, conf, ret, scan_date):
+    _seed_thesis(session, tid)
+    session.execute(
+        text(
+            "INSERT INTO thesis_evaluations "
+            "(thesis_id, horizon, scan_date, symbol, verdict, llm_confidence, "
+            " entry_price, exit_price, return_pct, hit) "
+            "VALUES (:t,:h,:d,'SYM',:v,:c,100,100,:r,:hit)"
+        ),
+        {"t": tid, "h": horizon, "d": scan_date, "v": verdict, "c": conf,
+         "r": ret, "hit": ret > 0},
+    )
+    session.commit()
+
+
+def _add_closed_trade(session, tid, symbol, *, exit_date, return_pct, pnl,
+                      exit_reason="target"):
+    _seed_thesis(session, tid)
+    session.add(PaperTrade(
+        thesis_id=tid, symbol=symbol, scan_date=date(2026, 2, 1),
+        session_name="close", status="closed", planned_entry_price=100.0,
+        stop_loss=90.0, target_price=120.0, entry_date=date(2026, 2, 2),
+        entry_price=100.0, shares=100, residual_cash=0.0,
+        exit_date=exit_date, exit_price=100 * (1 + return_pct),
+        exit_reason=exit_reason, return_pct=return_pct, pnl=pnl,
+    ))
+    session.commit()
+
+
+def test_headline_is_unbiased_fixed_horizon(pg_legacy_session):
+    s = pg_legacy_session
+    # Three 5d theses: 2 setup_long wins + 1 loss.
+    _add_eval(s, 1, horizon="5d", verdict="setup_long", conf=9, ret=0.05,
+              scan_date=date(2026, 2, 5))
+    _add_eval(s, 2, horizon="5d", verdict="setup_long", conf=8, ret=0.03,
+              scan_date=date(2026, 2, 5))
+    _add_eval(s, 3, horizon="5d", verdict="setup_long", conf=4, ret=-0.02,
+              scan_date=date(2026, 2, 5))
+
+    payload = compute_calibration_payload(AS_OF)
+    h5 = payload["headline_fixed_horizon"]["5d"]
+    assert h5["overall"]["n"] == 3
+    # 2 of 3 gains.
+    assert abs(h5["overall"]["win_rate"] - 2 / 3) < 1e-9
+    # The supplementary realized record exists and is labeled survivorship-prone.
+    assert "survivorship-prone" in payload["supplementary_realized"]["label"]
+
+
+def test_supplementary_last_k_closed_and_mtm(pg_legacy_session):
+    s = pg_legacy_session
+    # 12 closed trades — only the last K=10 by exit_date appear in the sample.
+    for i in range(12):
+        _add_closed_trade(
+            s, 100 + i, f"C{i:02d}",
+            exit_date=date(2026, 2, 2 + (i % 7)),
+            return_pct=0.01 * (i + 1), pnl=10.0 * (i + 1),
+        )
+    payload = compute_calibration_payload(AS_OF, k=10)
+    supp = payload["supplementary_realized"]
+    assert supp["n_closed_sample"] == 10
+    # MTM-including-open figure is carried (no open positions → equals realized).
+    assert "mtm_including_open_pnl_usd" in supp
+    # Headline empty (no thesis_evaluations) but supplementary still computed.
+    assert payload["headline_fixed_horizon"] == {}
+
+
+def test_persist_and_load_round_trip(pg_legacy_session):
+    s = pg_legacy_session
+    _add_eval(s, 1, horizon="1d", verdict="setup_long", conf=7, ret=0.02,
+              scan_date=date(2026, 2, 9))
+    payload = compute_calibration_payload(AS_OF)
+    persist_calibration(AS_OF, payload)
+
+    loaded = load_latest_calibration(AS_OF)
+    assert loaded is not None
+    assert loaded["as_of_date"] == AS_OF.isoformat()
+    # Idempotent upsert: re-persist same as_of → still one row.
+    persist_calibration(AS_OF, payload)
+    n = s.execute(select(PaperCalibration)).scalars().all()
+    assert len(n) == 1
+
+
+def test_load_latest_picks_most_recent_on_or_before(pg_legacy_session):
+    s = pg_legacy_session  # noqa: F841
+    persist_calibration(date(2026, 2, 5), {"as_of_date": "2026-02-05", "tag": "old"})
+    persist_calibration(date(2026, 2, 8), {"as_of_date": "2026-02-08", "tag": "new"})
+    # Future row must not be picked when asking as-of 2026-02-06.
+    persist_calibration(date(2026, 2, 12), {"as_of_date": "2026-02-12", "tag": "fut"})
+    got = load_latest_calibration(date(2026, 2, 6))
+    assert got["tag"] == "old"
+    got2 = load_latest_calibration(date(2026, 2, 9))
+    assert got2["tag"] == "new"

--- a/tests/test_paper/test_calibration_db.py
+++ b/tests/test_paper/test_calibration_db.py
@@ -94,6 +94,13 @@ def test_supplementary_last_k_closed_and_mtm(pg_legacy_session):
     assert supp["n_closed_sample"] == 10
     # MTM-including-open figure is carried (no open positions → equals realized).
     assert "mtm_including_open_pnl_usd" in supp
+    # codex iter-1 [P2]: the headline-paired realized P&L is the BOOK TOTAL over
+    # all 12 closed (sum 10*(1..12) = 780), NOT the last-K=10 sample sum. The
+    # sample sum is surfaced separately and is strictly smaller here.
+    assert supp["realized_pnl_usd"] == 780.0
+    assert supp["sample_realized_pnl_usd"] < supp["realized_pnl_usd"]
+    # With no open positions, MTM-incl-open equals the book-total realized.
+    assert supp["mtm_including_open_pnl_usd"] == supp["realized_pnl_usd"]
     # Headline empty (no thesis_evaluations) but supplementary still computed.
     assert payload["headline_fixed_horizon"] == {}
 

--- a/tests/test_paper/test_daily_wiring.py
+++ b/tests/test_paper/test_daily_wiring.py
@@ -66,17 +66,31 @@ def test_g1_daily_eval_runs_steps_in_order(monkeypatch):
         "rainier.paper.report.send_daily_paper_report", lambda *a, **k: True
     )
 
+    # D7a calibration (step vi) — runs AFTER the report.
+    def fake_calib_compute(as_of):
+        calls.append("calibration")
+        return {}
+
+    monkeypatch.setattr(
+        "rainier.paper.calibration.compute_calibration_payload", fake_calib_compute
+    )
+    monkeypatch.setattr(
+        "rainier.paper.calibration.persist_calibration", lambda *a, **k: None
+    )
+
     # Avoid the yesterday-rows DB fetch.
     monkeypatch.setattr(service, "load_settings_fresh", lambda: _FakeSettings())
 
     asyncio.run(service.run_daily_eval("2026-01-09"))
 
     # ingest precedes fill (G2); fill precedes update; update precedes horizon
-    # eval; horizon precedes the paper report (G1 authoritative order).
+    # eval; horizon precedes the paper report; report precedes calibration
+    # (step vi reuses the report's MTM figure — G1 authoritative order).
     assert calls.index("ingest") < calls.index("fill")
     assert calls.index("fill") < calls.index("update")
     assert calls.index("update") < calls.index("horizon")
     assert calls.index("horizon") < calls.index("report")
+    assert calls.index("report") < calls.index("calibration")
 
 
 class _FakeDiscord:
@@ -130,6 +144,12 @@ def test_g3_horizon_eval_still_runs(monkeypatch):
     )
     monkeypatch.setattr(
         "rainier.paper.report.send_daily_paper_report", lambda *a, **k: True
+    )
+    monkeypatch.setattr(
+        "rainier.paper.calibration.compute_calibration_payload", lambda d: {}
+    )
+    monkeypatch.setattr(
+        "rainier.paper.calibration.persist_calibration", lambda *a, **k: None
     )
     monkeypatch.setattr(service, "load_settings_fresh", lambda: _FakeSettings())
 

--- a/tests/test_paper/test_future_fills_and_lessons.py
+++ b/tests/test_paper/test_future_fills_and_lessons.py
@@ -1,0 +1,142 @@
+"""Phase 2 — future-fills-only time-stop adoption (verify-only regression) +
+weekly paper_lessons insight.
+
+Future-fills-only invariant (D6/E5, the fill wiring shipped in #117): adopting
+a learned time-stop snapshots it onto NEW fills at fill time; already-open
+positions filled before adoption keep their prior NULL — never retroactively
+mutated. This test PROVES that invariant; it adds no fill-wiring code.
+
+Postgres-only (paper_trade JSONB/partial-unique + thesis_evaluations).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import select, text
+
+from rainier.core.models import PaperTrade, StockPrice
+from rainier.paper.ingest import canonical_instant
+from rainier.paper.positions import fill_pending_positions
+
+pytestmark = pytest.mark.requires_postgres
+
+
+def _seed_thesis(session, tid):
+    session.execute(
+        text("INSERT INTO analysis_results (id, llm_model, prompt_template) "
+             "VALUES (:i,'m','t') ON CONFLICT DO NOTHING"),
+        {"i": tid},
+    )
+
+
+def _mk_pending(session, tid, symbol, scan_date):
+    _seed_thesis(session, tid)
+    session.add(PaperTrade(
+        thesis_id=tid, symbol=symbol, scan_date=scan_date, session_name="close",
+        status="pending", planned_entry_price=100.0, stop_loss=90.0,
+        target_price=120.0,
+    ))
+    session.commit()
+
+
+def _price(session, symbol, d, o, h, low, c):
+    session.execute(
+        text("INSERT INTO stocks (symbol) VALUES (:s) ON CONFLICT DO NOTHING"),
+        {"s": symbol},
+    )
+    session.add(StockPrice(symbol=symbol, date=canonical_instant(d), open=o,
+                           high=h, low=low, close=c, volume=1000))
+    session.commit()
+
+
+def _get(session, tid):
+    session.expire_all()
+    return session.execute(
+        select(PaperTrade).where(PaperTrade.thesis_id == tid)
+    ).scalars().first()
+
+
+def test_future_fills_only_time_stop_adoption(pg_legacy_session):
+    """A position filled BEFORE adoption keeps NULL time_stop_days; one filled
+    AFTER snapshots the learned k. No retroactive mutation."""
+    s = pg_legacy_session
+
+    # --- Pre-adoption: fill BEFORE the time-stop was learned (k=None). ---
+    before_scan = date(2026, 3, 2)  # Monday
+    _mk_pending(s, 1, "BEFORE", before_scan)
+    # T+1 = 2026-03-03; provide a clean open between stop/target.
+    _price(s, "BEFORE", date(2026, 3, 3), 100, 101, 99, 100)
+    res1 = fill_pending_positions(as_of=date(2026, 3, 3), learned_time_stop_days=None)
+    assert res1["filled"] == 1
+    before_pos = _get(s, 1)
+    assert before_pos.status == "open"
+    assert before_pos.time_stop_days is None  # filled before adoption → NULL
+
+    # --- Adoption happens (config now learned_time_stop_days=5). ---
+    # A NEW pending filled AFTER adoption snapshots k=5.
+    after_scan = date(2026, 3, 4)
+    _mk_pending(s, 2, "AFTER", after_scan)
+    _price(s, "AFTER", date(2026, 3, 5), 100, 101, 99, 100)
+    res2 = fill_pending_positions(as_of=date(2026, 3, 5), learned_time_stop_days=5)
+    assert res2["filled"] == 1
+    after_pos = _get(s, 2)
+    assert after_pos.status == "open"
+    assert after_pos.time_stop_days == 5  # filled after adoption → snapshots k
+
+    # The already-open BEFORE position is NEVER retroactively mutated, even
+    # though the later fill ran with k=5.
+    before_again = _get(s, 1)
+    assert before_again.time_stop_days is None
+
+
+# ---------------------------------------------------------------------------
+# weekly paper_lessons insight (D7c) from closed paper trades
+# ---------------------------------------------------------------------------
+
+
+def _add_closed(session, tid, symbol, *, exit_date, return_pct, pnl, reason):
+    _seed_thesis(session, tid)
+    session.add(PaperTrade(
+        thesis_id=tid, symbol=symbol, scan_date=date(2026, 3, 1),
+        session_name="close", status="closed", planned_entry_price=100.0,
+        stop_loss=90.0, target_price=120.0, entry_date=date(2026, 3, 2),
+        entry_price=100.0, shares=100, residual_cash=0.0, exit_date=exit_date,
+        exit_price=100 * (1 + return_pct), exit_reason=reason,
+        return_pct=return_pct, pnl=pnl,
+    ))
+    session.commit()
+
+
+def test_paper_lessons_insight_from_closed_trades(pg_legacy_session):
+    s = pg_legacy_session
+    from rainier.llm_thesis.research import check_paper_lessons
+
+    as_of = date(2026, 3, 20)
+    _add_closed(s, 1, "WIN", exit_date=date(2026, 3, 10), return_pct=0.10,
+                pnl=1000.0, reason="target")
+    _add_closed(s, 2, "LOS", exit_date=date(2026, 3, 12), return_pct=-0.05,
+                pnl=-500.0, reason="stop_loss")
+    _add_closed(s, 3, "TIM", exit_date=date(2026, 3, 15), return_pct=0.02,
+                pnl=200.0, reason="time_stop")
+
+    out = check_paper_lessons(eval_date=as_of, days=30)
+    assert len(out) == 1
+    ins = out[0]
+    assert ins.kind == "paper_lessons"
+    assert ins.severity == "info"
+    assert ins.action["kind"] == "noop"
+    ev = ins.evidence
+    assert ev["n_closed"] == 3
+    assert abs(ev["win_rate"] - 2 / 3) < 1e-9
+    assert ev["exit_reason_mix"] == {"target": 1, "stop_loss": 1, "time_stop": 1}
+    assert ev["best"]["symbol"] == "WIN"
+    assert ev["worst"]["symbol"] == "LOS"
+
+
+def test_paper_lessons_no_closed_trades_emits_nothing(pg_legacy_session):
+    s = pg_legacy_session  # noqa: F841
+    from rainier.llm_thesis.research import check_paper_lessons
+
+    assert check_paper_lessons(eval_date=date(2026, 3, 20), days=30) == []

--- a/tests/test_paper/test_migrations.py
+++ b/tests/test_paper/test_migrations.py
@@ -7,6 +7,7 @@ from sqlalchemy import inspect, text
 from sqlalchemy.exc import IntegrityError
 
 from rainier.core.models import (
+    PaperCalibration,
     PaperReportSnapshot,
     PaperSkip,
     PaperTrade,
@@ -116,6 +117,22 @@ def test_paper_trade_not_a_hypertable_marker():
     assert "paper_trade" not in HYPERTABLES
 
 
+def test_paper_calibration_orm_shape():
+    """D7a — PaperCalibration ORM: id/as_of_date/payload/created_at, JSONB
+    payload, UNIQUE(as_of_date), NOT a hypertable."""
+    cols = {c.name for c in inspect(PaperCalibration).columns}
+    assert {"id", "as_of_date", "payload", "created_at"} <= cols
+    uniques = [
+        c for c in PaperCalibration.__table__.constraints
+        if c.__class__.__name__ == "UniqueConstraint"
+    ]
+    assert any({col.name for col in c.columns} == {"as_of_date"} for c in uniques)
+    assert "JSON" in str(PaperCalibration.__table__.c.payload.type).upper()
+    from rainier.core.models import HYPERTABLES
+
+    assert "paper_calibration" not in HYPERTABLES
+
+
 # --------------------------------------------------------------------------
 # Postgres-only schema assertions (sqlite can't model these)
 # --------------------------------------------------------------------------
@@ -213,6 +230,37 @@ def test_a6_partial_unique_pending_open(pg_legacy_engine, first, second, should_
     else:
         with pg_legacy_engine.begin() as conn:
             _insert(conn, 102, second)
+
+
+@pytest.mark.requires_postgres
+def test_0007_paper_calibration_up_creates_table(pg_legacy_engine):
+    """D7a — the 0007 migration (applied by the fixture) creates
+    paper_calibration with UNIQUE(as_of_date)."""
+    insp = inspect(pg_legacy_engine)
+    schema = pg_legacy_engine.rainier_schema
+    assert "paper_calibration" in set(insp.get_table_names(schema=schema))
+    uqs = insp.get_unique_constraints("paper_calibration", schema=schema)
+    assert any(set(u["column_names"]) == {"as_of_date"} for u in uqs)
+
+
+@pytest.mark.requires_postgres
+def test_0007_paper_calibration_downgrade_drops_only_its_table(pg_legacy_engine):
+    """D7a downgrade drops paper_calibration; 0005 tables + FK targets remain."""
+    from pathlib import Path
+
+    down = (
+        Path(__file__).resolve().parents[2]
+        / "migrations" / "0007_paper_calibration_downgrade.sql"
+    )
+    with pg_legacy_engine.begin() as conn:
+        conn.execute(text(down.read_text()))
+    insp = inspect(pg_legacy_engine)
+    schema = pg_legacy_engine.rainier_schema
+    tables = set(insp.get_table_names(schema=schema))
+    assert "paper_calibration" not in tables
+    # 0005 tables + FK targets untouched.
+    assert {"paper_trade", "paper_skip", "paper_report_snapshot",
+            "analysis_results", "screened_stocks"} <= tables
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_research_helpers.py
+++ b/tests/test_research_helpers.py
@@ -1,0 +1,77 @@
+"""Shared in-memory ResearchInsight session for research unit tests.
+
+`emit_insight(db_session=...)` only needs query().filter().first(), add(),
+flush(). This minimal fake satisfies that so check-class tests stay
+network/Postgres-free and deterministic.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from rainier.core.models import ResearchInsight
+
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = rows
+        self._filters: list = []
+
+    def filter(self, *args):
+        self._filters.extend(args)
+        return self
+
+    def first(self):
+        candidates = list(self._rows)
+        for f in self._filters:
+            try:
+                col_name = f.left.key
+                expected = f.right.value
+            except AttributeError:
+                continue
+            candidates = [
+                r for r in candidates if getattr(r, col_name, None) == expected
+            ]
+        return candidates[0] if candidates else None
+
+    def all(self):
+        return list(self._rows)
+
+
+class MemSession:
+    def __init__(self):
+        self.rows: list[ResearchInsight] = []
+        self._next_id = 1
+        self.committed = False
+
+    def query(self, model):  # noqa: ARG002
+        return _Query(self.rows)
+
+    def add(self, row: ResearchInsight) -> None:
+        if row.id is None:
+            row.id = self._next_id
+            self._next_id += 1
+        if row.created_at is None:
+            row.created_at = datetime.now(timezone.utc)
+        if row.updated_at is None:
+            row.updated_at = datetime.now(timezone.utc)
+        if row.recurrence_count is None:
+            row.recurrence_count = 1
+        if row.status is None:
+            row.status = "pending"
+        self.rows.append(row)
+
+    def flush(self) -> None:
+        return None
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def close(self) -> None:
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False


### PR DESCRIPTION
## Summary
QU100-LLM feedback loop **Phase 2** (feedback INTO the LLM), on the legacy local-TimescaleDB engine. Stacks on #117 (Phase 0+1). Scope confirmed by operator 2026-06-04 (one PR; D7b weight-tuning deferred).

- **D7a calibration block** — new `PaperCalibration` ORM + migration `0007_paper_calibration.sql`; `paper/calibration.py` computes a bounded block: headline = UNBIASED `ThesisEvaluation` fixed-horizon (1d/5d/10d) stats by verdict + confidence bucket; supplementary = last K=10 closed paper trades (labeled realized-closed, survivorship-prone) + MTM-including-open. Injected into `build_user_message`; `prompt_version` bumped v1→v2 (config + settings.yaml) to bust the Tier-1 cache (calibration text is invisible to `input_hash`).
- **D7c weekly lessons** — `check_paper_lessons` reads closed paper P&L → `paper_lessons` insight (info/noop), wired into `run_research`.
- **D6 discover_time_stop (recommend-only)** — return-by-holding-day curve from `stock_prices` (as-of capped, survivor cohort), risk-adjusted Sharpe-like objective, min-survivors-per-k gate, recommend-only until k stable ≥2 runs → then `set_learned_time_stop_days` executor mutates the existing `learned_time_stop_days` config. New `time_stop_discovered` insight kind + executor.

Non-goals respected: `evaluate_exit`/`positions.py` unchanged (only a future-fills-only regression test added); `raise/lower_signal_weight` untouched; no D7b weight-tuning; no Phase 3/4; `market.*`/Neon untouched.

## Review
- /review: PASS (2 consecutive clean rounds).
- codex review: PASS (9 rounds, two consecutive clean). Notable fixes during review: the `prompt_version` bump was a no-op at the module constant (runtime reads `settings.llm_thesis.prompt_version`) — fixed in config + settings.yaml + regression test; the time-stop scorer brought to bit-exact parity with `evaluate_exit` (SL/TP-before-time-stop, gap-through-open, high/low session counting). No deferred findings.

## Test plan
- [x] Full suite 1380 passed, 169 skipped (Postgres-initdb-gated); ruff clean. 16 new regression tests.
- [ ] CI green