### PR TITLE
fix(breadth): wire backfill-spy into market-breadth-daily cron (P1)

### DIFF
--- a/config/cron.yaml
+++ b/config/cron.yaml
@@ -164,22 +164,33 @@ jobs:
   # seeded (breadth dashboard is live). On a fresh host, run the one-shot seed
   # first or flip this back to `enabled: false` until the seed completes.
   - name: market-breadth-daily
-    description: "Refresh sp500 OHLCV + compute breadth indicators (writes market.breadth_indicator_daily)"
+    description: "Refresh sp500 OHLCV + SPY benchmark OHLCV + compute breadth indicators (writes market.breadth_indicator_daily + market.benchmark_ohlcv)"
     schedule: "45 12 * * 1-5"   # 12:45 PST Mon-Fri (15 min pre-close)
     # This job is COMPUTE-ONLY since 2026-06-03 (retire-fengshen-dashboar-aec0):
     # the `&& scripts/publish-market-breadth.sh` tail was dropped because
     # fengshen's PG-backed /trading is now the canonical source and no longer
-    # reads git-pushed HTML. The two compute steps are KEPT — they write
-    # market.breadth_indicator_daily, which fengshen reads.
+    # reads git-pushed HTML. The compute steps are KEPT — they write the
+    # market.* tables fengshen reads.
     #
     # Compute chain (DESIGN-market-breadth-webpage.md §6, publish step retired):
-    #   1. yfinance incremental refresh -> data/cache/sp500_universe.parquet
-    #   2. indicator recompute          -> market.breadth_indicator_daily
+    #   1. SPY benchmark refresh   -> data/cache/spy_history.parquet
+    #                              -> market.benchmark_ohlcv (dual-write)
+    #   2. yfinance incremental    -> data/cache/sp500_universe.parquet
+    #   3. indicator recompute     -> market.breadth_indicator_daily (dual-write)
+    #
+    # `backfill-spy --incremental` is the FIRST step (added by
+    # benchmark-ohlcv-spy-stale): it is the ONLY command that writes
+    # market.benchmark_ohlcv — the SPY daily price pane fengshen's /trading
+    # reads. Before this fix it lived only in an operator-run command and was
+    # never scheduled, so market.benchmark_ohlcv silently went stale (last bar
+    # 2026-05-29) while breadth/thematic kept current. The incremental run
+    # fetches the trailing 5 calendar days and upserts on (symbol, date), so a
+    # missed cron self-heals and re-runs never duplicate rows.
     #
     # `&&` enforces serial execution and propagates the first non-zero exit
     # to cron-wrapper.sh, which fires the Discord alert (discord_on_failure
     # below).
-    command: "uv run rainier market-breadth backfill-ohlcv --incremental && uv run rainier market-breadth compute-indicators"
+    command: "uv run rainier market-breadth backfill-spy --incremental && uv run rainier market-breadth backfill-ohlcv --incremental && uv run rainier market-breadth compute-indicators"
     log: "data/market-breadth.log"
     discord_on_failure: true
     enabled: true

--- a/tests/test_cron_config.py
+++ b/tests/test_cron_config.py
@@ -51,6 +51,26 @@ def test_market_breadth_keeps_compute_drops_publish(jobs: dict[str, dict]) -> No
     assert not PUBLISH_SCRIPT_RE.search(cmd)
 
 
