### PR TITLE
fix: P0 qu100 latest-snapshot scoping by trading day + persist dedup

### DIFF
--- a/src/rainier/analysis/stock_screener.py
+++ b/src/rainier/analysis/stock_screener.py
@@ -185,22 +185,38 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
 
     Returns list of MoneyFlowSignal sorted by signal_strength descending.
     """
-    # Step 1: Latest QU100 snapshot — "Long in" stocks only
-    latest_ts = session.query(
-        func.max(MoneyFlowSnapshot.captured_at)
+    # Step 1: Latest QU100 snapshot — "Long in" stocks only.
+    #
+    # Scope "latest" by trading DAY, not insert time. The 2026-06-04 backfill
+    # stamped all 1,373 historical days with one shared `captured_at`, so the
+    # old `captured_at == max(captured_at)` selected every backfilled day at
+    # once (duplicate symbols across days -> CardinalityViolation downstream).
+    # Pick the most recent `data_date`, then the latest `captured_at` WITHIN
+    # that date — one clean trading-day snapshot regardless of insert collisions.
+    latest_date = session.query(
+        func.max(MoneyFlowSnapshot.data_date)
     ).scalar()
-    if latest_ts is None:
+    if latest_date is None:
         log.warning("No money flow snapshots in database")
         return []
 
-    # Staleness check: reject data older than 24 hours
+    latest_ts = (
+        session.query(func.max(MoneyFlowSnapshot.captured_at))
+        .filter(MoneyFlowSnapshot.data_date == latest_date)
+        .scalar()
+    )
+
+    # Staleness check: reject data older than 24 hours. Age is judged on the
+    # latest trading day's captured_at (when that day's snapshot was scraped).
     now = datetime.now(timezone.utc)
     ts = latest_ts if latest_ts.tzinfo else latest_ts.replace(tzinfo=timezone.utc)
     age_hours = (now - ts).total_seconds() / 3600
     if age_hours > 24:
         log.warning(
-            "Stale QU100 data (%.1f hours old, captured_at=%s) — skipping report",
+            "Stale QU100 data (%.1f hours old, data_date=%s captured_at=%s) — "
+            "skipping report",
             age_hours,
+            latest_date,
             latest_ts,
         )
         return []
@@ -217,6 +233,7 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
         .filter(
             MoneyFlowSnapshot.ranking_type == "top100",
             MoneyFlowSnapshot.long_short == "Long in",
+            MoneyFlowSnapshot.data_date == latest_date,
             MoneyFlowSnapshot.captured_at == latest_ts,
         )
         .order_by(MoneyFlowSnapshot.rank.asc())
@@ -224,8 +241,18 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
     )
 
     if not rows:
-        log.warning("No 'Long in' stocks found at %s", latest_ts)
+        log.warning(
+            "No 'Long in' stocks found at data_date=%s captured_at=%s",
+            latest_date,
+            latest_ts,
+        )
         return []
+
+    # Defensive dedup by symbol: even within one (data_date, captured_at) a
+    # symbol must appear once. Rows are rank-ascending, so the first occurrence
+    # is the best-ranked — keep it.
+    seen: set[str] = set()
+    rows = [r for r in rows if not (r.symbol in seen or seen.add(r.symbol))]
 
     # Step 2: Enrich each stock with capital flow data
     signals: list[MoneyFlowSignal] = []

--- a/src/rainier/analysis/stock_screener.py
+++ b/src/rainier/analysis/stock_screener.py
@@ -193,16 +193,27 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
     # once (duplicate symbols across days -> CardinalityViolation downstream).
     # Pick the most recent `data_date`, then the latest `captured_at` WITHIN
     # that date — one clean trading-day snapshot regardless of insert collisions.
-    latest_date = session.query(
-        func.max(MoneyFlowSnapshot.data_date)
-    ).scalar()
+    #
+    # Both the date and the timestamp are scoped to ranking_type == "top100"
+    # (the same scope as the row query below). A day whose newest scrape held
+    # only bottom100 (or another non-top100 partial) must NOT become the
+    # "latest" date — otherwise the top100 row filter returns nothing and the
+    # report blanks even though a fresh top100 snapshot exists on a prior day.
+    latest_date = (
+        session.query(func.max(MoneyFlowSnapshot.data_date))
+        .filter(MoneyFlowSnapshot.ranking_type == "top100")
+        .scalar()
+    )
     if latest_date is None:
         log.warning("No money flow snapshots in database")
         return []
 
     latest_ts = (
         session.query(func.max(MoneyFlowSnapshot.captured_at))
-        .filter(MoneyFlowSnapshot.data_date == latest_date)
+        .filter(
+            MoneyFlowSnapshot.ranking_type == "top100",
+            MoneyFlowSnapshot.data_date == latest_date,
+        )
         .scalar()
     )
 

--- a/src/rainier/llm_thesis/persistence.py
+++ b/src/rainier/llm_thesis/persistence.py
@@ -85,9 +85,18 @@ def persist_screened_stocks(
     """
     if not candidates:
         return 0
