### PR TITLE
fix(publish): accept linked worktrees in publish-dashboard checkout guard

### DIFF
--- a/scripts/publish-dashboard.sh
+++ b/scripts/publish-dashboard.sh
@@ -112,7 +112,9 @@ TARGET_TOPLEVEL="$(git -C "$TARGET_DIR" rev-parse --show-toplevel 2>/dev/null ||
 TARGET_ABS="$(cd "$TARGET_DIR" 2>/dev/null && pwd -P || true)"
 TARGET_TOP_ABS=""
 if [ -n "$TARGET_TOPLEVEL" ]; then
-    TARGET_TOP_ABS="$(cd "$TARGET_TOPLEVEL" && pwd -P)"
+    # `|| true` so a permission/race failure on cd degrades to the friendly
+    # error below instead of a bare `set -e` abort with no log line.
+    TARGET_TOP_ABS="$(cd "$TARGET_TOPLEVEL" 2>/dev/null && pwd -P || true)"
 fi
 if [ -z "$TARGET_TOP_ABS" ] || [ "$TARGET_ABS" != "$TARGET_TOP_ABS" ]; then
     log "ERROR target is not a git checkout: $TARGET_DIR"

--- a/scripts/publish-dashboard.sh
+++ b/scripts/publish-dashboard.sh
@@ -98,10 +98,23 @@ fi
 # Accept both a regular checkout (.git is a directory) and a linked worktree
 # (.git is a FILE — a gitdir pointer created by `git worktree add`). The old
 # `-d "$TARGET_DIR/.git"` test wrongly rejected worktrees, breaking the
-# shared-tree publish path. Ask git itself, and compare the printed value
-# ("true") rather than relying on exit code, which can be 0 even in bare/.git
-# internal dirs where this prints "false".
-if [ "$(git -C "$TARGET_DIR" rev-parse --is-inside-work-tree 2>/dev/null)" != "true" ]; then
+# shared-tree publish path.
+#
+# We require the target to be the worktree ROOT, not merely inside one: ask git
+# for the worktree top-level and compare it to TARGET_DIR. `--show-toplevel`
+# prints the root for both a regular checkout and a linked worktree, and errors
+# (empty output) for a non-repo — so this still rejects non-repos AND a
+# misconfigured subdir like `fengshen-site/public` (where DST_REL would
+# otherwise nest under the subdir and commit `public/public/trading/...`).
+TARGET_TOPLEVEL="$(git -C "$TARGET_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+# Resolve both to physical paths so a symlinked or trailing-slash TARGET_DIR
+# still matches git's canonical top-level.
+TARGET_ABS="$(cd "$TARGET_DIR" 2>/dev/null && pwd -P || true)"
+TARGET_TOP_ABS=""
+if [ -n "$TARGET_TOPLEVEL" ]; then
+    TARGET_TOP_ABS="$(cd "$TARGET_TOPLEVEL" && pwd -P)"
+fi
+if [ -z "$TARGET_TOP_ABS" ] || [ "$TARGET_ABS" != "$TARGET_TOP_ABS" ]; then
     log "ERROR target is not a git checkout: $TARGET_DIR"
     exit 1
 fi

--- a/scripts/publish-dashboard.sh
+++ b/scripts/publish-dashboard.sh
@@ -15,31 +15,47 @@
 # "the url will be /trading"). The source HTML is still read from
 # `$DASHBOARD_SOURCE_DIR/<name>.html`; only the destination path changes.
 #
+# SELF-ISOLATING PUBLISH (no dependency on the target checkout's state)
+# ---------------------------------------------------------------------
+# $TARGET_DIR (DASHBOARD_PUBLISH_TARGET_DIR, e.g. the operator's fengshen-site)
+# is a SHARED working tree — other agents leave it parked on their own worker
+# branches, sometimes dirty. Committing/pushing from it would either trip the
+# dirty-guard or push the WRONG branch. So this script NEVER operates on that
+# checkout. It treats $TARGET_DIR purely as "the repo to source a worktree
+# from": it fetches origin and publishes via an EPHEMERAL detached worktree on
+# origin/master, then removes it (trap on EXIT, so cleanup runs on failure too).
+#
 # ASCII flow:
 #
 #   rainier render CLI ─▶ $DASHBOARD_SOURCE_DIR/<name>.html
 #                                │
-#                                ▼   cp (creates dirs)
-#                    default:    $DASHBOARD_PUBLISH_TARGET_DIR/public/trading/<name>/index.html
-#                    with --root: $DASHBOARD_PUBLISH_TARGET_DIR/public/trading/index.html
+#   git -C $TARGET_DIR fetch origin                  (no checkout mutation)
+#   WT=$(mktemp -d); git -C $TARGET_DIR worktree add --detach $WT origin/master
+#                                │   trap: worktree remove --force + prune (EXIT)
+#                                ▼   cp into $WT/$DST_REL (creates dirs)
+#                    default:    $WT/public/trading/<name>/index.html
+#                    with --root: $WT/public/trading/index.html
 #                                │
-#                                ▼   git diff --quiet ?
+#                                ▼   staged diff vs HEAD (origin/master) ?
 #                          ┌──────┴───────┐
-#                       yes│              │no
+#                       no │              │ yes
 #                          ▼              ▼
-#                       exit 0     git add → commit "<name>: YYYY-MM-DD daily render"
-#                       (no-op)                 → git push (origin/main)
+#                       exit 0     git -C $WT commit "<name>: YYYY-MM-DD daily render"
+#                       (no-op)         → push origin HEAD:refs/heads/master
+#                                          (non-FF? re-fetch, reset $WT to new
+#                                           origin/master, re-apply, retry ≤3x)
 #                                                       │
 #                                                       ▼
 #                                            Cloudflare Pages auto-deploys
 #
 # Environment overrides (defaults match the operator's machine):
 #   DASHBOARD_SOURCE_DIR          rendered HTML lives here ($HOME/projects/rainier/out/dashboards)
-#   DASHBOARD_PUBLISH_TARGET_DIR  fengshen-site checkout    ($HOME/projects/fengshen-site)
+#   DASHBOARD_PUBLISH_TARGET_DIR  fengshen-site repo to SOURCE the worktree from
+#                                 ($HOME/projects/fengshen-site)
 #
 # Bootstrap note: the first publish for a brand-new <name> creates
-# `public/trading/<name>/` inside fengshen-site automatically — no manual
-# `.gitkeep` pre-step required. Astro serves `public/` verbatim, so the
+# `public/trading/<name>/` inside the ephemeral worktree automatically — no
+# manual `.gitkeep` pre-step required. Astro serves `public/` verbatim, so the
 # rendered HTML lives at `https://fengshen.dev/trading/<name>/` (or
 # `https://fengshen.dev/trading/` when `--root` is set).
 
@@ -86,9 +102,13 @@ if [ "$ROOT_PUBLISH" -eq 1 ]; then
 else
     DST_REL="public/trading/$NAME/index.html"
 fi
-DST="$TARGET_DIR/$DST_REL"
 
-log "name=$NAME source=$SRC target=$TARGET_DIR"
+# Branch on origin that fengshen-site deploys from. fengshen-site deploys
+# `master`; overridable so the test harness (bare origin seeded on `main`)
+# can exercise the same flow.
+PUBLISH_BRANCH="${DASHBOARD_PUBLISH_BRANCH:-master}"
+
+log "name=$NAME source=$SRC target=$TARGET_DIR branch=$PUBLISH_BRANCH"
 
 if [ ! -f "$SRC" ]; then
     log "ERROR rendered HTML missing: $SRC"
@@ -121,67 +141,80 @@ if [ -z "$TARGET_TOP_ABS" ] || [ "$TARGET_ABS" != "$TARGET_TOP_ABS" ]; then
     exit 1
 fi
 
-cd "$TARGET_DIR"
-
-# Bail if the working tree has unrelated dirt — don't auto-stash.
+# --- Self-isolating publish via an ephemeral origin/<branch> worktree -------
 #
-# The dirty decision is based on RELEVANT changes only: modified/staged/deleted
-# TRACKED files and stray untracked files. git-IGNORED paths are explicitly
-# disregarded — tool droppings such as `.gstack/browse-audit.jsonl` (left by the
-# gstack browse tooling) must never block a publish. This was the 2026-06-04 P0:
-# an untracked-but-ignored `.gstack/` tripped the guard and the breadth
-# dashboard never went live.
+# We never `cd` into $TARGET_DIR's checkout or touch its branch. Instead we
+# fetch origin and add a throwaway DETACHED worktree pinned at
+# origin/$PUBLISH_BRANCH, do all the copy/commit/push there, then remove it.
+# This makes the publish independent of whatever state the shared checkout is
+# parked in (different branch, dirty tree).
+
+log "fetching origin/$PUBLISH_BRANCH"
+git -C "$TARGET_DIR" fetch --quiet origin "$PUBLISH_BRANCH"
+
+WT="$(mktemp -d "${TMPDIR:-/tmp}/publish-dashboard.XXXXXX")"
+
+# Always reap the ephemeral worktree — on success AND on any failure/early-exit
+# (operator rule: cleanup is the last step, even on the failure path). `prune`
+# clears the parent repo's registry entry if `remove` couldn't (e.g. the dir
+# was already gone).
+cleanup() {
+    git -C "$TARGET_DIR" worktree remove --force "$WT" 2>/dev/null || rm -rf "$WT"
+    git -C "$TARGET_DIR" worktree prune 2>/dev/null || true
+}
+trap cleanup EXIT
+
+git -C "$TARGET_DIR" worktree add --quiet --detach "$WT" "origin/$PUBLISH_BRANCH"
+
+DST="$WT/$DST_REL"
+
+# Bounded non-fast-forward retry. The etf + market-breadth publishers run at
+# ~the same minute, and other agents push to master too, so origin can advance
+# between our fetch and our push. On a non-FF rejection we re-fetch, hard-reset
+# the EPHEMERAL worktree onto the NEW origin tip, re-apply the file, and retry.
 #
-# `git status --porcelain` already omits ignored files by default, but we make
-# the contract explicit (and log it) so a future git/config change to that
-# default can't silently re-break the publish. We additionally enumerate the
-# ignored paths that WERE present, purely for an operator-visible log line.
-RELEVANT_STATUS="$(git status --porcelain --untracked-files=normal)"
-if [ -n "$RELEVANT_STATUS" ]; then
-    log "ERROR target working tree dirty (uncommitted changes); refusing to publish"
-    git status --short >&2
-    exit 1
-fi
+# NOTE: `git reset --hard` here is SAFE and intentional — it operates ONLY on
+# $WT, this script's own throwaway detached worktree. It NEVER touches the
+# shared $TARGET_DIR checkout (which is forbidden). Do not "fix" this into a
+# shared-tree reset.
+MAX_ATTEMPTS=3
+attempt=1
+while :; do
+    mkdir -p "$(dirname "$DST")"
+    cp "$SRC" "$DST"
 
-# At this point the tree is clean except (possibly) for git-ignored paths.
-# Surface them so cron logs show the guard ran and chose to disregard them.
-# `--ignored` lists ignored entries as `!! <path>`; we keep only those lines.
-IGNORED_COUNT="$(git status --porcelain --ignored \
-    | grep -c '^!! ' || true)"
-if [ "${IGNORED_COUNT:-0}" -gt 0 ]; then
-    log "disregarding $IGNORED_COUNT git-ignored path(s) in target tree (not dirt)"
-fi
+    # Stage the (possibly new) file so the staged-vs-HEAD diff sees the intent.
+    git -C "$WT" add -- "$DST_REL"
 
-mkdir -p "$(dirname "$DST")"
-cp "$SRC" "$DST"
-
-# Track new files explicitly so `git diff --quiet --` sees the intent below.
-git add -- "$DST_REL"
-
-# `git diff --cached --quiet` returns 0 when staged tree matches HEAD, 1 otherwise.
-if git diff --cached --quiet -- "$DST_REL"; then
-    # Reset the noop stage to keep the working tree pristine.
-    git reset --quiet HEAD -- "$DST_REL" >/dev/null 2>&1 || true
-    # Recovery: if a prior run's commit never made it upstream (e.g., a
-    # non-fast-forward `git push` failure from an unrelated remote advance),
-    # the local branch is ahead of @{u}. Without this check, today's no-op
-    # would silently abandon that unpushed commit. Detect + push it now.
-    AHEAD="$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)"
-    if [ "$AHEAD" -gt 0 ]; then
-        log "no-op render, but $AHEAD local commit(s) ahead of upstream — pushing"
-        git push --quiet
-        log "done (recovered unpushed commits)"
+    # No-op: staged tree matches origin/$PUBLISH_BRANCH HEAD → nothing to do.
+    # Safe for cron retries (identical render shouldn't churn commits).
+    if git -C "$WT" diff --cached --quiet -- "$DST_REL"; then
+        log "no-op: rendered HTML matches the published copy (no commit)"
         exit 0
     fi
-    log "no-op: rendered HTML matches the published copy (no commit)"
-    exit 0
-fi
 
-DATE_TAG="$(date -u +%Y-%m-%d)"
-MSG="$NAME: $DATE_TAG daily render"
-log "committing: $MSG"
-git commit -m "$MSG" --quiet -- "$DST_REL"
+    DATE_TAG="$(date -u +%Y-%m-%d)"
+    MSG="$NAME: $DATE_TAG daily render"
+    log "committing: $MSG (attempt $attempt/$MAX_ATTEMPTS)"
+    git -C "$WT" commit -m "$MSG" --quiet -- "$DST_REL"
 
-log "pushing to origin"
-git push --quiet
-log "done"
+    log "pushing to origin/$PUBLISH_BRANCH"
+    # Push the detached HEAD straight to the remote branch ref — no local
+    # branch is created or moved anywhere.
+    if git -C "$WT" push --quiet origin "HEAD:refs/heads/$PUBLISH_BRANCH"; then
+        log "done"
+        exit 0
+    fi
+
+    if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+        log "ERROR push rejected after $MAX_ATTEMPTS attempts (origin/$PUBLISH_BRANCH kept advancing); giving up"
+        exit 1
+    fi
+
+    log "push rejected (non-fast-forward); re-fetching and rebasing onto new origin/$PUBLISH_BRANCH"
+    git -C "$TARGET_DIR" fetch --quiet origin "$PUBLISH_BRANCH"
+    # Reset the EPHEMERAL worktree only (see NOTE above) onto the new tip,
+    # discarding our just-made commit; the loop re-applies the file + re-commits.
+    git -C "$WT" reset --hard --quiet "origin/$PUBLISH_BRANCH"
+    attempt=$((attempt + 1))
+done

