### PR TITLE
design: multi-signal resonance gate for TQQQ (weighted dual-threshold)

### DIFF
--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -123,12 +123,9 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 
 ### 5.2 The panel (≤66 lookback)
 
-**Provenance — important:** v1 does **NOT** pin the full `regime_signal_search.build_signals` list. That list is mostly **>66** lookback (SMA100/150/200, EMA100/200, ROC120, 12-1 momentum, 90/120-day highs, slow 50/150 & 50/200 crosses) and uses **expanding** medians — both forbidden here. v1 instead:
-1. takes the **≤66 subset** of `build_signals` (the complement of the existing `BLOCK` exclusion set in `scripts/full_combo_search.py` / `leveraged_common.py`),
-2. **rewrites** its two expanding-median members to bounded windows (below),
-3. **adds** new members (SPY cross-asset, optional fractal, breadth proxy) as fresh code.
+**Provenance — important:** v1 does **NOT** pin the full `regime_signal_search.build_signals` list. That list is mostly **>66** lookback (SMA100/150/200, EMA100/200, ROC120, 12-1 momentum, 90/120-day highs, slow 50/150 & 50/200 crosses) and uses **expanding** medians — both forbidden here.
 
-The names below are the *intended* set, not a claim about the current prototype. The frozen final list + per-category counts are recorded at build time; new members (3) each count against the §6.4 parameter budget.
+**The enumerated list below IS the single source of truth** for the v1 panel (the resonance denominator and category counts derive from it — nothing else). It was *seeded* from the ≤66 subset of `build_signals` (the complement of the `BLOCK` set in `scripts/full_combo_search.py`), then deliberately **deduplicated** — keep one threshold per indicator (RSI>50, drop RSI>55; VIX<25, drop VIX<20/<30; one of ADX/+DI) so no single indicator is triple-counted in the consensus — with two expanding-median members **rewritten** to bounded form and `price>SMA66` **added**. So the list is *not* identical to the raw BLOCK-complement; where prose and the list disagree, **the list wins**. New members (SPY cross-asset, optional fractal, breadth proxy) are fresh code and each count against the §6.4 parameter budget. The frozen list is recorded verbatim at build time.
 
 - **Trend** (from ≤66 subset): price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
 - **Momentum** (from ≤66 subset): RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -98,9 +98,9 @@ v1 is **not** that naive version. Two differences, both of which we **A/B test**
 | `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `src/rainier/signals/panel.py` |
 | `ResonanceScorer` | panel + per-signal weights → daily score ∈ [0,1] | new `src/rainier/signals/resonance.py` |
 | `ResonanceGate` | dual-threshold state machine → daily **per-asset target weights** {TQQQ} | new `src/rainier/signals/resonance_gate.py` |
-| Daily-MTM sim | per-asset weights → equity, no lookahead, costs | `src/rainier/backtest/` (productionize `scripts/leveraged_common.py`) |
+| Daily-MTM sim | per-asset weights → equity, no lookahead, costs | `src/rainier/backtest/` (productionize `run_portfolio` from `scripts/regime_switch_study.py` — the per-asset variant; `leveraged_common.sim` is its scalar single-asset cousin) |
 
-**New boundary — NOT `SignalEmitter`.** `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades); the current engine consumes discrete trades and can't represent a held daily weight. v1 adds a **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily per-asset weight series` (a dict like `{TQQQ: 0 or 1}`, weights ≥0 summing ≤1, remainder cash). Per-asset (not a bare boolean) so a future non-cash risk-off is representable without a redesign; matches the existing `run_portfolio` sim, which already takes a per-asset weights dict. Additive: it doesn't touch `SignalEmitter` or the discrete-trade engine.
+**New boundary — NOT `SignalEmitter`.** `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades); the current engine consumes discrete trades and can't represent a held daily weight. v1 adds a **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily per-asset weight series` (a dict like `{TQQQ: 0 or 1}`, weights ≥0 summing ≤1, remainder cash). Per-asset (not a bare boolean) so a future non-cash risk-off is representable without a redesign; matches the existing **`run_portfolio`** sim (`scripts/regime_switch_study.py`), which already takes a per-asset weights dict (`{asset: series}`). Additive: it doesn't touch `SignalEmitter` or the discrete-trade engine.
 
 *Reference artifacts (local, NOT committed in this PR): the panel + sim live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`, `scripts/full_combo_search.py`, `scripts/resonance_study.py`). Numbers in this doc are exploratory, reproduced via those scripts. v1's **first step** is to promote them into `src/rainier/` (committed) per the `CLAUDE.md` module map.*
 
@@ -129,13 +129,13 @@ v1 is **trend-only** (Q7) — every member is a *risk-on / uptrend-confirming* s
 ### 5.4 The dual-threshold gate (state machine)
 
 ```
-score r[t]  ──►  if state==CASH  and r[t] ≥ BUY  → state = TQQQ (enter at close)
-            ──►  if state==TQQQ  and r[t] ≤ SELL → state = CASH (sell all)
+score r[t]  ──►  if state==CASH  and r[t] ≥ BUY  → state := TQQQ
+            ──►  if state==TQQQ  and r[t] ≤ SELL → state := CASH
             ──►  else                            → hold state
        BUY > SELL ; the gap is the hysteresis band.
 ```
 
-Boot: at the first valid bar `t0` (after the §5.5c per-member warmup), state = TQQQ if `r[t0] ≥ BUY` else CASH. Deterministic and unit-testable — a fixed score sequence yields a fixed state sequence; a test asserts it. No second hysteresis layer, no sizing curve.
+`state[t]` is decided on **close[t]** and is **effective on the t→t+1 return** (the +1 shift in §5.5) — no same-close execution, no lookahead. Boot: at the first valid bar `t0` (after the §5.5c per-member warmup), state = TQQQ if `r[t0] ≥ BUY` else CASH. Deterministic and unit-testable — a fixed score sequence yields a fixed state sequence; a test asserts it. No second hysteresis layer, no sizing curve.
 
 ### 5.5 No-lookahead + costs
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -14,7 +14,7 @@ We call the agreement of many signals **resonance**: when lots of independent in
 
 ### What the data *suggests* (a lead, not yet proof)
 
-Across 2020-10 → now we bucketed every day by how many of a 26-signal panel agreed, then looked at TQQQ's *next 20 days*:
+Across 2020-10 → now we bucketed every day by how many of a 26-signal *exploratory* panel agreed (the ≤66 subset of `build_signals` + SPY, as in `scripts/resonance_study.py`), then looked at TQQQ's *next 20 days*. (v1 freezes a slightly different ~22-member panel — §5.2 — so the resonance **denominator is the frozen count**, never a hardcoded 26.)
 
 ```
  signals agreeing →  win-rate of the next 20 days