+    # Defensive dedup by (scan_date, session_name, symbol). scan_date and
+    # session_name are constant for the batch, so dedup on symbol. An in-batch
+    # duplicate makes ON CONFLICT DO UPDATE touch the same row twice ->
+    # psycopg2 CardinalityViolation (the 2026-06-04 P0). Candidates arrive
+    # sorted by composite score descending, so the first occurrence is the
+    # best-ranked — keep it, drop the rest. This is the hard DB invariant; do
+    # it here even though `_screen_money_flow` also dedups upstream.
+    seen: set[str] = set()
+    deduped = [c for c in candidates if not (c.symbol in seen or seen.add(c.symbol))]
     rows = [
         _candidate_row(c, rank, scan_date, session_name)
-        for rank, c in enumerate(candidates, start=1)
+        for rank, c in enumerate(deduped, start=1)
     ]
     with get_session() as session:
         stmt = pg_insert(ScreenedStockRecord).values(rows)

--- a/tests/test_llm_thesis/test_persistence.py
+++ b/tests/test_llm_thesis/test_persistence.py
@@ -67,6 +67,61 @@ def test_candidate_row_money_flow_none_when_missing():
     assert row["money_flow_score"] is None
 
 
+def test_persist_screened_stocks_dedups_duplicate_symbol():
+    """P0 regression: an in-batch duplicate (scan_date, session_name, symbol)
+    must be deduped BEFORE the bulk upsert, or psycopg2 raises
+    CardinalityViolation ("ON CONFLICT DO UPDATE cannot affect row a second
+    time"). Capture the rows handed to pg_insert().values() and assert keys are
+    unique."""
+    captured: dict[str, list[dict]] = {}
+
+    def _capture(rows):
+        captured["rows"] = rows
+        return MagicMock()
+
+    cm, _ = _patched_session(rowcount=1)
+    cands = [_candidate("NVDA"), _candidate("TSLA"), _candidate("NVDA")]
+    with patch.object(persist_mod, "get_session", return_value=cm), patch.object(
+        persist_mod, "pg_insert"
+    ) as pg:
+        pg.return_value.values.side_effect = _capture
+        n = persist_mod.persist_screened_stocks(
+            cands, scan_date=date(2026, 6, 4), session_name="afternoon",
+        )
+
+    rows = captured["rows"]
+    keys = [(r["scan_date"], r["session_name"], r["symbol"]) for r in rows]
+    assert len(keys) == len(set(keys)), "duplicate (scan_date,session,symbol) reached upsert"
+    assert sorted(r["symbol"] for r in rows) == ["NVDA", "TSLA"]
+    assert n == len(rows) == 2
+
+
+def test_persist_screened_stocks_dedup_keeps_best_ranked():
+    """When a symbol appears twice, keep the first (best-ranked) occurrence —
+    candidates arrive sorted by composite score descending."""
+    captured: dict[str, list[dict]] = {}
+
+    def _capture(rows):
+        captured["rows"] = rows
+        return MagicMock()
+
+    cm, _ = _patched_session(rowcount=1)
+    # Two NVDA candidates: first has the stronger composite score.
+    strong = _candidate("NVDA", strength=0.9)
+    weak = _candidate("NVDA", strength=0.1)
+    with patch.object(persist_mod, "get_session", return_value=cm), patch.object(
+        persist_mod, "pg_insert"
+    ) as pg:
+        pg.return_value.values.side_effect = _capture
+        persist_mod.persist_screened_stocks(
+            [strong, weak], scan_date=date(2026, 6, 4), session_name="afternoon",
+        )
+
+    rows = captured["rows"]
+    assert len(rows) == 1
+    assert rows[0]["composite_score"] == 0.9
+
+
 def test_persist_screened_stocks_empty_returns_zero():
     n = persist_mod.persist_screened_stocks(
         [], scan_date=date(2026, 5, 7), session_name="afternoon"

--- a/tests/test_stock_screener.py
+++ b/tests/test_stock_screener.py
@@ -11,8 +11,12 @@ from rainier.analysis.stock_screener import screen_stocks
 
 def _patched_session_with_no_signals():
     fake = MagicMock()
-    # Layer 1 _screen_money_flow signature returns []
+    # Layer 1 _screen_money_flow returns [] when there is no data. It probes
+    # the latest top100 trading day via `query(...).filter(...).scalar()` and
+    # also via the unfiltered `query(...).scalar()` chain, so BOTH must resolve
+    # to None to exercise the no-data early return.
     fake.query.return_value.scalar.return_value = None
+    fake.query.return_value.filter.return_value.scalar.return_value = None
     cm = MagicMock()
     cm.__enter__.return_value = fake
     cm.__exit__.return_value = False

--- a/tests/test_stock_screener_latest_snapshot.py
+++ b/tests/test_stock_screener_latest_snapshot.py
@@ -1,0 +1,187 @@
+"""Regression: _screen_money_flow must scope the latest snapshot by trading day.
+
+P0 (2026-06-04): the QU100 backfill stamped all 1,373 trading days with one
+shared `captured_at`. The old `captured_at == max(captured_at)` selected every
+backfilled day at once (45,921 "Long in" rows, duplicate symbols across days),
+which then crashed the screened_stocks upsert with a CardinalityViolation.
+
+The fix scopes "latest snapshot" by `max(data_date)`, then the latest
+`captured_at` WITHIN that date — isolating one clean trading-day snapshot
+regardless of insert-time collisions. Staleness is judged on that date's
+captured_at. Signals are deduped by symbol.
+
+These tests build a raw-DDL SQLite table that mirrors the
+`money_flow_snapshots` / `stock_capital_flow` columns (the ORM models can't
+create on SQLite — composite PK + JSONB). The ORM-class queries inside
+`_screen_money_flow` run unmodified against those tables.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from rainier.analysis.stock_screener import _screen_money_flow
+
+_DDL_SNAPSHOTS = """
+CREATE TABLE money_flow_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    captured_at TIMESTAMP NOT NULL,
+    capture_session TEXT,
+    data_date DATE NOT NULL,
+    view_type TEXT,
+    ranking_type TEXT NOT NULL,
+    symbol TEXT NOT NULL,
+    rank INTEGER NOT NULL,
+    daily_change INTEGER,
+    sector TEXT,
+    industry TEXT,
+    long_short TEXT,
+    raw_data TEXT
+)
+"""
+
+_DDL_CAPITAL_FLOW = """
+CREATE TABLE stock_capital_flow (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    symbol TEXT NOT NULL,
+    captured_at TIMESTAMP NOT NULL,
+    flow_date DATE NOT NULL,
+    period_type TEXT NOT NULL,
+    week_start DATE,
+    week_end DATE,
+    capital_flow_direction TEXT,
+    long_short TEXT,
+    rank INTEGER,
+    rank_total INTEGER,
+    raw_data TEXT
+)
+"""
+
+
+@pytest.fixture
+def db_session():
+    eng = create_engine("sqlite://")
+    with eng.begin() as conn:
+        conn.execute(text(_DDL_SNAPSHOTS))
+        conn.execute(text(_DDL_CAPITAL_FLOW))
+    sess = Session(eng)
+    try:
+        yield sess
+    finally:
+        sess.close()
+        eng.dispose()
+
+
+def _insert_snapshot(
+    session: Session,
+    *,
+    symbol: str,
+    rank: int,
+    data_date: str,
+    captured_at: datetime,
+    ranking_type: str = "top100",
+    long_short: str = "Long in",
+    sector: str = "Technology",
+):
+    session.execute(
+        text(
+            "INSERT INTO money_flow_snapshots "
+            "(captured_at, capture_session, data_date, view_type, ranking_type, "
+            " symbol, rank, daily_change, sector, industry, long_short) "
+            "VALUES (:captured_at, 'afternoon', :data_date, 'daily', :ranking_type, "
+            " :symbol, :rank, 0, :sector, 'X', :long_short)"
+        ),
+        {
+            "captured_at": captured_at,
+            "data_date": data_date,
+            "ranking_type": ranking_type,
+            "symbol": symbol,
+            "rank": rank,
+            "sector": sector,
+            "long_short": long_short,
+        },
+    )
+    session.commit()
+
+
+def _recent_ts() -> datetime:
+    """A captured_at well within the 24h staleness window."""
+    return datetime.now(timezone.utc) - timedelta(hours=1)
+
+
+def test_backfill_shape_returns_only_latest_date(db_session):
+    """Many data_dates sharing ONE captured_at -> only the latest date's rows."""
+    shared_ts = _recent_ts()
+    # Backfill: 5 trading days, each with its own 2-symbol "Long in" snapshot,
+    # ALL stamped with the same captured_at (the backfill collision).
+    for i, d in enumerate(
+        ["2026-05-30", "2026-06-01", "2026-06-02", "2026-06-03", "2026-06-04"]
+    ):
+        _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date=d, captured_at=shared_ts)
+        _insert_snapshot(db_session, symbol="TSLA", rank=2, data_date=d, captured_at=shared_ts)
+
+    signals = _screen_money_flow(db_session)
+
+    # Only the latest data_date (2026-06-04) -> 2 unique symbols, not 10.
+    assert len(signals) == 2
+    symbols = sorted(s.symbol for s in signals)
+    assert symbols == ["NVDA", "TSLA"]
+
+
+def test_signals_are_unique_by_symbol(db_session):
+    """Even if the same symbol appears across days at one captured_at, dedup."""
+    shared_ts = _recent_ts()
+    for d in ["2026-06-02", "2026-06-03", "2026-06-04"]:
+        _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date=d, captured_at=shared_ts)
+
+    signals = _screen_money_flow(db_session)
+    assert [s.symbol for s in signals] == ["NVDA"]
+
+
+def test_latest_date_picks_latest_captured_at(db_session):
+    """Latest date has two captured_at (morning scrape + backfill) -> pick latest."""
+    latest_date = "2026-06-04"
+    early_ts = _recent_ts() - timedelta(hours=2)
+    late_ts = _recent_ts()
+    # Early snapshot: NVDA only. Late snapshot: NVDA + AMD (the real refresh).
+    _insert_snapshot(db_session, symbol="NVDA", rank=9, data_date=latest_date, captured_at=early_ts)
+    _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date=latest_date, captured_at=late_ts)
+    _insert_snapshot(db_session, symbol="AMD", rank=2, data_date=latest_date, captured_at=late_ts)
+
+    signals = _screen_money_flow(db_session)
+    by_symbol = {s.symbol: s for s in signals}
+    assert set(by_symbol) == {"NVDA", "AMD"}
+    # NVDA must reflect the LATE snapshot (rank 1), not the early one (rank 9).
+    assert by_symbol["NVDA"].rank == 1
+
+
+def test_stale_latest_date_skipped(db_session):
+    """Latest data_date's captured_at older than 24h -> skip (empty)."""
+    stale_ts = datetime.now(timezone.utc) - timedelta(hours=30)
+    _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date="2026-06-04", captured_at=stale_ts)
+
+    signals = _screen_money_flow(db_session)
+    assert signals == []
+
+
+def test_normal_single_day_unchanged(db_session):
+    """Normal single-day snapshot -> all its Long-in rows, unique symbols."""
+    ts = _recent_ts()
+    for i, sym in enumerate(["NVDA", "TSLA", "AMD"], start=1):
+        _insert_snapshot(db_session, symbol=sym, rank=i, data_date="2026-06-04", captured_at=ts)
+    # A short-in row on the same day must be excluded.
+    _insert_snapshot(
+        db_session, symbol="META", rank=4, data_date="2026-06-04",
+        captured_at=ts, long_short="Short in",
+    )
+
+    signals = _screen_money_flow(db_session)
+    assert sorted(s.symbol for s in signals) == ["AMD", "NVDA", "TSLA"]
+
+
+def test_empty_db_returns_empty(db_session):
+    assert _screen_money_flow(db_session) == []