--- a/scripts/publish-dashboard.sh
+++ b/scripts/publish-dashboard.sh
@@ -95,7 +95,13 @@ if [ ! -f "$SRC" ]; then
     exit 1
 fi
 
-if [ ! -d "$TARGET_DIR/.git" ]; then
+# Accept both a regular checkout (.git is a directory) and a linked worktree
+# (.git is a FILE — a gitdir pointer created by `git worktree add`). The old
+# `-d "$TARGET_DIR/.git"` test wrongly rejected worktrees, breaking the
+# shared-tree publish path. Ask git itself, and compare the printed value
+# ("true") rather than relying on exit code, which can be 0 even in bare/.git
+# internal dirs where this prints "false".
+if [ "$(git -C "$TARGET_DIR" rev-parse --is-inside-work-tree 2>/dev/null)" != "true" ]; then
     log "ERROR target is not a git checkout: $TARGET_DIR"
     exit 1
 fi

--- a/scripts/publish-etf-dashboard.sh
+++ b/scripts/publish-etf-dashboard.sh
@@ -52,6 +52,15 @@ fi
 
 cd "$PROJECT_DIR"
 
+# The render CLI now reads the canonical Neon market.thematic_features_daily
+# store by default (no --source flag needed). The renderer pulls .env itself
+# (get_settings -> load_dotenv) before building the engine.
+#
+# TODO(out-of-scope): we still hardcode `--asof $(date +%Y-%m-%d)`. When Neon's
+# latest data lags today (market holiday, source slip), the render fails loud
+# with "no rows for asof=<today>". The market-breadth wrapper omits --asof and
+# lets the CLI default to max(asof_date); a follow-up should do the same here
+# (drop --asof). Left as-is for this PR to keep scope tight.
 log "render asof=$ASOF rendered_at_pt=$RENDERED_AT_PT output=$OUTPUT"
 "$UV" run rainier dashboard render-etf-html \
     --asof "$ASOF" \

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -4052,19 +4052,33 @@ def market_breadth_compute_indicators(
 
 @market_breadth.command("render-html")
 @click.option(
+    "--source",
+    type=click.Choice(["neon", "parquet"]),
+    default="neon",
+    show_default=True,
+    help=(
+        "Data source. 'neon' (default) reads the canonical "
+        "market.breadth_indicator_daily + market.benchmark_ohlcv store; "
+        "'parquet' reads the local caches (--input / --spy-path). Passing "
+        "--input or --spy-path implies parquet."
+    ),
+)
+@click.option(
     "--input",
     "input_path",
     type=click.Path(exists=True),
-    default="data/cache/sp500_breadth_daily.parquet",
-    show_default=True,
-    help="Long-format breadth parquet (asof_date, indicator, value).",
+    default=None,
+    help=(
+        "Long-format breadth parquet (parquet source only). "
+        "[default: data/cache/sp500_breadth_daily.parquet]"
+    ),
 )
 @click.option(
     "--asof",
     default=None,
     help=(
         "Display + filter date (YYYY-MM-DD). Defaults to the most recent "
-        "asof_date present in the input parquet (the cron's 'today')."
+        "asof_date present in the source (parquet last row / Neon max)."
     ),
 )
 @click.option(
@@ -4091,41 +4105,49 @@ def market_breadth_compute_indicators(
     "--spy-path",
     "spy_path",
     type=click.Path(),
-    default="data/cache/spy_history.parquet",
-    show_default=True,
+    default=None,
     help=(
-        "Optional SPY OHLCV parquet (from `market-breadth backfill-spy`). "
+        "Optional SPY OHLCV parquet (parquet source only; implies parquet). "
         "When present, the SPY price pane renders at the top of the page. "
-        "Missing file → SPY pane is omitted (back-compat path)."
+        "Missing file → SPY pane is omitted (back-compat path). "
+        "[default: data/cache/spy_history.parquet]"
     ),
 )
 def market_breadth_render_html(
-    input_path: str,
+    source: str,
+    input_path: str | None,
     asof: str | None,
     rendered_at_pt: str,
     window_days: int,
     output_path: str,
-    spy_path: str,
+    spy_path: str | None,
 ) -> None:
     """Render the S&P 500 market-breadth self-contained HTML dashboard.
 
-    Reads `data/cache/sp500_breadth_daily.parquet` and writes a single
-    deterministic HTML file. Sub-second runtime on the operator's machine
-    for ~9k rows (12 indicators × ~750 days).
+    Default source is the canonical Neon ``market.breadth_indicator_daily``
+    store (SPY pane from ``market.benchmark_ohlcv``); ``--source parquet`` (or
+    passing ``--input`` / ``--spy-path``) reads the local caches for offline /
+    back-compat use. Fails loud on a zero-row Neon result — never silently
+    publishes a stale parquet.
     """
+    import os
     import sys
     from datetime import date as _date
 
     import pandas as _pd
 
-    from rainier.market_breadth.render import write_breadth_html
+    from rainier.market_breadth.render import render_breadth_html
 
-    if asof is None:
-        # Resolve asof from the parquet's last row so cron callers don't
-        # need to thread `$(date +%Y-%m-%d)` through (which would carry
-        # the same `%`-in-crontab footgun the publish-etf-dashboard.sh
-        # script was built to avoid).
-        breadth = _pd.read_parquet(input_path)
+    # Passing an explicit parquet path implies the parquet source (back-compat).
+    if input_path is not None or spy_path is not None:
+        source = "parquet"
+
+    if source == "parquet":
+        eff_input = input_path or "data/cache/sp500_breadth_daily.parquet"
+        if not Path(eff_input).exists():
+            click.echo(f"error: breadth parquet not found: {eff_input}", err=True)
+            sys.exit(1)
+        breadth = _pd.read_parquet(eff_input)
         # Fail-loud on zero-row parquet. Otherwise `.max()` returns `pd.NaT`,
         # `NaT.date()` returns `NaT` again (not a real Python `date`), and
         # `render_breadth_html(asof=NaT).isoformat()` renders the literal
@@ -4134,37 +4156,68 @@ def market_breadth_render_html(
         # `&&` propagates this non-zero exit to cron-wrapper.sh which fires
         # a Discord alert (discord_on_failure: true).
         if breadth.empty:
-            click.echo(
-                f"error: input parquet has no rows: {input_path}", err=True,
-            )
+            click.echo(f"error: input parquet has no rows: {eff_input}", err=True)
             sys.exit(1)
-        asof_max = breadth["asof_date"].max()
-        # Catch `NaT` even on non-empty parquets where every `asof_date`
-        # cell happens to be null. Same publish-stale rationale.
-        if _pd.isna(asof_max):
-            click.echo(
-                f"error: input parquet has no usable asof_date values: {input_path}",
-                err=True,
-            )
-            sys.exit(1)
-        if hasattr(asof_max, "date"):
-            asof_dt = asof_max.date()
-        elif isinstance(asof_max, _date):
-            asof_dt = asof_max
+        spy_ohlcv: _pd.DataFrame | None = None
+        eff_spy = spy_path or "data/cache/spy_history.parquet"
+        if Path(eff_spy).exists():
+            spy_ohlcv = _pd.read_parquet(eff_spy)
+        if asof is None:
+            asof_max = breadth["asof_date"].max()
+            # Catch `NaT` even on non-empty parquets where every `asof_date`
+            # cell happens to be null. Same publish-stale rationale.
+            if _pd.isna(asof_max):
+                click.echo(
+                    f"error: input parquet has no usable asof_date values: {eff_input}",
+                    err=True,
+                )
+                sys.exit(1)
+            if hasattr(asof_max, "date"):
+                asof_dt = asof_max.date()
+            elif isinstance(asof_max, _date):
+                asof_dt = asof_max
+            else:
+                asof_dt = _date.fromisoformat(str(asof_max))
         else:
-            asof_dt = _date.fromisoformat(str(asof_max))
-    else:
-        asof_dt = _date.fromisoformat(asof)
+            asof_dt = _date.fromisoformat(asof)
+    else:  # neon (default)
+        from rainier.dashboard import neon_source as _ns
+        from rainier.db.engine import get_engine
 
-    written = write_breadth_html(
-        breadth_path=input_path,
-        output_path=output_path,
+        # get_engine() reads os.environ["DATABASE_URL"] directly and does NOT
+        # load .env; load it first so the cron path (uv run from PROJECT_DIR)
+        # finds the var.
+        _ns.ensure_env_loaded()
+        engine = get_engine()
+        try:
+            asof_dt = (
+                _date.fromisoformat(asof)
+                if asof is not None
+                else _ns.latest_breadth_asof(engine)
+            )
+            breadth = _ns.load_breadth_neon(engine, asof_dt)
+            spy_ohlcv = _ns.load_spy_neon(engine)
+        except _ns.EmptyNeonResultError as exc:
+            click.echo(f"error: {exc}", err=True)
+            sys.exit(1)
+        finally:
+            engine.dispose()
+        if spy_ohlcv is not None and spy_ohlcv.empty:
+            spy_ohlcv = None
+
+    html = render_breadth_html(
+        breadth=breadth,
         asof=asof_dt,
         rendered_at_pt=rendered_at_pt,
         window_days=window_days,
-        spy_path=spy_path,
+        spy_ohlcv=spy_ohlcv,
     )
-    click.echo(f"wrote market-breadth dashboard -> {written}")
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out.with_suffix(out.suffix + ".tmp")
+    tmp.write_text(html, encoding="utf-8")
+    os.replace(tmp, out)
+    click.echo(f"wrote market-breadth dashboard -> {out}")
 
 
 # Composition root — wire the research engine's `llm-research` subgroup
@@ -4941,11 +4994,25 @@ def dashboard() -> None:
 
 @dashboard.command("render-etf-html")
 @click.option(
+    "--source",
+    type=click.Choice(["neon", "parquet"]),
+    default="neon",
+    show_default=True,
+    help=(
+        "Data source for the features frame. 'neon' (default) reads the "
+        "canonical market.thematic_features_daily store; 'parquet' reads the "
+        "local cache (--features). Passing --features implies parquet."
+    ),
+)
+@click.option(
     "--features",
     "features_path",
     type=click.Path(exists=True),
-    default="data/cache/thematic_features_daily.parquet",
-    show_default=True,
+    default=None,
+    help=(
+        "Local features parquet (parquet source only). "
+        "[default: data/cache/thematic_features_daily.parquet]"
+    ),
 )
 @click.option(
     "--registry",
@@ -4956,8 +5023,12 @@ def dashboard() -> None:
 )
 @click.option(
     "--asof",
-    required=True,
-    help="Date to render (YYYY-MM-DD). The renderer slices features to this asof_date.",
+    default=None,
+    help=(
+        "Date to render (YYYY-MM-DD). The renderer slices features to this "
+        "asof_date. Required for the parquet source; optional for neon "
+        "(defaults to max(asof_date) in market.thematic_features_daily)."
+    ),
 )
 @click.option(
     "--rendered-at-pt",
@@ -4992,9 +5063,10 @@ def dashboard() -> None:
     ),
 )
 def dashboard_render_etf_html(
-    features_path: str,
+    source: str,
+    features_path: str | None,
     registry_path: str,
-    asof: str,
+    asof: str | None,
     rendered_at_pt: str,
     history_days: int,
     output_path: str,
@@ -5002,29 +5074,75 @@ def dashboard_render_etf_html(
 ) -> None:
     """Render the ETF-ranks self-contained HTML dashboard.
 
-    Reads `thematic_features_daily.parquet` + `sector_registry.parquet` and
-    writes a single deterministic HTML file. Sub-second runtime on the
-    operator's machine for ~94 rows × 30-day history.
+    Default source is the canonical Neon ``market.thematic_features_daily``
+    store (kept fresh by other jobs); ``--source parquet`` (or passing
+    ``--features``) reads the local cache for offline / back-compat use. The
+    sector registry stays a parquet (human-edited config). Fails loud on a
+    zero-row Neon result — never silently publishes a stale parquet.
     """
+    import os
+    import sys
     from datetime import date as _date
 
-    from rainier.dashboard.render_etf import write_etf_html
+    import pandas as _pd
 
-    asof_dt = _date.fromisoformat(asof)
-    # CLI default points at the cache path; pass None to the renderer when
-    # the file doesn't exist so the renderer's fallback kicks in cleanly
-    # (no spurious "file not found" surprise).
+    from rainier.dashboard.render_etf import render_etf_html
+
+    # Passing an explicit --features implies the parquet source (back-compat).
+    if features_path is not None:
+        source = "parquet"
+
     names_arg: str | None = names_path if Path(names_path).exists() else None
-    written = write_etf_html(
-        features_path=features_path,
-        registry_path=registry_path,
-        output_path=output_path,
+    registry = _pd.read_parquet(registry_path)
+
+    if source == "parquet":
+        eff_features = features_path or "data/cache/thematic_features_daily.parquet"
+        if not Path(eff_features).exists():
+            click.echo(f"error: features parquet not found: {eff_features}", err=True)
+            sys.exit(1)
+        if asof is None:
+            click.echo(
+                "error: --asof is required for the parquet source", err=True
+            )
+            sys.exit(1)
+        features = _pd.read_parquet(eff_features)
+        asof_dt = _date.fromisoformat(asof)
+    else:  # neon (default)
+        from rainier.dashboard import neon_source as _ns
+        from rainier.db.engine import get_engine
+
+        # get_engine() reads os.environ["DATABASE_URL"] directly and does NOT
+        # load .env; load it first so the cron path (uv run from PROJECT_DIR)
+        # finds the var.
+        _ns.ensure_env_loaded()
+        engine = get_engine()
+        try:
+            asof_dt = (
+                _date.fromisoformat(asof)
+                if asof is not None
+                else _ns.latest_etf_asof(engine)
+            )
+            features = _ns.load_etf_features_neon(engine, asof_dt)
+        except _ns.EmptyNeonResultError as exc:
+            click.echo(f"error: {exc}", err=True)
+            sys.exit(1)
+        finally:
+            engine.dispose()
+
+    html = render_etf_html(
+        features=features,
+        registry=registry,
         asof=asof_dt,
         rendered_at_pt=rendered_at_pt,
         history_days=history_days,
         names_path=names_arg,
     )
-    click.echo(f"wrote ETF dashboard -> {written}")
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out.with_suffix(out.suffix + ".tmp")
+    tmp.write_text(html, encoding="utf-8")
+    os.replace(tmp, out)
+    click.echo(f"wrote ETF dashboard -> {out}")
 
 
 @dashboard.command("render-combined")

--- a/src/rainier/dashboard/neon_source.py
+++ b/src/rainier/dashboard/neon_source.py
@@ -1,0 +1,227 @@
+"""Neon (canonical ``market.*``) data loaders for the dashboard renderers.
+
+WHY THIS EXISTS
+---------------
+The ETF-ranks and market-breadth dashboards used to render exclusively from
+local parquet caches (``data/cache/thematic_features_daily.parquet``,
+``data/cache/sp500_breadth_daily.parquet``, a SPY history parquet). Those
+caches lag or go missing whenever their parquet-updater cron is disabled or
+slips — on 2026-06-05 the ETF dashboard published an *empty* page at 12:40
+even though Neon held that day's data. The canonical ``market.*`` store on
+Neon is kept fresh by other jobs (incl. PR #131's backfill-spy), so it is the
+source of truth.
+
+This module loads the SAME DataFrame shapes the pure render functions already
+expect — only the data SOURCE changes (Neon instead of parquet). The pure
+``render_*_html`` functions are untouched.
+
+    Neon market.thematic_features_daily ──▶ load_etf_features_neon ──┐
+    Neon market.breadth_indicator_daily ──▶ load_breadth_neon ───────┼─▶ pure render_*_html
+    Neon market.benchmark_ohlcv (SPY)   ──▶ load_spy_neon ───────────┘
+
+CRITICAL — .env loading
+-----------------------
+``rainier.db.engine.get_engine()`` reads ``os.environ["DATABASE_URL"]``
+directly and does NOT call ``load_dotenv()``. The cron wrappers run
+``uv run rainier ...`` from the project dir where ``.env`` lives, but the env
+var is only present once ``.env`` is loaded. So the CLI commands MUST call
+``ensure_env_loaded()`` (which invokes ``get_settings()`` → ``load_dotenv()``)
+BEFORE building the engine, or the Neon path raises "DATABASE_URL not set".
+
+FAIL LOUD
+---------
+Every loader raises ``EmptyNeonResultError`` when the resolved asof has zero rows.
+We never silently fall back to a stale parquet — that is exactly the failure
+mode this change is meant to kill. The CLI converts the exception into a
+non-zero exit so the cron chain's ``&&`` propagates the failure to the
+Discord alert.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pandas as pd
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+__all__ = [
+    "EmptyNeonResultError",
+    "ensure_env_loaded",
+    "latest_etf_asof",
+    "latest_breadth_asof",
+    "load_etf_features_neon",
+    "load_breadth_neon",
+    "load_spy_neon",
+]
+
+
+class EmptyNeonResultError(RuntimeError):
+    """Raised when a Neon query returns zero usable rows for the asof.
+
+    Caught by the CLI render commands and turned into a non-zero exit with a
+    clear message — never a silent fall-back to a stale parquet.
+    """
+
+
+def ensure_env_loaded() -> None:
+    """Load ``.env`` so ``DATABASE_URL`` is present before ``get_engine()``.
+
+    ``get_settings()`` calls ``load_dotenv()`` as a side effect (see
+    ``core/config.py``). We rely on that single, already-tested loader rather
+    than importing ``dotenv`` here so there is one source of truth for how
+    rainier discovers its env.
+    """
+    from rainier.core.config import get_settings
+
+    get_settings()
+
+
+# ---------------------------------------------------------------------------
+# asof resolution — mirror "latest parquet row wins"
+# ---------------------------------------------------------------------------
+
+
+def latest_etf_asof(engine: Engine) -> date:
+    """Return ``max(asof_date)`` from ``market.thematic_features_daily``.
+
+    Raises ``EmptyNeonResultError`` when the table is empty (no asof to render).
+    """
+    sql = text("SELECT max(asof_date) AS m FROM market.thematic_features_daily")
+    with engine.connect() as conn:
+        value = conn.execute(sql).scalar_one_or_none()
+    if value is None:
+        raise EmptyNeonResultError(
+            "market.thematic_features_daily is empty — no asof_date to render"
+        )
+    return _as_date(value)
+
+
+def latest_breadth_asof(engine: Engine) -> date:
+    """Return ``max(asof_date)`` from ``market.breadth_indicator_daily``.
+
+    Raises ``EmptyNeonResultError`` when the table is empty.
+    """
+    sql = text("SELECT max(asof_date) AS m FROM market.breadth_indicator_daily")
+    with engine.connect() as conn:
+        value = conn.execute(sql).scalar_one_or_none()
+    if value is None:
+        raise EmptyNeonResultError(
+            "market.breadth_indicator_daily is empty — no asof_date to render"
+        )
+    return _as_date(value)
+
+
+# ---------------------------------------------------------------------------
+# loaders
+# ---------------------------------------------------------------------------
+
+
+def load_etf_features_neon(engine: Engine, asof: date) -> pd.DataFrame:
+    """Load the ETF features frame for ``render_etf_html`` from Neon.
+
+    The pure renderer needs HISTORY (prior ``asof_date`` rows per symbol) for
+    its sparklines, so we load every row ``asof_date <= asof`` — not just the
+    single asof slice. The frame carries the columns the renderer requires:
+    ``asof_date, symbol, sector_id, rank, rank_delta_1d, rank_delta_5d,
+    r_5, r_10, r_20, ret_ytd, top15_streak`` (plus the rest of the table,
+    which the renderer ignores).
+
+    Raises ``EmptyNeonResultError`` if no row exists exactly at ``asof`` (the
+    renderer would otherwise produce a valid-but-empty page).
+    """
+    sql = text(
+        """
+        SELECT *
+        FROM market.thematic_features_daily
+        WHERE asof_date <= :asof
+        ORDER BY asof_date, symbol
+        """
+    )
+    with engine.connect() as conn:
+        df = pd.read_sql(sql, conn, params={"asof": asof.isoformat()})
+    if df.empty:
+        raise EmptyNeonResultError(
+            f"market.thematic_features_daily has no rows on or before {asof.isoformat()}"
+        )
+    # The renderer filters to == asof; guard here so a missing asof slice fails
+    # loud instead of rendering an empty page from the history-only rows.
+    asof_str = asof.isoformat()
+    asof_col = _asof_as_iso(df["asof_date"])
+    if not (asof_col == asof_str).any():
+        raise EmptyNeonResultError(
+            f"market.thematic_features_daily has no rows for asof={asof_str} "
+            "(history present but not the requested day)"
+        )
+    return df
+
+
+def load_breadth_neon(engine: Engine, asof: date) -> pd.DataFrame:
+    """Load the long-format breadth frame for ``render_breadth_html`` from Neon.
+
+    Returns the FULL history (``asof_date, indicator, value``); the renderer
+    applies its own ``asof`` cutoff + trailing-window slice. We do not bound
+    by asof here because the breadth charts draw a multi-year trailing series.
+
+    Raises ``EmptyNeonResultError`` when the table is empty or has no row on or
+    before ``asof`` (a render against an asof predating all data would be an
+    empty page).
+    """
+    sql = text(
+        """
+        SELECT asof_date, indicator, value
+        FROM market.breadth_indicator_daily
+        WHERE asof_date <= :asof
+        ORDER BY asof_date, indicator
+        """
+    )
+    with engine.connect() as conn:
+        df = pd.read_sql(sql, conn, params={"asof": asof.isoformat()})
+    if df.empty:
+        raise EmptyNeonResultError(
+            f"market.breadth_indicator_daily has no rows on or before {asof.isoformat()}"
+        )
+    return df
+
+
+def load_spy_neon(engine: Engine, symbol: str = "SPY") -> pd.DataFrame:
+    """Load the SPY (benchmark) OHLCV frame for the breadth SPY price pane.
+
+    Schema matches what ``_spy_to_wide`` expects: ``symbol, date, open, high,
+    low, close, volume, ...``. The renderer treats an empty frame as "omit the
+    SPY pane" (back-compat), so a missing SPY series is NOT fatal — we return
+    an empty DataFrame rather than raising. (The breadth indicators themselves
+    are the fail-loud gate; SPY is an optional pane.)
+    """
+    sql = text(
+        """
+        SELECT symbol, date, open, high, low, close, volume,
+               fetched_at, yfinance_version
+        FROM market.benchmark_ohlcv
+        WHERE symbol = :symbol
+        ORDER BY date
+        """
+    )
+    with engine.connect() as conn:
+        df = pd.read_sql(sql, conn, params={"symbol": symbol})
+    return df
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _as_date(value: object) -> date:
+    """Coerce a DB-returned asof value (date / datetime / iso string) to ``date``."""
+    if isinstance(value, date) and not isinstance(value, pd.Timestamp):
+        return value
+    return pd.to_datetime(value).date()
+
+
+def _asof_as_iso(col: pd.Series) -> pd.Series:
+    """Return ``asof_date`` as ISO ``YYYY-MM-DD`` strings for comparison."""
+    if pd.api.types.is_datetime64_any_dtype(col):
+        return col.dt.strftime("%Y-%m-%d")
+    # date objects / strings: round-trip through to_datetime for uniformity.
+    return pd.to_datetime(col).dt.strftime("%Y-%m-%d")

--- a/tests/test_dashboard/test_cli_render_source.py
+++ b/tests/test_dashboard/test_cli_render_source.py
@@ -1,0 +1,236 @@
+"""CLI tests for the `--source {neon,parquet}` switch on the two dashboard
+render commands (`dashboard render-etf-html`, `market-breadth render-html`).
+
+Covers:
+  - parquet back-compat path still renders a non-empty page (explicit
+    --source parquet AND the implicit-by---features/--input path).
+  - neon is the DEFAULT source and routes through the Neon loaders +
+    ensure_env_loaded (we monkeypatch the loaders so no DB is needed).
+  - a zero-row Neon result fails loud (non-zero exit), never a silent
+    empty page.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+from click.testing import CliRunner
+
+from rainier.cli import cli
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+ETF_FEATURES = FIXTURES / "etf_features_small.parquet"
+ETF_REGISTRY = FIXTURES / "etf_sector_registry_small.parquet"
+BREADTH = FIXTURES / "sp500_breadth_small.parquet"
+ETF_ASOF = "2026-05-25"
+
+
+# ---------------------------------------------------------------------------
+# parquet back-compat
+# ---------------------------------------------------------------------------
+
+
+def test_etf_parquet_explicit_source(tmp_path):
+    out = tmp_path / "etf.html"
+    res = CliRunner().invoke(
+        cli,
+        [
+            "dashboard", "render-etf-html",
+            "--source", "parquet",
+            "--features", str(ETF_FEATURES),
+            "--registry", str(ETF_REGISTRY),
+            "--asof", ETF_ASOF,
+            "--rendered-at-pt", "12:40",
+            "--output", str(out),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    html = out.read_text()
+    assert "Universe: 0" not in html
+
+
+def test_etf_features_path_implies_parquet(tmp_path, monkeypatch):
+    """Passing --features alone (no --source) must imply parquet — it must NOT
+    try to hit Neon. We make the Neon path explode if reached."""
+    import rainier.dashboard.neon_source as ns
+
+    def boom(*_a, **_k):
+        raise AssertionError("neon path reached despite explicit --features")
+
+    monkeypatch.setattr(ns, "ensure_env_loaded", boom)
+
+    out = tmp_path / "etf.html"
+    res = CliRunner().invoke(
+        cli,
+        [
+            "dashboard", "render-etf-html",
+            "--features", str(ETF_FEATURES),
+            "--registry", str(ETF_REGISTRY),
+            "--asof", ETF_ASOF,
+            "--rendered-at-pt", "12:40",
+            "--output", str(out),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert "Universe: 0" not in out.read_text()
+
+
+def test_breadth_input_implies_parquet(tmp_path, monkeypatch):
+    import rainier.dashboard.neon_source as ns
+
+    def boom(*_a, **_k):
+        raise AssertionError("neon path reached despite explicit --input")
+
+    monkeypatch.setattr(ns, "ensure_env_loaded", boom)
+
+    out = tmp_path / "breadth.html"
+    res = CliRunner().invoke(
+        cli,
+        [
+            "market-breadth", "render-html",
+            "--input", str(BREADTH),
+            "--rendered-at-pt", "12:40",
+            "--output", str(out),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert "No breadth data available" not in out.read_text()
+
+
+# ---------------------------------------------------------------------------
+# neon is the default
+# ---------------------------------------------------------------------------
+
+
+def test_etf_neon_is_default(tmp_path, monkeypatch):
+    """No --source / --features → neon path: ensure_env_loaded called, loaders
+    invoked, engine disposed."""
+    import rainier.dashboard.neon_source as ns
+
+    calls = {"env": 0, "asof": 0, "load": 0}
+
+    class FakeEngine:
+        def dispose(self):
+            calls["disposed"] = True
+
+    monkeypatch.setattr(ns, "ensure_env_loaded", lambda: calls.__setitem__("env", 1))
+    monkeypatch.setattr("rainier.db.engine.get_engine", lambda: FakeEngine())
+    monkeypatch.setattr(
+        ns, "latest_etf_asof",
+        lambda _e: (calls.__setitem__("asof", 1), date(2026, 5, 25))[1],
+    )
+
+    feats = pd.read_parquet(ETF_FEATURES)
+
+    def fake_load(_e, _asof):
+        calls["load"] = 1
+        return feats
+
+    monkeypatch.setattr(ns, "load_etf_features_neon", fake_load)
+
+    out = tmp_path / "etf.html"
+    res = CliRunner().invoke(
+        cli,
+        [
+            "dashboard", "render-etf-html",
+            "--registry", str(ETF_REGISTRY),
+            "--rendered-at-pt", "12:40",
+            "--output", str(out),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert calls["env"] == 1 and calls["asof"] == 1 and calls["load"] == 1
+    assert calls.get("disposed") is True, "engine must be disposed"
+    assert "Universe: 0" not in out.read_text()
+
+
+def test_etf_neon_fails_loud_on_empty(tmp_path, monkeypatch):
+    """A zero-row Neon result must exit non-zero — never a silent empty page."""
+    import rainier.dashboard.neon_source as ns
+
+    class FakeEngine:
+        def dispose(self):
+            pass
+
+    monkeypatch.setattr(ns, "ensure_env_loaded", lambda: None)
+    monkeypatch.setattr("rainier.db.engine.get_engine", lambda: FakeEngine())
+
+    def raise_empty(_e):
+        raise ns.EmptyNeonResultError("no asof")
+
+    monkeypatch.setattr(ns, "latest_etf_asof", raise_empty)
+
+    out = tmp_path / "etf.html"
+    res = CliRunner().invoke(
+        cli,
+        [
+            "dashboard", "render-etf-html",
+            "--registry", str(ETF_REGISTRY),
+            "--rendered-at-pt", "12:40",
+            "--output", str(out),
+        ],
+    )
+    assert res.exit_code != 0, res.output
+    assert "error" in res.output.lower()
+    assert not out.exists(), "must not write an output file on empty Neon"
+
+
+def test_breadth_neon_is_default(tmp_path, monkeypatch):
+    import rainier.dashboard.neon_source as ns
+
+    calls = {}
+
+    class FakeEngine:
+        def dispose(self):
+            calls["disposed"] = True
+
+    monkeypatch.setattr(ns, "ensure_env_loaded", lambda: calls.__setitem__("env", 1))
+    monkeypatch.setattr("rainier.db.engine.get_engine", lambda: FakeEngine())
+    monkeypatch.setattr(ns, "latest_breadth_asof", lambda _e: date(2026, 5, 25))
+
+    breadth = pd.read_parquet(BREADTH)
+    monkeypatch.setattr(ns, "load_breadth_neon", lambda _e, _a: breadth)
+    monkeypatch.setattr(ns, "load_spy_neon", lambda _e: pd.DataFrame())
+
+    out = tmp_path / "breadth.html"
+    res = CliRunner().invoke(
+        cli,
+        [
+            "market-breadth", "render-html",
+            "--rendered-at-pt", "12:40",
+            "--output", str(out),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert calls.get("env") == 1 and calls.get("disposed") is True
+    assert "No breadth data available" not in out.read_text()
+
+
+def test_breadth_neon_fails_loud_on_empty(tmp_path, monkeypatch):
+    import rainier.dashboard.neon_source as ns
+
+    class FakeEngine:
+        def dispose(self):
+            pass
+
+    monkeypatch.setattr(ns, "ensure_env_loaded", lambda: None)
+    monkeypatch.setattr("rainier.db.engine.get_engine", lambda: FakeEngine())
+    monkeypatch.setattr(
+        ns, "latest_breadth_asof",
+        lambda _e: (_ for _ in ()).throw(ns.EmptyNeonResultError("empty")),
+    )
+
+    out = tmp_path / "breadth.html"
+    res = CliRunner().invoke(
+        cli,
+        [
+            "market-breadth", "render-html",
+            "--rendered-at-pt", "12:40",
+            "--output", str(out),
+        ],
+    )
+    assert res.exit_code != 0, res.output
+    assert "error" in res.output.lower()
+    assert not out.exists()

--- a/tests/test_dashboard/test_neon_source.py
+++ b/tests/test_dashboard/test_neon_source.py
@@ -1,0 +1,316 @@
+"""Unit tests for `rainier.dashboard.neon_source` — the Neon (canonical
+``market.*``) data loaders that feed the dashboard renderers by default.
+
+We avoid requiring a live Postgres by building an in-memory SQLite engine and
+ATTACHing a database aliased ``market`` so the loaders' schema-qualified
+``market.<table>`` SQL resolves. The loaders only need the engine + plain SQL,
+so this faithfully exercises the column-projection + fail-loud + asof logic.
+
+A separate ``requires_postgres`` integration test (skipped unless a live DB is
+configured) renders a non-empty dashboard end-to-end from Neon.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+
+import pandas as pd
+import pytest
+from sqlalchemy import create_engine, text
+
+from rainier.dashboard import neon_source as ns
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite engine with a `market` schema (via ATTACH)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def market_engine():
+    """SQLite engine with an attached ``market`` schema, seeded with small
+    thematic_features / breadth / benchmark fixtures."""
+    # A single shared in-memory connection (StaticPool) so the ATTACH + seed
+    # persist for the loader's later connect() calls.
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    with engine.begin() as conn:
+        conn.execute(text("ATTACH DATABASE ':memory:' AS market"))
+        conn.execute(
+            text(
+                """
+                CREATE TABLE market.thematic_features_daily (
+                    asof_date TEXT, symbol TEXT, sector_id INTEGER,
+                    rank INTEGER, rank_delta_1d INTEGER, rank_delta_5d INTEGER,
+                    r_5 INTEGER, r_10 INTEGER, r_20 INTEGER,
+                    ret_ytd REAL, top15_streak INTEGER
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE market.breadth_indicator_daily (
+                    asof_date TEXT, indicator TEXT, value REAL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE market.benchmark_ohlcv (
+                    symbol TEXT, date TEXT, open REAL, high REAL, low REAL,
+                    close REAL, volume INTEGER, fetched_at TEXT,
+                    yfinance_version TEXT
+                )
+                """
+            )
+        )
+    yield engine
+    engine.dispose()
+
+
+def _seed_features(engine, rows: list[dict]) -> None:
+    with engine.begin() as conn:
+        for r in rows:
+            conn.execute(
+                text(
+                    "INSERT INTO market.thematic_features_daily "
+                    "(asof_date, symbol, sector_id, rank, rank_delta_1d, "
+                    "rank_delta_5d, r_5, r_10, r_20, ret_ytd, top15_streak) "
+                    "VALUES (:asof_date, :symbol, :sector_id, :rank, "
+                    ":rank_delta_1d, :rank_delta_5d, :r_5, :r_10, :r_20, "
+                    ":ret_ytd, :top15_streak)"
+                ),
+                r,
+            )
+
+
+def _feat_row(asof: str, symbol: str, rank: int) -> dict:
+    return {
+        "asof_date": asof, "symbol": symbol, "sector_id": 1, "rank": rank,
+        "rank_delta_1d": 0, "rank_delta_5d": 0, "r_5": 1, "r_10": 1,
+        "r_20": 1, "ret_ytd": 0.1, "top15_streak": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# ETF features loader
+# ---------------------------------------------------------------------------
+
+REQUIRED_ETF_COLS = {
+    "asof_date", "symbol", "sector_id", "rank", "rank_delta_1d",
+    "rank_delta_5d", "r_5", "r_10", "r_20", "ret_ytd", "top15_streak",
+}
+
+
+def test_load_etf_features_returns_required_columns(market_engine):
+    _seed_features(
+        market_engine,
+        [
+            _feat_row("2026-06-04", "AAA", 90),
+            _feat_row("2026-06-05", "AAA", 92),
+            _feat_row("2026-06-05", "BBB", 50),
+        ],
+    )
+    df = ns.load_etf_features_neon(market_engine, date(2026, 6, 5))
+    assert REQUIRED_ETF_COLS.issubset(set(df.columns)), (
+        f"missing required cols: {REQUIRED_ETF_COLS - set(df.columns)}"
+    )
+    # History is included (the 2026-06-04 AAA row), not just the asof slice.
+    assert len(df) == 3
+    assert {"AAA", "BBB"}.issubset(set(df["symbol"]))
+
+
+def test_load_etf_features_renders_non_empty(market_engine):
+    """The loaded frame drives the pure renderer to a non-empty page."""
+    from rainier.dashboard.render_etf import render_etf_html
+
+    _seed_features(
+        market_engine,
+        [_feat_row("2026-06-05", "AAA", 90), _feat_row("2026-06-05", "BBB", 50)],
+    )
+    df = ns.load_etf_features_neon(market_engine, date(2026, 6, 5))
+    registry = pd.DataFrame({"sector_id": [1], "sector_name": ["Tech"]})
+    html = render_etf_html(
+        features=df, registry=registry, asof=date(2026, 6, 5),
+        rendered_at_pt="12:40",
+    )
+    assert "Universe: 0" not in html
+    assert "AAA" in html and "BBB" in html
+
+
+def test_load_etf_features_raises_on_empty(market_engine):
+    with pytest.raises(ns.EmptyNeonResultError):
+        ns.load_etf_features_neon(market_engine, date(2026, 6, 5))
+
+
+def test_load_etf_features_raises_when_asof_absent(market_engine):
+    """History present but no row exactly at asof → fail loud (don't render an
+    empty page from history-only rows)."""
+    _seed_features(market_engine, [_feat_row("2026-06-01", "AAA", 90)])
+    with pytest.raises(ns.EmptyNeonResultError):
+        ns.load_etf_features_neon(market_engine, date(2026, 6, 5))
+
+
+def test_latest_etf_asof(market_engine):
+    _seed_features(
+        market_engine,
+        [_feat_row("2026-06-01", "AAA", 90), _feat_row("2026-06-05", "AAA", 91)],
+    )
+    assert ns.latest_etf_asof(market_engine) == date(2026, 6, 5)
+
+
+def test_latest_etf_asof_raises_on_empty(market_engine):
+    with pytest.raises(ns.EmptyNeonResultError):
+        ns.latest_etf_asof(market_engine)
+
+
+# ---------------------------------------------------------------------------
+# Breadth + SPY loaders
+# ---------------------------------------------------------------------------
+
+
+def _seed_breadth(engine, rows: list[dict]) -> None:
+    with engine.begin() as conn:
+        for r in rows:
+            conn.execute(
+                text(
+                    "INSERT INTO market.breadth_indicator_daily "
+                    "(asof_date, indicator, value) "
+                    "VALUES (:asof_date, :indicator, :value)"
+                ),
+                r,
+            )
+
+
+def test_load_breadth_returns_long_columns(market_engine):
+    _seed_breadth(
+        market_engine,
+        [
+            {"asof_date": "2026-06-04", "indicator": "pct_above_50ma", "value": 55.0},
+            {"asof_date": "2026-06-05", "indicator": "pct_above_50ma", "value": 60.0},
+        ],
+    )
+    df = ns.load_breadth_neon(market_engine, date(2026, 6, 5))
+    assert set(df.columns) == {"asof_date", "indicator", "value"}
+    assert len(df) == 2  # full history <= asof
+
+
+def test_load_breadth_raises_on_empty(market_engine):
+    with pytest.raises(ns.EmptyNeonResultError):
+        ns.load_breadth_neon(market_engine, date(2026, 6, 5))
+
+
+def test_latest_breadth_asof(market_engine):
+    _seed_breadth(
+        market_engine,
+        [
+            {"asof_date": "2026-06-02", "indicator": "x", "value": 1.0},
+            {"asof_date": "2026-06-05", "indicator": "x", "value": 2.0},
+        ],
+    )
+    assert ns.latest_breadth_asof(market_engine) == date(2026, 6, 5)
+
+
+def test_load_spy_filters_symbol(market_engine):
+    with market_engine.begin() as conn:
+        for sym, c in [("SPY", 500.0), ("QQQ", 400.0)]:
+            conn.execute(
+                text(
+                    "INSERT INTO market.benchmark_ohlcv "
+                    "(symbol, date, open, high, low, close, volume, "
+                    "fetched_at, yfinance_version) VALUES "
+                    "(:s, '2026-06-05', :c, :c, :c, :c, 1000, '2026-06-05', '1')"
+                ),
+                {"s": sym, "c": c},
+            )
+    df = ns.load_spy_neon(market_engine)
+    assert set(df["symbol"]) == {"SPY"}, "must filter to symbol='SPY'"
+    assert "date" in df.columns and "close" in df.columns
+
+
+def test_load_spy_empty_when_absent(market_engine):
+    """No SPY rows → empty frame (NOT an error; the SPY pane is optional)."""
+    df = ns.load_spy_neon(market_engine)
+    assert df.empty
+
+
+# ---------------------------------------------------------------------------
+# ensure_env_loaded — the cron .env gotcha
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_env_loaded_invokes_dotenv(monkeypatch):
+    """ensure_env_loaded() must route through get_settings()'s load_dotenv() so
+    the canonical engine (which reads os.environ directly, NO .env) finds
+    DATABASE_URL on the cron path. We stub load_dotenv to set the var and
+    assert ensure_env_loaded() makes it present — proving the .env hop happens
+    before any get_engine() call."""
+    import rainier.core.config as cfg
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    # get_settings() caches a process-lifetime singleton; clear it so our
+    # stubbed load_dotenv is actually invoked (not short-circuited by a prior
+    # test's cached Settings).
+    monkeypatch.setattr(cfg, "_settings", None)
+
+    called = {"n": 0}
+
+    def fake_load_dotenv(*_a, **_k):
+        called["n"] += 1
+        os.environ["DATABASE_URL"] = "postgresql+psycopg://u:p@localhost/x"
+        return True
+
+    monkeypatch.setattr(cfg, "load_dotenv", fake_load_dotenv)
+
+    try:
+        ns.ensure_env_loaded()
+        assert called["n"] >= 1, (
+            "ensure_env_loaded must call load_dotenv via get_settings"
+        )
+        assert os.environ.get("DATABASE_URL") == "postgresql+psycopg://u:p@localhost/x"
+    finally:
+        # The stub wrote DATABASE_URL via raw os.environ (untracked by
+        # monkeypatch); clear it so it can't leak into later tests.
+        os.environ.pop("DATABASE_URL", None)
+
+
+# ---------------------------------------------------------------------------
+# requires_postgres — end-to-end from a real DB (skipped without one)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_postgres
+def test_neon_render_end_to_end(monkeypatch):
+    """Render a non-empty ETF dashboard from a live Postgres market schema.
+
+    Skips unless DATABASE_URL points at a Postgres with seeded market.* data.
+    This is the integration guard the task plan asks for; the SQLite tests
+    above cover the loader logic deterministically in CI.
+    """
+    # Require an EXPLICIT test URL — never silently borrow the ambient
+    # DATABASE_URL (which may point at production Neon or a stub set by another
+    # test). The operator opts in via RAINIER_TEST_DATABASE_URL.
+    url = os.environ.get("RAINIER_TEST_DATABASE_URL")
+    if not url or not url.startswith("postgresql"):
+        pytest.skip("no live Postgres configured (set RAINIER_TEST_DATABASE_URL)")
+
+    from rainier.db.engine import get_engine
+
+    monkeypatch.setenv("DATABASE_URL", url)
+    engine = get_engine()
+    try:
+        asof = ns.latest_etf_asof(engine)
+        df = ns.load_etf_features_neon(engine, asof)
+    finally:
+        engine.dispose()
+    assert not df.empty
+    assert REQUIRED_ETF_COLS.issubset(set(df.columns))

--- a/tests/test_scripts/test_publish_dashboard.py
+++ b/tests/test_scripts/test_publish_dashboard.py
@@ -510,6 +510,38 @@ def test_publish_accepts_linked_worktree(
 
 
 # ---------------------------------------------------------------------------
+# Test 6c — a SUBDIRECTORY inside a repo (not the worktree root) is rejected.
+# `--is-inside-work-tree` alone would wrongly accept `fengshen-site/public`,
+# nesting the publish as `public/public/trading/...`; the guard must require
+# the target to be the worktree top-level. (codex iter-1 [P2] hardening.)
+# ---------------------------------------------------------------------------
+
+
+def test_publish_rejects_subdir_of_repo(source_dir: Path, target_repo: Path):
+    """Pointing the target at a subdir inside the repo (not the root) must be
+    rejected with the checkout-guard error and must not publish."""
+    name = "etf-ranks"
+    (source_dir / f"{name}.html").write_text("<html>v1</html>")
+
+    subdir = target_repo / "public"  # inside the work tree, but not its root
+    assert subdir.is_dir()
+
+    result = _run_publisher(name, source_dir=source_dir, target_repo=subdir)
+    assert result.returncode != 0, (
+        f"subdir target must be rejected, got rc={result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    combined = (result.stdout + result.stderr).lower()
+    assert "not a git" in combined or "git checkout" in combined, (
+        f"expected checkout-guard error, got:\n{result.stdout}\n{result.stderr}"
+    )
+    # No nested publish should have been created under the subdir.
+    assert not (subdir / "public" / "trading" / name).exists(), (
+        "must not nest a publish under a subdir target"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Test 7 — pending unpushed commits are recovered on the no-op path.
 # Regression for the "yesterday push failed + today identical render"
 # corner case where the local repo silently drifts ahead of origin.

--- a/tests/test_scripts/test_publish_dashboard.py
+++ b/tests/test_scripts/test_publish_dashboard.py
@@ -1,15 +1,20 @@
-"""Unit tests for scripts/publish-dashboard.sh.
+"""Unit tests for scripts/publish-dashboard.sh — self-isolating publisher.
 
-Generic dashboard publisher — copies `out/dashboards/<name>.html` into a
-target git repo's `public/trading/<name>/index.html` and pushes when
-the content actually changed.
+The publisher copies `out/dashboards/<name>.html` into a target git repo's
+`public/trading/<name>/index.html` and pushes it to the deploy branch on
+`origin`. It NEVER operates on the target checkout directly: it sources an
+ephemeral detached worktree on `origin/<branch>`, commits + pushes there, and
+removes the worktree afterwards (trap on EXIT). This makes the publish robust
+to whatever state the shared fengshen-site checkout is parked in (a different
+branch, a dirty tree).
 
-Tests use temporary git repos as both the source dashboard dir and
-the publish target (no writes to ~/projects/fengshen-site). The
-script is selected via the `DASHBOARD_PUBLISH_TARGET_DIR` env var
-so CI never touches the operator's real fengshen-site checkout.
+Harness: a BARE origin repo + a working clone (TARGET_DIR). The script is
+pointed at the clone via `DASHBOARD_PUBLISH_TARGET_DIR`, and the deploy branch
+is overridden to `main` (the seeded branch) via `DASHBOARD_PUBLISH_BRANCH` so
+CI never touches the operator's real fengshen-site checkout.
 
-Test plan pinned by docs/TASK-PLAN-etf-dashboard-publish-cr-31aa.md §Tests.
+Test plan pinned by docs/TASK-PLAN-etf-dashboard-publish-cr-31aa.md §Tests and
+the Part B robustness fix (extend-133).
 """
 
 from __future__ import annotations
@@ -24,6 +29,10 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "publish-dashboard.sh"
 CRON_WRAPPER = ROOT / "scripts" / "cron-wrapper.sh"
+
+# The harness seeds the bare origin on `main`; the script defaults to `master`.
+# Override so the publish targets the branch the harness actually created.
+PUBLISH_BRANCH = "main"
 
 
 # ---------------------------------------------------------------------------
@@ -61,31 +70,40 @@ def _git(*args: str, cwd: Path, check: bool = True, env: dict | None = None) -> 
 
 
 @pytest.fixture
-def target_repo(tmp_path: Path) -> Path:
-    """A bare-ish git repo that simulates the fengshen-site checkout.
-
-    We create both a 'remote' bare repo and a 'local' working clone, so the
-    publish script can `git push` against a real remote (locally) without
-    touching the network or the operator's real repo.
-    """
+def remote_repo(tmp_path: Path) -> Path:
+    """A BARE origin repo seeded with one commit on `main`. The publisher
+    pushes here; tests read `origin/main` from a fresh fetch to assert what
+    actually landed upstream (the whole point of the self-isolating flow)."""
     remote = tmp_path / "fengshen-site-remote.git"
     subprocess.run(
-        ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+        ["git", "init", "--bare", "-b", "main", str(remote)],
+        check=True,
+        capture_output=True,
     )
+    # Seed an initial commit on main via a scratch clone, then discard it.
+    seed = tmp_path / "_seed"
+    subprocess.run(
+        ["git", "clone", str(remote), str(seed)], check=True, capture_output=True
+    )
+    (seed / "public").mkdir()
+    (seed / "public" / ".gitkeep").write_text("")
+    _git("checkout", "-B", "main", cwd=seed)
+    _git("add", "public/.gitkeep", cwd=seed)
+    _git("commit", "-m", "init", cwd=seed)
+    _git("push", "-u", "origin", "main", cwd=seed)
+    return remote
 
+
+@pytest.fixture
+def target_repo(tmp_path: Path, remote_repo: Path) -> Path:
+    """A working clone of the bare origin — simulates the fengshen-site
+    checkout the script is pointed at (DASHBOARD_PUBLISH_TARGET_DIR)."""
     local = tmp_path / "fengshen-site"
     subprocess.run(
-        ["git", "clone", str(remote), str(local)], check=True, capture_output=True
+        ["git", "clone", str(remote_repo), str(local)],
+        check=True,
+        capture_output=True,
     )
-
-    # Need an initial commit on `main` so the push has something to fast-forward
-    # from. Astro project layout: `public/` is the static asset root.
-    (local / "public").mkdir()
-    (local / "public" / ".gitkeep").write_text("")
-    _git("checkout", "-B", "main", cwd=local)
-    _git("add", "public/.gitkeep", cwd=local)
-    _git("commit", "-m", "init", cwd=local)
-    _git("push", "-u", "origin", "main", cwd=local)
     return local
 
 
@@ -110,6 +128,7 @@ def _run_publisher(
         {
             "DASHBOARD_SOURCE_DIR": str(source_dir),
             "DASHBOARD_PUBLISH_TARGET_DIR": str(target_repo),
+            "DASHBOARD_PUBLISH_BRANCH": PUBLISH_BRANCH,
             # Deterministic git identity inside the script as well.
             "GIT_AUTHOR_NAME": "Test",
             "GIT_AUTHOR_EMAIL": "test@example.com",
@@ -130,302 +149,302 @@ def _run_publisher(
     )
 
 
-# ---------------------------------------------------------------------------
-# Test 1 — no-op when rendered HTML is identical to what's already published.
-# ---------------------------------------------------------------------------
+def _published_html(remote_repo: Path, rel: str) -> str:
+    """Read a file as it exists on the bare origin's HEAD (deploy branch)."""
+    return subprocess.run(
+        ["git", "-C", str(remote_repo), "show", f"{PUBLISH_BRANCH}:{rel}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
 
 
-def test_publish_no_op_on_clean(source_dir: Path, target_repo: Path):
-    """Re-running with byte-identical HTML must exit 0 without a new commit."""
-    name = "etf-ranks"
-    html = "<html><body>identical</body></html>"
-    (source_dir / f"{name}.html").write_text(html)
-
-    # Pre-seed the destination with the same content + commit it so the next
-    # publish is a true no-op.
-    dest_dir = target_repo / "public" / "trading" / name
-    dest_dir.mkdir(parents=True)
-    (dest_dir / "index.html").write_text(html)
-    _git("add", f"public/trading/{name}/index.html", cwd=target_repo)
-    _git("commit", "-m", f"{name}: pre-seed", cwd=target_repo)
-    _git("push", "origin", "main", cwd=target_repo)
-
-    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
-    result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
-    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
-
-    assert result.returncode == 0, (
-        f"expected clean exit on no-op, got rc={result.returncode}\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
-    )
-    assert head_before == head_after, "no-op must not create a new commit"
-    # Friendly log so the operator can grep cron logs for "no-op".
-    assert "no-op" in result.stdout.lower() or "no change" in result.stdout.lower()
+def _origin_head(remote_repo: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(remote_repo), "rev-parse", PUBLISH_BRANCH],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
 
 
 # ---------------------------------------------------------------------------
-# Test 2 — fresh target gets dir created + file copied + committed.
+# Test 1 — publish lands the rendered HTML on origin's deploy branch.
 # ---------------------------------------------------------------------------
 
 
-def test_publish_creates_dir(source_dir: Path, target_repo: Path):
-    """First-ever publish creates `public/trading/<name>/` and lands index.html."""
+def test_publish_lands_on_origin(
+    source_dir: Path, target_repo: Path, remote_repo: Path
+):
+    """A fresh publish copies the HTML, commits, and pushes to origin/<branch>."""
     name = "etf-ranks"
     html = "<html><body>first publish</body></html>"
     (source_dir / f"{name}.html").write_text(html)
-
-    dest = target_repo / "public" / "trading" / name / "index.html"
-    assert not dest.exists(), "test precondition: destination should not exist"
 
     result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
     assert result.returncode == 0, (
         f"rc={result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
 
-    assert dest.exists(), "destination index.html must be created"
-    assert dest.read_text() == html
+    rel = f"public/trading/{name}/index.html"
+    assert _published_html(remote_repo, rel) == html, "HTML must land on origin"
 
-    # Commit must have happened.
-    log = _git(
-        "log", "--oneline", "-n", "1", "--", f"public/trading/{name}/index.html",
-        cwd=target_repo,
+
+# ---------------------------------------------------------------------------
+# Test 2 — THE KEY TEST: the publish succeeds even when the target checkout is
+# on a DIFFERENT branch and DIRTY. This proves the publisher no longer depends
+# on the shared checkout's state (Part B, extend-133).
+# ---------------------------------------------------------------------------
+
+
+def test_publish_succeeds_when_checkout_dirty_and_off_branch(
+    source_dir: Path, target_repo: Path, remote_repo: Path
+):
+    """Park the TARGET_DIR clone on a different branch AND make it dirty; the
+    publish must STILL land on origin's deploy branch."""
+    name = "market-breadth"
+    html = "<html><body>breadth published from isolated worktree</body></html>"
+    (source_dir / f"{name}.html").write_text(html)
+
+    # Park the checkout on a worker branch and dirty both a tracked and an
+    # untracked file — exactly the shared-tree state that broke the old flow.
+    _git("checkout", "-b", "worker/some-other-work", cwd=target_repo)
+    (target_repo / "public" / ".gitkeep").write_text("hand-edited\n")
+    (target_repo / "stray-uncommitted.txt").write_text("WIP\n")
+
+    head_before = _origin_head(remote_repo)
+    result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
+    assert result.returncode == 0, (
+        "publish must succeed regardless of checkout state\n"
+        f"rc={result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
-    assert name in log, f"commit log missing dashboard name: {log!r}"
+
+    rel = f"public/trading/{name}/index.html"
+    assert _published_html(remote_repo, rel) == html, (
+        "HTML must land on origin even from a dirty / off-branch checkout"
+    )
+    assert _origin_head(remote_repo) != head_before, "origin must have advanced"
+
+    # The shared checkout's dirt is untouched — we never operated on it.
+    assert (target_repo / "stray-uncommitted.txt").exists()
+    assert (target_repo / "public" / ".gitkeep").read_text() == "hand-edited\n"
+    current_branch = _git(
+        "rev-parse", "--abbrev-ref", "HEAD", cwd=target_repo
+    ).strip()
+    assert current_branch == "worker/some-other-work", (
+        "publish must not move the checkout off its branch"
+    )
 
 
 # ---------------------------------------------------------------------------
-# Test 3 — when the source HTML differs, script commits with expected
-# message format and runs `git push`.
+# Test 3 — modified source HTML produces a `<name>: YYYY-MM-DD daily render`
+# commit on origin.
 # ---------------------------------------------------------------------------
 
 
-def test_publish_commits_when_changed(source_dir: Path, target_repo: Path):
-    """A modified source HTML produces a commit `<name>: YYYY-MM-DD daily render`
-    and the commit lands on origin/main."""
+def test_publish_commits_when_changed(
+    source_dir: Path, target_repo: Path, remote_repo: Path
+):
     name = "etf-ranks"
-    # Seed an initial publish.
     (source_dir / f"{name}.html").write_text("<html>v1</html>")
     r1 = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
     assert r1.returncode == 0, r1.stderr
 
-    # Now modify the source and re-publish.
     (source_dir / f"{name}.html").write_text("<html>v2 updated</html>")
     r2 = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
     assert r2.returncode == 0, (
         f"rc={r2.returncode}\nstdout: {r2.stdout}\nstderr: {r2.stderr}"
     )
 
-    # Latest commit message: `<name>: YYYY-MM-DD daily render`
-    head_msg = _git("log", "-1", "--pretty=%s", cwd=target_repo).strip()
+    head_msg = subprocess.run(
+        ["git", "-C", str(remote_repo), "log", "-1", "--pretty=%s", PUBLISH_BRANCH],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
     assert re.match(
         rf"^{re.escape(name)}: \d{{4}}-\d{{2}}-\d{{2}} daily render$", head_msg
     ), f"unexpected commit subject: {head_msg!r}"
 
-    # And the push made it to the remote.
-    local_head = _git("rev-parse", "HEAD", cwd=target_repo).strip()
-    remote_head = _git("rev-parse", "origin/main", cwd=target_repo).strip()
-    assert local_head == remote_head, "publisher must `git push` after commit"
+    rel = f"public/trading/{name}/index.html"
+    assert _published_html(remote_repo, rel) == "<html>v2 updated</html>"
 
 
 # ---------------------------------------------------------------------------
-# Test 4 — bail (non-zero, no commit) when target has uncommitted changes.
+# Test 4 — no-op when rendered HTML is byte-identical to what's published.
 # ---------------------------------------------------------------------------
 
 
-def test_publish_bails_on_dirty_target(source_dir: Path, target_repo: Path):
-    """Dirty target working tree → script exits non-zero and does NOT commit
-    or stash anything."""
-    name = "etf-ranks"
-    (source_dir / f"{name}.html").write_text("<html>clean source</html>")
-
-    # Dirty the target: untracked file + modified tracked file.
-    (target_repo / "public" / ".gitkeep").write_text("modified\n")
-    (target_repo / "stray.txt").write_text("untracked\n")
-
-    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
-    result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
-    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
-
-    assert result.returncode != 0, (
-        "publisher must exit non-zero when target is dirty\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
-    )
-    assert head_before == head_after, "publisher must not commit when bailing"
-
-    # Stray + modified files must still be there — no auto-stash.
-    assert (target_repo / "stray.txt").exists(), "must not stash untracked files"
-    assert (target_repo / "public" / ".gitkeep").read_text() == "modified\n"
-
-    # Clear, actionable error message on stdout or stderr.
-    combined = (result.stdout + result.stderr).lower()
-    assert "dirty" in combined or "uncommitted" in combined, (
-        f"expected dirty/uncommitted in output, got:\n{result.stdout}\n{result.stderr}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Test 4b — a target whose ONLY working-tree change is a git-IGNORED untracked
-# path must still publish. Regression for the 2026-06-04 P0: the gstack browse
-# tooling left `fengshen-site/.gstack/browse-audit.jsonl` (untracked, but
-# `.gitignore`d), tripping the dirty-tree guard and blocking the daily breadth
-# publish. The guard must base "dirty" on tracked/relevant changes only.
-# ---------------------------------------------------------------------------
-
-
-def test_publish_proceeds_with_only_ignored_untracked(
-    source_dir: Path, target_repo: Path
+def test_publish_no_op_on_identical(
+    source_dir: Path, target_repo: Path, remote_repo: Path
 ):
-    """An ignored untracked path (e.g. `.gstack/`) must NOT block a publish."""
-    name = "market-breadth"
-    html = "<html><body>breadth</body></html>"
+    name = "etf-ranks"
+    html = "<html><body>identical</body></html>"
     (source_dir / f"{name}.html").write_text(html)
 
-    # Ignore `.gstack/` in the target repo (committed `.gitignore`), then drop
-    # an untracked file under it — exactly the P0 droppings.
-    (target_repo / ".gitignore").write_text(".gstack/\n")
-    _git("add", ".gitignore", cwd=target_repo)
-    _git("commit", "-m", "ignore .gstack/", cwd=target_repo)
-    gstack_dir = target_repo / ".gstack"
-    gstack_dir.mkdir()
-    (gstack_dir / "browse-audit.jsonl").write_text('{"audit": 1}\n')
+    r1 = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
+    assert r1.returncode == 0, r1.stderr
+    head_after_first = _origin_head(remote_repo)
 
-    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    # Second run, identical content → no commit, no push, clean exit.
+    r2 = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
+    assert r2.returncode == 0, (
+        f"rc={r2.returncode}\nstdout: {r2.stdout}\nstderr: {r2.stderr}"
+    )
+    assert "no-op" in r2.stdout.lower() or "no change" in r2.stdout.lower()
+    assert _origin_head(remote_repo) == head_after_first, (
+        "identical render must not create a new commit on origin"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — ephemeral worktree is cleaned up after the run (success path).
+# No leftover worktrees registered, tmp dir gone.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_cleans_up_worktree(
+    source_dir: Path, target_repo: Path, remote_repo: Path
+):
+    name = "etf-ranks"
+    (source_dir / f"{name}.html").write_text("<html>v1</html>")
     result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
-    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    assert result.returncode == 0, result.stderr
 
+    # `git worktree list` should show only the main checkout (no leftovers).
+    wt_list = _git("worktree", "list", cwd=target_repo)
+    lines = [ln for ln in wt_list.splitlines() if ln.strip()]
+    assert len(lines) == 1, (
+        f"expected only the main worktree, got:\n{wt_list}"
+    )
+    # And no stray publish-dashboard.* temp dirs survived.
+    assert not list(Path("/tmp").glob("publish-dashboard.*")) or all(
+        not p.exists() for p in Path("/tmp").glob("publish-dashboard.*")
+    ), "ephemeral worktree tmp dir must be removed"
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — concurrency: a non-fast-forward push (origin advanced under us) is
+# retried by re-fetching + rebasing the ephemeral worktree, then re-pushing.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_retries_on_non_fast_forward(
+    source_dir: Path, target_repo: Path, remote_repo: Path, tmp_path: Path
+):
+    """Force a REAL non-fast-forward on the publisher's first push, then assert
+    it re-fetches, rebases its ephemeral worktree onto the new tip, and lands
+    on the second attempt — without clobbering the concurrent commit.
+
+    Mechanism: a `pre-receive` hook on the bare origin advances the branch with
+    a concurrent commit during the publisher's FIRST push, so that push is
+    rejected non-FF; on the SECOND push the hook is inert (one-shot via a flag
+    file) and the push succeeds. This deterministically exercises the retry
+    loop instead of relying on wall-clock timing."""
+    name = "etf-ranks"
+    (source_dir / f"{name}.html").write_text("<html>ours</html>")
+
+    # One-shot pre-receive hook: on its first invocation it injects a
+    # concurrent commit onto the branch (advancing origin under the pushing
+    # client, which makes the client's update non-FF and rejected), then drops
+    # a flag so subsequent pushes pass through untouched.
+    hooks = remote_repo / "hooks"
+    hooks.mkdir(exist_ok=True)
+    flag = tmp_path / "hook-fired.flag"
+    concurrent_tree_repo = tmp_path / "_hook_worker"
+    subprocess.run(
+        ["git", "clone", str(remote_repo), str(concurrent_tree_repo)],
+        check=True,
+        capture_output=True,
+    )
+    (concurrent_tree_repo / "CONCURRENT.txt").write_text("from another agent\n")
+    _git("add", "CONCURRENT.txt", cwd=concurrent_tree_repo)
+    _git("commit", "-m", "concurrent: unrelated change", cwd=concurrent_tree_repo)
+    concurrent_sha = _git("rev-parse", "HEAD", cwd=concurrent_tree_repo).strip()
+
+    # Seed the concurrent commit's objects into the bare repo (a hidden ref)
+    # BEFORE the hook is installed, so the hook's update-ref can reach the SHA.
+    _git("push", "origin", f"{concurrent_sha}:refs/heads/_seed_objects",
+         cwd=concurrent_tree_repo)
+
+    # Modern git runs pre-receive inside a quarantine env where ref updates are
+    # forbidden; unset the quarantine vars and target the bare git-dir directly
+    # so the hook can advance the branch (simulating a concurrent push that
+    # landed between the publisher's fetch and its push).
+    pre_receive = hooks / "pre-receive"
+    pre_receive.write_text(
+        "#!/bin/bash\n"
+        "set -e\n"
+        f'if [ ! -f "{flag}" ]; then\n'
+        f'  touch "{flag}"\n'
+        "  env -u GIT_QUARANTINE_PATH -u GIT_OBJECT_DIRECTORY "
+        "-u GIT_ALTERNATE_OBJECT_DIRECTORIES \\\n"
+        f'    git --git-dir="{remote_repo}" update-ref '
+        f"refs/heads/{PUBLISH_BRANCH} {concurrent_sha}\n"
+        '  echo "hook: injected concurrent commit, rejecting this push" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    pre_receive.chmod(0o755)
+
+    result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
     assert result.returncode == 0, (
-        "publish must proceed when the only target change is an ignored path\n"
+        "publish must recover from a non-FF rejection via retry\n"
         f"rc={result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
-    # A new commit must have landed (the rendered HTML).
-    assert head_before != head_after, "publish must commit the rendered HTML"
-    dst = target_repo / "public" / "trading" / name / "index.html"
-    assert dst.exists() and dst.read_text() == html
-    # The ignored droppings are untouched (never committed, never deleted).
-    assert (gstack_dir / "browse-audit.jsonl").exists()
-    porcelain = _git("status", "--porcelain", cwd=target_repo)
-    assert ".gstack" not in porcelain, "ignored path must not become tracked"
-    # The guard explicitly announces it disregarded an ignored path, so cron
-    # logs make it obvious the dirty-tree check was applied (not skipped).
-    assert "ignored" in result.stdout.lower(), (
-        "guard should log that it disregarded git-ignored path(s); "
-        f"stdout: {result.stdout}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Test 4c — a dirty TRACKED file still blocks the publish, even when an ignored
-# untracked path is also present. The hardened guard must not become so lax it
-# sweeps real edits.
-# ---------------------------------------------------------------------------
-
-
-def test_publish_bails_on_dirty_tracked_even_with_ignored(
-    source_dir: Path, target_repo: Path
-):
-    """A modified tracked file must still refuse, regardless of ignored droppings."""
-    name = "market-breadth"
-    (source_dir / f"{name}.html").write_text("<html>clean source</html>")
-
-    # Ignore `.gstack/` and add an untracked ignored file (the benign case)...
-    (target_repo / ".gitignore").write_text(".gstack/\n")
-    _git("add", ".gitignore", cwd=target_repo)
-    _git("commit", "-m", "ignore .gstack/", cwd=target_repo)
-    (target_repo / ".gstack").mkdir()
-    (target_repo / ".gstack" / "browse-audit.jsonl").write_text("{}\n")
-    # ...AND a genuinely dirty TRACKED file (the case we must still catch).
-    (target_repo / "public" / ".gitkeep").write_text("hand-edited\n")
-
-    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
-    result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
-    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
-
-    assert result.returncode != 0, (
-        "dirty TRACKED file must still block the publish\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
-    )
-    assert head_before == head_after, "must not commit when a tracked file is dirty"
-    assert (target_repo / "public" / ".gitkeep").read_text() == "hand-edited\n"
+    assert flag.exists(), "the non-FF hook must have fired (race not exercised)"
     combined = (result.stdout + result.stderr).lower()
-    assert "dirty" in combined or "uncommitted" in combined
-
-
-# ---------------------------------------------------------------------------
-# Test 4d — an untracked, NON-ignored file still blocks the publish. The
-# hardened guard ignores only git-IGNORED paths; a genuinely stray untracked
-# file (not in `.gitignore`) is still "dirt" we refuse to sweep up.
-# ---------------------------------------------------------------------------
-
-
-def test_publish_bails_on_untracked_non_ignored(
-    source_dir: Path, target_repo: Path
-):
-    """A stray untracked file that is NOT ignored must still refuse."""
-    name = "market-breadth"
-    (source_dir / f"{name}.html").write_text("<html>clean source</html>")
-
-    # Untracked, and NOT covered by any .gitignore entry.
-    (target_repo / "stray-note.txt").write_text("forgot to commit this\n")
-
-    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
-    result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
-    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
-
-    assert result.returncode != 0, (
-        "stray untracked (non-ignored) file must still block the publish\n"
+    assert "non-fast-forward" in combined or "rejected" in combined, (
+        "publisher should log the non-FF retry; "
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
-    assert head_before == head_after, "must not commit when an untracked file is present"
-    assert (target_repo / "stray-note.txt").exists(), "must not stash untracked files"
+
+    # Both the concurrent file AND our render must exist on origin (no clobber).
+    rel = f"public/trading/{name}/index.html"
+    assert _published_html(remote_repo, rel) == "<html>ours</html>"
+    concurrent = subprocess.run(
+        ["git", "-C", str(remote_repo), "show", f"{PUBLISH_BRANCH}:CONCURRENT.txt"],
+        capture_output=True,
+        text=True,
+    )
+    assert concurrent.returncode == 0, (
+        "concurrent agent's commit must survive (publish must not clobber it)"
+    )
 
 
 # ---------------------------------------------------------------------------
-# Test 5 — missing source HTML produces a clean non-zero exit (no copy, no
-# commit). `set -euo pipefail` + the early `[ ! -f "$SRC" ]` guard must turn
-# this into a meaningful error, NOT a silent success.
+# Test 7 — missing source HTML produces a clean non-zero exit (no copy, no
+# commit, nothing pushed).
 # ---------------------------------------------------------------------------
 
 
-def test_publish_errors_when_source_missing(source_dir: Path, target_repo: Path):
-    """No rendered HTML at the source path → exit non-zero, no commit."""
+def test_publish_errors_when_source_missing(
+    source_dir: Path, target_repo: Path, remote_repo: Path
+):
     name = "etf-ranks"
-    # Intentionally do NOT write `etf-ranks.html` into source_dir.
     assert not (source_dir / f"{name}.html").exists()
 
-    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    head_before = _origin_head(remote_repo)
     result = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
-    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
-
     assert result.returncode != 0, (
         f"missing source must produce non-zero exit, got rc={result.returncode}\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
-    assert head_before == head_after, "must not commit when source is missing"
-
+    assert _origin_head(remote_repo) == head_before, "must not push when source missing"
     combined = (result.stdout + result.stderr).lower()
-    assert "missing" in combined or "no such" in combined, (
-        f"expected actionable error mentioning missing source, got:\n"
-        f"{result.stdout}\n{result.stderr}"
-    )
-
-    # And no file should have been published.
-    dst = target_repo / "public" / "trading" / name / "index.html"
-    assert not dst.exists(), "must not create destination when source is missing"
+    assert "missing" in combined or "no such" in combined
 
 
 # ---------------------------------------------------------------------------
-# Test 6 — target is not a git checkout → clean non-zero exit, no file copy.
-# Protects against misconfiguration (DASHBOARD_PUBLISH_TARGET_DIR pointing at
-# a plain directory instead of the fengshen-site clone).
+# Test 8 — target is not a git checkout → clean non-zero exit, nothing pushed.
 # ---------------------------------------------------------------------------
 
 
 def test_publish_errors_when_target_not_git(tmp_path: Path, source_dir: Path):
-    """Non-git target → exit non-zero, no file written."""
     name = "etf-ranks"
     (source_dir / f"{name}.html").write_text("<html>v1</html>")
 
-    # Plain directory, no .git/ inside.
     not_a_git_repo = tmp_path / "fengshen-site-but-not-really"
     not_a_git_repo.mkdir()
     assert not (not_a_git_repo / ".git").exists()
@@ -437,89 +456,18 @@ def test_publish_errors_when_target_not_git(tmp_path: Path, source_dir: Path):
         f"non-git target must produce non-zero exit, got rc={result.returncode}\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
-
     combined = (result.stdout + result.stderr).lower()
-    assert "not a git" in combined or "git checkout" in combined, (
-        f"expected error mentioning git checkout, got:\n"
-        f"{result.stdout}\n{result.stderr}"
-    )
-
-    # And no destination directory created.
-    dst = not_a_git_repo / "public" / "trading" / name
-    assert not dst.exists(), "must not create destination on non-git target"
+    assert "not a git" in combined or "git checkout" in combined
 
 
 # ---------------------------------------------------------------------------
-# Test 6b — a linked git worktree (`git worktree add`) is a valid target.
-# Its `.git` is a FILE (gitdir pointer), not a directory, so the old
-# `-d "$TARGET_DIR/.git"` guard wrongly rejected it. The checkout guard must
-# accept it and proceed PAST the "target is not a git checkout" error.
-# Regression for the shared-tree publish path (publish into an isolated
-# worktree on origin/master rather than the main checkout).
-# ---------------------------------------------------------------------------
-
-
-def test_publish_accepts_linked_worktree(
-    tmp_path: Path, source_dir: Path, target_repo: Path
-):
-    """A `git worktree add` target (`.git` is a file) must NOT be rejected by
-    the checkout guard. The publish should succeed end-to-end."""
-    name = "etf-ranks"
-    html = "<html><body>worktree publish</body></html>"
-    (source_dir / f"{name}.html").write_text(html)
-
-    # Create a linked worktree in the target repo. `main` is already checked
-    # out in the primary tree, so put the worktree on a fresh branch that
-    # tracks origin/main (the publish path commits + `git push`es upstream).
-    # Its `.git` is a FILE pointing into the parent's `.git/worktrees/<id>`,
-    # not a directory — exactly the case the old `-d` guard mishandled.
-    worktree = tmp_path / "fengshen-site-worktree"
-    _git(
-        "worktree", "add", "-b", "publish-wt", str(worktree), "origin/main",
-        cwd=target_repo,
-    )
-    _git("branch", "--set-upstream-to=origin/main", "publish-wt", cwd=worktree)
-    # The worktree branch name (`publish-wt`) differs from its upstream
-    # (`main`); push.default=upstream makes `git push` target the tracked
-    # branch regardless of name (the shared-tree publish setup the operator
-    # uses, where the worktree publishes to origin/master).
-    _git("config", "push.default", "upstream", cwd=worktree)
-    gitpath = worktree / ".git"
-    assert gitpath.is_file(), (
-        "test precondition: a linked worktree's .git must be a FILE, not a dir"
-    )
-
-    result = _run_publisher(name, source_dir=source_dir, target_repo=worktree)
-
-    # The script must get PAST the checkout guard — that's the core regression.
-    combined = (result.stdout + result.stderr).lower()
-    assert "target is not a git checkout" not in combined, (
-        "checkout guard wrongly rejected a linked worktree\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
-    )
-
-    # And it should actually publish (proceed through copy/commit/push).
-    assert result.returncode == 0, (
-        f"publish into a worktree must succeed, got rc={result.returncode}\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
-    )
-    dst = worktree / "public" / "trading" / name / "index.html"
-    assert dst.exists() and dst.read_text() == html, (
-        "rendered HTML must land in the worktree's public/ tree"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Test 6c — a SUBDIRECTORY inside a repo (not the worktree root) is rejected.
-# `--is-inside-work-tree` alone would wrongly accept `fengshen-site/public`,
-# nesting the publish as `public/public/trading/...`; the guard must require
-# the target to be the worktree top-level. (codex iter-1 [P2] hardening.)
+# Test 8b — a SUBDIRECTORY inside a repo (not the worktree root) is rejected.
+# The checkout guard requires the target to be the worktree top-level so the
+# publish path can't accidentally nest under a subdir. (Carried from #133.)
 # ---------------------------------------------------------------------------
 
 
 def test_publish_rejects_subdir_of_repo(source_dir: Path, target_repo: Path):
-    """Pointing the target at a subdir inside the repo (not the root) must be
-    rejected with the checkout-guard error and must not publish."""
     name = "etf-ranks"
     (source_dir / f"{name}.html").write_text("<html>v1</html>")
 
@@ -532,84 +480,57 @@ def test_publish_rejects_subdir_of_repo(source_dir: Path, target_repo: Path):
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
     combined = (result.stdout + result.stderr).lower()
-    assert "not a git" in combined or "git checkout" in combined, (
-        f"expected checkout-guard error, got:\n{result.stdout}\n{result.stderr}"
-    )
-    # No nested publish should have been created under the subdir.
-    assert not (subdir / "public" / "trading" / name).exists(), (
-        "must not nest a publish under a subdir target"
-    )
+    assert "not a git" in combined or "git checkout" in combined
 
 
 # ---------------------------------------------------------------------------
-# Test 7 — pending unpushed commits are recovered on the no-op path.
-# Regression for the "yesterday push failed + today identical render"
-# corner case where the local repo silently drifts ahead of origin.
+# Test 8c — a linked git worktree (`git worktree add`) is still a valid target.
+# Its `.git` is a FILE (gitdir pointer), not a directory; the checkout guard
+# must accept it and proceed. (Carried from #133 — the publisher now sources
+# its OWN worktree from this target, so the target itself may legitimately be
+# a worktree.)
 # ---------------------------------------------------------------------------
 
 
-def test_publish_pushes_pending_commits_on_noop(
-    source_dir: Path, target_repo: Path
+def test_publish_accepts_linked_worktree(
+    tmp_path: Path, source_dir: Path, target_repo: Path, remote_repo: Path
 ):
-    """After a prior commit is left local-only (simulating a failed push),
-    a subsequent no-op render must detect the ahead-of-upstream state and
-    push the pending commit instead of exiting silently."""
     name = "etf-ranks"
-    html = "<html>v1</html>"
+    html = "<html><body>worktree publish</body></html>"
     (source_dir / f"{name}.html").write_text(html)
 
-    # First run: lands a commit and pushes.
-    r1 = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
-    assert r1.returncode == 0, r1.stderr
-
-    # Simulate "yesterday's push failed" by rewinding the remote one commit.
-    # Resolve the parent SHA in the working clone (where the reflog lives),
-    # then point the bare remote's main ref at it directly. We avoid
-    # `HEAD~1` against the bare repo because its HEAD is symbolic-only.
-    remote_url = _git("config", "remote.origin.url", cwd=target_repo).strip()
-    parent_sha = _git("rev-parse", "HEAD~1", cwd=target_repo).strip()
+    # Create a linked worktree of the target clone (its `.git` is a FILE).
+    worktree = tmp_path / "fengshen-site-worktree"
     _git(
-        "update-ref",
-        "refs/heads/main",
-        parent_sha,
-        cwd=Path(remote_url),
+        "worktree", "add", "-b", "publish-wt", str(worktree), PUBLISH_BRANCH,
+        cwd=target_repo,
     )
-    # Confirm we are now ahead of origin/main.
-    _git("fetch", "origin", cwd=target_repo)
-    ahead = _git(
-        "rev-list", "--count", "origin/main..HEAD", cwd=target_repo
-    ).strip()
-    assert ahead == "1", f"setup error: expected 1 ahead, got {ahead}"
-
-    # Re-run with identical source HTML → the no-op path triggers, but the
-    # pending commit must still be pushed.
-    r2 = _run_publisher(name, source_dir=source_dir, target_repo=target_repo)
-    assert r2.returncode == 0, (
-        f"rc={r2.returncode}\nstdout: {r2.stdout}\nstderr: {r2.stderr}"
+    assert (worktree / ".git").is_file(), (
+        "test precondition: a linked worktree's .git must be a FILE, not a dir"
     )
 
-    # Local and origin should be back in sync.
-    _git("fetch", "origin", cwd=target_repo)
-    local_head = _git("rev-parse", "HEAD", cwd=target_repo).strip()
-    origin_head = _git("rev-parse", "origin/main", cwd=target_repo).strip()
-    assert local_head == origin_head, (
-        f"pending commit was not recovered: local={local_head[:8]} "
-        f"origin={origin_head[:8]}"
+    result = _run_publisher(name, source_dir=source_dir, target_repo=worktree)
+    combined = (result.stdout + result.stderr).lower()
+    assert "target is not a git checkout" not in combined, (
+        "checkout guard wrongly rejected a linked worktree\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
+    assert result.returncode == 0, (
+        f"publish from a linked-worktree target must succeed, got rc={result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    rel = f"public/trading/{name}/index.html"
+    assert _published_html(remote_repo, rel) == html
 
 
 # ---------------------------------------------------------------------------
-# Test 7b — `--root` flag publishes to `public/trading/index.html` (the
-# combined trading dashboard's URL = `/trading/`, DESIGN §4 D1 operator
-# override 2026-05-27). Default path remains `public/trading/<name>/`.
+# Test 9 — `--root` flag publishes to `public/trading/index.html`.
 # ---------------------------------------------------------------------------
 
 
 def test_publish_root_flag_lands_at_trading_root(
-    source_dir: Path, target_repo: Path
+    source_dir: Path, target_repo: Path, remote_repo: Path
 ):
-    """With `--root`, the rendered HTML lands at `public/trading/index.html`,
-    not the default `public/trading/<name>/index.html`."""
     name = "dashboard"
     html = "<html><body>combined v1</body></html>"
     (source_dir / f"{name}.html").write_text(html)
@@ -620,29 +541,22 @@ def test_publish_root_flag_lands_at_trading_root(
     assert result.returncode == 0, (
         f"rc={result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
-
-    root_dst = target_repo / "public" / "trading" / "index.html"
-    nested_dst = target_repo / "public" / "trading" / name / "index.html"
-
-    assert root_dst.exists(), (
-        f"--root must publish to public/trading/index.html (got nothing at {root_dst})"
+    assert _published_html(remote_repo, "public/trading/index.html") == html
+    # The nested per-name path must NOT also be created.
+    nested = subprocess.run(
+        ["git", "-C", str(remote_repo), "show",
+         f"{PUBLISH_BRANCH}:public/trading/{name}/index.html"],
+        capture_output=True,
+        text=True,
     )
-    assert root_dst.read_text() == html
-    assert not nested_dst.exists(), (
-        "--root must NOT also create the nested `public/trading/<name>/` path "
-        f"(found stale file at {nested_dst})"
-    )
+    assert nested.returncode != 0, "--root must not also create the nested path"
 
 
 def test_publish_root_flag_rejects_unknown_args(
     source_dir: Path, target_repo: Path
 ):
-    """Unknown flags after `<name>` exit non-zero with a usage hint —
-    silent ignore would let typos like `--roto` silently fall back to the
-    default nested path and silently misroute the combined dashboard."""
     name = "dashboard"
     (source_dir / f"{name}.html").write_text("<html>v1</html>")
-
     result = _run_publisher(
         name, source_dir=source_dir, target_repo=target_repo, extra_args=["--bogus"]
     )
@@ -651,31 +565,30 @@ def test_publish_root_flag_rejects_unknown_args(
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
     combined = (result.stdout + result.stderr).lower()
-    assert "unknown" in combined or "usage" in combined, (
-        f"expected unknown-flag error, got:\n{result.stdout}\n{result.stderr}"
-    )
+    assert "unknown" in combined or "usage" in combined
+
+
+def test_publish_rejects_path_traversal_name(
+    source_dir: Path, target_repo: Path
+):
+    """A `<name>` with `/` or `..` is rejected before any git op (carried)."""
+    (source_dir / "etf-ranks.html").write_text("<html>v1</html>")
+    for bad in ["../escape", "a/b", ".."]:
+        result = _run_publisher(bad, source_dir=source_dir, target_repo=target_repo)
+        assert result.returncode != 0, f"name {bad!r} must be rejected"
+        combined = (result.stdout + result.stderr).lower()
+        assert "invalid" in combined or "usage" in combined
 
 
 # ---------------------------------------------------------------------------
-# Test 8 — cron-wrapper integration: invokes render then publish in order.
+# Test 10 — cron-wrapper integration: invokes render then publish in order.
 # ---------------------------------------------------------------------------
 
 
 def test_cron_wrapper_invokes_render_then_publish(tmp_path: Path):
-    """`cron-wrapper.sh` runs the supplied command verbatim and logs phases.
-
-    We construct a 'fake render && fake publish' command that drops two files
-    in order, then assert the file order matches (render first, publish
-    second) and the wrapper's [OK] line appears in the log.
-
-    This is the integration shape used by the new cron entry; the wrapper is
-    already generic so we're verifying it cleanly hosts the new chained
-    command without bespoke per-job code.
-    """
+    """`cron-wrapper.sh` runs the supplied command verbatim and logs phases."""
     project = tmp_path / "rainier"
     (project / "scripts").mkdir(parents=True)
-    # Drop the real wrapper into a clone of the project layout cron-wrapper.sh
-    # expects (it cd's into `dirname(scripts)/`).
     wrapper_dst = project / "scripts" / "cron-wrapper.sh"
     wrapper_dst.write_text(CRON_WRAPPER.read_text())
     wrapper_dst.chmod(0o755)
@@ -684,12 +597,8 @@ def test_cron_wrapper_invokes_render_then_publish(tmp_path: Path):
     marker_publish = tmp_path / "publish.marker"
     log = tmp_path / "cron.log"
 
-    # The command argument is `eval`d by cron-wrapper, exactly as it would be
-    # from cron.yaml. Order matters: render must touch its marker FIRST, then
-    # `&&` chains to the publisher.
     command = (
         f"date >> {marker_render} && "
-        # tiny sleep so mtimes differ even on coarse filesystems
         f"sleep 0.01 && "
         f"date >> {marker_publish}"
     )
@@ -714,8 +623,6 @@ def test_cron_wrapper_invokes_render_then_publish(tmp_path: Path):
     )
     assert marker_render.exists(), "render step never ran"
     assert marker_publish.exists(), "publish step never ran"
-
-    # Render's marker must be older than publish's marker — proves order.
     assert marker_render.stat().st_mtime <= marker_publish.stat().st_mtime, (
         "render must run before publish"
     )

--- a/tests/test_scripts/test_publish_dashboard.py
+++ b/tests/test_scripts/test_publish_dashboard.py
@@ -450,6 +450,66 @@ def test_publish_errors_when_target_not_git(tmp_path: Path, source_dir: Path):
 
 
 # ---------------------------------------------------------------------------
+# Test 6b — a linked git worktree (`git worktree add`) is a valid target.
+# Its `.git` is a FILE (gitdir pointer), not a directory, so the old
+# `-d "$TARGET_DIR/.git"` guard wrongly rejected it. The checkout guard must
+# accept it and proceed PAST the "target is not a git checkout" error.
+# Regression for the shared-tree publish path (publish into an isolated
+# worktree on origin/master rather than the main checkout).
+# ---------------------------------------------------------------------------
+
+
+def test_publish_accepts_linked_worktree(
+    tmp_path: Path, source_dir: Path, target_repo: Path
+):
+    """A `git worktree add` target (`.git` is a file) must NOT be rejected by
+    the checkout guard. The publish should succeed end-to-end."""
+    name = "etf-ranks"
+    html = "<html><body>worktree publish</body></html>"
+    (source_dir / f"{name}.html").write_text(html)
+
+    # Create a linked worktree in the target repo. `main` is already checked
+    # out in the primary tree, so put the worktree on a fresh branch that
+    # tracks origin/main (the publish path commits + `git push`es upstream).
+    # Its `.git` is a FILE pointing into the parent's `.git/worktrees/<id>`,
+    # not a directory — exactly the case the old `-d` guard mishandled.
+    worktree = tmp_path / "fengshen-site-worktree"
+    _git(
+        "worktree", "add", "-b", "publish-wt", str(worktree), "origin/main",
+        cwd=target_repo,
+    )
+    _git("branch", "--set-upstream-to=origin/main", "publish-wt", cwd=worktree)
+    # The worktree branch name (`publish-wt`) differs from its upstream
+    # (`main`); push.default=upstream makes `git push` target the tracked
+    # branch regardless of name (the shared-tree publish setup the operator
+    # uses, where the worktree publishes to origin/master).
+    _git("config", "push.default", "upstream", cwd=worktree)
+    gitpath = worktree / ".git"
+    assert gitpath.is_file(), (
+        "test precondition: a linked worktree's .git must be a FILE, not a dir"
+    )
+
+    result = _run_publisher(name, source_dir=source_dir, target_repo=worktree)
+
+    # The script must get PAST the checkout guard — that's the core regression.
+    combined = (result.stdout + result.stderr).lower()
+    assert "target is not a git checkout" not in combined, (
+        "checkout guard wrongly rejected a linked worktree\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    # And it should actually publish (proceed through copy/commit/push).
+    assert result.returncode == 0, (
+        f"publish into a worktree must succeed, got rc={result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    dst = worktree / "public" / "trading" / name / "index.html"
+    assert dst.exists() and dst.read_text() == html, (
+        "rendered HTML must land in the worktree's public/ tree"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Test 7 — pending unpushed commits are recovered on the no-op path.
 # Regression for the "yesterday push failed + today identical render"
 # corner case where the local repo silently drifts ahead of origin.

--- a/tests/test_scripts/test_publish_etf_dashboard.py
+++ b/tests/test_scripts/test_publish_etf_dashboard.py
@@ -163,6 +163,9 @@ def _run_wrapper(
             "RAINIER_UV": str(uv_stub),
             "DASHBOARD_SOURCE_DIR": str(source_dir),
             "DASHBOARD_PUBLISH_TARGET_DIR": str(target_repo),
+            # The harness seeds `main`; the publisher defaults to `master`.
+            # Override so the isolated-worktree publish targets the seeded branch.
+            "DASHBOARD_PUBLISH_BRANCH": "main",
             "GIT_AUTHOR_NAME": "Test",
             "GIT_AUTHOR_EMAIL": "test@example.com",
             "GIT_COMMITTER_NAME": "Test",
@@ -215,23 +218,27 @@ def test_empty_render_is_not_published(
     empty_html = f"<html><body><p>{EMPTY_MARKER}</p></body></html>"
     uv_stub = _write_uv_stub(tmp_path, source_dir, empty_html)
 
-    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    origin_before = _git("rev-parse", "origin/main", cwd=target_repo).strip()
     result = _run_wrapper(
         tmp_path=tmp_path,
         source_dir=source_dir,
         target_repo=target_repo,
         uv_stub=uv_stub,
     )
-    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    _git("fetch", "origin", cwd=target_repo)
+    origin_after = _git("rev-parse", "origin/main", cwd=target_repo).strip()
 
     assert result.returncode != 0, (
         f"empty render must exit non-zero, got rc={result.returncode}\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
-    assert head_before == head_after, "must not commit on empty render"
+    assert origin_before == origin_after, "must not push on empty render"
 
-    dst = target_repo / "public" / "trading" / "etf-ranks" / "index.html"
-    assert not dst.exists(), "must not publish empty HTML"
+    published = _git(
+        "show", "origin/main:public/trading/etf-ranks/index.html",
+        cwd=target_repo, check=False,
+    )
+    assert published == "", "must not publish empty HTML to origin"
 
     combined = (result.stdout + result.stderr).lower()
     assert "empty" in combined or "no features" in combined, (
@@ -263,22 +270,20 @@ def test_happy_path_publishes(
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
 
-    dst = target_repo / "public" / "trading" / "etf-ranks" / "index.html"
-    assert dst.exists(), "publish step did not land index.html"
-    # Read against the rendered content (textwrap.dedent in the stub adds a
-    # trailing newline, so use `in` rather than equality).
-    assert HAPPY_MARKER in dst.read_text()
+    # The publisher is self-isolating: it lands the file on origin/main via an
+    # ephemeral worktree, NOT in the target working checkout. Assert against
+    # what reached origin (fetch fresh, then read the remote-tracking ref).
+    _git("fetch", "origin", cwd=target_repo)
+    published = _git(
+        "show", "origin/main:public/trading/etf-ranks/index.html", cwd=target_repo
+    )
+    assert HAPPY_MARKER in published, "publish step did not land index.html on origin"
 
     # Commit subject from publish-dashboard.sh.
-    head_msg = _git("log", "-1", "--pretty=%s", cwd=target_repo).strip()
+    head_msg = _git("log", "-1", "--pretty=%s", "origin/main", cwd=target_repo).strip()
     assert re.match(
         r"^etf-ranks: \d{4}-\d{2}-\d{2} daily render$", head_msg
     ), f"unexpected commit subject: {head_msg!r}"
-
-    # And pushed to origin.
-    local_head = _git("rev-parse", "HEAD", cwd=target_repo).strip()
-    remote_head = _git("rev-parse", "origin/main", cwd=target_repo).strip()
-    assert local_head == remote_head, "wrapper did not push to origin"
 
 
 # ---------------------------------------------------------------------------
@@ -303,17 +308,21 @@ def test_renderer_failure_halts_chain(
     )
     stub.chmod(0o755)
 
-    head_before = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    origin_before = _git("rev-parse", "origin/main", cwd=target_repo).strip()
     result = _run_wrapper(
         tmp_path=tmp_path,
         source_dir=source_dir,
         target_repo=target_repo,
         uv_stub=stub,
     )
-    head_after = _git("rev-parse", "HEAD", cwd=target_repo).strip()
+    _git("fetch", "origin", cwd=target_repo)
+    origin_after = _git("rev-parse", "origin/main", cwd=target_repo).strip()
 
     assert result.returncode != 0, "renderer failure must propagate"
-    assert head_before == head_after, "no commit on renderer failure"
+    assert origin_before == origin_after, "no push on renderer failure"
 
-    dst = target_repo / "public" / "trading" / "etf-ranks" / "index.html"
-    assert not dst.exists(), "must not publish when render failed"
+    published = _git(
+        "show", "origin/main:public/trading/etf-ranks/index.html",
+        cwd=target_repo, check=False,
+    )
+    assert published == "", "must not publish when render failed"


### PR DESCRIPTION
## Scope

Fold two durable robustness fixes into the dashboard publish path so the live
dashboards (fengshen.dev/trading/market-breadth/ and /etf-ranks/) stop going
stale. Three changes total:

### 1. Worktree-accept guard (original #133)
`publish-dashboard.sh` now accepts a linked git worktree as the target (its
`.git` is a file, not a dir) and requires the target be the worktree ROOT
(rejects a repo subdir like `fengshen-site/public`).

### 2. Render dashboards from canonical Neon by default (Part A)
The render CLIs read local parquet caches that lag or go missing (the etf
parquet-updater cron is disabled, so the etf dashboard rendered empty at 12:40
even though Neon had the data). Neon `market.*` is the source of truth.

- New `--source {neon,parquet}` on `dashboard render-etf-html` and
  `market-breadth render-html`, **default `neon`**.
- Neon path: new `rainier/dashboard/neon_source.py` loads the SAME DataFrame
  shapes the pure renderers expect from `market.thematic_features_daily`,
  `market.breadth_indicator_daily`, and `market.benchmark_ohlcv` (SPY pane,
  `symbol='SPY'`). Pure `render_*_html` functions untouched.
- `--source parquet` (or passing `--features`/`--input`/`--spy-path`) keeps the
  existing local-cache path for offline/tests. sector_registry stays a parquet
  (human-edited config).
- auto-asof: `max(asof_date)` from the relevant Neon table (same semantics as
  "latest parquet row wins").
- `.env` gotcha handled: `get_engine()` reads `os.environ["DATABASE_URL"]`
  directly and does NOT load `.env`; the Neon path calls
  `ensure_env_loaded()` (→ `get_settings()` → `load_dotenv()`) before building
  the engine, so the cron path (`uv run rainier ...` from PROJECT_DIR) works.
- **Fail loud** on zero Neon rows for the asof (non-zero exit, no silent
  fall-back to a stale parquet). Empty-render guards in the wrappers stay.
- Note: `publish-etf-dashboard.sh` still hardcodes `--asof $(date +%Y-%m-%d)`;
  left as-is (out of scope) with a `# TODO` to drop it like the breadth wrapper.

### 3. Self-isolating publish via ephemeral origin/master worktree (Part B)
`publish-dashboard.sh` did `cd "$TARGET_DIR"` (the shared fengshen-site
checkout) then commit + push — but that tree is parked on other agents' worker
branches and is often dirty, so the publish failed the dirty-guard or pushed
the wrong branch. Rewrite so it NEVER operates on the main checkout:

- Validate `$TARGET_DIR` is a git repo root, then `git -C "$TARGET_DIR" fetch`.
- Create an EPHEMERAL detached worktree at `origin/<branch>` in a `mktemp -d`,
  with `trap cleanup EXIT` (worktree remove --force + prune) so it's reaped on
  success AND failure.
- Copy HTML into the worktree, no-op detection (unchanged vs origin → exit 0),
  commit, `push origin HEAD:refs/heads/<branch>` (no local branch touched).
- Bounded non-FF retry (≤3): re-fetch, `git reset --hard` the EPHEMERAL
  worktree onto the new origin tip (explicitly commented as safe — it's our
  throwaway tree, never the shared checkout), re-apply, re-push; fail loud after.
- Deploy branch is `master` (overridable via `DASHBOARD_PUBLISH_BRANCH` for the
  test harness). `--root`, slug sanitization, source-exists check, log lines,
  exit codes preserved.

## Tests
- [x] `test_neon_source.py` — loaders return required columns, fail loud on
      empty, asof resolution, SPY symbol filter, `ensure_env_loaded` invokes
      load_dotenv; `requires_postgres` end-to-end (skips without live DB).
- [x] `test_cli_render_source.py` — parquet back-compat (explicit + implied),
      neon is default + engine disposed, fail-loud-on-empty for both commands.
- [x] `test_publish_dashboard.py` reworked to a bare-origin harness: lands on
      origin/master; KEY TEST publishes successfully when the checkout is dirty
      AND on a different branch; no-op; ephemeral worktree cleaned up;
      deterministic non-FF retry (pre-receive hook injects a concurrent commit);
      subdir/non-git/linked-worktree guards; path-traversal; `--root`.
- [x] `test_publish_etf_dashboard.py` updated to assert against origin (the
      self-isolating flow lands on origin, not the working checkout).
- [x] `ruff check src/ tests/` clean. `bash -n` clean.

Note: one pre-existing, environment-dependent failure
(`test_db_backfill.py::test_cli_backfill_requires_database_url`) is unrelated
to this PR — it asserts a missing `DATABASE_URL` fails, but the operator's
on-disk `.env` is reloaded by `load_dotenv()` and defeats the test's
`monkeypatch.delenv`. Not touched by this branch.

## Review
- codex review (`--base origin/main`, high effort): 2 consecutive clean runs,
  no P0/P1. final codex GATE: PASS.
- /review skill: clean, no findings on changed surface. GATE: PASS.

## Deferred [P2]/[P3]
- `publish-etf-dashboard.sh` `--asof today` hardcode (TODO noted in script).