@@ -73,7 +73,7 @@ Separate **timing** from **conviction**:
 
 ```
 LAYER 1 — TIMING (fast):        LAYER 2 — CONVICTION (resonance):
-  asymmetric SMA22/44 gate         consensus of the 26-signal panel
+  asymmetric SMA22/44 gate         consensus of the ≤66-lookback panel (§5.2)
   decides IN vs OUT of TQQQ        decides HOW BIG when in
         │                                  │
         └──────────────┬───────────────────┘
@@ -132,7 +132,7 @@ The names below are the *intended* set, not a claim about the current prototype.
 
 - **Trend** (from ≤66 subset): price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
 - **Momentum** (from ≤66 subset): RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
-- **Volatility** (rewritten): realizedVol(20) < its **rolling-40 median** (20+40 = 60 *total* span), ATR%(14) < its rolling-46 median, VIX<25, VIX<SMA20, VIX-falling. *(Replaces the prototype's `expanding(60).median()` — an expanding window has unbounded lookback.)*
+- **Volatility** (rewritten): realizedVol(20, rolling std) < its **rolling-40 median** (20+40 = 60, both finite), ATR%(14, **simple rolling mean** of true range — *not* Wilder/EWMA) < its rolling-46 median (14+46 = 60, both finite), VIX<25, VIX<SMA20, VIX-falling. *(Replaces the prototype's `expanding(60).median()` AND its Wilder-EWMA `atr_pct` — both have unbounded lookback; the finite-window invariant §5.5(b) requires simple rolling forms here.)*
 - **Structure** (from ≤66 subset): within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
 - **Cross-asset** (NEW code): SPY>SMA22, SPY>SMA44 — `build_signals(qqq, vix)` takes no SPY today; v1 adds an SPY input.
 - **(NEW, optional)** fractal:simple_turn — not in `build_signals`; added if Q7 says so.

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -115,7 +115,7 @@ v1 is **trend-only** (Q7) — every member is a *risk-on / uptrend-confirming* s
 - **Volatility:** realizedVol(20, rolling std) < its **rolling-40 median** (20+40 = 60, finite), ATR%(14, **simple rolling mean** of true range, *not* Wilder/EWMA) < its rolling-46 median (14+46 = 60), VIX<25, VIX<SMA20, VIX-falling. *(Replaces the prototype's `expanding(60).median()` and EWMA `atr_pct` — both unbounded.)*
 - **Structure:** within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
 - **Cross-asset:** SPY>SMA22, SPY>SMA44 (NEW code — `build_signals(qqq, vix)` takes no SPY today; v1 adds an SPY input).
-- **Breadth (NEW, in v1 — Q5):** **% of top-N QQQ holdings above their SMA** — the closest proxy to "market breadth" (yfinance has no breadth index). Built in v1, and **also surfaced on the QQQ market-breadth dashboard** (separate deliverable, §7).
+- **Breadth (NEW, in v1 — Q5):** **% of top-N QQQ holdings above their SMA50** (the SMA period is pinned ≤66, *not* the conventional 200-day, to honor the cap). Two hard requirements: (1) use **point-in-time** constituents — computing "% above MA" from *today's* holdings on *past* dates leaks survivorship bias into the score; if point-in-time holdings aren't available, use a **frozen ex-ante universe** and **exclude breadth from the OOS claims** in §6.2. (2) it's a finite-window member (SMA50 over a fixed universe), counted in the §5.5 invariant. Built in v1, and **also surfaced on the QQQ market-breadth dashboard** (separate deliverable, §7).
 
 *Every member's **composed/total** lookback ≤ 66 (a 20-day measure vs a 40-day median = 60, not "66 because the outer window is 66"). Finite-window members have exact composed support ≤66; EMA-family members (EMA, RSI, MACD, ADX) have bounded effective memory (invariant in §5.5).*
 
@@ -123,7 +123,7 @@ v1 is **trend-only** (Q7) — every member is a *risk-on / uptrend-confirming* s
 
 `resonance[t] = Σ wᵢ · signalᵢ[t] / Σ wᵢ` ∈ [0,1] — the **power-weighted** fraction risk-on.
 
-- **Per-signal power weights `wᵢ`** (Q2) — a strong signal moves the score more. Default prior = **category-balanced** (Q4): the 5 categories weighted equally, split within, so the many trend signals don't make the score really mean "trend ×4." Beyond that prior, weights are a **swept/tested** config (capped per §6.4 — every free weight is overfit risk on a tiny sample).
+- **Per-signal power weights `wᵢ`** (Q2) — a strong signal moves the score more. Default prior = **category-balanced** (Q4): the **6 categories** (Trend, Momentum, Volatility, Structure, Cross-asset, Breadth) weighted equally, split within, so the many trend signals don't make the score really mean "trend ×4." Beyond that prior, weights are a **swept/tested** config (capped per §6.4 — every free weight is overfit risk on a tiny sample).
 - A/B includes **equal-weight vs category-balanced vs tuned** weights to confirm weighting actually helps (Q4: "testing can tell us more").
 
 ### 5.4 The dual-threshold gate (state machine)
@@ -145,7 +145,7 @@ Every input (TQQQ, QQQ, SPY, VIX, breadth) uses its **close[t]** value; the scor
 
 **Leakage test:** inject a known future spike into bar *t+1*; assert state[t] is unchanged across all inputs.
 
-**Lookback invariant:** the **composed/total** lookback of every member ≤ 66, no expanding windows. "Composed" matters for *nested* indicators (realizedVol(20) into a rolling-k median has span 20+k, so k ≤ 46). *Finite-window* members (SMA, rolling-median, Donchian, ROC, rewritten nested-vol) have exact composed support ≤66; *EMA-family* (EMA, RSI, MACD, ADX) have bounded effective memory. Tests: (a) every composed span ≤66; (b) finite-window signals bit-identical when history before *t−66* dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX double-smoothed, MACD-hist EMAs-of-EMAs) and set the buffer from the *slowest* member. The two prototype `expanding(60).median()` members fail test (b) and **must** be rewritten — required, not optional.
+**Lookback invariant:** the **composed/total** lookback of every member ≤ 66, no expanding windows. "Composed" matters for *nested* indicators (realizedVol(20) into a rolling-k median has span 20+k, so k ≤ 46). *Finite-window* members (SMA, rolling-median, Donchian, ROC, rewritten nested-vol, breadth-%-above-SMA50) have exact composed support ≤66; *EMA-family* (EMA, RSI, MACD, ADX) have bounded effective memory. Tests: (a) every composed span ≤66; (b) finite-window signals bit-identical when history before *t−66* dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX double-smoothed, MACD-hist EMAs-of-EMAs), take the *slowest* member, and **freeze that as a pre-registered integer constant** (e.g. WARMUP_BARS=150) — the warmup must NOT shift with data, or `t0` moves run-to-run; the determinism test asserts `t0` is data-independent. The two prototype `expanding(60).median()` members fail test (b) and **must** be rewritten — required, not optional.
 
 ### 5.6 Config (and what is NOT swept)
 
@@ -167,15 +167,17 @@ The gate, panel, weights, and thresholds were all discovered on 2020-10→now. F
 
 | Test | Protocol | Pass criteria |
 |---|---|---|
-| Re-derived split | Re-run the **entire** selection (panel, weights, BUY/SELL thresholds, combination mode) on **only ≤2022-12** data — discard prior picks — report **once** on 2023→now | edge persists. If impractical, 2023→now is **descriptive only** and the row below is load-bearing. |
+| Re-derived split (**mandatory**) | Re-run the **entire** selection (panel, weights, BUY/SELL thresholds, combination mode) on **only ≤2022-12** data — discard prior picks — report **once** on 2023→now | edge persists on the held-out slice |
 | **True OOS** (load-bearing) | run the frozen config on **synthetic 3× QQQ pre-2010** (dot-com + GFC) and a **different leveraged underlying** | edge survives on data that informed no choice |
+
+The re-derived split is **required**, not optional — the True-OOS row alone (synthetic + a near-clone underlying) is **not sufficient** to ship. Minimum to ship: the re-derived 2023→now slice **plus** ≥1 genuinely independent True-OOS slice (pre-2010 synthetic or SOXL — *not* SPXL/UPRO, which §6.2 flags as near-clones).
 
 For a different underlying, the signal source **switches** to that underlying's own inputs. **SPXL/UPRO are near-clones** of the QQQ trade → weak evidence; **SOXL (semis)** is genuinely different → stronger. For pre-2010 synthetic, **pre-register** the cost params (`rate` = historical 3-month T-bill *series*; `fee` fixed) and report drawdown sensitivity to ±50 bps fee. In-window per-regime numbers are **descriptive only**.
 
 ### 6.3 The A/B — does the weighted gate actually beat the simple one?
 | Test | Comparators (all on the §6.2 OOS slices) | Pass criteria |
 |---|---|---|
-| Gate A/B | resonance-gate · SMA22/44-gate · (resonance AND SMA) · (resonance OR SMA) · buy-hold TQQQ · buy-hold QQQ | the resonance-gate (or a combination) must beat the **SMA22/44 gate AND buy-hold** on Calmar **and** drawdown, on **every** OOS slice. If the plain SMA gate wins, **ship the SMA gate** and stop. |
+| Gate A/B | resonance-gate · SMA22/44-gate · (resonance AND SMA) · (resonance OR SMA) · buy-hold TQQQ · buy-hold QQQ | the resonance-gate (or a combination) must beat the **SMA22/44 gate AND buy-hold** on Calmar **and** drawdown, on **every** required OOS slice (§6.2). **Anti-gaming:** a *combination* (AND/OR) winner must ALSO (i) beat its own SMA-only component, and (ii) the **resonance-only** gate must itself beat buy-hold on ≥1 slice — otherwise the weighted score isn't carrying signal, the combination is just the SMA gate in disguise, and the conclusion is **ship the SMA gate**. |
 | Weighting A/B | equal-weight vs category-balanced vs tuned weights | weighting must measurably help, else use equal weights (simpler) |
 
 ### 6.4 Overfit guard (hard, not vibes)

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -116,7 +116,7 @@ Your example — *buy TQQQ when QQQ<SMA10 AND VIX<23 AND fractal buy AND SPY<SMA
 
 - **Trend:** price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
 - **Momentum:** RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
-- **Volatility:** realizedVol<expanding-median, ATR%<median, VIX<25, VIX<SMA20, VIX-falling.
+- **Volatility:** realizedVol<rolling-66 median, ATR%<rolling-66 median, VIX<25, VIX<SMA20, VIX-falling. *(Use a bounded 66-bar rolling median, NOT an expanding median — an expanding window grows past the 66-bar cap and would violate the constraint.)*
 - **Structure:** within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
 - **Cross-asset:** SPY>SMA22, SPY>SMA44 (broad-market confirm).
 - **(Optional)** fractal:simple_turn as a momentum/structure member.
@@ -138,6 +138,8 @@ Your example — *buy TQQQ when QQQ<SMA10 AND VIX<23 AND fractal buy AND SPY<SMA
 ### 5.5 No-lookahead + costs
 
 Signals computed on close[t]; target weight applied to t+1 return (shift +1). Warmup buffer: load from 2019-06 so every ≤66 signal is valid by 2020-10; **measure only over 2020-10 → now** (real TQQQ). Charge turnover cost on size changes; cash earns the 13-week T-bill.
+
+**Lookback invariant:** every panel signal must use a *bounded* window ≤ 66 bars — no expanding/all-history windows (medians, z-scores, percentiles included). A unit test asserts each signal's first valid index ≤ 66 and that its value at bar *t* is unchanged when history before *t−66* is truncated.
 
 ### 5.6 Config (sweepable)
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -1,0 +1,181 @@
+# Design Plan — Multi-Signal Resonance for TQQQ Conviction
+
+**Status:** draft for review · **Scope:** signal-resonance layer for the TQQQ timing strategy · **Window:** 2020-10 → now (real TQQQ) · **Constraint:** no moving-average / lookback > 66 bars · **Depends on:** existing `signals/`, `backtest/` engine · **PR base:** main
+
+---
+
+## 1. The problem, in plain English
+
+We want to buy TQQQ (3× Nasdaq-100) **only when we're confident**, and size the bet to that confidence. A single indicator — "price is above its 44-day average" — flips in and out on every wiggle and gives plenty of false buys. We have *dozens* of signals (trend, momentum, volatility, structure). The question this plan answers:
+
+> **How do we combine many signals into one "conviction score" so that more agreement → more confidence → a bigger, higher-win-rate bet — without the lag that killed naive consensus voting?**
+
+We call the agreement of many signals **resonance**: when lots of independent indicators all say "risk-on" at once, that's a stronger, more trustworthy signal than any one of them alone.
+
+### What we already proved (so this isn't a guess)
+
+Across 2020-10 → now we bucketed every day by how many of a 26-signal panel agreed, then looked at TQQQ's *next 20 days*:
+
+```
+ signals agreeing →  win-rate of the next 20 days
+   0–20%               48%   (coin flip)
+  20–40%               59%
+  40–60%               60%
+  60–80%               61%
+  80–100%              62%   ← most agreement = highest win-rate
+```
+
+**Resonance is real: more agreement genuinely raises the win-rate (48% → 62%).** That is the empirical foundation of this design. One nuance we also found: the *biggest forward returns* come at **60–80%** agreement (a building consensus, early in a move), not at 100% (which tends to be mid-trend, after the easy money). So conviction should reward *strong* consensus but not blindly chase *unanimous* consensus.
+
+---
+
+## 2. How it works today
+
+Right now there is no integrated system — just a pile of exploratory scripts. Two things exist:
+
+- **A 26-signal panel** (`regime_signal_search.build_signals`), each emitting a daily risk-on (1) / risk-off (0) series, all with lookback ≤ 66.
+- **A timing gate** — the asymmetric SMA gate (enter when QQQ > SMA22, exit when QQQ < SMA44). In-window it was the single best risk-adjusted design (Calmar ≈ 1.37, #2 of 270 in a full sweep, on a stable plateau).
+
+```
+TODAY:  one signal  ──►  in/out of TQQQ at full size
+        (e.g. price>SMA44)         (binary, no notion of confidence)
+```
+
+There is **no concept of conviction or position size** — every trade is all-or-nothing, and the dozens of other signals are unused.
+
+---
+
+## 3. What goes wrong (why we don't just "vote")
+
+The obvious idea — *be in TQQQ when ≥70% of signals agree, else cash* — we tested. **It underperforms the simple gate** (Calmar 0.20 vs 0.34 full-cycle; worse in-window too). Why:
+
+```
+THE LAG TRAP:
+   price ────╲                      ╱──── recovery
+              ╲                    ╱
+   gate exits  ╲__________________╱   gate re-enters (fast)
+                  ▲              ▲
+   votes flip   LATE           LATE   ← consensus needs many signals to flip;
+   risk-off  (already down)  (misses the bounce)
+```
+
+- **Entering on consensus lags the bottom:** by the time 70% of signals turn risk-on, the rebound is half over.
+- **Exiting on consensus lags the top:** the drawdown is already eaten before enough signals flip.
+- Consensus voting flips *less* (less whipsaw) but each move is *late*, so it has higher win-rate yet **worse risk-adjusted return**.
+
+**Lesson: resonance is good at measuring *confidence*, bad at deciding *timing*.** The fast SMA gate is the opposite — good timing, no confidence. The design uses each for what it's good at.
+
+---
+
+## 4. The fix — a two-layer design
+
+Separate **timing** from **conviction**:
+
+```
+LAYER 1 — TIMING (fast):        LAYER 2 — CONVICTION (resonance):
+  asymmetric SMA22/44 gate         consensus of the 26-signal panel
+  decides IN vs OUT of TQQQ        decides HOW BIG when in
+        │                                  │
+        └──────────────┬───────────────────┘
+                       ▼
+            position size = gate_on × size(resonance)
+```
+
+- **Layer 1 (gate)** answers *"should I be in TQQQ at all right now?"* — fast, responsive, the proven timing engine. When the gate is OFF → cash (T-bills). No lag penalty on timing.
+- **Layer 2 (resonance)** answers *"how convinced am I?"* — when the gate is ON, scale the position by the conviction score. High resonance (many signals agree) → full 3× exposure. Weak resonance (signals split) → reduced exposure (e.g. partial TQQQ + cash, or 1× QQQ).
+
+This directly uses the confirmed 48%→62% win-rate edge as a **sizing** signal, where lag doesn't hurt, instead of a **timing** signal, where it does.
+
+### Your "confirmed buy" idea fits here
+
+Your example — *buy TQQQ when QQQ<SMA10 AND VIX<23 AND fractal buy AND SPY<SMA10 AND breadth<30%* — is exactly a **high-conviction entry**: a cluster of signals resonating. In this design that's not a separate rule; it's the **high end of the resonance score**. A confirmed buy = gate ON **and** resonance above a high threshold → full size. The design generalizes your 5-signal idea into a tunable conviction dial across the whole panel.
+
+### What it looks like day to day
+
+```
+  gate OFF                         → 0% TQQQ (cash, earning T-bills)
+  gate ON, resonance 50–65%        → reduced size (e.g. 40–60% TQQQ)
+  gate ON, resonance 65–80%        → full size      (peak-return zone)
+  gate ON, resonance > 80%         → full size, but capped (don't chase unanimity)
+```
+
+---
+
+## 5. Implementation detail (for engineers)
+
+### 5.1 Components
+
+| Component | Role | Where |
+|---|---|---|
+| `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `signals/panel.py` |
+| `ResonanceScorer` | panel → daily conviction score ∈ [0,1] (weighted consensus) | new `signals/resonance.py` |
+| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily target weight | new `signals/resonance_strategy.py` |
+| Daily-MTM sim | weight → equity, no lookahead, financing + costs | reuse `leveraged_common.sim` |
+
+### 5.2 The panel (≤66 lookback, ~26 signals)
+
+- **Trend:** price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
+- **Momentum:** RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
+- **Volatility:** realizedVol<expanding-median, ATR%<median, VIX<25, VIX<SMA20, VIX-falling.
+- **Structure:** within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
+- **Cross-asset:** SPY>SMA22, SPY>SMA44 (broad-market confirm).
+- **(Optional)** fractal:simple_turn as a momentum/structure member.
+- **(Gap)** market breadth (% NDX above its MA) — not in yfinance; needs a proxy (compute "% of top-N QQQ holdings above their SMA"). Tracked as a follow-up, not v1-blocking.
+
+### 5.3 Scoring
+
+`resonance[t] = Σ wᵢ · signalᵢ[t] / Σ wᵢ` — weighted fraction risk-on.
+
+- **Category-balanced weights** so one over-represented family (we have many trend signals) doesn't dominate: weight each of the 5 categories equally, split within. Avoids "resonance" really being "trend, four times."
+- **Hysteresis** on the score feeding any threshold, to avoid size chatter at the boundary.
+
+### 5.4 Sizing curve (gate-ON only)
+
+`size(r)` maps resonance → target TQQQ fraction, clamped [0, 1]:
+- piecewise: `0` below `r_lo` (≈0.5), ramp to `1` by `r_hi` (≈0.7), flat `1` above (cap — don't over-size unanimity).
+- turnover-aware: round size to coarse steps (e.g. 0/0.5/1.0) so it doesn't rebalance daily and bleed cost.
+
+### 5.5 No-lookahead + costs
+
+Signals computed on close[t]; target weight applied to t+1 return (shift +1). Warmup buffer: load from 2019-06 so every ≤66 signal is valid by 2020-10; **measure only over 2020-10 → now** (real TQQQ). Charge turnover cost on size changes; cash earns the 13-week T-bill.
+
+### 5.6 Config (sweepable)
+
+`panel members · per-category weights · gate (entry/exit SMA) · sizing curve (r_lo, r_hi, steps) · hysteresis band · rebalance granularity`.
+
+---
+
+## 6. Test plan
+
+| Test | Input | Expected / pass criteria |
+|---|---|---|
+| Thesis (sanity) | resonance buckets × fwd-20d TQQQ | win-rate rises with resonance (reproduce 48→62%) |
+| Strategy backtest | 2020-10→now, real TQQQ | beats SMA22/44-gate baseline on Calmar **and** drawdown, or it's not worth the complexity |
+| Sizing ablation | full-size gate vs resonance-sized | resonance sizing improves Calmar / cuts drawdown at similar return |
+| Per-regime | 2021 bull / 2022 bear / 2023-24 / 2025 | smaller drawdown in 2022 & 2025 than the bare gate |
+| Walk-forward | 60/40 split in-window | sized strategy's edge survives OOS split |
+| Cost/turnover | sweep rebalance granularity | net edge survives realistic cost; switches stay sane |
+| Baseline floor | vs buy-hold TQQQ & QQQ | must beat both risk-adjusted |
+
+**Honesty rails (carried from prior work):** one real bear (2022) in this window — sub-20% drawdown here is optimistic; the bare gate's *full-cycle* drawdown was −76%. Report in-window numbers as in-window. No single-best-cell worship; prefer plateaus.
+
+---
+
+## 7. Open decisions (need your call)
+
+- **Q1 — Risk-off floor:** when the gate is OFF, hold **cash/T-bills** (max safety) or **1× QQQ** (stay exposed)? Prior tests: cash was cleaner; QQQ-floor lifted return but raised drawdown.
+- **Q2 — Sizing granularity:** continuous size = f(resonance), or coarse **steps** (0 / ½ / full) to cut turnover? Steps are simpler and cheaper; continuous is smoother.
+- **Q3 — Does resonance also gate entry, or only size?** Pure design: gate=timing, resonance=size only. Your "confirmed buy" instinct suggests *also* requiring a minimum resonance to enter at all (veto low-conviction). Include the veto, or keep layers clean?
+- **Q4 — Panel weighting:** equal-per-signal (simple) or **category-balanced** (so trend doesn't dominate)? I lean category-balanced.
+- **Q5 — Breadth proxy now or later?** Build the "% of top QQQ holdings above MA" breadth signal for v1, or ship v1 without it and add later?
+- **Q6 — Max conviction cap:** cap size at full 3× TQQQ, or allow a *defensive* sub-full mode (e.g. never exceed 1× in the first N days after a regime flip)?
+
+---
+
+## 8. Why this is the right shape
+
+- Uses the **proven** edge (resonance → win-rate) where it works (sizing), not where it doesn't (timing).
+- Keeps the **proven** timing engine (SMA gate) untouched and responsive.
+- Generalizes your multi-signal "confirmed buy" into a tunable conviction dial.
+- Respects the constraints we established (≤66 MAs, 2020-10 window, real TQQQ, costs, no-lookahead).
+- Falsifiable: if resonance sizing doesn't beat the bare gate on Calmar **and** drawdown (§6), we don't ship it — simpler wins.

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -86,9 +86,14 @@ LAYER 1 — TIMING (fast):        LAYER 2 — CONVICTION (resonance):
 
 This directly uses the confirmed 48%→62% win-rate edge as a **sizing** signal, where lag doesn't hurt, instead of a **timing** signal, where it does.
 
-### Your "confirmed buy" idea fits here
+### Your "confirmed buy" is a *second* axis — pullback resonance
 
-Your example — *buy TQQQ when QQQ<SMA10 AND VIX<23 AND fractal buy AND SPY<SMA10 AND breadth<30%* — is exactly a **high-conviction entry**: a cluster of signals resonating. In this design that's not a separate rule; it's the **high end of the resonance score**. A confirmed buy = gate ON **and** resonance above a high threshold → full size. The design generalizes your 5-signal idea into a tunable conviction dial across the whole panel.
+A distinction the design must respect: your example — *QQQ<SMA10 AND SPY<SMA10 AND breadth<30% AND VIX<23 AND fractal buy* — is built from **oversold / pullback** conditions (price *below* short MAs, washed-out breadth). The trend-resonance score above counts *risk-on* signals (price *above* MAs), so this exact cluster would score **low**, not high. They are two different axes:
+
+- **Trend resonance** — "the uptrend is broadly confirmed" (price above MAs, momentum positive, vol calm). Drives Layer-2 **sizing**.
+- **Pullback resonance** — "an oversold dip is bottoming *inside* an uptrend" (price below SMA10, breadth washed out, fractal turn, VIX not panicked). A separate **entry** trigger for buying the dip.
+
+v1 models your confirmed-buy as an **optional pullback sub-score / alternate entry**, regime-gated (only buy dips while a slower trend filter is still up — don't catch knives in a real bear), **not** as the high end of trend resonance. Richer, and an open decision (Q7).
 
 ### What it looks like day to day
 
@@ -109,8 +114,10 @@ Your example — *buy TQQQ when QQQ<SMA10 AND VIX<23 AND fractal buy AND SPY<SMA
 |---|---|---|
 | `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `src/rainier/signals/panel.py` |
 | `ResonanceScorer` | panel → daily conviction score ∈ [0,1] (weighted consensus) | new `src/rainier/signals/resonance.py` |
-| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily target weight (implements/extends the `SignalEmitter` boundary) | new `src/rainier/signals/resonance_strategy.py` |
-| Daily-MTM sim | weight → equity, no lookahead, financing + costs | `src/rainier/backtest/` (productionize the prototype in `scripts/leveraged_common.py`) |
+| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily **target-weight series** ∈ [0,1] | new `src/rainier/signals/resonance_strategy.py` |
+| Daily-MTM sim | weight series → equity, no lookahead, financing + costs | `src/rainier/backtest/` (productionize the prototype in `scripts/leveraged_common.py`) |
+
+**New boundary — NOT `SignalEmitter`.** The existing `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades) and the current engine consumes discrete trades — it *cannot* represent a continuously-sized daily weight. v1 introduces a distinct **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily target-weight series ∈ [0,1]` — plus a weight-consuming backtest path (the daily-MTM sim). This is **additive**: it does not change `SignalEmitter` or the discrete-trade engine, which keep serving the pin-bar/fractal strategies.
 
 *Note: the panel signals and the daily-MTM sim currently live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`). v1 promotes them into `src/rainier/` per the module map in `CLAUDE.md`; the scripts are the reference implementation, not the shipping location.*
 
@@ -173,6 +180,7 @@ Signals computed on close[t]; target weight applied to t+1 return (shift +1). Wa
 - **Q4 — Panel weighting:** equal-per-signal (simple) or **category-balanced** (so trend doesn't dominate)? I lean category-balanced.
 - **Q5 — Breadth proxy now or later?** Build the "% of top QQQ holdings above MA" breadth signal for v1, or ship v1 without it and add later?
 - **Q6 — Max conviction cap:** cap size at full 3× TQQQ, or allow a *defensive* sub-full mode (e.g. never exceed 1× in the first N days after a regime flip)?
+- **Q7 — Pullback axis in v1?** Include the second (pullback/oversold) conviction axis — your confirmed-buy idea — in v1, or ship trend-resonance sizing first and add pullback entries in v2? Needs the breadth proxy (Q5) to be at its best.
 
 ---
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -81,10 +81,10 @@ LAYER 1 — TIMING (fast):        LAYER 2 — CONVICTION (resonance):
             position size = gate_on × size(resonance)
 ```
 
-- **Layer 1 (gate)** answers *"should I be in TQQQ at all right now?"* — fast, responsive, the proven timing engine. When the gate is OFF → cash (T-bills). No lag penalty on timing.
+- **Layer 1 (gate)** answers *"should I be in TQQQ at all right now?"* — fast, responsive, the best-tested timing engine so far. When the gate is OFF → cash (T-bills). No lag penalty on timing.
 - **Layer 2 (resonance)** answers *"how convinced am I?"* — when the gate is ON, scale the position by the conviction score. High resonance (many signals agree) → full 3× exposure. Weak resonance (signals split) → reduced exposure (e.g. partial TQQQ + cash, or 1× QQQ).
 
-This directly uses the confirmed 48%→62% win-rate edge as a **sizing** signal, where lag doesn't hurt, instead of a **timing** signal, where it does.
+This uses the **candidate** 48%→62% win-rate edge (pending §6.1 significance) as a **sizing** signal, where lag doesn't hurt, instead of a **timing** signal, where it does.
 
 ### Your "confirmed buy" is a *second* axis — pullback resonance
 
@@ -123,17 +123,22 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 
 ### 5.2 The panel (≤66 lookback)
 
-*The exact membership and per-category counts are **pinned from `regime_signal_search.build_signals`** at build time (the prototype's real list), not the prose below — the "~26" figure is provisional and the breadth "(Gap)" / "(Optional)" members are excluded until added. Category-balanced weighting (§5.3) depends on the final per-category counts, so v1 records the frozen list explicitly.*
+**Provenance — important:** v1 does **NOT** pin the full `regime_signal_search.build_signals` list. That list is mostly **>66** lookback (SMA100/150/200, EMA100/200, ROC120, 12-1 momentum, 90/120-day highs, slow 50/150 & 50/200 crosses) and uses **expanding** medians — both forbidden here. v1 instead:
+1. takes the **≤66 subset** of `build_signals` (the complement of the existing `BLOCK` exclusion set in `scripts/full_combo_search.py` / `leveraged_common.py`),
+2. **rewrites** its two expanding-median members to bounded windows (below),
+3. **adds** new members (SPY cross-asset, optional fractal, breadth proxy) as fresh code.
 
-- **Trend:** price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
-- **Momentum:** RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
-- **Volatility:** realizedVol<rolling-66 median, ATR%<rolling-66 median, VIX<25, VIX<SMA20, VIX-falling. *(Use a bounded 66-bar rolling median, NOT an expanding median — an expanding window grows past the 66-bar cap and would violate the constraint.)*
-- **Structure:** within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
-- **Cross-asset:** SPY>SMA22, SPY>SMA44 (broad-market confirm).
-- **(Optional)** fractal:simple_turn as a momentum/structure member.
-- **(Gap)** market breadth (% NDX above its MA) — not in yfinance; needs a proxy (compute "% of top-N QQQ holdings above their SMA"). Tracked as a follow-up, not v1-blocking.
+The names below are the *intended* set, not a claim about the current prototype. The frozen final list + per-category counts are recorded at build time; new members (3) each count against the §6.4 parameter budget.
 
-*Every member's controlling parameter (window / EMA-span / period) is ≤ 66. Finite-window members (SMA, rolling-median, Donchian, ROC) have exact support ≤66; EMA-family members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — theoretically infinite tail but bounded **effective** memory (see the invariant in §5.5).*
+- **Trend** (from ≤66 subset): price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
+- **Momentum** (from ≤66 subset): RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
+- **Volatility** (rewritten): realizedVol(20) < its **rolling-40 median** (20+40 = 60 *total* span), ATR%(14) < its rolling-46 median, VIX<25, VIX<SMA20, VIX-falling. *(Replaces the prototype's `expanding(60).median()` — an expanding window has unbounded lookback.)*
+- **Structure** (from ≤66 subset): within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
+- **Cross-asset** (NEW code): SPY>SMA22, SPY>SMA44 — `build_signals(qqq, vix)` takes no SPY today; v1 adds an SPY input.
+- **(NEW, optional)** fractal:simple_turn — not in `build_signals`; added if Q7 says so.
+- **(Gap)** market breadth (% NDX above its MA) — not in yfinance; proxy = "% of top-N QQQ holdings above their SMA". Follow-up, not v1-blocking.
+
+*Every member's **composed/total** lookback is ≤ 66 — a 20-day measure compared to a 40-day median counts as 60, not "66 because the outer window is 66." Finite-window members have exact composed support ≤66; EMA-family members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — infinite tail in theory, bounded **effective** memory (invariant in §5.5).*
 
 ### 5.3 Scoring
 
@@ -148,14 +153,15 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 
 ```
 raw resonance r[t]  ──►  (1) curve: size = clamp((r−r_lo)/(r_hi−r_lo), 0, 1)
-                    ──►  (2) round to coarse step ∈ {0, ½, 1}
-                    ──►  (3) hysteresis ON THE STEPPED VALUE: only change the
-                              held step if the new step differs by ≥1 level AND
-                              persists ≥ `dwell` bars  (one place, applied last)
-                    ──►  (4) rebalance only when the held step changes
+                    ──►  (2) round to coarse step ∈ {0, ½, 1}  → target_step[t]
+                    ──►  (3) hysteresis: the HELD step moves to target_step[t]
+                              only after target_step has held the SAME new value
+                              for ≥ `dwell` consecutive bars; otherwise the held
+                              step is carried forward unchanged
+                    ──►  (4) rebalance only when the held step actually changes
 ```
 
-Hysteresis lives **only** at step (3), on the rounded step — not on the raw score (that was the §5.3 over-spec; remove it there). This makes the path deterministic and unit-testable.
+Boot: at the first valid bar `t0`, held_step = target_step[t0] (no dwell required — there is no prior to confirm against). Moves are **direct** to the confirmed target (e.g. 0→1 in one transition once the new step holds `dwell` bars), not forced stepwise through ½. Hysteresis lives **only** here — not on the raw score (the §5.3 over-spec is removed). Deterministic and unit-testable; a test asserts a fixed input sequence yields a fixed held-step sequence.
 
 ### 5.5 No-lookahead + costs
 
@@ -165,7 +171,7 @@ Every input (TQQQ, QQQ, SPY, VIX) uses its **close[t]** value; the Layer-1 gate 
 
 **Leakage test:** inject a known future spike into bar *t+1*; assert weight[t] is unchanged (zero leakage), across all four inputs and both layers.
 
-**Lookback invariant:** no indicator parameter (window / EMA-span / period) exceeds 66 bars, and no expanding/all-history windows. *Finite-window* members (SMA, rolling-median, Donchian, ROC) have exact support ≤66. *EMA-family* members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — infinite tail in theory, bounded *effective* memory. Tests: (a) every signal's max parameter ≤66; (b) finite-window signals bit-identical when history before *t−66* is dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX is double-smoothed, MACD-hist is EMAs-of-EMAs, so they need more warmup than a raw EMA) and set the buffer from the *slowest* member, not a global asserted constant.
+**Lookback invariant:** the **composed/total** lookback of every member ≤ 66 bars, and no expanding/all-history windows. "Composed" matters for *nested* indicators: `realizedVol(20)` fed into a `rolling-k median` has total span `20+k`, so the median window must be ≤46, not 66. *Finite-window* members (SMA, rolling-median, Donchian, ROC, and the rewritten nested-vol members) have exact composed support ≤66. *EMA-family* members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — infinite tail in theory, bounded *effective* memory. Tests: (a) every signal's composed span ≤66 (inner+outer for nested); (b) finite-window signals bit-identical when history before *t−66* is dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX is double-smoothed, MACD-hist is EMAs-of-EMAs, so they need more warmup than a raw EMA) and set the buffer from the *slowest* member, not a global asserted constant. The two prototype `expanding(60).median()` members fail test (b) and **must** be rewritten to the bounded form in §5.2 — this is a required panel change, not optional.
 
 ### 5.6 Config (and what is NOT swept)
 
@@ -186,20 +192,22 @@ The window has **one** bear (2022). A sizing overlay that simply de-levers *mech
 
 ### 6.2 No data-snooping — frozen train/test + genuine OOS
 
-The gate (SMA22/44), the panel, and the sizing thresholds were all discovered on 2020-10→now. So an in-window 60/40 split is **not** out-of-sample — the "OOS" slice already shaped the choices.
+The gate (SMA22/44), the panel, and the sizing thresholds were all discovered on 2020-10→now. So merely *freezing* that config and reporting 2023→now still leaks — the held-out slice already shaped the choices.
 
 | Test | Protocol | Pass criteria |
 |---|---|---|
-| Frozen split | **freeze** gate + panel + r_lo/r_hi + weights on a train slice (≤2022-12), report untouched on 2023→now | edge persists on the held-out slice |
-| **True OOS** | run the *frozen* config on a **different leveraged underlying** (SPXL/UPRO/SOXL) and on **synthetic 3× QQQ pre-2010** | edge survives on data that did not inform any choice — this is the real test |
+| Re-derived split | Re-run the **entire** selection pipeline (gate sweep, bucket thresholds, panel, weights) using **only ≤2022-12** data — discard the prior full-window picks — then report **once** on 2023→now, untouched | edge persists. If re-deriving is impractical, 2023→now is **descriptive only** and the load-bearing test is the row below. |
+| **True OOS** (load-bearing) | run the frozen config on **synthetic 3× QQQ pre-2010** (dot-com + GFC — the regimes leverage decay punishes most) and on a **different leveraged underlying** | edge survives on data that informed no choice |
 
-In-window per-regime numbers (2021/2022/2023-24/2025) are **descriptive only**, never validation — one path each, and 2025 is a partial year.
+**Genuine-independence caveats:** for a different underlying, the signal source **switches** to that underlying's own inputs (SPX/QQQ-correlated), with gate/panel *structure* held fixed. **SPXL/UPRO are near-clones of the QQQ trade** → weak independent evidence; **SOXL (semis)** is a genuinely different regime → stronger. For pre-2010 synthetic, **pre-register** the cost params before running: `rate` = the historical 3-month T-bill *series* (not a constant — it swings 0–5%), `fee` = a fixed expense; report drawdown **sensitivity** to ±50 bps fee, since the dot-com/GFC verdict hinges on them.
+
+In-window per-regime numbers (2021/2022/2023-24/2025) are **descriptive only**, never validation — one path each, 2025 partial.
 
 ### 6.3 Is it the *signal*, or just less leverage?
 
-| Test | Control | Pass criteria |
+| Test | Control (precisely pinned) | Pass criteria |
 |---|---|---|
-| Matched-exposure | a **constant** scaler and a **volatility-targeted** scaler, each tuned to the *same average exposure* as the resonance sizer | resonance must beat *both* matched-exposure controls on Calmar — otherwise the "edge" is just de-levering and we ship the simpler vol-target instead |
+| Matched-exposure | (a) **constant** scaler = the resonance sizer's *exact* mean weight; (b) **vol-target** scaler matched on *both* mean exposure AND realized-vol budget. Both computed on the **frozen §6.2 test slice**, not re-fit. | resonance must beat the **better** of (a)/(b) on Calmar — else the "edge" is just de-levering, and we ship the simpler vol-target instead |
 
 ### 6.4 Overfit guard (hard, not vibes)
 
@@ -228,8 +236,8 @@ Must beat buy-hold TQQQ **and** QQQ risk-adjusted, **and** the bare SMA22/44 gat
 
 ## 8. Why this is the right shape
 
-- Uses the **proven** edge (resonance → win-rate) where it works (sizing), not where it doesn't (timing).
-- Keeps the **proven** timing engine (SMA gate) untouched and responsive.
+- Uses the **candidate** edge (resonance → win-rate, pending §6.1) where it would work (sizing), not where it doesn't (timing).
+- Keeps the **best-tested** timing engine (SMA gate) untouched and responsive.
 - Generalizes your multi-signal "confirmed buy" into a tunable conviction dial.
 - Respects the constraints we established (≤66 MAs, 2020-10 window, real TQQQ, costs, no-lookahead).
 - Falsifiable: if resonance sizing doesn't beat the bare gate on Calmar **and** drawdown (§6), we don't ship it — simpler wins.

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -114,12 +114,12 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 |---|---|---|
 | `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `src/rainier/signals/panel.py` |
 | `ResonanceScorer` | panel → daily conviction score ∈ [0,1] (weighted consensus) | new `src/rainier/signals/resonance.py` |
-| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily **target-weight series** ∈ [0,1] | new `src/rainier/signals/resonance_strategy.py` |
-| Daily-MTM sim | weight series → equity, no lookahead, financing + costs | `src/rainier/backtest/` (productionize the prototype in `scripts/leveraged_common.py`) |
+| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily **per-asset target weights** {TQQQ, QQQ}, remainder cash | new `src/rainier/signals/resonance_strategy.py` |
+| Daily-MTM sim | per-asset weights → equity, no lookahead, financing + costs | `src/rainier/backtest/` (productionize the prototype in `scripts/leveraged_common.py`) |
 
-**New boundary — NOT `SignalEmitter`.** The existing `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades) and the current engine consumes discrete trades — it *cannot* represent a continuously-sized daily weight. v1 introduces a distinct **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily target-weight series ∈ [0,1]` — plus a weight-consuming backtest path (the daily-MTM sim). This is **additive**: it does not change `SignalEmitter` or the discrete-trade engine, which keep serving the pin-bar/fractal strategies.
+**New boundary — NOT `SignalEmitter`.** The existing `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades) and the current engine consumes discrete trades — it *cannot* represent a continuously-sized daily weight. v1 introduces a distinct **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily **per-asset** target-weight series` (a dict like `{TQQQ: w1, QQQ: w2}`, weights ≥0 summing ≤1, remainder cash) — plus a weight-consuming backtest path. **Per-asset, not a scalar TQQQ-fraction**, precisely so the Q1 "1× QQQ risk-off floor" option is representable without a redesign; this also matches the existing `run_portfolio` sim, which already takes a per-asset weights dict. Additive: it does not change `SignalEmitter` or the discrete-trade engine, which keep serving the pin-bar/fractal strategies.
 
-*Note: the panel signals and the daily-MTM sim currently live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`). v1 promotes them into `src/rainier/` per the module map in `CLAUDE.md`; the scripts are the reference implementation, not the shipping location.*
+*Reference artifacts (local, NOT committed in this design PR): the panel signals and daily-MTM sim live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`, `scripts/full_combo_search.py`, `scripts/resonance_study.py`). They are the working reference, not a landed dependency — so until v1 lands, the numbers in this doc are **exploratory and reproduced via those local scripts**. v1's **first implementation step** is to promote them into `src/rainier/` (committed) per the `CLAUDE.md` module map, making the panel + studies reproducible from the tree.*
 
 ### 5.2 The panel (≤66 lookback)
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -12,7 +12,7 @@ We want to buy TQQQ (3× Nasdaq-100) **only when we're confident**, and size the
 
 We call the agreement of many signals **resonance**: when lots of independent indicators all say "risk-on" at once, that's a stronger, more trustworthy signal than any one of them alone.
 
-### What we already proved (so this isn't a guess)
+### What the data *suggests* (a lead, not yet proof)
 
 Across 2020-10 → now we bucketed every day by how many of a 26-signal panel agreed, then looked at TQQQ's *next 20 days*:
 
@@ -25,7 +25,7 @@ Across 2020-10 → now we bucketed every day by how many of a 26-signal panel ag
   80–100%              62%   ← most agreement = highest win-rate
 ```
 
-**Resonance is real: more agreement genuinely raises the win-rate (48% → 62%).** That is the empirical foundation of this design. One nuance we also found: the *biggest forward returns* come at **60–80%** agreement (a building consensus, early in a move), not at 100% (which tends to be mid-trend, after the easy money). So conviction should reward *strong* consensus but not blindly chase *unanimous* consensus.
+The win-rate rises with agreement — a promising, monotone signal. **But treat it as a lead, not proof, until it clears the bar in §6.** Two reasons to be skeptical: (1) the forward-20-day windows **overlap** (adjacent days share ~19/20 of their data), so the *effective* sample is ~N/20 ≈ a few dozen independent points spread over 5 buckets — too few to call significant without confidence intervals; (2) it's one window dominated by a single 2022 bear and the 2020–21 recovery. The "biggest returns at 60–80% agreement" remark is likewise an unverified in-sample observation (and win-rate ≠ mean return — different statistics). **§6 gates this:** report block-bootstrap CIs and the effective non-overlapping N per bucket; only call it real once a CI excludes the null. The rest of this plan is conditional on that.
 
 ---
 
@@ -47,7 +47,7 @@ There is **no concept of conviction or position size** — every trade is all-or
 
 ## 3. What goes wrong (why we don't just "vote")
 
-The obvious idea — *be in TQQQ when ≥70% of signals agree, else cash* — we tested. **It underperforms the simple gate** (Calmar 0.20 vs 0.34 full-cycle; worse in-window too). Why:
+The obvious idea — *be in TQQQ when ≥70% of signals agree, else cash* — we tested. It underperformed the simple gate (Calmar 0.20 vs 0.34 on the synthetic full-cycle; worse in-window too). *This negative result is **motivating, not load-bearing** — same one-window caveats apply; it's enough to steer away from voting-as-a-gate, not a proven fact.* The mechanism is clear regardless:
 
 ```
 THE LAG TRAP:
@@ -121,7 +121,9 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 
 *Note: the panel signals and the daily-MTM sim currently live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`). v1 promotes them into `src/rainier/` per the module map in `CLAUDE.md`; the scripts are the reference implementation, not the shipping location.*
 
-### 5.2 The panel (≤66 lookback, ~26 signals)
+### 5.2 The panel (≤66 lookback)
+
+*The exact membership and per-category counts are **pinned from `regime_signal_search.build_signals`** at build time (the prototype's real list), not the prose below — the "~26" figure is provisional and the breadth "(Gap)" / "(Optional)" members are excluded until added. Category-balanced weighting (§5.3) depends on the final per-category counts, so v1 records the frozen list explicitly.*
 
 - **Trend:** price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
 - **Momentum:** RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
@@ -138,43 +140,77 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 `resonance[t] = Σ wᵢ · signalᵢ[t] / Σ wᵢ` — weighted fraction risk-on.
 
 - **Category-balanced weights** so one over-represented family (we have many trend signals) doesn't dominate: weight each of the 5 categories equally, split within. Avoids "resonance" really being "trend, four times."
-- **Hysteresis** on the score feeding any threshold, to avoid size chatter at the boundary.
+- Anti-chatter hysteresis is applied **once**, at the stepped-value stage of the §5.4 state machine — *not* here on the raw score (avoids the double-hysteresis ambiguity).
 
-### 5.4 Sizing curve (gate-ON only)
+### 5.4 Sizing curve + state machine (gate-ON only)
 
-`size(r)` maps resonance → target TQQQ fraction, clamped [0, 1]:
-- piecewise: `0` below `r_lo` (≈0.5), ramp to `1` by `r_hi` (≈0.7), flat `1` above (cap — don't over-size unanimity).
-- turnover-aware: round size to coarse steps (e.g. 0/0.5/1.0) so it doesn't rebalance daily and bleed cost.
+`size(r)` maps resonance → target TQQQ fraction, clamped [0, 1]: `0` below `r_lo`, ramp to `1` by `r_hi`, flat `1` above. To avoid ambiguity, the weight is computed by **one** ordered state machine — no second hysteresis layer:
+
+```
+raw resonance r[t]  ──►  (1) curve: size = clamp((r−r_lo)/(r_hi−r_lo), 0, 1)
+                    ──►  (2) round to coarse step ∈ {0, ½, 1}
+                    ──►  (3) hysteresis ON THE STEPPED VALUE: only change the
+                              held step if the new step differs by ≥1 level AND
+                              persists ≥ `dwell` bars  (one place, applied last)
+                    ──►  (4) rebalance only when the held step changes
+```
+
+Hysteresis lives **only** at step (3), on the rounded step — not on the raw score (that was the §5.3 over-spec; remove it there). This makes the path deterministic and unit-testable.
 
 ### 5.5 No-lookahead + costs
 
-Signals computed on close[t]; target weight applied to t+1 return (shift +1). Warmup buffer: load from 2019-06 so every ≤66 signal is valid by 2020-10; **measure only over 2020-10 → now** (real TQQQ). Charge turnover cost on size changes; cash earns the 13-week T-bill.
+Every input (TQQQ, QQQ, SPY, VIX) uses its **close[t]** value; the Layer-1 gate and the Layer-2 size both use the *same* timestamp alignment and the *same* +1 shift — weight decided on close[t] is applied to the t→t+1 return. Warmup buffer: load from 2019-06 so every ≤66 signal is valid by 2020-10; **measure only over 2020-10 → now** (real TQQQ).
 
-**Lookback invariant:** no indicator parameter (window / EMA-span / period) exceeds 66 bars, and no expanding/all-history windows (medians, z-scores, percentiles). Two flavors:
-- *Finite-window* members (SMA, rolling-median, Donchian, ROC) — exact support ≤66.
-- *EMA-family* members (EMA, RSI, MACD, ADX) — recursively smoothed, span/period ≤66; infinite tail in theory but bounded *effective* memory once warmed up.
+**Costs — no double-counting:** real adjusted TQQQ prices *already embed* the 3× daily-reset financing and decay. So on real TQQQ we charge **only** (a) turnover/slippage on rebalances and (b) the T-bill rate the cash sleeve earns/forgoes — **NOT** a synthetic 3× financing charge (that would double-count). The synthetic-3× financing formula (`3·r − 2·rate − fee`) is reserved for the §6.2 pre-2010 OOS test, where no real ETF exists.
 
-Tests: (a) assert every signal's max parameter ≤66; (b) finite-window signals are bit-identical when history before *t−66* is truncated; (c) EMA-family signals converge to <1e-6 relative given ≥150 warmup bars (the 2019-06 buffer supplies ~330). This is why the constraint says ≤66 *parameter*, not ≤66 *exact support*.
+**Leakage test:** inject a known future spike into bar *t+1*; assert weight[t] is unchanged (zero leakage), across all four inputs and both layers.
 
-### 5.6 Config (sweepable)
+**Lookback invariant:** no indicator parameter (window / EMA-span / period) exceeds 66 bars, and no expanding/all-history windows. *Finite-window* members (SMA, rolling-median, Donchian, ROC) have exact support ≤66. *EMA-family* members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — infinite tail in theory, bounded *effective* memory. Tests: (a) every signal's max parameter ≤66; (b) finite-window signals bit-identical when history before *t−66* is dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX is double-smoothed, MACD-hist is EMAs-of-EMAs, so they need more warmup than a raw EMA) and set the buffer from the *slowest* member, not a global asserted constant.
 
-`panel members · per-category weights · gate (entry/exit SMA) · sizing curve (r_lo, r_hi, steps) · hysteresis band · rebalance granularity`.
+### 5.6 Config (and what is NOT swept)
+
+Swept: `panel membership · per-category weights · gate (entry/exit SMA) · rebalance granularity`. **Fixed a priori (not swept):** `r_lo`, `r_hi` (read off the §6.1 bucket curve), the cap-above-`r_hi` rule (kept only if §6.1 says the 60–80% return peak is significant). Total free parameters tuned on data are **capped and pre-registered** before any OOS run (see §6.4) — the effective sample is tiny, so every extra knob is overfit risk.
 
 ---
 
 ## 6. Test plan
 
-| Test | Input | Expected / pass criteria |
-|---|---|---|
-| Thesis (sanity) | resonance buckets × fwd-20d TQQQ | win-rate rises with resonance (reproduce 48→62%) |
-| Strategy backtest | 2020-10→now, real TQQQ | beats SMA22/44-gate baseline on Calmar **and** drawdown, or it's not worth the complexity |
-| Sizing ablation | full-size gate vs resonance-sized | resonance sizing improves Calmar / cuts drawdown at similar return |
-| Per-regime | 2021 bull / 2022 bear / 2023-24 / 2025 | smaller drawdown in 2022 & 2025 than the bare gate |
-| Walk-forward | 60/40 split in-window | sized strategy's edge survives OOS split |
-| Cost/turnover | sweep rebalance granularity | net edge survives realistic cost; switches stay sane |
-| Baseline floor | vs buy-hold TQQQ & QQQ | must beat both risk-adjusted |
+The window has **one** bear (2022). A sizing overlay that simply de-levers *mechanically* cuts drawdown, so naive "beats the gate on drawdown" proves nothing. The plan below is built to *try to kill* the idea, not flatter it.
 
-**Honesty rails (carried from prior work):** one real bear (2022) in this window — sub-20% drawdown here is optimistic; the bare gate's *full-cycle* drawdown was −76%. Report in-window numbers as in-window. No single-best-cell worship; prefer plateaus.
+### 6.1 Significance, not just point estimates
+
+| Test | Input | Pass criteria |
+|---|---|---|
+| Thesis CI | resonance buckets × fwd-20d | report **block-bootstrap CIs** + effective non-overlapping N per bucket; the win-rate trend must have a CI that excludes the null. If it doesn't, the premise fails — stop. |
+| Return-by-bucket | same buckets, forward *return* (not win-rate) | show the return curve with CIs; only keep the "cap above 80%" rule if the 60–80% peak is significant — else drop the cap and the claim. |
+
+### 6.2 No data-snooping — frozen train/test + genuine OOS
+
+The gate (SMA22/44), the panel, and the sizing thresholds were all discovered on 2020-10→now. So an in-window 60/40 split is **not** out-of-sample — the "OOS" slice already shaped the choices.
+
+| Test | Protocol | Pass criteria |
+|---|---|---|
+| Frozen split | **freeze** gate + panel + r_lo/r_hi + weights on a train slice (≤2022-12), report untouched on 2023→now | edge persists on the held-out slice |
+| **True OOS** | run the *frozen* config on a **different leveraged underlying** (SPXL/UPRO/SOXL) and on **synthetic 3× QQQ pre-2010** | edge survives on data that did not inform any choice — this is the real test |
+
+In-window per-regime numbers (2021/2022/2023-24/2025) are **descriptive only**, never validation — one path each, and 2025 is a partial year.
+
+### 6.3 Is it the *signal*, or just less leverage?
+
+| Test | Control | Pass criteria |
+|---|---|---|
+| Matched-exposure | a **constant** scaler and a **volatility-targeted** scaler, each tuned to the *same average exposure* as the resonance sizer | resonance must beat *both* matched-exposure controls on Calmar — otherwise the "edge" is just de-levering and we ship the simpler vol-target instead |
+
+### 6.4 Overfit guard (hard, not vibes)
+
+- **Cap free parameters tuned on data.** Fix `r_lo`/`r_hi` *a priori* from the §6.1 bucket curve — do **not** re-sweep them. Pre-register a single config before looking at OOS.
+- Penalize multiple testing: report a **deflated** Sharpe/Calmar (Bonferroni or López de Prado deflated-Sharpe) over the number of configs tried.
+- Cost/turnover: net edge must survive realistic cost; report switch count.
+
+### 6.5 Baseline floor
+Must beat buy-hold TQQQ **and** QQQ risk-adjusted, **and** the bare SMA22/44 gate, **and** the matched-exposure control. Failing any → don't ship; simpler wins.
+
+**Honesty rails:** sub-20% drawdown in this window is optimistic — the bare gate's *full-cycle* (1999–2026 synthetic) drawdown was −76%. Report in-window numbers as in-window. No single-best-cell worship; prefer plateaus. If §6.1 or §6.3 fails, the design is **rejected**, not patched.
 
 ---
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -131,6 +131,8 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 - **(Optional)** fractal:simple_turn as a momentum/structure member.
 - **(Gap)** market breadth (% NDX above its MA) — not in yfinance; needs a proxy (compute "% of top-N QQQ holdings above their SMA"). Tracked as a follow-up, not v1-blocking.
 
+*Every member's controlling parameter (window / EMA-span / period) is ≤ 66. Finite-window members (SMA, rolling-median, Donchian, ROC) have exact support ≤66; EMA-family members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — theoretically infinite tail but bounded **effective** memory (see the invariant in §5.5).*
+
 ### 5.3 Scoring
 
 `resonance[t] = Σ wᵢ · signalᵢ[t] / Σ wᵢ` — weighted fraction risk-on.
@@ -148,7 +150,11 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 
 Signals computed on close[t]; target weight applied to t+1 return (shift +1). Warmup buffer: load from 2019-06 so every ≤66 signal is valid by 2020-10; **measure only over 2020-10 → now** (real TQQQ). Charge turnover cost on size changes; cash earns the 13-week T-bill.
 
-**Lookback invariant:** every panel signal must use a *bounded* window ≤ 66 bars — no expanding/all-history windows (medians, z-scores, percentiles included). A unit test asserts each signal's first valid index ≤ 66 and that its value at bar *t* is unchanged when history before *t−66* is truncated.
+**Lookback invariant:** no indicator parameter (window / EMA-span / period) exceeds 66 bars, and no expanding/all-history windows (medians, z-scores, percentiles). Two flavors:
+- *Finite-window* members (SMA, rolling-median, Donchian, ROC) — exact support ≤66.
+- *EMA-family* members (EMA, RSI, MACD, ADX) — recursively smoothed, span/period ≤66; infinite tail in theory but bounded *effective* memory once warmed up.
+
+Tests: (a) assert every signal's max parameter ≤66; (b) finite-window signals are bit-identical when history before *t−66* is truncated; (c) EMA-family signals converge to <1e-6 relative given ≥150 warmup bars (the 2019-06 buffer supplies ~330). This is why the constraint says ≤66 *parameter*, not ≤66 *exact support*.
 
 ### 5.6 Config (sweepable)
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -1,20 +1,20 @@
-# Design Plan — Multi-Signal Resonance for TQQQ Conviction
+# Design Plan — Multi-Signal Resonance Gate for TQQQ
 
-**Status:** draft for review · **Scope:** signal-resonance layer for the TQQQ timing strategy · **Window:** 2020-10 → now (real TQQQ) · **Constraint:** no moving-average / lookback > 66 bars · **Depends on:** `src/rainier/signals/`, `src/rainier/backtest/` engine · **PR base:** main
+**Status:** decisions locked, for build review · **Scope:** a weighted-signal entry/exit gate for TQQQ · **Window:** 2020-10 → now (real TQQQ) · **Constraint:** no moving-average / lookback > 66 bars · **Depends on:** `src/rainier/signals/`, `src/rainier/backtest/` · **PR base:** main
 
 ---
 
 ## 1. The problem, in plain English
 
-We want to buy TQQQ (3× Nasdaq-100) **only when we're confident**, and size the bet to that confidence. A single indicator — "price is above its 44-day average" — flips in and out on every wiggle and gives plenty of false buys. We have *dozens* of signals (trend, momentum, volatility, structure). The question this plan answers:
+We want to buy and sell TQQQ (3× Nasdaq-100) on the **combined verdict of many signals**, not one. A single indicator — "price is above its 44-day average" — flips on every wiggle and gives false buys. We have *dozens* of signals (trend, momentum, volatility, structure). The model you want:
 
-> **How do we combine many signals into one "conviction score" so that more agreement → more confidence → a bigger, higher-win-rate bet — without the lag that killed naive consensus voting?**
+> **Give each signal a power weight. Add them into one confidence score. When the score crosses a BUY line → buy TQQQ. When it drops below a SELL line → sell everything to cash.** The gap between the two lines stops the whipsaw.
 
-We call the agreement of many signals **resonance**: when lots of independent indicators all say "risk-on" at once, that's a stronger, more trustworthy signal than any one of them alone.
+We call the weighted agreement of many signals **resonance**: when lots of independent indicators line up, the score is high and the buy is more trustworthy than any one signal alone.
 
 ### What the data *suggests* (a lead, not yet proof)
 
-Across 2020-10 → now we bucketed every day by how many of a 26-signal *exploratory* panel agreed (the ≤66 subset of `build_signals` + SPY, as in `scripts/resonance_study.py`), then looked at TQQQ's *next 20 days*. (v1 freezes a slightly different ~22-member panel — §5.2 — so the resonance **denominator is the frozen count**, never a hardcoded 26.)
+On 2020-10 → now we bucketed every day by how many signals agreed, then looked at TQQQ's *next 20 days*:
 
 ```
  signals agreeing →  win-rate of the next 20 days
@@ -25,84 +25,67 @@ Across 2020-10 → now we bucketed every day by how many of a 26-signal *explora
   80–100%              62%   ← most agreement = highest win-rate
 ```
 
-The win-rate rises with agreement — a promising, monotone signal. **But treat it as a lead, not proof, until it clears the bar in §6.** Two reasons to be skeptical: (1) the forward-20-day windows **overlap** (adjacent days share ~19/20 of their data), so the *effective* sample is ~N/20 ≈ a few dozen independent points spread over 5 buckets — too few to call significant without confidence intervals; (2) it's one window dominated by a single 2022 bear and the 2020–21 recovery. The "biggest returns at 60–80% agreement" remark is likewise an unverified in-sample observation (and win-rate ≠ mean return — different statistics). **§6 gates this:** report block-bootstrap CIs and the effective non-overlapping N per bucket; only call it real once a CI excludes the null. The rest of this plan is conditional on that.
+More agreement → higher win-rate. That is the premise of a "buy when the score is high" gate. **But treat it as a lead, not proof, until §6.** Two reasons to doubt it: (1) the forward-20-day windows **overlap** (adjacent days share ~19/20 of their data), so the *effective* sample is ~N/20 ≈ a few dozen independent points over 5 buckets — too few to be significant without confidence intervals; (2) it's one window dominated by a single 2022 bear + the 2020–21 recovery. **§6 gates it:** block-bootstrap CIs + effective N per bucket; only call it real once a CI excludes the null.
 
 ---
 
 ## 2. How it works today
 
-Right now there is no integrated system — just a pile of exploratory scripts. Two things exist:
+No integrated system — just exploratory scripts. Two pieces exist:
 
-- **An exploratory signal panel** (`regime_signal_search.build_signals`), each emitting a daily risk-on (1) / risk-off (0) series. It is *unfiltered* — most members today use >66 lookback and two use expanding medians; v1 takes only its **≤66 subset** and rewrites the expanding members (see §5.2).
-- **A timing gate** — the asymmetric SMA gate (enter when QQQ > SMA22, exit when QQQ < SMA44). In-window it was the single best risk-adjusted design (Calmar ≈ 1.37, #2 of 270 in a full sweep, on a stable plateau).
+- **An exploratory signal panel** (`regime_signal_search.build_signals`), each member a daily risk-on (1) / risk-off (0) series. It's *unfiltered* — most members use >66 lookback and two use expanding medians; v1 takes only its **≤66 subset** and rewrites the expanding members (§5.2). There is **no weighting and no combined score** today.
+- **A timing gate** — the asymmetric SMA gate (enter QQQ > SMA22, exit QQQ < SMA44). In-window the best single-signal design (Calmar ≈ 1.37, #2 of 270, on a stable plateau). This is the **bar to beat**.
 
 ```
-TODAY:  one signal  ──►  in/out of TQQQ at full size
-        (e.g. price>SMA44)         (binary, no notion of confidence)
+TODAY:  one signal  ──►  in/out of TQQQ
+        (e.g. price>SMA44)        (binary, one indicator, no weighting)
 ```
-
-There is **no concept of conviction or position size** — every trade is all-or-nothing, and the dozens of other signals are unused.
 
 ---
 
-## 3. What goes wrong (why we don't just "vote")
+## 3. What we learned, and how v1 differs
 
-The obvious idea — *be in TQQQ when ≥70% of signals agree, else cash* — we tested. It underperformed the simple gate (Calmar 0.20 vs 0.34 on the synthetic full-cycle; worse in-window too). *This negative result is **motivating, not load-bearing** — same one-window caveats apply; it's enough to steer away from voting-as-a-gate, not a proven fact.* The mechanism is clear regardless:
+We already tested the **naive** version — equal-weight consensus, "be in when ≥70% agree." **It lagged and lost** to the simple SMA gate (Calmar 0.20 vs 0.34 on the synthetic full-cycle). Why consensus lags:
 
 ```
 THE LAG TRAP:
    price ────╲                      ╱──── recovery
               ╲                    ╱
-   gate exits  ╲__________________╱   gate re-enters (fast)
+   exits late  ╲__________________╱   re-enters late
                   ▲              ▲
-   votes flip   LATE           LATE   ← consensus needs many signals to flip;
-   risk-off  (already down)  (misses the bounce)
+   score drops  LATE           LATE   ← it takes many signals to flip the score;
+   below sell (already down)  (misses the bounce)
 ```
 
-- **Entering on consensus lags the bottom:** by the time 70% of signals turn risk-on, the rebound is half over.
-- **Exiting on consensus lags the top:** the drawdown is already eaten before enough signals flip.
-- Consensus voting flips *less* (less whipsaw) but each move is *late*, so it has higher win-rate yet **worse risk-adjusted return**.
+v1 is **not** that naive version. Two differences, both of which we **A/B test** rather than assume:
+- **Power weights** per signal (not equal) — a strong signal moves the score more.
+- **Two tunable lines** (buy high, sell lower) instead of one 70% line — the gap is a hysteresis buffer that can be tuned to cut whipsaw.
 
-**Lesson: resonance is good at measuring *confidence*, bad at deciding *timing*.** The fast SMA gate is the opposite — good timing, no confidence. The design uses each for what it's good at.
+**Honesty rail:** this is still the *vote-gate family* that lost to the SMA gate once already. v1 earns its place only if the A/B test (§6) shows the weighted dual-threshold gate beats the SMA22/44 gate **and** buy-hold, out-of-sample. If it doesn't, we ship the SMA gate and stop. Eyes open.
 
 ---
 
-## 4. The fix — a two-layer design
-
-Separate **timing** from **conviction**:
+## 4. The design — a weighted-score dual-threshold gate
 
 ```
-LAYER 1 — TIMING (fast):        LAYER 2 — CONVICTION (resonance):
-  asymmetric SMA22/44 gate         consensus of the ≤66-lookback panel (§5.2)
-  decides IN vs OUT of TQQQ        decides HOW BIG when in
-        │                                  │
-        └──────────────┬───────────────────┘
-                       ▼
-            position size = gate_on × size(resonance)
+   ≤66 signals, each with a power weight
+            │
+            ▼
+   resonance score  r[t] = Σ wᵢ·signalᵢ[t] / Σ wᵢ   ∈ [0,1]
+            │
+            ▼
+   ┌─ if flat AND r ≥ BUY line   → buy TQQQ (full)
+   ├─ if held AND r ≤ SELL line  → sell all → cash
+   └─ else                       → hold current state
+            │
+            ▼
+   position is BINARY: 100% TQQQ or 100% cash. No sizing.
 ```
 
-- **Layer 1 (gate)** answers *"should I be in TQQQ at all right now?"* — fast, responsive, the best-tested timing engine so far. When the gate is OFF → cash (T-bills). No lag penalty on timing.
-- **Layer 2 (resonance)** answers *"how convinced am I?"* — when the gate is ON, scale the position by the conviction score. High resonance (many signals agree) → full 3× exposure. Weak resonance (signals split) → reduced exposure (e.g. partial TQQQ + cash, or 1× QQQ).
-
-This uses the **candidate** 48%→62% win-rate edge (pending §6.1 significance) as a **sizing** signal, where lag doesn't hurt, instead of a **timing** signal, where it does.
-
-### Your "confirmed buy" is a *second* axis — pullback resonance
-
-A distinction the design must respect: your example — *QQQ<SMA10 AND SPY<SMA10 AND breadth<30% AND VIX<23 AND fractal buy* — is built from **oversold / pullback** conditions (price *below* short MAs, washed-out breadth). The trend-resonance score above counts *risk-on* signals (price *above* MAs), so this exact cluster would score **low**, not high. They are two different axes:
-
-- **Trend resonance** — "the uptrend is broadly confirmed" (price above MAs, momentum positive, vol calm). Drives Layer-2 **sizing**.
-- **Pullback resonance** — "an oversold dip is bottoming *inside* an uptrend" (price below SMA10, breadth washed out, fractal turn, VIX not panicked). A separate **entry** trigger for buying the dip.
-
-v1 models your confirmed-buy as an **optional pullback sub-score / alternate entry**, regime-gated (only buy dips while a slower trend filter is still up — don't catch knives in a real bear), **not** as the high end of trend resonance. Richer, and an open decision (Q7).
-
-### What it looks like day to day
-
-```
-  gate OFF                         → 0% TQQQ (cash, earning T-bills)
-  gate ON, resonance 50–65%        → reduced size (e.g. 40–60% TQQQ)
-  gate ON, resonance 65–80%        → full size      (peak-return zone)
-  gate ON, resonance > 80%         → full size, but capped (don't chase unanimity)
-```
+- **Binary, no sizing** — you were right that "size by conviction" was likely noise; v1 drops it. The score's only job is to cross the buy/sell lines.
+- **Risk-off = 100% cash/T-bills** (Q1). When out, we hold nothing but cash.
+- **BUY line > SELL line** (Q2) — the gap is the hysteresis band; widening it trades fewer trades for later entries (a swept config).
+- The whole gate is **A/B tested against the SMA22/44 gate** and against combinations (resonance-gate alone, SMA alone, resonance AND SMA, resonance OR SMA) — data picks the winner (Q3).
 
 ---
 
@@ -113,128 +96,114 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 | Component | Role | Where |
 |---|---|---|
 | `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `src/rainier/signals/panel.py` |
-| `ResonanceScorer` | panel → daily conviction score ∈ [0,1] (weighted consensus) | new `src/rainier/signals/resonance.py` |
-| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily **per-asset target weights** {TQQQ, QQQ}, remainder cash | new `src/rainier/signals/resonance_strategy.py` |
-| Daily-MTM sim | per-asset weights → equity, no lookahead, financing + costs | `src/rainier/backtest/` (productionize the prototype in `scripts/leveraged_common.py`) |
+| `ResonanceScorer` | panel + per-signal weights → daily score ∈ [0,1] | new `src/rainier/signals/resonance.py` |
+| `ResonanceGate` | dual-threshold state machine → daily **per-asset target weights** {TQQQ} | new `src/rainier/signals/resonance_gate.py` |
+| Daily-MTM sim | per-asset weights → equity, no lookahead, costs | `src/rainier/backtest/` (productionize `scripts/leveraged_common.py`) |
 
-**New boundary — NOT `SignalEmitter`.** The existing `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades) and the current engine consumes discrete trades — it *cannot* represent a continuously-sized daily weight. v1 introduces a distinct **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily **per-asset** target-weight series` (a dict like `{TQQQ: w1, QQQ: w2}`, weights ≥0 summing ≤1, remainder cash) — plus a weight-consuming backtest path. **Per-asset, not a scalar TQQQ-fraction**, precisely so the Q1 "1× QQQ risk-off floor" option is representable without a redesign; this also matches the existing `run_portfolio` sim, which already takes a per-asset weights dict. Additive: it does not change `SignalEmitter` or the discrete-trade engine, which keep serving the pin-bar/fractal strategies.
+**New boundary — NOT `SignalEmitter`.** `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades); the current engine consumes discrete trades and can't represent a held daily weight. v1 adds a **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily per-asset weight series` (a dict like `{TQQQ: 0 or 1}`, weights ≥0 summing ≤1, remainder cash). Per-asset (not a bare boolean) so a future non-cash risk-off is representable without a redesign; matches the existing `run_portfolio` sim, which already takes a per-asset weights dict. Additive: it doesn't touch `SignalEmitter` or the discrete-trade engine.
 
-*Reference artifacts (local, NOT committed in this design PR): the panel signals and daily-MTM sim live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`, `scripts/full_combo_search.py`, `scripts/resonance_study.py`). They are the working reference, not a landed dependency — so until v1 lands, the numbers in this doc are **exploratory and reproduced via those local scripts**. v1's **first implementation step** is to promote them into `src/rainier/` (committed) per the `CLAUDE.md` module map, making the panel + studies reproducible from the tree.*
+*Reference artifacts (local, NOT committed in this PR): the panel + sim live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`, `scripts/full_combo_search.py`, `scripts/resonance_study.py`). Numbers in this doc are exploratory, reproduced via those scripts. v1's **first step** is to promote them into `src/rainier/` (committed) per the `CLAUDE.md` module map.*
 
-### 5.2 The panel (≤66 lookback)
+### 5.2 The panel (≤66 lookback, trend-only for v1)
 
-**Provenance — important:** v1 does **NOT** pin the full `regime_signal_search.build_signals` list. That list is mostly **>66** lookback (SMA100/150/200, EMA100/200, ROC120, 12-1 momentum, 90/120-day highs, slow 50/150 & 50/200 crosses) and uses **expanding** medians — both forbidden here.
+v1 is **trend-only** (Q7) — every member is a *risk-on / uptrend-confirming* signal (price above MAs, momentum up, vol calm). Pullback/oversold signals (price *below* short MAs) are deferred to v2.
 
-**The enumerated list below IS the single source of truth** for the v1 panel (the resonance denominator and category counts derive from it — nothing else). It was *seeded* from the ≤66 subset of `build_signals` (the complement of the `BLOCK` set in `scripts/full_combo_search.py`), then deliberately **deduplicated** — keep one threshold per indicator (RSI>50, drop RSI>55; VIX<25, drop VIX<20/<30; one of ADX/+DI) so no single indicator is triple-counted in the consensus — with two expanding-median members **rewritten** to bounded form and `price>SMA66` **added**. So the list is *not* identical to the raw BLOCK-complement; where prose and the list disagree, **the list wins**. New members (SPY cross-asset, optional fractal, breadth proxy) are fresh code and each count against the §6.4 parameter budget. The frozen list is recorded verbatim at build time.
+**The enumerated list below IS the single source of truth** (the score denominator and category counts derive from it). It was *seeded* from the ≤66 subset of `build_signals` (complement of the `BLOCK` set in `scripts/full_combo_search.py`), then **deduplicated** — one threshold per indicator (RSI>50, drop RSI>55; VIX<25, drop VIX<20/<30; one of ADX/+DI) so no indicator is triple-counted — with the two expanding-median members **rewritten** to bounded form and `price>SMA66` **added**. Where prose and the list disagree, **the list wins**.
 
-- **Trend** (from ≤66 subset): price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
-- **Momentum** (from ≤66 subset): RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
-- **Volatility** (rewritten): realizedVol(20, rolling std) < its **rolling-40 median** (20+40 = 60, both finite), ATR%(14, **simple rolling mean** of true range — *not* Wilder/EWMA) < its rolling-46 median (14+46 = 60, both finite), VIX<25, VIX<SMA20, VIX-falling. *(Replaces the prototype's `expanding(60).median()` AND its Wilder-EWMA `atr_pct` — both have unbounded lookback; the finite-window invariant §5.5(b) requires simple rolling forms here.)*
-- **Structure** (from ≤66 subset): within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
-- **Cross-asset** (NEW code): SPY>SMA22, SPY>SMA44 — `build_signals(qqq, vix)` takes no SPY today; v1 adds an SPY input.
-- **(NEW, optional)** fractal:simple_turn — not in `build_signals`; added if Q7 says so.
-- **(Gap)** market breadth (% NDX above its MA) — not in yfinance; proxy = "% of top-N QQQ holdings above their SMA". Follow-up, not v1-blocking.
+- **Trend:** price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
+- **Momentum:** RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
+- **Volatility:** realizedVol(20, rolling std) < its **rolling-40 median** (20+40 = 60, finite), ATR%(14, **simple rolling mean** of true range, *not* Wilder/EWMA) < its rolling-46 median (14+46 = 60), VIX<25, VIX<SMA20, VIX-falling. *(Replaces the prototype's `expanding(60).median()` and EWMA `atr_pct` — both unbounded.)*
+- **Structure:** within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
+- **Cross-asset:** SPY>SMA22, SPY>SMA44 (NEW code — `build_signals(qqq, vix)` takes no SPY today; v1 adds an SPY input).
+- **Breadth (NEW, in v1 — Q5):** **% of top-N QQQ holdings above their SMA** — the closest proxy to "market breadth" (yfinance has no breadth index). Built in v1, and **also surfaced on the QQQ market-breadth dashboard** (separate deliverable, §7).
 
-*Every member's **composed/total** lookback is ≤ 66 — a 20-day measure compared to a 40-day median counts as 60, not "66 because the outer window is 66." Finite-window members have exact composed support ≤66; EMA-family members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — infinite tail in theory, bounded **effective** memory (invariant in §5.5).*
+*Every member's **composed/total** lookback ≤ 66 (a 20-day measure vs a 40-day median = 60, not "66 because the outer window is 66"). Finite-window members have exact composed support ≤66; EMA-family members (EMA, RSI, MACD, ADX) have bounded effective memory (invariant in §5.5).*
 
-### 5.3 Scoring
+### 5.3 Scoring (power weights)
 
-`resonance[t] = Σ wᵢ · signalᵢ[t] / Σ wᵢ` — weighted fraction risk-on.
+`resonance[t] = Σ wᵢ · signalᵢ[t] / Σ wᵢ` ∈ [0,1] — the **power-weighted** fraction risk-on.
 
-- **Category-balanced weights** so one over-represented family (we have many trend signals) doesn't dominate: weight each of the 5 categories equally, split within. Avoids "resonance" really being "trend, four times."
-- Anti-chatter hysteresis is applied **once**, at the stepped-value stage of the §5.4 state machine — *not* here on the raw score (avoids the double-hysteresis ambiguity).
+- **Per-signal power weights `wᵢ`** (Q2) — a strong signal moves the score more. Default prior = **category-balanced** (Q4): the 5 categories weighted equally, split within, so the many trend signals don't make the score really mean "trend ×4." Beyond that prior, weights are a **swept/tested** config (capped per §6.4 — every free weight is overfit risk on a tiny sample).
+- A/B includes **equal-weight vs category-balanced vs tuned** weights to confirm weighting actually helps (Q4: "testing can tell us more").
 
-### 5.4 Sizing curve + state machine (gate-ON only)
-
-`size(r)` maps resonance → target TQQQ fraction, clamped [0, 1]: `0` below `r_lo`, ramp to `1` by `r_hi`, flat `1` above. To avoid ambiguity, the weight is computed by **one** ordered state machine — no second hysteresis layer:
+### 5.4 The dual-threshold gate (state machine)
 
 ```
-raw resonance r[t]  ──►  (1) curve: size = clamp((r−r_lo)/(r_hi−r_lo), 0, 1)
-                    ──►  (2) round to coarse step ∈ {0, ½, 1}  → target_step[t]
-                    ──►  (3) hysteresis: the HELD step moves to target_step[t]
-                              only after target_step has held the SAME new value
-                              for ≥ `dwell` consecutive bars; otherwise the held
-                              step is carried forward unchanged
-                    ──►  (4) rebalance only when the held step actually changes
+score r[t]  ──►  if state==CASH  and r[t] ≥ BUY  → state = TQQQ (enter at close)
+            ──►  if state==TQQQ  and r[t] ≤ SELL → state = CASH (sell all)
+            ──►  else                            → hold state
+       BUY > SELL ; the gap is the hysteresis band.
 ```
 
-Boot: at the first valid bar `t0` (after the §5.5c per-member warmup), held_step = target_step[t0] — provisional, taken without confirmation since there's no prior; every *subsequent* move still requires the full `dwell`. Moves are **direct** to the confirmed target (e.g. 0→1 in one transition once the new step holds `dwell` bars), not forced stepwise through ½. The dwell counter resets whenever target_step changes value. Hysteresis lives **only** here — not on the raw score (the §5.3 over-spec is removed). Deterministic and unit-testable; a test asserts a fixed input sequence yields a fixed held-step sequence.
+Boot: at the first valid bar `t0` (after the §5.5c per-member warmup), state = TQQQ if `r[t0] ≥ BUY` else CASH. Deterministic and unit-testable — a fixed score sequence yields a fixed state sequence; a test asserts it. No second hysteresis layer, no sizing curve.
 
 ### 5.5 No-lookahead + costs
 
-Every input (TQQQ, QQQ, SPY, VIX) uses its **close[t]** value; the Layer-1 gate and the Layer-2 size both use the *same* timestamp alignment and the *same* +1 shift — weight decided on close[t] is applied to the t→t+1 return. Warmup buffer: load from 2019-06 so every ≤66 signal is valid by 2020-10; **measure only over 2020-10 → now** (real TQQQ).
+Every input (TQQQ, QQQ, SPY, VIX, breadth) uses its **close[t]** value; the score and the gate share the *same* timestamp alignment and the *same* +1 shift — state decided on close[t] applies to the t→t+1 return. Warmup buffer from 2019-06; **measure only over 2020-10 → now** (real TQQQ).
 
-**Costs — no double-counting:** real adjusted TQQQ prices *already embed* the 3× daily-reset financing and decay. So on real TQQQ we charge **only** (a) turnover/slippage on rebalances and (b) the T-bill rate the cash sleeve earns/forgoes — **NOT** a synthetic 3× financing charge (that would double-count). The synthetic-3× financing formula (`3·r − 2·rate − fee`) is reserved for the §6.2 pre-2010 OOS test, where no real ETF exists.
+**Costs — no double-counting:** real adjusted TQQQ prices *already embed* the 3× daily-reset financing and decay. On real TQQQ we charge **only** (a) turnover/slippage on each buy/sell and (b) the T-bill rate the cash sleeve earns — **NOT** a synthetic 3× financing charge. The synthetic formula (`3·r − 2·rate − fee`) is reserved for the §6.2 pre-2010 OOS test.
 
-**Leakage test:** inject a known future spike into bar *t+1*; assert weight[t] is unchanged (zero leakage), across all four inputs and both layers.
+**Leakage test:** inject a known future spike into bar *t+1*; assert state[t] is unchanged across all inputs.
 
-**Lookback invariant:** the **composed/total** lookback of every member ≤ 66 bars, and no expanding/all-history windows. "Composed" matters for *nested* indicators: `realizedVol(20)` fed into a `rolling-k median` has total span `20+k`, so the median window must be ≤46, not 66. *Finite-window* members (SMA, rolling-median, Donchian, ROC, and the rewritten nested-vol members) have exact composed support ≤66. *EMA-family* members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — infinite tail in theory, bounded *effective* memory. Tests: (a) every signal's composed span ≤66 (inner+outer for nested); (b) finite-window signals bit-identical when history before *t−66* is dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX is double-smoothed, MACD-hist is EMAs-of-EMAs, so they need more warmup than a raw EMA) and set the buffer from the *slowest* member, not a global asserted constant. The two prototype `expanding(60).median()` members fail test (b) and **must** be rewritten to the bounded form in §5.2 — this is a required panel change, not optional.
+**Lookback invariant:** the **composed/total** lookback of every member ≤ 66, no expanding windows. "Composed" matters for *nested* indicators (realizedVol(20) into a rolling-k median has span 20+k, so k ≤ 46). *Finite-window* members (SMA, rolling-median, Donchian, ROC, rewritten nested-vol) have exact composed support ≤66; *EMA-family* (EMA, RSI, MACD, ADX) have bounded effective memory. Tests: (a) every composed span ≤66; (b) finite-window signals bit-identical when history before *t−66* dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX double-smoothed, MACD-hist EMAs-of-EMAs) and set the buffer from the *slowest* member. The two prototype `expanding(60).median()` members fail test (b) and **must** be rewritten — required, not optional.
 
 ### 5.6 Config (and what is NOT swept)
 
-Swept: `panel membership · per-category weights · gate (entry/exit SMA) · rebalance granularity`. **Fixed a priori (not swept):** `r_lo`, `r_hi` (read off the §6.1 bucket curve), the cap-above-`r_hi` rule (kept only if §6.1 says the 60–80% return peak is significant). Total free parameters tuned on data are **capped and pre-registered** before any OOS run (see §6.4) — the effective sample is tiny, so every extra knob is overfit risk.
+Swept: `panel membership · per-signal weights · BUY threshold · SELL threshold · gate-combination mode (resonance-only / SMA-only / AND / OR)`. Total free parameters tuned on data are **capped and pre-registered** before any OOS run (§6.4) — the effective sample is tiny, every extra knob is overfit risk.
 
 ---
 
-## 6. Test plan
+## 6. Test plan — A/B against the SMA gate, built to *reject*
 
-The window has **one** bear (2022). A sizing overlay that simply de-levers *mechanically* cuts drawdown, so naive "beats the gate on drawdown" proves nothing. The plan below is built to *try to kill* the idea, not flatter it.
+The window has **one** bear (2022). The plan tries to kill the idea, not flatter it.
 
 ### 6.1 Significance, not just point estimates
-
 | Test | Input | Pass criteria |
 |---|---|---|
-| Thesis CI | resonance buckets × fwd-20d | report **block-bootstrap CIs** + effective non-overlapping N per bucket; the win-rate trend must have a CI that excludes the null. If it doesn't, the premise fails — stop. |
-| Return-by-bucket | same buckets, forward *return* (not win-rate) | show the return curve with CIs; only keep the "cap above 80%" rule if the 60–80% peak is significant — else drop the cap and the claim. |
+| Thesis CI | resonance buckets × fwd-20d | block-bootstrap CIs + effective non-overlapping N per bucket; the win-rate trend's CI must exclude the null. If not, the premise fails — stop. |
 
 ### 6.2 No data-snooping — frozen train/test + genuine OOS
-
-The gate (SMA22/44), the panel, and the sizing thresholds were all discovered on 2020-10→now. So merely *freezing* that config and reporting 2023→now still leaks — the held-out slice already shaped the choices.
+The gate, panel, weights, and thresholds were all discovered on 2020-10→now. Freezing that config and reporting 2023→now still leaks.
 
 | Test | Protocol | Pass criteria |
 |---|---|---|
-| Re-derived split | Re-run the **entire** selection pipeline (gate sweep, bucket thresholds, panel, weights) using **only ≤2022-12** data — discard the prior full-window picks — then report **once** on 2023→now, untouched | edge persists. If re-deriving is impractical, 2023→now is **descriptive only** and the load-bearing test is the row below. |
-| **True OOS** (load-bearing) | run the frozen config on **synthetic 3× QQQ pre-2010** (dot-com + GFC — the regimes leverage decay punishes most) and on a **different leveraged underlying** | edge survives on data that informed no choice |
+| Re-derived split | Re-run the **entire** selection (panel, weights, BUY/SELL thresholds, combination mode) on **only ≤2022-12** data — discard prior picks — report **once** on 2023→now | edge persists. If impractical, 2023→now is **descriptive only** and the row below is load-bearing. |
+| **True OOS** (load-bearing) | run the frozen config on **synthetic 3× QQQ pre-2010** (dot-com + GFC) and a **different leveraged underlying** | edge survives on data that informed no choice |
 
-**Genuine-independence caveats:** for a different underlying, the signal source **switches** to that underlying's own inputs (SPX/QQQ-correlated), with gate/panel *structure* held fixed. **SPXL/UPRO are near-clones of the QQQ trade** → weak independent evidence; **SOXL (semis)** is a genuinely different regime → stronger. For pre-2010 synthetic, **pre-register** the cost params before running: `rate` = the historical 3-month T-bill *series* (not a constant — it swings 0–5%), `fee` = a fixed expense; report drawdown **sensitivity** to ±50 bps fee, since the dot-com/GFC verdict hinges on them.
+For a different underlying, the signal source **switches** to that underlying's own inputs. **SPXL/UPRO are near-clones** of the QQQ trade → weak evidence; **SOXL (semis)** is genuinely different → stronger. For pre-2010 synthetic, **pre-register** the cost params (`rate` = historical 3-month T-bill *series*; `fee` fixed) and report drawdown sensitivity to ±50 bps fee. In-window per-regime numbers are **descriptive only**.
 
-In-window per-regime numbers (2021/2022/2023-24/2025) are **descriptive only**, never validation — one path each, 2025 partial.
-
-### 6.3 Is it the *signal*, or just less leverage?
-
-| Test | Control (precisely pinned) | Pass criteria |
+### 6.3 The A/B — does the weighted gate actually beat the simple one?
+| Test | Comparators (all on the §6.2 OOS slices) | Pass criteria |
 |---|---|---|
-| Matched-exposure | (a) **constant** scaler = the resonance sizer's *exact* mean weight; (b) **vol-target** scaler matched on *both* mean exposure AND realized-vol budget. **Per slice:** on each §6.2 OOS slice, both controls' mean is re-derived from *that slice's own* realized resonance-weight series (not carried across underlyings). | resonance must beat the **better** of (a)/(b) on Calmar **on every §6.2 OOS slice** (2023→now, pre-2010 synthetic, different-underlying) — not one cherry-picked slice. Else the "edge" is just de-levering, and we ship the simpler vol-target instead. |
+| Gate A/B | resonance-gate · SMA22/44-gate · (resonance AND SMA) · (resonance OR SMA) · buy-hold TQQQ · buy-hold QQQ | the resonance-gate (or a combination) must beat the **SMA22/44 gate AND buy-hold** on Calmar **and** drawdown, on **every** OOS slice. If the plain SMA gate wins, **ship the SMA gate** and stop. |
+| Weighting A/B | equal-weight vs category-balanced vs tuned weights | weighting must measurably help, else use equal weights (simpler) |
 
 ### 6.4 Overfit guard (hard, not vibes)
+- **Cap free parameters tuned on data**; pre-register a single config before OOS.
+- Penalize multiple testing: report a **deflated** Sharpe/Calmar (Bonferroni or López de Prado) over the number of configs tried.
+- Cost/turnover: net edge must survive realistic cost; report switch count (the dual-threshold gap is the lever).
 
-- **Cap free parameters tuned on data.** Fix `r_lo`/`r_hi` *a priori* from the §6.1 bucket curve — do **not** re-sweep them. Pre-register a single config before looking at OOS.
-- Penalize multiple testing: report a **deflated** Sharpe/Calmar (Bonferroni or López de Prado deflated-Sharpe) over the number of configs tried.
-- Cost/turnover: net edge must survive realistic cost; report switch count.
-
-### 6.5 Baseline floor
-Must beat buy-hold TQQQ **and** QQQ risk-adjusted, **and** the bare SMA22/44 gate, **and** the matched-exposure control. Failing any → don't ship; simpler wins.
-
-**Honesty rails:** sub-20% drawdown in this window is optimistic — the bare gate's *full-cycle* (1999–2026 synthetic) drawdown was −76%. Report in-window numbers as in-window. No single-best-cell worship; prefer plateaus. If §6.1 or §6.3 fails, the design is **rejected**, not patched.
+**Honesty rails:** sub-20% drawdown in this window is optimistic — the bare gate's *full-cycle* (1999–2026 synthetic) drawdown was −76%. Report in-window as in-window. Prefer plateaus over single best cells. **If §6.1 or §6.3 fails, the design is rejected, not patched.**
 
 ---
 
-## 7. Open decisions (need your call)
+## 7. Decisions (locked)
 
-- **Q1 — Risk-off floor:** when the gate is OFF, hold **cash/T-bills** (max safety) or **1× QQQ** (stay exposed)? Prior tests: cash was cleaner; QQQ-floor lifted return but raised drawdown.
-- **Q2 — Sizing granularity:** continuous size = f(resonance), or coarse **steps** (0 / ½ / full) to cut turnover? Steps are simpler and cheaper; continuous is smoother.
-- **Q3 — Does resonance also gate entry, or only size?** Pure design: gate=timing, resonance=size only. Your "confirmed buy" instinct suggests *also* requiring a minimum resonance to enter at all (veto low-conviction). Include the veto, or keep layers clean?
-- **Q4 — Panel weighting:** equal-per-signal (simple) or **category-balanced** (so trend doesn't dominate)? I lean category-balanced.
-- **Q5 — Breadth proxy now or later?** Build the "% of top QQQ holdings above MA" breadth signal for v1, or ship v1 without it and add later?
-- **Q6 — Max conviction cap:** cap size at full 3× TQQQ, or allow a *defensive* sub-full mode (e.g. never exceed 1× in the first N days after a regime flip)?
-- **Q7 — Pullback axis in v1?** Include the second (pullback/oversold) conviction axis — your confirmed-buy idea — in v1, or ship trend-resonance sizing first and add pullback entries in v2? Needs the breadth proxy (Q5) to be at its best.
+| # | Decision | Choice |
+|---|---|---|
+| Q1 | Risk-off floor | **Sell all → 100% cash/T-bills.** No QQQ floor. |
+| Q2/Q3 | Gate model | **Power-weighted score + dual BUY/SELL thresholds, binary in/out, no sizing.** A/B tested vs the SMA gate and combinations. |
+| Q4 | Weighting | **Category-balanced** prior + per-signal power weights; equal-vs-balanced-vs-tuned A/B'd. |
+| Q5 | Breadth | **Build "% of top-N QQQ holdings above MA" in v1**, and **add it to the QQQ market-breadth dashboard** (separate deliverable). |
+| Q6 | Conviction cap | **N/A** — no sizing, so no cap. |
+| Q7 | Pullback axis | **v1 trend-only.** Pullback/oversold entries deferred to v2. |
 
 ---
 
-## 8. Why this is the right shape
+## 8. Why this shape
 
-- Uses the **candidate** edge (resonance → win-rate, pending §6.1) where it would work (sizing), not where it doesn't (timing).
-- Keeps the **best-tested** timing engine (SMA gate) untouched and responsive.
-- Generalizes your multi-signal "confirmed buy" into a tunable conviction dial.
-- Respects the constraints we established (≤66 MAs, 2020-10 window, real TQQQ, costs, no-lookahead).
-- Falsifiable: if resonance sizing doesn't beat the bare gate on Calmar **and** drawdown (§6), we don't ship it — simpler wins.
+- It's *your* model: weighted signals, one score, a buy line and a sell line, binary in/out.
+- It keeps the proven SMA gate as the explicit **bar to beat**, and A/B tests honestly instead of assuming the weighted gate wins.
+- Trend-only v1 is the simplest version that can be tested; pullback (a contrarian, opposite-direction setup) is cleanly deferred to v2.
+- Respects every constraint (≤66 MAs, 2020-10 window, real TQQQ, costs, no-lookahead) and the rigor from review (CIs, true OOS, overfit guard).
+- **Falsifiable:** if the weighted gate doesn't beat the SMA gate + buy-hold out-of-sample (§6.3), we don't ship it — simpler wins.

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -1,6 +1,6 @@
 # Design Plan — Multi-Signal Resonance for TQQQ Conviction
 
-**Status:** draft for review · **Scope:** signal-resonance layer for the TQQQ timing strategy · **Window:** 2020-10 → now (real TQQQ) · **Constraint:** no moving-average / lookback > 66 bars · **Depends on:** existing `signals/`, `backtest/` engine · **PR base:** main
+**Status:** draft for review · **Scope:** signal-resonance layer for the TQQQ timing strategy · **Window:** 2020-10 → now (real TQQQ) · **Constraint:** no moving-average / lookback > 66 bars · **Depends on:** `src/rainier/signals/`, `src/rainier/backtest/` engine · **PR base:** main
 
 ---
 
@@ -107,10 +107,12 @@ Your example — *buy TQQQ when QQQ<SMA10 AND VIX<23 AND fractal buy AND SPY<SMA
 
 | Component | Role | Where |
 |---|---|---|
-| `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `signals/panel.py` |
-| `ResonanceScorer` | panel → daily conviction score ∈ [0,1] (weighted consensus) | new `signals/resonance.py` |
-| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily target weight | new `signals/resonance_strategy.py` |
-| Daily-MTM sim | weight → equity, no lookahead, financing + costs | reuse `leveraged_common.sim` |
+| `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `src/rainier/signals/panel.py` |
+| `ResonanceScorer` | panel → daily conviction score ∈ [0,1] (weighted consensus) | new `src/rainier/signals/resonance.py` |
+| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily target weight (implements/extends the `SignalEmitter` boundary) | new `src/rainier/signals/resonance_strategy.py` |
+| Daily-MTM sim | weight → equity, no lookahead, financing + costs | `src/rainier/backtest/` (productionize the prototype in `scripts/leveraged_common.py`) |
+
+*Note: the panel signals and the daily-MTM sim currently live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`). v1 promotes them into `src/rainier/` per the module map in `CLAUDE.md`; the scripts are the reference implementation, not the shipping location.*
 
 ### 5.2 The panel (≤66 lookback, ~26 signals)
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -33,7 +33,7 @@ The win-rate rises with agreement — a promising, monotone signal. **But treat 
 
 Right now there is no integrated system — just a pile of exploratory scripts. Two things exist:
 
-- **A 26-signal panel** (`regime_signal_search.build_signals`), each emitting a daily risk-on (1) / risk-off (0) series, all with lookback ≤ 66.
+- **An exploratory signal panel** (`regime_signal_search.build_signals`), each emitting a daily risk-on (1) / risk-off (0) series. It is *unfiltered* — most members today use >66 lookback and two use expanding medians; v1 takes only its **≤66 subset** and rewrites the expanding members (see §5.2).
 - **A timing gate** — the asymmetric SMA gate (enter when QQQ > SMA22, exit when QQQ < SMA44). In-window it was the single best risk-adjusted design (Calmar ≈ 1.37, #2 of 270 in a full sweep, on a stable plateau).
 
 ```
@@ -161,7 +161,7 @@ raw resonance r[t]  ──►  (1) curve: size = clamp((r−r_lo)/(r_hi−r_lo),
                     ──►  (4) rebalance only when the held step actually changes
 ```
 
-Boot: at the first valid bar `t0`, held_step = target_step[t0] (no dwell required — there is no prior to confirm against). Moves are **direct** to the confirmed target (e.g. 0→1 in one transition once the new step holds `dwell` bars), not forced stepwise through ½. Hysteresis lives **only** here — not on the raw score (the §5.3 over-spec is removed). Deterministic and unit-testable; a test asserts a fixed input sequence yields a fixed held-step sequence.
+Boot: at the first valid bar `t0` (after the §5.5c per-member warmup), held_step = target_step[t0] — provisional, taken without confirmation since there's no prior; every *subsequent* move still requires the full `dwell`. Moves are **direct** to the confirmed target (e.g. 0→1 in one transition once the new step holds `dwell` bars), not forced stepwise through ½. The dwell counter resets whenever target_step changes value. Hysteresis lives **only** here — not on the raw score (the §5.3 over-spec is removed). Deterministic and unit-testable; a test asserts a fixed input sequence yields a fixed held-step sequence.
 
 ### 5.5 No-lookahead + costs
 
@@ -207,7 +207,7 @@ In-window per-regime numbers (2021/2022/2023-24/2025) are **descriptive only**, 
 
 | Test | Control (precisely pinned) | Pass criteria |
 |---|---|---|
-| Matched-exposure | (a) **constant** scaler = the resonance sizer's *exact* mean weight; (b) **vol-target** scaler matched on *both* mean exposure AND realized-vol budget. Both computed on the **frozen §6.2 test slice**, not re-fit. | resonance must beat the **better** of (a)/(b) on Calmar — else the "edge" is just de-levering, and we ship the simpler vol-target instead |
+| Matched-exposure | (a) **constant** scaler = the resonance sizer's *exact* mean weight; (b) **vol-target** scaler matched on *both* mean exposure AND realized-vol budget. **Per slice:** on each §6.2 OOS slice, both controls' mean is re-derived from *that slice's own* realized resonance-weight series (not carried across underlyings). | resonance must beat the **better** of (a)/(b) on Calmar **on every §6.2 OOS slice** (2023→now, pre-2010 synthetic, different-underlying) — not one cherry-picked slice. Else the "edge" is just de-levering, and we ship the simpler vol-target instead. |
 
 ### 6.4 Overfit guard (hard, not vibes)
 

--- a/docs/NOTE-resonance-as-maunakea-goal.md
+++ b/docs/NOTE-resonance-as-maunakea-goal.md
@@ -1,0 +1,60 @@
+# Note — Resonance Gate-Search as the Flagship Maunakea Trading Goal
+
+**Status:** forward-pointer (not v1 work) · **Owner of the eventual build:** the maunakea *trading wrapper* (downstream, Phase 4) · **Blocked on:** maunakea `Engine.run()` (Phase 2) + `recurse()` (Phase 3), both `NotImplementedError` today
+
+---
+
+## Why this note exists
+
+The whole TQQQ resonance investigation (10+ exploratory studies in `docs/REPORT-*.html`, scripts in `scripts/`) was me **hand-cranking** a research loop: propose a signal/gate combo → backtest → A/B vs the SMA22/44 gate → check OOS → guard against overfit → propose the next combo. **That loop is exactly what maunakea automates.** This note captures it as a ready-made goal so the trading wrapper has a real first target the day maunakea's iterate/recurse machinery exists.
+
+## Architecture reminder (so this lands in the right place)
+
+Per `~/projects/maunakea/CLAUDE.md`, maunakea core is **domain-agnostic** — CI enforces zero `rainier` references in `src/maunakea/`. Trading lives in a **downstream wrapper** (Phase 4 in maunakea's roadmap), never in core.
+
+```
+maunakea core (engine: suggest/run/recurse)  ──used by──►  trading wrapper (THIS goal)
+                                                                  │ data from / strategy to
+                                                                  ▼
+                                                              rainier (data backfill, execution, live signals)
+```
+
+- **rainier** ships the data (per `DESIGN-rainier-data-backfill-for-maunakea`) and runs the vetted gate as a live `WeightStrategy` (the v1 we're building now in `src/rainier/signals/`).
+- **The trading wrapper** points maunakea at that data with the goal below and lets the engine search recursively.
+
+## The goal spec (for the wrapper)
+
+```
+dataset: QQQ, TQQQ, SPY, VIX, IRX daily (rainier backfill) — real adjusted prices,
+         2010→now real TQQQ + synthetic 3×QQQ pre-2010 for OOS.
+
+goal:    "Find a daily entry/exit gate for TQQQ that beats the SMA22/44 gate AND
+          buy-and-hold on Calmar AND max-drawdown, out-of-sample, net of cost."
+
+hard guardrails (the wrapper must hand maunakea these as constraints, because the
+hand-search proved they're where naive results die):
+  - no moving-average / lookback > 66 bars (composed/nested span counts)
+  - no-lookahead: signal on close[t], effective t→t+1
+  - real TQQQ already embeds 3× financing — charge only turnover + cash-leg rate;
+    synthetic 3× (3·r − 2·rate − fee) ONLY pre-2010 where no real ETF exists
+  - validate on a re-derived ≤2022 train / 2023→now test AND a genuinely independent
+    slice (pre-2010 synthetic or SOXL — NOT SPXL/UPRO near-clones)
+  - de-levering is not edge: must beat a matched-exposure control
+  - deflated Sharpe over #configs tried; pre-register the final config
+
+known baseline to beat (from the hand-search):
+  asymmetric SMA22/44 gate → TQQQ/cash : in-window Calmar ≈ 1.37, full-cycle Calmar ≈ 0.34,
+  full-cycle (1999–2026) max drawdown ≈ −76%. Hard to beat. If maunakea can't, the
+  honest answer is "ship the SMA gate" — and that's a valid recursive-loop result.
+```
+
+## What "recursive" buys us here that the hand-search couldn't
+
+- **Breadth of search** — the hand-search tried ~270 SMA pairs + ~80 signal add-ons. Maunakea can sweep far wider without me getting bored or sloppy.
+- **Self-improvement** — its `meta_suggestion` learns *how to search this space better* (e.g. "stop proposing slow-MA exits, they overfit the one 2022 bear"), which is the lesson it took me ten messages to learn by hand.
+- **Honesty by construction** — the guardrails above become the engine's scoring constraints, so it can't reward a leaky/overfit result.
+
+## Status / next
+
+- **Now:** rainier builds the resonance gate v1 (the hand-found candidate) as a live strategy. See `DESIGN-multi-signal-resonance.md`.
+- **When maunakea Phase 2/3 land:** stand up the trading wrapper, hand it this goal + guardrails, and let it try to beat the v1 gate. The v1 gate becomes maunakea's first concrete "can you do better than the human?" benchmark.


### PR DESCRIPTION
Design plan for a weighted-signal entry/exit gate for TQQQ (the operator's model: power-weighted score of ~23 ≤66-lookback trend signals → BUY line / SELL line → binary in/out, cash when out). Trend-only v1; pullback deferred to v2. A/B tested against the SMA22/44 gate.

**Scope:** design doc + the maunakea-wrapper forward-note. No code yet — v1 implementation stacks on this branch.

**Locked decisions (Q1–Q7):** cash floor · weighted dual-threshold gate, no sizing · category-balanced + per-signal weights · breadth ("% top-N QQQ holdings above SMA50", point-in-time) in v1 + QQQ breadth dashboard · no cap · trend-only v1.

**Review:** multi-round codex + claude adversarial review, both gates PASS (no P0/P1). Reviewers caught and we fixed: overlapping-window stats → block-bootstrap CIs; data-snooping → re-derived OOS + true OOS; gameable A/B → anti-gaming criteria; breadth survivorship → point-in-time constituents; nested-window lookback; state-machine lookahead; financing double-count.

Files:
- `docs/DESIGN-multi-signal-resonance.md` (source of truth; `.html` render gitignored)
- `docs/NOTE-resonance-as-maunakea-goal.md` (Phase-4 trading-wrapper goal spec)

Test plan: N/A (design doc). v1 build (stacked PR) carries the tests + the §6 falsifiable evaluation.