--- a/tests/test_stock_screener_latest_snapshot.py
+++ b/tests/test_stock_screener_latest_snapshot.py
@@ -190,5 +190,24 @@ def test_normal_single_day_unchanged(db_session):
     assert sorted(s.symbol for s in signals) == ["AMD", "NVDA", "TSLA"]
 
 
+def test_newest_day_non_top100_does_not_blank_report(db_session):
+    """Codex P2 regression: the newest data_date holding only a non-top100
+    partial scrape must NOT be selected as "latest". The date/timestamp scope
+    must match the top100 row query, so the screener falls back to the most
+    recent day that actually has top100 rows instead of returning empty."""
+    ts = _recent_ts()
+    # 2026-06-03: real top100 snapshot (the answer we want).
+    _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date="2026-06-03", captured_at=ts)
+    _insert_snapshot(db_session, symbol="TSLA", rank=2, data_date="2026-06-03", captured_at=ts)
+    # 2026-06-04: NEWER data_date, but only a bottom100 partial — no top100.
+    _insert_snapshot(
+        db_session, symbol="META", rank=1, data_date="2026-06-04",
+        captured_at=ts, ranking_type="bottom100",
+    )
+
+    signals = _screen_money_flow(db_session)
+    assert sorted(s.symbol for s in signals) == ["NVDA", "TSLA"]
+
+
 def test_empty_db_returns_empty(db_session):
     assert _screen_money_flow(db_session) == []