+def test_market_breadth_refreshes_benchmark_ohlcv(jobs: dict[str, dict]) -> None:
+    """REGRESSION (benchmark-ohlcv-spy-stale): the daily breadth cron must invoke
+    `backfill-spy`, the ONLY command that writes market.benchmark_ohlcv (via
+    _dual_write_benchmark_pg). Before this fix the daily job ran backfill-ohlcv +
+    compute-indicators but never backfill-spy, so benchmark_ohlcv (SPY price pane
+    fengshen reads) silently went stale — breadth/thematic kept current while the
+    SPY OHLCV table lagged from 2026-05-29 onward.
+
+    The job is enabled and the command runs backfill-spy --incremental so today's
+    SPY bar lands in market.benchmark_ohlcv every trading day."""
+    job = jobs["market-breadth-daily"]
+    assert job["enabled"] is True
+    cmd = job["command"]
+    assert "backfill-spy" in cmd, (
+        "market-breadth-daily must run `backfill-spy` to keep market.benchmark_ohlcv "
+        "fresh — without it the SPY price pane fengshen reads goes stale"
+    )
+    assert "--incremental" in cmd
+
+
 def test_no_enabled_job_publishes_to_fengshen(jobs: dict[str, dict]) -> None:
     """Net invariant: zero enabled jobs git-push HTML to fengshen-site."""
     offenders = [

--- a/tests/test_db_breadth_write.py
+++ b/tests/test_db_breadth_write.py
@@ -433,6 +433,68 @@ def test_backfill_spy_cli_dual_writes(migrated_engine, tmp_path, database_url):
     assert _count(migrated_engine, "benchmark_ohlcv") == len(spy)
 
 
+@pytest.mark.requires_postgres
+def test_backfill_spy_incremental_cli_idempotent(migrated_engine, tmp_path, database_url):
+    """REGRESSION (benchmark-ohlcv-spy-stale): the daily cron runs
+    `market-breadth backfill-spy --incremental`, which is the ONLY writer of
+    market.benchmark_ohlcv. Re-running it (a missed-cron catch-up, or two runs in
+    a day) must UPSERT on (symbol, date) — no duplicate rows. This guards the
+    table fengshen's /trading SPY price pane reads against silent dupes when the
+    scheduled job re-fires.
+    """
+    from rainier.cli import cli
+
+    days = _trading_days(date(2024, 1, 2), 6)
+
+    def fake_fetch(syms, start, end):
+        return {
+            s: pd.DataFrame(
+                {
+                    "date": days,
+                    "open": [400.0 + i for i in range(len(days))],
+                    "high": [401.0 + i for i in range(len(days))],
+                    "low": [399.0 + i for i in range(len(days))],
+                    "close": [400.5 + i for i in range(len(days))],
+                    "volume": [70_000_000 + i for i in range(len(days))],
+                }
+            )
+            for s in syms
+        }
+
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    out_path = cache / "spy_history.parquet"
+
+    import rainier.market_breadth.ohlcv_backfill as obf
+
+    orig = obf._yfinance_fetch
+    obf._yfinance_fetch = fake_fetch
+    try:
+        for _ in range(2):  # run the incremental cron command twice
+            res = CliRunner().invoke(
+                cli,
+                [
+                    "market-breadth", "backfill-spy",
+                    "--incremental", "--output", str(out_path),
+                ],
+            )
+            assert res.exit_code == 0, res.output
+    finally:
+        obf._yfinance_fetch = orig
+
+    spy = pd.read_parquet(out_path)
+    # No duplicate (symbol, date) in PG, and PG matches the (deduped) parquet.
+    assert _count(migrated_engine, "benchmark_ohlcv") == len(spy)
+    with migrated_engine.connect() as conn:
+        dupes = conn.execute(
+            text(
+                "SELECT count(*) FROM (SELECT symbol, date FROM market.benchmark_ohlcv "
+                "GROUP BY symbol, date HAVING count(*) > 1) d"
+            )
+        ).scalar_one()
+    assert dupes == 0, "re-running incremental backfill-spy created duplicate rows"
+
+
 # ---------------------------------------------------------------------------
 # One-shot backfill parity + verify-coverage (both new tables)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`market.benchmark_ohlcv` (the SPY daily OHLCV table feeding fengshen's `/trading` Breadth SPY-price chart) went stale at **2026-05-29** while breadth/thematic data stayed current.

## Root cause

The ONLY writer of `market.benchmark_ohlcv` is `rainier market-breadth backfill-spy` (via its `_dual_write_benchmark_pg` path). That command was never scheduled in any cron job — it only ran on manual operator invocation. The daily `market-breadth-daily` cron ran `backfill-ohlcv --incremental && compute-indicators` but never `backfill-spy`, so the SPY price table silently lagged after the last manual run.

## Fix

`config/cron.yaml` `market-breadth-daily` command now leads with `backfill-spy --incremental`:

    uv run rainier market-breadth backfill-spy --incremental \
      && uv run rainier market-breadth backfill-ohlcv --incremental \
      && uv run rainier market-breadth compute-indicators

Incremental mode fetches the trailing 5 calendar days and upserts on `(symbol, date)`, so a missed cron self-heals and re-runs never duplicate rows. Description + inline comments updated to document the new first step.

## Backfill (already applied + verified)

The 2026-05-30..06-05 gap was already backfilled to Neon out-of-band before this PR: `benchmark_ohlcv` SPY is current through **2026-06-05** (5 new rows 06-01..06-05, 0 dupes). Re-running incremental was confirmed idempotent (row count unchanged, 0 dupes). No backfill action is needed on merge.

## Reviewers

- **Codex review:** PASS — no P0/P1 across two consecutive runs (`model_reasoning_effort=high`). One deferred [P2] below.
- **/review (gstack skill):** PASS — no findings. Critical pass clean (no SQL/race/shell-injection/enum surface; cron tokens are static literals; relies on the existing `(symbol, date)` upsert contract).

### Deferred findings
- **[P2]** Fresh-host seed gap: on a host where `data/cache/spy_history.parquet` / `market.benchmark_ohlcv` was never one-shot seeded, `backfill-spy --incremental` initializes with only ~5 days of history; the SPY pane wants multi-year history. This is an orthogonal bootstrap concern (production is already seeded and fully fixed by this PR). Track separately as a bootstrap hardening task (require/perform the one-shot SPY seed, or make `--incremental` refuse to initialize an absent cache).

## Test plan

- [x] `tests/test_cron_config.py::test_market_breadth_refreshes_benchmark_ohlcv` — regression: daily breadth cron must invoke `backfill-spy --incremental` (would have caught the stall).
- [x] `tests/test_db_breadth_write.py::test_backfill_spy_incremental_cli_idempotent` — PG: re-running incremental `backfill-spy` UPSERTs, no duplicate `(symbol, date)` rows.
- [x] Non-pg suite green: `uv run pytest tests/ -q -k "not requires_postgres"` → 1397 passed, 9 skipped.
- [x] `uv run ruff check src/ tests/` → clean.

codex iterations: 0 (no P0/P1 to fix; 2 consecutive clean runs)
/review invocations: 1