--- a/tests/test_stock_screener_latest_snapshot.py
+++ b/tests/test_stock_screener_latest_snapshot.py
@@ -109,8 +109,15 @@ def _insert_snapshot(
 
 
 def _recent_ts() -> datetime:
-    """A captured_at well within the 24h staleness window."""
-    return datetime.now(timezone.utc) - timedelta(hours=1)
+    """A captured_at well within the 24h staleness window.
+
+    Stored tz-naive UTC: SQLite's TIMESTAMP affinity drops tz offsets on the
+    equality-bind path, so a tz-aware value would round-trip to a string that
+    never equality-matches the stored row (a SQLite harness artifact — real
+    Postgres `timestamptz` matches fine). The screener's staleness check
+    re-stamps naive values as UTC, so this faithfully mirrors production.
+    """
+    return (datetime.now(timezone.utc) - timedelta(hours=1)).replace(tzinfo=None)
 
 
 def test_backfill_shape_returns_only_latest_date(db_session):
@@ -161,7 +168,7 @@ def test_latest_date_picks_latest_captured_at(db_session):
 
 def test_stale_latest_date_skipped(db_session):
     """Latest data_date's captured_at older than 24h -> skip (empty)."""
-    stale_ts = datetime.now(timezone.utc) - timedelta(hours=30)
+    stale_ts = (datetime.now(timezone.utc) - timedelta(hours=30)).replace(tzinfo=None)
     _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date="2026-06-04", captured_at=stale_ts)
 
     signals = _screen_money_flow(db_session)


### PR DESCRIPTION
## Summary
P0: QU100-LLM produced no theses because today's backfill stamped 1,373 trading days with one captured_at; the screener's `captured_at == max(captured_at)` then grabbed all days → dup symbols → screened_stocks CardinalityViolation. Fix: scope the latest snapshot by max(data_date) then the latest captured_at within that day (scoped to ranking_type=top100) + defensive symbol dedup before the upsert. No row deletion; legacy local engine only.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 2)

## Test plan
- [ ] CI green
- [ ] verify locally  (+8 tests, full suite 1353 passing)