### PR TITLE
feat(signals): Multi-Signal Resonance Gate v1 for TQQQ + §6 A/B evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ reports/tqqq_*
 # pf_btest_*.md) are NOT ignored. Rendered backtest/demo HTML + XLSX are.
 docs/*-backtest-*.html
 docs/tqqq_*.html
+docs/REPORT-resonance-gate-v1.html
 reports/*.html
 reports/*.xlsx
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -123,12 +123,9 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 
 ### 5.2 The panel (≤66 lookback)
 
-**Provenance — important:** v1 does **NOT** pin the full `regime_signal_search.build_signals` list. That list is mostly **>66** lookback (SMA100/150/200, EMA100/200, ROC120, 12-1 momentum, 90/120-day highs, slow 50/150 & 50/200 crosses) and uses **expanding** medians — both forbidden here. v1 instead:
-1. takes the **≤66 subset** of `build_signals` (the complement of the existing `BLOCK` exclusion set in `scripts/full_combo_search.py` / `leveraged_common.py`),
-2. **rewrites** its two expanding-median members to bounded windows (below),
-3. **adds** new members (SPY cross-asset, optional fractal, breadth proxy) as fresh code.
+**Provenance — important:** v1 does **NOT** pin the full `regime_signal_search.build_signals` list. That list is mostly **>66** lookback (SMA100/150/200, EMA100/200, ROC120, 12-1 momentum, 90/120-day highs, slow 50/150 & 50/200 crosses) and uses **expanding** medians — both forbidden here.
 
-The names below are the *intended* set, not a claim about the current prototype. The frozen final list + per-category counts are recorded at build time; new members (3) each count against the §6.4 parameter budget.
+**The enumerated list below IS the single source of truth** for the v1 panel (the resonance denominator and category counts derive from it — nothing else). It was *seeded* from the ≤66 subset of `build_signals` (the complement of the `BLOCK` set in `scripts/full_combo_search.py`), then deliberately **deduplicated** — keep one threshold per indicator (RSI>50, drop RSI>55; VIX<25, drop VIX<20/<30; one of ADX/+DI) so no single indicator is triple-counted in the consensus — with two expanding-median members **rewritten** to bounded form and `price>SMA66` **added**. So the list is *not* identical to the raw BLOCK-complement; where prose and the list disagree, **the list wins**. New members (SPY cross-asset, optional fractal, breadth proxy) are fresh code and each count against the §6.4 parameter budget. The frozen list is recorded verbatim at build time.
 
 - **Trend** (from ≤66 subset): price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
 - **Momentum** (from ≤66 subset): RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -98,9 +98,9 @@ v1 is **not** that naive version. Two differences, both of which we **A/B test**
 | `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `src/rainier/signals/panel.py` |
 | `ResonanceScorer` | panel + per-signal weights → daily score ∈ [0,1] | new `src/rainier/signals/resonance.py` |
 | `ResonanceGate` | dual-threshold state machine → daily **per-asset target weights** {TQQQ} | new `src/rainier/signals/resonance_gate.py` |
-| Daily-MTM sim | per-asset weights → equity, no lookahead, costs | `src/rainier/backtest/` (productionize `scripts/leveraged_common.py`) |
+| Daily-MTM sim | per-asset weights → equity, no lookahead, costs | `src/rainier/backtest/` (productionize `run_portfolio` from `scripts/regime_switch_study.py` — the per-asset variant; `leveraged_common.sim` is its scalar single-asset cousin) |
 
-**New boundary — NOT `SignalEmitter`.** `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades); the current engine consumes discrete trades and can't represent a held daily weight. v1 adds a **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily per-asset weight series` (a dict like `{TQQQ: 0 or 1}`, weights ≥0 summing ≤1, remainder cash). Per-asset (not a bare boolean) so a future non-cash risk-off is representable without a redesign; matches the existing `run_portfolio` sim, which already takes a per-asset weights dict. Additive: it doesn't touch `SignalEmitter` or the discrete-trade engine.
+**New boundary — NOT `SignalEmitter`.** `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades); the current engine consumes discrete trades and can't represent a held daily weight. v1 adds a **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily per-asset weight series` (a dict like `{TQQQ: 0 or 1}`, weights ≥0 summing ≤1, remainder cash). Per-asset (not a bare boolean) so a future non-cash risk-off is representable without a redesign; matches the existing **`run_portfolio`** sim (`scripts/regime_switch_study.py`), which already takes a per-asset weights dict (`{asset: series}`). Additive: it doesn't touch `SignalEmitter` or the discrete-trade engine.
 
 *Reference artifacts (local, NOT committed in this PR): the panel + sim live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`, `scripts/full_combo_search.py`, `scripts/resonance_study.py`). Numbers in this doc are exploratory, reproduced via those scripts. v1's **first step** is to promote them into `src/rainier/` (committed) per the `CLAUDE.md` module map.*
 
@@ -129,13 +129,13 @@ v1 is **trend-only** (Q7) — every member is a *risk-on / uptrend-confirming* s
 ### 5.4 The dual-threshold gate (state machine)
 
 ```
-score r[t]  ──►  if state==CASH  and r[t] ≥ BUY  → state = TQQQ (enter at close)
-            ──►  if state==TQQQ  and r[t] ≤ SELL → state = CASH (sell all)
+score r[t]  ──►  if state==CASH  and r[t] ≥ BUY  → state := TQQQ
+            ──►  if state==TQQQ  and r[t] ≤ SELL → state := CASH
             ──►  else                            → hold state
        BUY > SELL ; the gap is the hysteresis band.
 ```
 
-Boot: at the first valid bar `t0` (after the §5.5c per-member warmup), state = TQQQ if `r[t0] ≥ BUY` else CASH. Deterministic and unit-testable — a fixed score sequence yields a fixed state sequence; a test asserts it. No second hysteresis layer, no sizing curve.
+`state[t]` is decided on **close[t]** and is **effective on the t→t+1 return** (the +1 shift in §5.5) — no same-close execution, no lookahead. Boot: at the first valid bar `t0` (after the §5.5c per-member warmup), state = TQQQ if `r[t0] ≥ BUY` else CASH. Deterministic and unit-testable — a fixed score sequence yields a fixed state sequence; a test asserts it. No second hysteresis layer, no sizing curve.
 
 ### 5.5 No-lookahead + costs
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -14,7 +14,7 @@ We call the agreement of many signals **resonance**: when lots of independent in
 
 ### What the data *suggests* (a lead, not yet proof)
 
-Across 2020-10 → now we bucketed every day by how many of a 26-signal panel agreed, then looked at TQQQ's *next 20 days*:
+Across 2020-10 → now we bucketed every day by how many of a 26-signal *exploratory* panel agreed (the ≤66 subset of `build_signals` + SPY, as in `scripts/resonance_study.py`), then looked at TQQQ's *next 20 days*. (v1 freezes a slightly different ~22-member panel — §5.2 — so the resonance **denominator is the frozen count**, never a hardcoded 26.)
 
 ```
  signals agreeing →  win-rate of the next 20 days
@@ -73,7 +73,7 @@ Separate **timing** from **conviction**:
 
 ```
 LAYER 1 — TIMING (fast):        LAYER 2 — CONVICTION (resonance):
-  asymmetric SMA22/44 gate         consensus of the 26-signal panel
+  asymmetric SMA22/44 gate         consensus of the ≤66-lookback panel (§5.2)
   decides IN vs OUT of TQQQ        decides HOW BIG when in
         │                                  │
         └──────────────┬───────────────────┘
@@ -132,7 +132,7 @@ The names below are the *intended* set, not a claim about the current prototype.
 
 - **Trend** (from ≤66 subset): price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
 - **Momentum** (from ≤66 subset): RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
-- **Volatility** (rewritten): realizedVol(20) < its **rolling-40 median** (20+40 = 60 *total* span), ATR%(14) < its rolling-46 median, VIX<25, VIX<SMA20, VIX-falling. *(Replaces the prototype's `expanding(60).median()` — an expanding window has unbounded lookback.)*
+- **Volatility** (rewritten): realizedVol(20, rolling std) < its **rolling-40 median** (20+40 = 60, both finite), ATR%(14, **simple rolling mean** of true range — *not* Wilder/EWMA) < its rolling-46 median (14+46 = 60, both finite), VIX<25, VIX<SMA20, VIX-falling. *(Replaces the prototype's `expanding(60).median()` AND its Wilder-EWMA `atr_pct` — both have unbounded lookback; the finite-window invariant §5.5(b) requires simple rolling forms here.)*
 - **Structure** (from ≤66 subset): within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
 - **Cross-asset** (NEW code): SPY>SMA22, SPY>SMA44 — `build_signals(qqq, vix)` takes no SPY today; v1 adds an SPY input.
 - **(NEW, optional)** fractal:simple_turn — not in `build_signals`; added if Q7 says so.

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -115,7 +115,7 @@ v1 is **trend-only** (Q7) — every member is a *risk-on / uptrend-confirming* s
 - **Volatility:** realizedVol(20, rolling std) < its **rolling-40 median** (20+40 = 60, finite), ATR%(14, **simple rolling mean** of true range, *not* Wilder/EWMA) < its rolling-46 median (14+46 = 60), VIX<25, VIX<SMA20, VIX-falling. *(Replaces the prototype's `expanding(60).median()` and EWMA `atr_pct` — both unbounded.)*
 - **Structure:** within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
 - **Cross-asset:** SPY>SMA22, SPY>SMA44 (NEW code — `build_signals(qqq, vix)` takes no SPY today; v1 adds an SPY input).
-- **Breadth (NEW, in v1 — Q5):** **% of top-N QQQ holdings above their SMA** — the closest proxy to "market breadth" (yfinance has no breadth index). Built in v1, and **also surfaced on the QQQ market-breadth dashboard** (separate deliverable, §7).
+- **Breadth (NEW, in v1 — Q5):** **% of top-N QQQ holdings above their SMA50** (the SMA period is pinned ≤66, *not* the conventional 200-day, to honor the cap). Two hard requirements: (1) use **point-in-time** constituents — computing "% above MA" from *today's* holdings on *past* dates leaks survivorship bias into the score; if point-in-time holdings aren't available, use a **frozen ex-ante universe** and **exclude breadth from the OOS claims** in §6.2. (2) it's a finite-window member (SMA50 over a fixed universe), counted in the §5.5 invariant. Built in v1, and **also surfaced on the QQQ market-breadth dashboard** (separate deliverable, §7).
 
 *Every member's **composed/total** lookback ≤ 66 (a 20-day measure vs a 40-day median = 60, not "66 because the outer window is 66"). Finite-window members have exact composed support ≤66; EMA-family members (EMA, RSI, MACD, ADX) have bounded effective memory (invariant in §5.5).*
 
@@ -123,7 +123,7 @@ v1 is **trend-only** (Q7) — every member is a *risk-on / uptrend-confirming* s
 
 `resonance[t] = Σ wᵢ · signalᵢ[t] / Σ wᵢ` ∈ [0,1] — the **power-weighted** fraction risk-on.
 
-- **Per-signal power weights `wᵢ`** (Q2) — a strong signal moves the score more. Default prior = **category-balanced** (Q4): the 5 categories weighted equally, split within, so the many trend signals don't make the score really mean "trend ×4." Beyond that prior, weights are a **swept/tested** config (capped per §6.4 — every free weight is overfit risk on a tiny sample).
+- **Per-signal power weights `wᵢ`** (Q2) — a strong signal moves the score more. Default prior = **category-balanced** (Q4): the **6 categories** (Trend, Momentum, Volatility, Structure, Cross-asset, Breadth) weighted equally, split within, so the many trend signals don't make the score really mean "trend ×4." Beyond that prior, weights are a **swept/tested** config (capped per §6.4 — every free weight is overfit risk on a tiny sample).
 - A/B includes **equal-weight vs category-balanced vs tuned** weights to confirm weighting actually helps (Q4: "testing can tell us more").
 
 ### 5.4 The dual-threshold gate (state machine)
@@ -145,7 +145,7 @@ Every input (TQQQ, QQQ, SPY, VIX, breadth) uses its **close[t]** value; the scor
 
 **Leakage test:** inject a known future spike into bar *t+1*; assert state[t] is unchanged across all inputs.
 
-**Lookback invariant:** the **composed/total** lookback of every member ≤ 66, no expanding windows. "Composed" matters for *nested* indicators (realizedVol(20) into a rolling-k median has span 20+k, so k ≤ 46). *Finite-window* members (SMA, rolling-median, Donchian, ROC, rewritten nested-vol) have exact composed support ≤66; *EMA-family* (EMA, RSI, MACD, ADX) have bounded effective memory. Tests: (a) every composed span ≤66; (b) finite-window signals bit-identical when history before *t−66* dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX double-smoothed, MACD-hist EMAs-of-EMAs) and set the buffer from the *slowest* member. The two prototype `expanding(60).median()` members fail test (b) and **must** be rewritten — required, not optional.
+**Lookback invariant:** the **composed/total** lookback of every member ≤ 66, no expanding windows. "Composed" matters for *nested* indicators (realizedVol(20) into a rolling-k median has span 20+k, so k ≤ 46). *Finite-window* members (SMA, rolling-median, Donchian, ROC, rewritten nested-vol, breadth-%-above-SMA50) have exact composed support ≤66; *EMA-family* (EMA, RSI, MACD, ADX) have bounded effective memory. Tests: (a) every composed span ≤66; (b) finite-window signals bit-identical when history before *t−66* dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX double-smoothed, MACD-hist EMAs-of-EMAs), take the *slowest* member, and **freeze that as a pre-registered integer constant** (e.g. WARMUP_BARS=150) — the warmup must NOT shift with data, or `t0` moves run-to-run; the determinism test asserts `t0` is data-independent. The two prototype `expanding(60).median()` members fail test (b) and **must** be rewritten — required, not optional.
 
 ### 5.6 Config (and what is NOT swept)
 
@@ -167,15 +167,17 @@ The gate, panel, weights, and thresholds were all discovered on 2020-10→now. F
 
 | Test | Protocol | Pass criteria |
 |---|---|---|
-| Re-derived split | Re-run the **entire** selection (panel, weights, BUY/SELL thresholds, combination mode) on **only ≤2022-12** data — discard prior picks — report **once** on 2023→now | edge persists. If impractical, 2023→now is **descriptive only** and the row below is load-bearing. |
+| Re-derived split (**mandatory**) | Re-run the **entire** selection (panel, weights, BUY/SELL thresholds, combination mode) on **only ≤2022-12** data — discard prior picks — report **once** on 2023→now | edge persists on the held-out slice |
 | **True OOS** (load-bearing) | run the frozen config on **synthetic 3× QQQ pre-2010** (dot-com + GFC) and a **different leveraged underlying** | edge survives on data that informed no choice |
+
+The re-derived split is **required**, not optional — the True-OOS row alone (synthetic + a near-clone underlying) is **not sufficient** to ship. Minimum to ship: the re-derived 2023→now slice **plus** ≥1 genuinely independent True-OOS slice (pre-2010 synthetic or SOXL — *not* SPXL/UPRO, which §6.2 flags as near-clones).
 
 For a different underlying, the signal source **switches** to that underlying's own inputs. **SPXL/UPRO are near-clones** of the QQQ trade → weak evidence; **SOXL (semis)** is genuinely different → stronger. For pre-2010 synthetic, **pre-register** the cost params (`rate` = historical 3-month T-bill *series*; `fee` fixed) and report drawdown sensitivity to ±50 bps fee. In-window per-regime numbers are **descriptive only**.
 
 ### 6.3 The A/B — does the weighted gate actually beat the simple one?
 | Test | Comparators (all on the §6.2 OOS slices) | Pass criteria |
 |---|---|---|
-| Gate A/B | resonance-gate · SMA22/44-gate · (resonance AND SMA) · (resonance OR SMA) · buy-hold TQQQ · buy-hold QQQ | the resonance-gate (or a combination) must beat the **SMA22/44 gate AND buy-hold** on Calmar **and** drawdown, on **every** OOS slice. If the plain SMA gate wins, **ship the SMA gate** and stop. |
+| Gate A/B | resonance-gate · SMA22/44-gate · (resonance AND SMA) · (resonance OR SMA) · buy-hold TQQQ · buy-hold QQQ | the resonance-gate (or a combination) must beat the **SMA22/44 gate AND buy-hold** on Calmar **and** drawdown, on **every** required OOS slice (§6.2). **Anti-gaming:** a *combination* (AND/OR) winner must ALSO (i) beat its own SMA-only component, and (ii) the **resonance-only** gate must itself beat buy-hold on ≥1 slice — otherwise the weighted score isn't carrying signal, the combination is just the SMA gate in disguise, and the conclusion is **ship the SMA gate**. |
 | Weighting A/B | equal-weight vs category-balanced vs tuned weights | weighting must measurably help, else use equal weights (simpler) |
 
 ### 6.4 Overfit guard (hard, not vibes)

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -116,7 +116,7 @@ Your example — *buy TQQQ when QQQ<SMA10 AND VIX<23 AND fractal buy AND SPY<SMA
 
 - **Trend:** price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
 - **Momentum:** RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
-- **Volatility:** realizedVol<expanding-median, ATR%<median, VIX<25, VIX<SMA20, VIX-falling.
+- **Volatility:** realizedVol<rolling-66 median, ATR%<rolling-66 median, VIX<25, VIX<SMA20, VIX-falling. *(Use a bounded 66-bar rolling median, NOT an expanding median — an expanding window grows past the 66-bar cap and would violate the constraint.)*
 - **Structure:** within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
 - **Cross-asset:** SPY>SMA22, SPY>SMA44 (broad-market confirm).
 - **(Optional)** fractal:simple_turn as a momentum/structure member.
@@ -138,6 +138,8 @@ Your example — *buy TQQQ when QQQ<SMA10 AND VIX<23 AND fractal buy AND SPY<SMA
 ### 5.5 No-lookahead + costs
 
 Signals computed on close[t]; target weight applied to t+1 return (shift +1). Warmup buffer: load from 2019-06 so every ≤66 signal is valid by 2020-10; **measure only over 2020-10 → now** (real TQQQ). Charge turnover cost on size changes; cash earns the 13-week T-bill.
+
+**Lookback invariant:** every panel signal must use a *bounded* window ≤ 66 bars — no expanding/all-history windows (medians, z-scores, percentiles included). A unit test asserts each signal's first valid index ≤ 66 and that its value at bar *t* is unchanged when history before *t−66* is truncated.
 
 ### 5.6 Config (sweepable)
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -1,0 +1,181 @@
+# Design Plan — Multi-Signal Resonance for TQQQ Conviction
+
+**Status:** draft for review · **Scope:** signal-resonance layer for the TQQQ timing strategy · **Window:** 2020-10 → now (real TQQQ) · **Constraint:** no moving-average / lookback > 66 bars · **Depends on:** existing `signals/`, `backtest/` engine · **PR base:** main
+
+---
+
+## 1. The problem, in plain English
+
+We want to buy TQQQ (3× Nasdaq-100) **only when we're confident**, and size the bet to that confidence. A single indicator — "price is above its 44-day average" — flips in and out on every wiggle and gives plenty of false buys. We have *dozens* of signals (trend, momentum, volatility, structure). The question this plan answers:
+
+> **How do we combine many signals into one "conviction score" so that more agreement → more confidence → a bigger, higher-win-rate bet — without the lag that killed naive consensus voting?**
+
+We call the agreement of many signals **resonance**: when lots of independent indicators all say "risk-on" at once, that's a stronger, more trustworthy signal than any one of them alone.
+
+### What we already proved (so this isn't a guess)
+
+Across 2020-10 → now we bucketed every day by how many of a 26-signal panel agreed, then looked at TQQQ's *next 20 days*:
+
+```
+ signals agreeing →  win-rate of the next 20 days
+   0–20%               48%   (coin flip)
+  20–40%               59%
+  40–60%               60%
+  60–80%               61%
+  80–100%              62%   ← most agreement = highest win-rate
+```
+
+**Resonance is real: more agreement genuinely raises the win-rate (48% → 62%).** That is the empirical foundation of this design. One nuance we also found: the *biggest forward returns* come at **60–80%** agreement (a building consensus, early in a move), not at 100% (which tends to be mid-trend, after the easy money). So conviction should reward *strong* consensus but not blindly chase *unanimous* consensus.
+
+---
+
+## 2. How it works today
+
+Right now there is no integrated system — just a pile of exploratory scripts. Two things exist:
+
+- **A 26-signal panel** (`regime_signal_search.build_signals`), each emitting a daily risk-on (1) / risk-off (0) series, all with lookback ≤ 66.
+- **A timing gate** — the asymmetric SMA gate (enter when QQQ > SMA22, exit when QQQ < SMA44). In-window it was the single best risk-adjusted design (Calmar ≈ 1.37, #2 of 270 in a full sweep, on a stable plateau).
+
+```
+TODAY:  one signal  ──►  in/out of TQQQ at full size
+        (e.g. price>SMA44)         (binary, no notion of confidence)
+```
+
+There is **no concept of conviction or position size** — every trade is all-or-nothing, and the dozens of other signals are unused.
+
+---
+
+## 3. What goes wrong (why we don't just "vote")
+
+The obvious idea — *be in TQQQ when ≥70% of signals agree, else cash* — we tested. **It underperforms the simple gate** (Calmar 0.20 vs 0.34 full-cycle; worse in-window too). Why:
+
+```
+THE LAG TRAP:
+   price ────╲                      ╱──── recovery
+              ╲                    ╱
+   gate exits  ╲__________________╱   gate re-enters (fast)
+                  ▲              ▲
+   votes flip   LATE           LATE   ← consensus needs many signals to flip;
+   risk-off  (already down)  (misses the bounce)
+```
+
+- **Entering on consensus lags the bottom:** by the time 70% of signals turn risk-on, the rebound is half over.
+- **Exiting on consensus lags the top:** the drawdown is already eaten before enough signals flip.
+- Consensus voting flips *less* (less whipsaw) but each move is *late*, so it has higher win-rate yet **worse risk-adjusted return**.
+
+**Lesson: resonance is good at measuring *confidence*, bad at deciding *timing*.** The fast SMA gate is the opposite — good timing, no confidence. The design uses each for what it's good at.
+
+---
+
+## 4. The fix — a two-layer design
+
+Separate **timing** from **conviction**:
+
+```
+LAYER 1 — TIMING (fast):        LAYER 2 — CONVICTION (resonance):
+  asymmetric SMA22/44 gate         consensus of the 26-signal panel
+  decides IN vs OUT of TQQQ        decides HOW BIG when in
+        │                                  │
+        └──────────────┬───────────────────┘
+                       ▼
+            position size = gate_on × size(resonance)
+```
+
+- **Layer 1 (gate)** answers *"should I be in TQQQ at all right now?"* — fast, responsive, the proven timing engine. When the gate is OFF → cash (T-bills). No lag penalty on timing.
+- **Layer 2 (resonance)** answers *"how convinced am I?"* — when the gate is ON, scale the position by the conviction score. High resonance (many signals agree) → full 3× exposure. Weak resonance (signals split) → reduced exposure (e.g. partial TQQQ + cash, or 1× QQQ).
+
+This directly uses the confirmed 48%→62% win-rate edge as a **sizing** signal, where lag doesn't hurt, instead of a **timing** signal, where it does.
+
+### Your "confirmed buy" idea fits here
+
+Your example — *buy TQQQ when QQQ<SMA10 AND VIX<23 AND fractal buy AND SPY<SMA10 AND breadth<30%* — is exactly a **high-conviction entry**: a cluster of signals resonating. In this design that's not a separate rule; it's the **high end of the resonance score**. A confirmed buy = gate ON **and** resonance above a high threshold → full size. The design generalizes your 5-signal idea into a tunable conviction dial across the whole panel.
+
+### What it looks like day to day
+
+```
+  gate OFF                         → 0% TQQQ (cash, earning T-bills)
+  gate ON, resonance 50–65%        → reduced size (e.g. 40–60% TQQQ)
+  gate ON, resonance 65–80%        → full size      (peak-return zone)
+  gate ON, resonance > 80%         → full size, but capped (don't chase unanimity)
+```
+
+---
+
+## 5. Implementation detail (for engineers)
+
+### 5.1 Components
+
+| Component | Role | Where |
+|---|---|---|
+| `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `signals/panel.py` |
+| `ResonanceScorer` | panel → daily conviction score ∈ [0,1] (weighted consensus) | new `signals/resonance.py` |
+| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily target weight | new `signals/resonance_strategy.py` |
+| Daily-MTM sim | weight → equity, no lookahead, financing + costs | reuse `leveraged_common.sim` |
+
+### 5.2 The panel (≤66 lookback, ~26 signals)
+
+- **Trend:** price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
+- **Momentum:** RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
+- **Volatility:** realizedVol<expanding-median, ATR%<median, VIX<25, VIX<SMA20, VIX-falling.
+- **Structure:** within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
+- **Cross-asset:** SPY>SMA22, SPY>SMA44 (broad-market confirm).
+- **(Optional)** fractal:simple_turn as a momentum/structure member.
+- **(Gap)** market breadth (% NDX above its MA) — not in yfinance; needs a proxy (compute "% of top-N QQQ holdings above their SMA"). Tracked as a follow-up, not v1-blocking.
+
+### 5.3 Scoring
+
+`resonance[t] = Σ wᵢ · signalᵢ[t] / Σ wᵢ` — weighted fraction risk-on.
+
+- **Category-balanced weights** so one over-represented family (we have many trend signals) doesn't dominate: weight each of the 5 categories equally, split within. Avoids "resonance" really being "trend, four times."
+- **Hysteresis** on the score feeding any threshold, to avoid size chatter at the boundary.
+
+### 5.4 Sizing curve (gate-ON only)
+
+`size(r)` maps resonance → target TQQQ fraction, clamped [0, 1]:
+- piecewise: `0` below `r_lo` (≈0.5), ramp to `1` by `r_hi` (≈0.7), flat `1` above (cap — don't over-size unanimity).
+- turnover-aware: round size to coarse steps (e.g. 0/0.5/1.0) so it doesn't rebalance daily and bleed cost.
+
+### 5.5 No-lookahead + costs
+
+Signals computed on close[t]; target weight applied to t+1 return (shift +1). Warmup buffer: load from 2019-06 so every ≤66 signal is valid by 2020-10; **measure only over 2020-10 → now** (real TQQQ). Charge turnover cost on size changes; cash earns the 13-week T-bill.
+
+### 5.6 Config (sweepable)
+
+`panel members · per-category weights · gate (entry/exit SMA) · sizing curve (r_lo, r_hi, steps) · hysteresis band · rebalance granularity`.
+
+---
+
+## 6. Test plan
+
+| Test | Input | Expected / pass criteria |
+|---|---|---|
+| Thesis (sanity) | resonance buckets × fwd-20d TQQQ | win-rate rises with resonance (reproduce 48→62%) |
+| Strategy backtest | 2020-10→now, real TQQQ | beats SMA22/44-gate baseline on Calmar **and** drawdown, or it's not worth the complexity |
+| Sizing ablation | full-size gate vs resonance-sized | resonance sizing improves Calmar / cuts drawdown at similar return |
+| Per-regime | 2021 bull / 2022 bear / 2023-24 / 2025 | smaller drawdown in 2022 & 2025 than the bare gate |
+| Walk-forward | 60/40 split in-window | sized strategy's edge survives OOS split |
+| Cost/turnover | sweep rebalance granularity | net edge survives realistic cost; switches stay sane |
+| Baseline floor | vs buy-hold TQQQ & QQQ | must beat both risk-adjusted |
+
+**Honesty rails (carried from prior work):** one real bear (2022) in this window — sub-20% drawdown here is optimistic; the bare gate's *full-cycle* drawdown was −76%. Report in-window numbers as in-window. No single-best-cell worship; prefer plateaus.
+
+---
+
+## 7. Open decisions (need your call)
+
+- **Q1 — Risk-off floor:** when the gate is OFF, hold **cash/T-bills** (max safety) or **1× QQQ** (stay exposed)? Prior tests: cash was cleaner; QQQ-floor lifted return but raised drawdown.
+- **Q2 — Sizing granularity:** continuous size = f(resonance), or coarse **steps** (0 / ½ / full) to cut turnover? Steps are simpler and cheaper; continuous is smoother.
+- **Q3 — Does resonance also gate entry, or only size?** Pure design: gate=timing, resonance=size only. Your "confirmed buy" instinct suggests *also* requiring a minimum resonance to enter at all (veto low-conviction). Include the veto, or keep layers clean?
+- **Q4 — Panel weighting:** equal-per-signal (simple) or **category-balanced** (so trend doesn't dominate)? I lean category-balanced.
+- **Q5 — Breadth proxy now or later?** Build the "% of top QQQ holdings above MA" breadth signal for v1, or ship v1 without it and add later?
+- **Q6 — Max conviction cap:** cap size at full 3× TQQQ, or allow a *defensive* sub-full mode (e.g. never exceed 1× in the first N days after a regime flip)?
+
+---
+
+## 8. Why this is the right shape
+
+- Uses the **proven** edge (resonance → win-rate) where it works (sizing), not where it doesn't (timing).
+- Keeps the **proven** timing engine (SMA gate) untouched and responsive.
+- Generalizes your multi-signal "confirmed buy" into a tunable conviction dial.
+- Respects the constraints we established (≤66 MAs, 2020-10 window, real TQQQ, costs, no-lookahead).
+- Falsifiable: if resonance sizing doesn't beat the bare gate on Calmar **and** drawdown (§6), we don't ship it — simpler wins.

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -86,9 +86,14 @@ LAYER 1 — TIMING (fast):        LAYER 2 — CONVICTION (resonance):
 
 This directly uses the confirmed 48%→62% win-rate edge as a **sizing** signal, where lag doesn't hurt, instead of a **timing** signal, where it does.
 
-### Your "confirmed buy" idea fits here
+### Your "confirmed buy" is a *second* axis — pullback resonance
 
-Your example — *buy TQQQ when QQQ<SMA10 AND VIX<23 AND fractal buy AND SPY<SMA10 AND breadth<30%* — is exactly a **high-conviction entry**: a cluster of signals resonating. In this design that's not a separate rule; it's the **high end of the resonance score**. A confirmed buy = gate ON **and** resonance above a high threshold → full size. The design generalizes your 5-signal idea into a tunable conviction dial across the whole panel.
+A distinction the design must respect: your example — *QQQ<SMA10 AND SPY<SMA10 AND breadth<30% AND VIX<23 AND fractal buy* — is built from **oversold / pullback** conditions (price *below* short MAs, washed-out breadth). The trend-resonance score above counts *risk-on* signals (price *above* MAs), so this exact cluster would score **low**, not high. They are two different axes:
+
+- **Trend resonance** — "the uptrend is broadly confirmed" (price above MAs, momentum positive, vol calm). Drives Layer-2 **sizing**.
+- **Pullback resonance** — "an oversold dip is bottoming *inside* an uptrend" (price below SMA10, breadth washed out, fractal turn, VIX not panicked). A separate **entry** trigger for buying the dip.
+
+v1 models your confirmed-buy as an **optional pullback sub-score / alternate entry**, regime-gated (only buy dips while a slower trend filter is still up — don't catch knives in a real bear), **not** as the high end of trend resonance. Richer, and an open decision (Q7).
 
 ### What it looks like day to day
 
@@ -109,8 +114,10 @@ Your example — *buy TQQQ when QQQ<SMA10 AND VIX<23 AND fractal buy AND SPY<SMA
 |---|---|---|
 | `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `src/rainier/signals/panel.py` |
 | `ResonanceScorer` | panel → daily conviction score ∈ [0,1] (weighted consensus) | new `src/rainier/signals/resonance.py` |
-| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily target weight (implements/extends the `SignalEmitter` boundary) | new `src/rainier/signals/resonance_strategy.py` |
-| Daily-MTM sim | weight → equity, no lookahead, financing + costs | `src/rainier/backtest/` (productionize the prototype in `scripts/leveraged_common.py`) |
+| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily **target-weight series** ∈ [0,1] | new `src/rainier/signals/resonance_strategy.py` |
+| Daily-MTM sim | weight series → equity, no lookahead, financing + costs | `src/rainier/backtest/` (productionize the prototype in `scripts/leveraged_common.py`) |
+
+**New boundary — NOT `SignalEmitter`.** The existing `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades) and the current engine consumes discrete trades — it *cannot* represent a continuously-sized daily weight. v1 introduces a distinct **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily target-weight series ∈ [0,1]` — plus a weight-consuming backtest path (the daily-MTM sim). This is **additive**: it does not change `SignalEmitter` or the discrete-trade engine, which keep serving the pin-bar/fractal strategies.
 
 *Note: the panel signals and the daily-MTM sim currently live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`). v1 promotes them into `src/rainier/` per the module map in `CLAUDE.md`; the scripts are the reference implementation, not the shipping location.*
 
@@ -173,6 +180,7 @@ Signals computed on close[t]; target weight applied to t+1 return (shift +1). Wa
 - **Q4 — Panel weighting:** equal-per-signal (simple) or **category-balanced** (so trend doesn't dominate)? I lean category-balanced.
 - **Q5 — Breadth proxy now or later?** Build the "% of top QQQ holdings above MA" breadth signal for v1, or ship v1 without it and add later?
 - **Q6 — Max conviction cap:** cap size at full 3× TQQQ, or allow a *defensive* sub-full mode (e.g. never exceed 1× in the first N days after a regime flip)?
+- **Q7 — Pullback axis in v1?** Include the second (pullback/oversold) conviction axis — your confirmed-buy idea — in v1, or ship trend-resonance sizing first and add pullback entries in v2? Needs the breadth proxy (Q5) to be at its best.
 
 ---
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -81,10 +81,10 @@ LAYER 1 — TIMING (fast):        LAYER 2 — CONVICTION (resonance):
             position size = gate_on × size(resonance)
 ```
 
-- **Layer 1 (gate)** answers *"should I be in TQQQ at all right now?"* — fast, responsive, the proven timing engine. When the gate is OFF → cash (T-bills). No lag penalty on timing.
+- **Layer 1 (gate)** answers *"should I be in TQQQ at all right now?"* — fast, responsive, the best-tested timing engine so far. When the gate is OFF → cash (T-bills). No lag penalty on timing.
 - **Layer 2 (resonance)** answers *"how convinced am I?"* — when the gate is ON, scale the position by the conviction score. High resonance (many signals agree) → full 3× exposure. Weak resonance (signals split) → reduced exposure (e.g. partial TQQQ + cash, or 1× QQQ).
 
-This directly uses the confirmed 48%→62% win-rate edge as a **sizing** signal, where lag doesn't hurt, instead of a **timing** signal, where it does.
+This uses the **candidate** 48%→62% win-rate edge (pending §6.1 significance) as a **sizing** signal, where lag doesn't hurt, instead of a **timing** signal, where it does.
 
 ### Your "confirmed buy" is a *second* axis — pullback resonance
 
@@ -123,17 +123,22 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 
 ### 5.2 The panel (≤66 lookback)
 
-*The exact membership and per-category counts are **pinned from `regime_signal_search.build_signals`** at build time (the prototype's real list), not the prose below — the "~26" figure is provisional and the breadth "(Gap)" / "(Optional)" members are excluded until added. Category-balanced weighting (§5.3) depends on the final per-category counts, so v1 records the frozen list explicitly.*
+**Provenance — important:** v1 does **NOT** pin the full `regime_signal_search.build_signals` list. That list is mostly **>66** lookback (SMA100/150/200, EMA100/200, ROC120, 12-1 momentum, 90/120-day highs, slow 50/150 & 50/200 crosses) and uses **expanding** medians — both forbidden here. v1 instead:
+1. takes the **≤66 subset** of `build_signals` (the complement of the existing `BLOCK` exclusion set in `scripts/full_combo_search.py` / `leveraged_common.py`),
+2. **rewrites** its two expanding-median members to bounded windows (below),
+3. **adds** new members (SPY cross-asset, optional fractal, breadth proxy) as fresh code.
 
-- **Trend:** price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
-- **Momentum:** RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
-- **Volatility:** realizedVol<rolling-66 median, ATR%<rolling-66 median, VIX<25, VIX<SMA20, VIX-falling. *(Use a bounded 66-bar rolling median, NOT an expanding median — an expanding window grows past the 66-bar cap and would violate the constraint.)*
-- **Structure:** within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
-- **Cross-asset:** SPY>SMA22, SPY>SMA44 (broad-market confirm).
-- **(Optional)** fractal:simple_turn as a momentum/structure member.
-- **(Gap)** market breadth (% NDX above its MA) — not in yfinance; needs a proxy (compute "% of top-N QQQ holdings above their SMA"). Tracked as a follow-up, not v1-blocking.
+The names below are the *intended* set, not a claim about the current prototype. The frozen final list + per-category counts are recorded at build time; new members (3) each count against the §6.4 parameter budget.
 
-*Every member's controlling parameter (window / EMA-span / period) is ≤ 66. Finite-window members (SMA, rolling-median, Donchian, ROC) have exact support ≤66; EMA-family members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — theoretically infinite tail but bounded **effective** memory (see the invariant in §5.5).*
+- **Trend** (from ≤66 subset): price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
+- **Momentum** (from ≤66 subset): RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
+- **Volatility** (rewritten): realizedVol(20) < its **rolling-40 median** (20+40 = 60 *total* span), ATR%(14) < its rolling-46 median, VIX<25, VIX<SMA20, VIX-falling. *(Replaces the prototype's `expanding(60).median()` — an expanding window has unbounded lookback.)*
+- **Structure** (from ≤66 subset): within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
+- **Cross-asset** (NEW code): SPY>SMA22, SPY>SMA44 — `build_signals(qqq, vix)` takes no SPY today; v1 adds an SPY input.
+- **(NEW, optional)** fractal:simple_turn — not in `build_signals`; added if Q7 says so.
+- **(Gap)** market breadth (% NDX above its MA) — not in yfinance; proxy = "% of top-N QQQ holdings above their SMA". Follow-up, not v1-blocking.
+
+*Every member's **composed/total** lookback is ≤ 66 — a 20-day measure compared to a 40-day median counts as 60, not "66 because the outer window is 66." Finite-window members have exact composed support ≤66; EMA-family members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — infinite tail in theory, bounded **effective** memory (invariant in §5.5).*
 
 ### 5.3 Scoring
 
@@ -148,14 +153,15 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 
 ```
 raw resonance r[t]  ──►  (1) curve: size = clamp((r−r_lo)/(r_hi−r_lo), 0, 1)
-                    ──►  (2) round to coarse step ∈ {0, ½, 1}
-                    ──►  (3) hysteresis ON THE STEPPED VALUE: only change the
-                              held step if the new step differs by ≥1 level AND
-                              persists ≥ `dwell` bars  (one place, applied last)
-                    ──►  (4) rebalance only when the held step changes
+                    ──►  (2) round to coarse step ∈ {0, ½, 1}  → target_step[t]
+                    ──►  (3) hysteresis: the HELD step moves to target_step[t]
+                              only after target_step has held the SAME new value
+                              for ≥ `dwell` consecutive bars; otherwise the held
+                              step is carried forward unchanged
+                    ──►  (4) rebalance only when the held step actually changes
 ```
 
-Hysteresis lives **only** at step (3), on the rounded step — not on the raw score (that was the §5.3 over-spec; remove it there). This makes the path deterministic and unit-testable.
+Boot: at the first valid bar `t0`, held_step = target_step[t0] (no dwell required — there is no prior to confirm against). Moves are **direct** to the confirmed target (e.g. 0→1 in one transition once the new step holds `dwell` bars), not forced stepwise through ½. Hysteresis lives **only** here — not on the raw score (the §5.3 over-spec is removed). Deterministic and unit-testable; a test asserts a fixed input sequence yields a fixed held-step sequence.
 
 ### 5.5 No-lookahead + costs
 
@@ -165,7 +171,7 @@ Every input (TQQQ, QQQ, SPY, VIX) uses its **close[t]** value; the Layer-1 gate 
 
 **Leakage test:** inject a known future spike into bar *t+1*; assert weight[t] is unchanged (zero leakage), across all four inputs and both layers.
 
-**Lookback invariant:** no indicator parameter (window / EMA-span / period) exceeds 66 bars, and no expanding/all-history windows. *Finite-window* members (SMA, rolling-median, Donchian, ROC) have exact support ≤66. *EMA-family* members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — infinite tail in theory, bounded *effective* memory. Tests: (a) every signal's max parameter ≤66; (b) finite-window signals bit-identical when history before *t−66* is dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX is double-smoothed, MACD-hist is EMAs-of-EMAs, so they need more warmup than a raw EMA) and set the buffer from the *slowest* member, not a global asserted constant.
+**Lookback invariant:** the **composed/total** lookback of every member ≤ 66 bars, and no expanding/all-history windows. "Composed" matters for *nested* indicators: `realizedVol(20)` fed into a `rolling-k median` has total span `20+k`, so the median window must be ≤46, not 66. *Finite-window* members (SMA, rolling-median, Donchian, ROC, and the rewritten nested-vol members) have exact composed support ≤66. *EMA-family* members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — infinite tail in theory, bounded *effective* memory. Tests: (a) every signal's composed span ≤66 (inner+outer for nested); (b) finite-window signals bit-identical when history before *t−66* is dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX is double-smoothed, MACD-hist is EMAs-of-EMAs, so they need more warmup than a raw EMA) and set the buffer from the *slowest* member, not a global asserted constant. The two prototype `expanding(60).median()` members fail test (b) and **must** be rewritten to the bounded form in §5.2 — this is a required panel change, not optional.
 
 ### 5.6 Config (and what is NOT swept)
 
@@ -186,20 +192,22 @@ The window has **one** bear (2022). A sizing overlay that simply de-levers *mech
 
 ### 6.2 No data-snooping — frozen train/test + genuine OOS
 
-The gate (SMA22/44), the panel, and the sizing thresholds were all discovered on 2020-10→now. So an in-window 60/40 split is **not** out-of-sample — the "OOS" slice already shaped the choices.
+The gate (SMA22/44), the panel, and the sizing thresholds were all discovered on 2020-10→now. So merely *freezing* that config and reporting 2023→now still leaks — the held-out slice already shaped the choices.
 
 | Test | Protocol | Pass criteria |
 |---|---|---|
-| Frozen split | **freeze** gate + panel + r_lo/r_hi + weights on a train slice (≤2022-12), report untouched on 2023→now | edge persists on the held-out slice |
-| **True OOS** | run the *frozen* config on a **different leveraged underlying** (SPXL/UPRO/SOXL) and on **synthetic 3× QQQ pre-2010** | edge survives on data that did not inform any choice — this is the real test |
+| Re-derived split | Re-run the **entire** selection pipeline (gate sweep, bucket thresholds, panel, weights) using **only ≤2022-12** data — discard the prior full-window picks — then report **once** on 2023→now, untouched | edge persists. If re-deriving is impractical, 2023→now is **descriptive only** and the load-bearing test is the row below. |
+| **True OOS** (load-bearing) | run the frozen config on **synthetic 3× QQQ pre-2010** (dot-com + GFC — the regimes leverage decay punishes most) and on a **different leveraged underlying** | edge survives on data that informed no choice |
 
-In-window per-regime numbers (2021/2022/2023-24/2025) are **descriptive only**, never validation — one path each, and 2025 is a partial year.
+**Genuine-independence caveats:** for a different underlying, the signal source **switches** to that underlying's own inputs (SPX/QQQ-correlated), with gate/panel *structure* held fixed. **SPXL/UPRO are near-clones of the QQQ trade** → weak independent evidence; **SOXL (semis)** is a genuinely different regime → stronger. For pre-2010 synthetic, **pre-register** the cost params before running: `rate` = the historical 3-month T-bill *series* (not a constant — it swings 0–5%), `fee` = a fixed expense; report drawdown **sensitivity** to ±50 bps fee, since the dot-com/GFC verdict hinges on them.
+
+In-window per-regime numbers (2021/2022/2023-24/2025) are **descriptive only**, never validation — one path each, 2025 partial.
 
 ### 6.3 Is it the *signal*, or just less leverage?
 
-| Test | Control | Pass criteria |
+| Test | Control (precisely pinned) | Pass criteria |
 |---|---|---|
-| Matched-exposure | a **constant** scaler and a **volatility-targeted** scaler, each tuned to the *same average exposure* as the resonance sizer | resonance must beat *both* matched-exposure controls on Calmar — otherwise the "edge" is just de-levering and we ship the simpler vol-target instead |
+| Matched-exposure | (a) **constant** scaler = the resonance sizer's *exact* mean weight; (b) **vol-target** scaler matched on *both* mean exposure AND realized-vol budget. Both computed on the **frozen §6.2 test slice**, not re-fit. | resonance must beat the **better** of (a)/(b) on Calmar — else the "edge" is just de-levering, and we ship the simpler vol-target instead |
 
 ### 6.4 Overfit guard (hard, not vibes)
 
@@ -228,8 +236,8 @@ Must beat buy-hold TQQQ **and** QQQ risk-adjusted, **and** the bare SMA22/44 gat
 
 ## 8. Why this is the right shape
 
-- Uses the **proven** edge (resonance → win-rate) where it works (sizing), not where it doesn't (timing).
-- Keeps the **proven** timing engine (SMA gate) untouched and responsive.
+- Uses the **candidate** edge (resonance → win-rate, pending §6.1) where it would work (sizing), not where it doesn't (timing).
+- Keeps the **best-tested** timing engine (SMA gate) untouched and responsive.
 - Generalizes your multi-signal "confirmed buy" into a tunable conviction dial.
 - Respects the constraints we established (≤66 MAs, 2020-10 window, real TQQQ, costs, no-lookahead).
 - Falsifiable: if resonance sizing doesn't beat the bare gate on Calmar **and** drawdown (§6), we don't ship it — simpler wins.

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -114,12 +114,12 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 |---|---|---|
 | `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `src/rainier/signals/panel.py` |
 | `ResonanceScorer` | panel → daily conviction score ∈ [0,1] (weighted consensus) | new `src/rainier/signals/resonance.py` |
-| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily **target-weight series** ∈ [0,1] | new `src/rainier/signals/resonance_strategy.py` |
-| Daily-MTM sim | weight series → equity, no lookahead, financing + costs | `src/rainier/backtest/` (productionize the prototype in `scripts/leveraged_common.py`) |
+| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily **per-asset target weights** {TQQQ, QQQ}, remainder cash | new `src/rainier/signals/resonance_strategy.py` |
+| Daily-MTM sim | per-asset weights → equity, no lookahead, financing + costs | `src/rainier/backtest/` (productionize the prototype in `scripts/leveraged_common.py`) |
 
-**New boundary — NOT `SignalEmitter`.** The existing `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades) and the current engine consumes discrete trades — it *cannot* represent a continuously-sized daily weight. v1 introduces a distinct **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily target-weight series ∈ [0,1]` — plus a weight-consuming backtest path (the daily-MTM sim). This is **additive**: it does not change `SignalEmitter` or the discrete-trade engine, which keep serving the pin-bar/fractal strategies.
+**New boundary — NOT `SignalEmitter`.** The existing `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades) and the current engine consumes discrete trades — it *cannot* represent a continuously-sized daily weight. v1 introduces a distinct **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily **per-asset** target-weight series` (a dict like `{TQQQ: w1, QQQ: w2}`, weights ≥0 summing ≤1, remainder cash) — plus a weight-consuming backtest path. **Per-asset, not a scalar TQQQ-fraction**, precisely so the Q1 "1× QQQ risk-off floor" option is representable without a redesign; this also matches the existing `run_portfolio` sim, which already takes a per-asset weights dict. Additive: it does not change `SignalEmitter` or the discrete-trade engine, which keep serving the pin-bar/fractal strategies.
 
-*Note: the panel signals and the daily-MTM sim currently live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`). v1 promotes them into `src/rainier/` per the module map in `CLAUDE.md`; the scripts are the reference implementation, not the shipping location.*
+*Reference artifacts (local, NOT committed in this design PR): the panel signals and daily-MTM sim live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`, `scripts/full_combo_search.py`, `scripts/resonance_study.py`). They are the working reference, not a landed dependency — so until v1 lands, the numbers in this doc are **exploratory and reproduced via those local scripts**. v1's **first implementation step** is to promote them into `src/rainier/` (committed) per the `CLAUDE.md` module map, making the panel + studies reproducible from the tree.*
 
 ### 5.2 The panel (≤66 lookback)
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -12,7 +12,7 @@ We want to buy TQQQ (3× Nasdaq-100) **only when we're confident**, and size the
 
 We call the agreement of many signals **resonance**: when lots of independent indicators all say "risk-on" at once, that's a stronger, more trustworthy signal than any one of them alone.
 
-### What we already proved (so this isn't a guess)
+### What the data *suggests* (a lead, not yet proof)
 
 Across 2020-10 → now we bucketed every day by how many of a 26-signal panel agreed, then looked at TQQQ's *next 20 days*:
 
@@ -25,7 +25,7 @@ Across 2020-10 → now we bucketed every day by how many of a 26-signal panel ag
   80–100%              62%   ← most agreement = highest win-rate
 ```
 
-**Resonance is real: more agreement genuinely raises the win-rate (48% → 62%).** That is the empirical foundation of this design. One nuance we also found: the *biggest forward returns* come at **60–80%** agreement (a building consensus, early in a move), not at 100% (which tends to be mid-trend, after the easy money). So conviction should reward *strong* consensus but not blindly chase *unanimous* consensus.
+The win-rate rises with agreement — a promising, monotone signal. **But treat it as a lead, not proof, until it clears the bar in §6.** Two reasons to be skeptical: (1) the forward-20-day windows **overlap** (adjacent days share ~19/20 of their data), so the *effective* sample is ~N/20 ≈ a few dozen independent points spread over 5 buckets — too few to call significant without confidence intervals; (2) it's one window dominated by a single 2022 bear and the 2020–21 recovery. The "biggest returns at 60–80% agreement" remark is likewise an unverified in-sample observation (and win-rate ≠ mean return — different statistics). **§6 gates this:** report block-bootstrap CIs and the effective non-overlapping N per bucket; only call it real once a CI excludes the null. The rest of this plan is conditional on that.
 
 ---
 
@@ -47,7 +47,7 @@ There is **no concept of conviction or position size** — every trade is all-or
 
 ## 3. What goes wrong (why we don't just "vote")
 
-The obvious idea — *be in TQQQ when ≥70% of signals agree, else cash* — we tested. **It underperforms the simple gate** (Calmar 0.20 vs 0.34 full-cycle; worse in-window too). Why:
+The obvious idea — *be in TQQQ when ≥70% of signals agree, else cash* — we tested. It underperformed the simple gate (Calmar 0.20 vs 0.34 on the synthetic full-cycle; worse in-window too). *This negative result is **motivating, not load-bearing** — same one-window caveats apply; it's enough to steer away from voting-as-a-gate, not a proven fact.* The mechanism is clear regardless:
 
 ```
 THE LAG TRAP:
@@ -121,7 +121,9 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 
 *Note: the panel signals and the daily-MTM sim currently live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`). v1 promotes them into `src/rainier/` per the module map in `CLAUDE.md`; the scripts are the reference implementation, not the shipping location.*
 
-### 5.2 The panel (≤66 lookback, ~26 signals)
+### 5.2 The panel (≤66 lookback)
+
+*The exact membership and per-category counts are **pinned from `regime_signal_search.build_signals`** at build time (the prototype's real list), not the prose below — the "~26" figure is provisional and the breadth "(Gap)" / "(Optional)" members are excluded until added. Category-balanced weighting (§5.3) depends on the final per-category counts, so v1 records the frozen list explicitly.*
 
 - **Trend:** price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
 - **Momentum:** RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
@@ -138,43 +140,77 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 `resonance[t] = Σ wᵢ · signalᵢ[t] / Σ wᵢ` — weighted fraction risk-on.
 
 - **Category-balanced weights** so one over-represented family (we have many trend signals) doesn't dominate: weight each of the 5 categories equally, split within. Avoids "resonance" really being "trend, four times."
-- **Hysteresis** on the score feeding any threshold, to avoid size chatter at the boundary.
+- Anti-chatter hysteresis is applied **once**, at the stepped-value stage of the §5.4 state machine — *not* here on the raw score (avoids the double-hysteresis ambiguity).
 
-### 5.4 Sizing curve (gate-ON only)
+### 5.4 Sizing curve + state machine (gate-ON only)
 
-`size(r)` maps resonance → target TQQQ fraction, clamped [0, 1]:
-- piecewise: `0` below `r_lo` (≈0.5), ramp to `1` by `r_hi` (≈0.7), flat `1` above (cap — don't over-size unanimity).
-- turnover-aware: round size to coarse steps (e.g. 0/0.5/1.0) so it doesn't rebalance daily and bleed cost.
+`size(r)` maps resonance → target TQQQ fraction, clamped [0, 1]: `0` below `r_lo`, ramp to `1` by `r_hi`, flat `1` above. To avoid ambiguity, the weight is computed by **one** ordered state machine — no second hysteresis layer:
+
+```
+raw resonance r[t]  ──►  (1) curve: size = clamp((r−r_lo)/(r_hi−r_lo), 0, 1)
+                    ──►  (2) round to coarse step ∈ {0, ½, 1}
+                    ──►  (3) hysteresis ON THE STEPPED VALUE: only change the
+                              held step if the new step differs by ≥1 level AND
+                              persists ≥ `dwell` bars  (one place, applied last)
+                    ──►  (4) rebalance only when the held step changes
+```
+
+Hysteresis lives **only** at step (3), on the rounded step — not on the raw score (that was the §5.3 over-spec; remove it there). This makes the path deterministic and unit-testable.
 
 ### 5.5 No-lookahead + costs
 
-Signals computed on close[t]; target weight applied to t+1 return (shift +1). Warmup buffer: load from 2019-06 so every ≤66 signal is valid by 2020-10; **measure only over 2020-10 → now** (real TQQQ). Charge turnover cost on size changes; cash earns the 13-week T-bill.
+Every input (TQQQ, QQQ, SPY, VIX) uses its **close[t]** value; the Layer-1 gate and the Layer-2 size both use the *same* timestamp alignment and the *same* +1 shift — weight decided on close[t] is applied to the t→t+1 return. Warmup buffer: load from 2019-06 so every ≤66 signal is valid by 2020-10; **measure only over 2020-10 → now** (real TQQQ).
 
-**Lookback invariant:** no indicator parameter (window / EMA-span / period) exceeds 66 bars, and no expanding/all-history windows (medians, z-scores, percentiles). Two flavors:
-- *Finite-window* members (SMA, rolling-median, Donchian, ROC) — exact support ≤66.
-- *EMA-family* members (EMA, RSI, MACD, ADX) — recursively smoothed, span/period ≤66; infinite tail in theory but bounded *effective* memory once warmed up.
+**Costs — no double-counting:** real adjusted TQQQ prices *already embed* the 3× daily-reset financing and decay. So on real TQQQ we charge **only** (a) turnover/slippage on rebalances and (b) the T-bill rate the cash sleeve earns/forgoes — **NOT** a synthetic 3× financing charge (that would double-count). The synthetic-3× financing formula (`3·r − 2·rate − fee`) is reserved for the §6.2 pre-2010 OOS test, where no real ETF exists.
 
-Tests: (a) assert every signal's max parameter ≤66; (b) finite-window signals are bit-identical when history before *t−66* is truncated; (c) EMA-family signals converge to <1e-6 relative given ≥150 warmup bars (the 2019-06 buffer supplies ~330). This is why the constraint says ≤66 *parameter*, not ≤66 *exact support*.
+**Leakage test:** inject a known future spike into bar *t+1*; assert weight[t] is unchanged (zero leakage), across all four inputs and both layers.
 
-### 5.6 Config (sweepable)
+**Lookback invariant:** no indicator parameter (window / EMA-span / period) exceeds 66 bars, and no expanding/all-history windows. *Finite-window* members (SMA, rolling-median, Donchian, ROC) have exact support ≤66. *EMA-family* members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — infinite tail in theory, bounded *effective* memory. Tests: (a) every signal's max parameter ≤66; (b) finite-window signals bit-identical when history before *t−66* is dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX is double-smoothed, MACD-hist is EMAs-of-EMAs, so they need more warmup than a raw EMA) and set the buffer from the *slowest* member, not a global asserted constant.
 
-`panel members · per-category weights · gate (entry/exit SMA) · sizing curve (r_lo, r_hi, steps) · hysteresis band · rebalance granularity`.
+### 5.6 Config (and what is NOT swept)
+
+Swept: `panel membership · per-category weights · gate (entry/exit SMA) · rebalance granularity`. **Fixed a priori (not swept):** `r_lo`, `r_hi` (read off the §6.1 bucket curve), the cap-above-`r_hi` rule (kept only if §6.1 says the 60–80% return peak is significant). Total free parameters tuned on data are **capped and pre-registered** before any OOS run (see §6.4) — the effective sample is tiny, so every extra knob is overfit risk.
 
 ---
 
 ## 6. Test plan
 
-| Test | Input | Expected / pass criteria |
-|---|---|---|
-| Thesis (sanity) | resonance buckets × fwd-20d TQQQ | win-rate rises with resonance (reproduce 48→62%) |
-| Strategy backtest | 2020-10→now, real TQQQ | beats SMA22/44-gate baseline on Calmar **and** drawdown, or it's not worth the complexity |
-| Sizing ablation | full-size gate vs resonance-sized | resonance sizing improves Calmar / cuts drawdown at similar return |
-| Per-regime | 2021 bull / 2022 bear / 2023-24 / 2025 | smaller drawdown in 2022 & 2025 than the bare gate |
-| Walk-forward | 60/40 split in-window | sized strategy's edge survives OOS split |
-| Cost/turnover | sweep rebalance granularity | net edge survives realistic cost; switches stay sane |
-| Baseline floor | vs buy-hold TQQQ & QQQ | must beat both risk-adjusted |
+The window has **one** bear (2022). A sizing overlay that simply de-levers *mechanically* cuts drawdown, so naive "beats the gate on drawdown" proves nothing. The plan below is built to *try to kill* the idea, not flatter it.
 
-**Honesty rails (carried from prior work):** one real bear (2022) in this window — sub-20% drawdown here is optimistic; the bare gate's *full-cycle* drawdown was −76%. Report in-window numbers as in-window. No single-best-cell worship; prefer plateaus.
+### 6.1 Significance, not just point estimates
+
+| Test | Input | Pass criteria |
+|---|---|---|
+| Thesis CI | resonance buckets × fwd-20d | report **block-bootstrap CIs** + effective non-overlapping N per bucket; the win-rate trend must have a CI that excludes the null. If it doesn't, the premise fails — stop. |
+| Return-by-bucket | same buckets, forward *return* (not win-rate) | show the return curve with CIs; only keep the "cap above 80%" rule if the 60–80% peak is significant — else drop the cap and the claim. |
+
+### 6.2 No data-snooping — frozen train/test + genuine OOS
+
+The gate (SMA22/44), the panel, and the sizing thresholds were all discovered on 2020-10→now. So an in-window 60/40 split is **not** out-of-sample — the "OOS" slice already shaped the choices.
+
+| Test | Protocol | Pass criteria |
+|---|---|---|
+| Frozen split | **freeze** gate + panel + r_lo/r_hi + weights on a train slice (≤2022-12), report untouched on 2023→now | edge persists on the held-out slice |
+| **True OOS** | run the *frozen* config on a **different leveraged underlying** (SPXL/UPRO/SOXL) and on **synthetic 3× QQQ pre-2010** | edge survives on data that did not inform any choice — this is the real test |
+
+In-window per-regime numbers (2021/2022/2023-24/2025) are **descriptive only**, never validation — one path each, and 2025 is a partial year.
+
+### 6.3 Is it the *signal*, or just less leverage?
+
+| Test | Control | Pass criteria |
+|---|---|---|
+| Matched-exposure | a **constant** scaler and a **volatility-targeted** scaler, each tuned to the *same average exposure* as the resonance sizer | resonance must beat *both* matched-exposure controls on Calmar — otherwise the "edge" is just de-levering and we ship the simpler vol-target instead |
+
+### 6.4 Overfit guard (hard, not vibes)
+
+- **Cap free parameters tuned on data.** Fix `r_lo`/`r_hi` *a priori* from the §6.1 bucket curve — do **not** re-sweep them. Pre-register a single config before looking at OOS.
+- Penalize multiple testing: report a **deflated** Sharpe/Calmar (Bonferroni or López de Prado deflated-Sharpe) over the number of configs tried.
+- Cost/turnover: net edge must survive realistic cost; report switch count.
+
+### 6.5 Baseline floor
+Must beat buy-hold TQQQ **and** QQQ risk-adjusted, **and** the bare SMA22/44 gate, **and** the matched-exposure control. Failing any → don't ship; simpler wins.
+
+**Honesty rails:** sub-20% drawdown in this window is optimistic — the bare gate's *full-cycle* (1999–2026 synthetic) drawdown was −76%. Report in-window numbers as in-window. No single-best-cell worship; prefer plateaus. If §6.1 or §6.3 fails, the design is **rejected**, not patched.
 
 ---
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -131,6 +131,8 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 - **(Optional)** fractal:simple_turn as a momentum/structure member.
 - **(Gap)** market breadth (% NDX above its MA) — not in yfinance; needs a proxy (compute "% of top-N QQQ holdings above their SMA"). Tracked as a follow-up, not v1-blocking.
 
+*Every member's controlling parameter (window / EMA-span / period) is ≤ 66. Finite-window members (SMA, rolling-median, Donchian, ROC) have exact support ≤66; EMA-family members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — theoretically infinite tail but bounded **effective** memory (see the invariant in §5.5).*
+
 ### 5.3 Scoring
 
 `resonance[t] = Σ wᵢ · signalᵢ[t] / Σ wᵢ` — weighted fraction risk-on.
@@ -148,7 +150,11 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 
 Signals computed on close[t]; target weight applied to t+1 return (shift +1). Warmup buffer: load from 2019-06 so every ≤66 signal is valid by 2020-10; **measure only over 2020-10 → now** (real TQQQ). Charge turnover cost on size changes; cash earns the 13-week T-bill.
 
-**Lookback invariant:** every panel signal must use a *bounded* window ≤ 66 bars — no expanding/all-history windows (medians, z-scores, percentiles included). A unit test asserts each signal's first valid index ≤ 66 and that its value at bar *t* is unchanged when history before *t−66* is truncated.
+**Lookback invariant:** no indicator parameter (window / EMA-span / period) exceeds 66 bars, and no expanding/all-history windows (medians, z-scores, percentiles). Two flavors:
+- *Finite-window* members (SMA, rolling-median, Donchian, ROC) — exact support ≤66.
+- *EMA-family* members (EMA, RSI, MACD, ADX) — recursively smoothed, span/period ≤66; infinite tail in theory but bounded *effective* memory once warmed up.
+
+Tests: (a) assert every signal's max parameter ≤66; (b) finite-window signals are bit-identical when history before *t−66* is truncated; (c) EMA-family signals converge to <1e-6 relative given ≥150 warmup bars (the 2019-06 buffer supplies ~330). This is why the constraint says ≤66 *parameter*, not ≤66 *exact support*.
 
 ### 5.6 Config (sweepable)
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -1,20 +1,20 @@
-# Design Plan — Multi-Signal Resonance for TQQQ Conviction
+# Design Plan — Multi-Signal Resonance Gate for TQQQ
 
-**Status:** draft for review · **Scope:** signal-resonance layer for the TQQQ timing strategy · **Window:** 2020-10 → now (real TQQQ) · **Constraint:** no moving-average / lookback > 66 bars · **Depends on:** `src/rainier/signals/`, `src/rainier/backtest/` engine · **PR base:** main
+**Status:** decisions locked, for build review · **Scope:** a weighted-signal entry/exit gate for TQQQ · **Window:** 2020-10 → now (real TQQQ) · **Constraint:** no moving-average / lookback > 66 bars · **Depends on:** `src/rainier/signals/`, `src/rainier/backtest/` · **PR base:** main
 
 ---
 
 ## 1. The problem, in plain English
 
-We want to buy TQQQ (3× Nasdaq-100) **only when we're confident**, and size the bet to that confidence. A single indicator — "price is above its 44-day average" — flips in and out on every wiggle and gives plenty of false buys. We have *dozens* of signals (trend, momentum, volatility, structure). The question this plan answers:
+We want to buy and sell TQQQ (3× Nasdaq-100) on the **combined verdict of many signals**, not one. A single indicator — "price is above its 44-day average" — flips on every wiggle and gives false buys. We have *dozens* of signals (trend, momentum, volatility, structure). The model you want:
 
-> **How do we combine many signals into one "conviction score" so that more agreement → more confidence → a bigger, higher-win-rate bet — without the lag that killed naive consensus voting?**
+> **Give each signal a power weight. Add them into one confidence score. When the score crosses a BUY line → buy TQQQ. When it drops below a SELL line → sell everything to cash.** The gap between the two lines stops the whipsaw.
 
-We call the agreement of many signals **resonance**: when lots of independent indicators all say "risk-on" at once, that's a stronger, more trustworthy signal than any one of them alone.
+We call the weighted agreement of many signals **resonance**: when lots of independent indicators line up, the score is high and the buy is more trustworthy than any one signal alone.
 
 ### What the data *suggests* (a lead, not yet proof)
 
-Across 2020-10 → now we bucketed every day by how many of a 26-signal *exploratory* panel agreed (the ≤66 subset of `build_signals` + SPY, as in `scripts/resonance_study.py`), then looked at TQQQ's *next 20 days*. (v1 freezes a slightly different ~22-member panel — §5.2 — so the resonance **denominator is the frozen count**, never a hardcoded 26.)
+On 2020-10 → now we bucketed every day by how many signals agreed, then looked at TQQQ's *next 20 days*:
 
 ```
  signals agreeing →  win-rate of the next 20 days
@@ -25,84 +25,67 @@ Across 2020-10 → now we bucketed every day by how many of a 26-signal *explora
   80–100%              62%   ← most agreement = highest win-rate
 ```
 
-The win-rate rises with agreement — a promising, monotone signal. **But treat it as a lead, not proof, until it clears the bar in §6.** Two reasons to be skeptical: (1) the forward-20-day windows **overlap** (adjacent days share ~19/20 of their data), so the *effective* sample is ~N/20 ≈ a few dozen independent points spread over 5 buckets — too few to call significant without confidence intervals; (2) it's one window dominated by a single 2022 bear and the 2020–21 recovery. The "biggest returns at 60–80% agreement" remark is likewise an unverified in-sample observation (and win-rate ≠ mean return — different statistics). **§6 gates this:** report block-bootstrap CIs and the effective non-overlapping N per bucket; only call it real once a CI excludes the null. The rest of this plan is conditional on that.
+More agreement → higher win-rate. That is the premise of a "buy when the score is high" gate. **But treat it as a lead, not proof, until §6.** Two reasons to doubt it: (1) the forward-20-day windows **overlap** (adjacent days share ~19/20 of their data), so the *effective* sample is ~N/20 ≈ a few dozen independent points over 5 buckets — too few to be significant without confidence intervals; (2) it's one window dominated by a single 2022 bear + the 2020–21 recovery. **§6 gates it:** block-bootstrap CIs + effective N per bucket; only call it real once a CI excludes the null.
 
 ---
 
 ## 2. How it works today
 
-Right now there is no integrated system — just a pile of exploratory scripts. Two things exist:
+No integrated system — just exploratory scripts. Two pieces exist:
 
-- **An exploratory signal panel** (`regime_signal_search.build_signals`), each emitting a daily risk-on (1) / risk-off (0) series. It is *unfiltered* — most members today use >66 lookback and two use expanding medians; v1 takes only its **≤66 subset** and rewrites the expanding members (see §5.2).
-- **A timing gate** — the asymmetric SMA gate (enter when QQQ > SMA22, exit when QQQ < SMA44). In-window it was the single best risk-adjusted design (Calmar ≈ 1.37, #2 of 270 in a full sweep, on a stable plateau).
+- **An exploratory signal panel** (`regime_signal_search.build_signals`), each member a daily risk-on (1) / risk-off (0) series. It's *unfiltered* — most members use >66 lookback and two use expanding medians; v1 takes only its **≤66 subset** and rewrites the expanding members (§5.2). There is **no weighting and no combined score** today.
+- **A timing gate** — the asymmetric SMA gate (enter QQQ > SMA22, exit QQQ < SMA44). In-window the best single-signal design (Calmar ≈ 1.37, #2 of 270, on a stable plateau). This is the **bar to beat**.
 
 ```
-TODAY:  one signal  ──►  in/out of TQQQ at full size
-        (e.g. price>SMA44)         (binary, no notion of confidence)
+TODAY:  one signal  ──►  in/out of TQQQ
+        (e.g. price>SMA44)        (binary, one indicator, no weighting)
 ```
-
-There is **no concept of conviction or position size** — every trade is all-or-nothing, and the dozens of other signals are unused.
 
 ---
 
-## 3. What goes wrong (why we don't just "vote")
+## 3. What we learned, and how v1 differs
 
-The obvious idea — *be in TQQQ when ≥70% of signals agree, else cash* — we tested. It underperformed the simple gate (Calmar 0.20 vs 0.34 on the synthetic full-cycle; worse in-window too). *This negative result is **motivating, not load-bearing** — same one-window caveats apply; it's enough to steer away from voting-as-a-gate, not a proven fact.* The mechanism is clear regardless:
+We already tested the **naive** version — equal-weight consensus, "be in when ≥70% agree." **It lagged and lost** to the simple SMA gate (Calmar 0.20 vs 0.34 on the synthetic full-cycle). Why consensus lags:
 
 ```
 THE LAG TRAP:
    price ────╲                      ╱──── recovery
               ╲                    ╱
-   gate exits  ╲__________________╱   gate re-enters (fast)
+   exits late  ╲__________________╱   re-enters late
                   ▲              ▲
-   votes flip   LATE           LATE   ← consensus needs many signals to flip;
-   risk-off  (already down)  (misses the bounce)
+   score drops  LATE           LATE   ← it takes many signals to flip the score;
+   below sell (already down)  (misses the bounce)
 ```
 
-- **Entering on consensus lags the bottom:** by the time 70% of signals turn risk-on, the rebound is half over.
-- **Exiting on consensus lags the top:** the drawdown is already eaten before enough signals flip.
-- Consensus voting flips *less* (less whipsaw) but each move is *late*, so it has higher win-rate yet **worse risk-adjusted return**.
+v1 is **not** that naive version. Two differences, both of which we **A/B test** rather than assume:
+- **Power weights** per signal (not equal) — a strong signal moves the score more.
+- **Two tunable lines** (buy high, sell lower) instead of one 70% line — the gap is a hysteresis buffer that can be tuned to cut whipsaw.
 
-**Lesson: resonance is good at measuring *confidence*, bad at deciding *timing*.** The fast SMA gate is the opposite — good timing, no confidence. The design uses each for what it's good at.
+**Honesty rail:** this is still the *vote-gate family* that lost to the SMA gate once already. v1 earns its place only if the A/B test (§6) shows the weighted dual-threshold gate beats the SMA22/44 gate **and** buy-hold, out-of-sample. If it doesn't, we ship the SMA gate and stop. Eyes open.
 
 ---
 
-## 4. The fix — a two-layer design
-
-Separate **timing** from **conviction**:
+## 4. The design — a weighted-score dual-threshold gate
 
 ```
-LAYER 1 — TIMING (fast):        LAYER 2 — CONVICTION (resonance):
-  asymmetric SMA22/44 gate         consensus of the ≤66-lookback panel (§5.2)
-  decides IN vs OUT of TQQQ        decides HOW BIG when in
-        │                                  │
-        └──────────────┬───────────────────┘
-                       ▼
-            position size = gate_on × size(resonance)
+   ≤66 signals, each with a power weight
+            │
+            ▼
+   resonance score  r[t] = Σ wᵢ·signalᵢ[t] / Σ wᵢ   ∈ [0,1]
+            │
+            ▼
+   ┌─ if flat AND r ≥ BUY line   → buy TQQQ (full)
+   ├─ if held AND r ≤ SELL line  → sell all → cash
+   └─ else                       → hold current state
+            │
+            ▼
+   position is BINARY: 100% TQQQ or 100% cash. No sizing.
 ```
 
-- **Layer 1 (gate)** answers *"should I be in TQQQ at all right now?"* — fast, responsive, the best-tested timing engine so far. When the gate is OFF → cash (T-bills). No lag penalty on timing.
-- **Layer 2 (resonance)** answers *"how convinced am I?"* — when the gate is ON, scale the position by the conviction score. High resonance (many signals agree) → full 3× exposure. Weak resonance (signals split) → reduced exposure (e.g. partial TQQQ + cash, or 1× QQQ).
-
-This uses the **candidate** 48%→62% win-rate edge (pending §6.1 significance) as a **sizing** signal, where lag doesn't hurt, instead of a **timing** signal, where it does.
-
-### Your "confirmed buy" is a *second* axis — pullback resonance
-
-A distinction the design must respect: your example — *QQQ<SMA10 AND SPY<SMA10 AND breadth<30% AND VIX<23 AND fractal buy* — is built from **oversold / pullback** conditions (price *below* short MAs, washed-out breadth). The trend-resonance score above counts *risk-on* signals (price *above* MAs), so this exact cluster would score **low**, not high. They are two different axes:
-
-- **Trend resonance** — "the uptrend is broadly confirmed" (price above MAs, momentum positive, vol calm). Drives Layer-2 **sizing**.
-- **Pullback resonance** — "an oversold dip is bottoming *inside* an uptrend" (price below SMA10, breadth washed out, fractal turn, VIX not panicked). A separate **entry** trigger for buying the dip.
-
-v1 models your confirmed-buy as an **optional pullback sub-score / alternate entry**, regime-gated (only buy dips while a slower trend filter is still up — don't catch knives in a real bear), **not** as the high end of trend resonance. Richer, and an open decision (Q7).
-
-### What it looks like day to day
-
-```
-  gate OFF                         → 0% TQQQ (cash, earning T-bills)
-  gate ON, resonance 50–65%        → reduced size (e.g. 40–60% TQQQ)
-  gate ON, resonance 65–80%        → full size      (peak-return zone)
-  gate ON, resonance > 80%         → full size, but capped (don't chase unanimity)
-```
+- **Binary, no sizing** — you were right that "size by conviction" was likely noise; v1 drops it. The score's only job is to cross the buy/sell lines.
+- **Risk-off = 100% cash/T-bills** (Q1). When out, we hold nothing but cash.
+- **BUY line > SELL line** (Q2) — the gap is the hysteresis band; widening it trades fewer trades for later entries (a swept config).
+- The whole gate is **A/B tested against the SMA22/44 gate** and against combinations (resonance-gate alone, SMA alone, resonance AND SMA, resonance OR SMA) — data picks the winner (Q3).
 
 ---
 
@@ -113,128 +96,114 @@ v1 models your confirmed-buy as an **optional pullback sub-score / alternate ent
 | Component | Role | Where |
 |---|---|---|
 | `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `src/rainier/signals/panel.py` |
-| `ResonanceScorer` | panel → daily conviction score ∈ [0,1] (weighted consensus) | new `src/rainier/signals/resonance.py` |
-| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily **per-asset target weights** {TQQQ, QQQ}, remainder cash | new `src/rainier/signals/resonance_strategy.py` |
-| Daily-MTM sim | per-asset weights → equity, no lookahead, financing + costs | `src/rainier/backtest/` (productionize the prototype in `scripts/leveraged_common.py`) |
+| `ResonanceScorer` | panel + per-signal weights → daily score ∈ [0,1] | new `src/rainier/signals/resonance.py` |
+| `ResonanceGate` | dual-threshold state machine → daily **per-asset target weights** {TQQQ} | new `src/rainier/signals/resonance_gate.py` |
+| Daily-MTM sim | per-asset weights → equity, no lookahead, costs | `src/rainier/backtest/` (productionize `scripts/leveraged_common.py`) |
 
-**New boundary — NOT `SignalEmitter`.** The existing `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades) and the current engine consumes discrete trades — it *cannot* represent a continuously-sized daily weight. v1 introduces a distinct **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily **per-asset** target-weight series` (a dict like `{TQQQ: w1, QQQ: w2}`, weights ≥0 summing ≤1, remainder cash) — plus a weight-consuming backtest path. **Per-asset, not a scalar TQQQ-fraction**, precisely so the Q1 "1× QQQ risk-off floor" option is representable without a redesign; this also matches the existing `run_portfolio` sim, which already takes a per-asset weights dict. Additive: it does not change `SignalEmitter` or the discrete-trade engine, which keep serving the pin-bar/fractal strategies.
+**New boundary — NOT `SignalEmitter`.** `SignalEmitter` returns `list[Signal]` (discrete entry/SL/TP trades); the current engine consumes discrete trades and can't represent a held daily weight. v1 adds a **`WeightStrategy`** protocol — `(df, symbol, timeframe) → daily per-asset weight series` (a dict like `{TQQQ: 0 or 1}`, weights ≥0 summing ≤1, remainder cash). Per-asset (not a bare boolean) so a future non-cash risk-off is representable without a redesign; matches the existing `run_portfolio` sim, which already takes a per-asset weights dict. Additive: it doesn't touch `SignalEmitter` or the discrete-trade engine.
 
-*Reference artifacts (local, NOT committed in this design PR): the panel signals and daily-MTM sim live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`, `scripts/full_combo_search.py`, `scripts/resonance_study.py`). They are the working reference, not a landed dependency — so until v1 lands, the numbers in this doc are **exploratory and reproduced via those local scripts**. v1's **first implementation step** is to promote them into `src/rainier/` (committed) per the `CLAUDE.md` module map, making the panel + studies reproducible from the tree.*
+*Reference artifacts (local, NOT committed in this PR): the panel + sim live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`, `scripts/full_combo_search.py`, `scripts/resonance_study.py`). Numbers in this doc are exploratory, reproduced via those scripts. v1's **first step** is to promote them into `src/rainier/` (committed) per the `CLAUDE.md` module map.*
 
-### 5.2 The panel (≤66 lookback)
+### 5.2 The panel (≤66 lookback, trend-only for v1)
 
-**Provenance — important:** v1 does **NOT** pin the full `regime_signal_search.build_signals` list. That list is mostly **>66** lookback (SMA100/150/200, EMA100/200, ROC120, 12-1 momentum, 90/120-day highs, slow 50/150 & 50/200 crosses) and uses **expanding** medians — both forbidden here.
+v1 is **trend-only** (Q7) — every member is a *risk-on / uptrend-confirming* signal (price above MAs, momentum up, vol calm). Pullback/oversold signals (price *below* short MAs) are deferred to v2.
 
-**The enumerated list below IS the single source of truth** for the v1 panel (the resonance denominator and category counts derive from it — nothing else). It was *seeded* from the ≤66 subset of `build_signals` (the complement of the `BLOCK` set in `scripts/full_combo_search.py`), then deliberately **deduplicated** — keep one threshold per indicator (RSI>50, drop RSI>55; VIX<25, drop VIX<20/<30; one of ADX/+DI) so no single indicator is triple-counted in the consensus — with two expanding-median members **rewritten** to bounded form and `price>SMA66` **added**. So the list is *not* identical to the raw BLOCK-complement; where prose and the list disagree, **the list wins**. New members (SPY cross-asset, optional fractal, breadth proxy) are fresh code and each count against the §6.4 parameter budget. The frozen list is recorded verbatim at build time.
+**The enumerated list below IS the single source of truth** (the score denominator and category counts derive from it). It was *seeded* from the ≤66 subset of `build_signals` (complement of the `BLOCK` set in `scripts/full_combo_search.py`), then **deduplicated** — one threshold per indicator (RSI>50, drop RSI>55; VIX<25, drop VIX<20/<30; one of ADX/+DI) so no indicator is triple-counted — with the two expanding-median members **rewritten** to bounded form and `price>SMA66` **added**. Where prose and the list disagree, **the list wins**.
 
-- **Trend** (from ≤66 subset): price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
-- **Momentum** (from ≤66 subset): RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
-- **Volatility** (rewritten): realizedVol(20, rolling std) < its **rolling-40 median** (20+40 = 60, both finite), ATR%(14, **simple rolling mean** of true range — *not* Wilder/EWMA) < its rolling-46 median (14+46 = 60, both finite), VIX<25, VIX<SMA20, VIX-falling. *(Replaces the prototype's `expanding(60).median()` AND its Wilder-EWMA `atr_pct` — both have unbounded lookback; the finite-window invariant §5.5(b) requires simple rolling forms here.)*
-- **Structure** (from ≤66 subset): within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
-- **Cross-asset** (NEW code): SPY>SMA22, SPY>SMA44 — `build_signals(qqq, vix)` takes no SPY today; v1 adds an SPY input.
-- **(NEW, optional)** fractal:simple_turn — not in `build_signals`; added if Q7 says so.
-- **(Gap)** market breadth (% NDX above its MA) — not in yfinance; proxy = "% of top-N QQQ holdings above their SMA". Follow-up, not v1-blocking.
+- **Trend:** price > SMA{20,50,66}, price > EMA{20,50}, SMA22>SMA44, SMA50-rising.
+- **Momentum:** RSI14>50, MACD-hist>0, ROC{20,60}>0, price>Donchian50-mid.
+- **Volatility:** realizedVol(20, rolling std) < its **rolling-40 median** (20+40 = 60, finite), ATR%(14, **simple rolling mean** of true range, *not* Wilder/EWMA) < its rolling-46 median (14+46 = 60), VIX<25, VIX<SMA20, VIX-falling. *(Replaces the prototype's `expanding(60).median()` and EWMA `atr_pct` — both unbounded.)*
+- **Structure:** within 5% of 60-day high, ADX>20 & +DI>−DI, higher-high+higher-low.
+- **Cross-asset:** SPY>SMA22, SPY>SMA44 (NEW code — `build_signals(qqq, vix)` takes no SPY today; v1 adds an SPY input).
+- **Breadth (NEW, in v1 — Q5):** **% of top-N QQQ holdings above their SMA** — the closest proxy to "market breadth" (yfinance has no breadth index). Built in v1, and **also surfaced on the QQQ market-breadth dashboard** (separate deliverable, §7).
 
-*Every member's **composed/total** lookback is ≤ 66 — a 20-day measure compared to a 40-day median counts as 60, not "66 because the outer window is 66." Finite-window members have exact composed support ≤66; EMA-family members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — infinite tail in theory, bounded **effective** memory (invariant in §5.5).*
+*Every member's **composed/total** lookback ≤ 66 (a 20-day measure vs a 40-day median = 60, not "66 because the outer window is 66"). Finite-window members have exact composed support ≤66; EMA-family members (EMA, RSI, MACD, ADX) have bounded effective memory (invariant in §5.5).*
 
-### 5.3 Scoring
+### 5.3 Scoring (power weights)
 
-`resonance[t] = Σ wᵢ · signalᵢ[t] / Σ wᵢ` — weighted fraction risk-on.
+`resonance[t] = Σ wᵢ · signalᵢ[t] / Σ wᵢ` ∈ [0,1] — the **power-weighted** fraction risk-on.
 
-- **Category-balanced weights** so one over-represented family (we have many trend signals) doesn't dominate: weight each of the 5 categories equally, split within. Avoids "resonance" really being "trend, four times."
-- Anti-chatter hysteresis is applied **once**, at the stepped-value stage of the §5.4 state machine — *not* here on the raw score (avoids the double-hysteresis ambiguity).
+- **Per-signal power weights `wᵢ`** (Q2) — a strong signal moves the score more. Default prior = **category-balanced** (Q4): the 5 categories weighted equally, split within, so the many trend signals don't make the score really mean "trend ×4." Beyond that prior, weights are a **swept/tested** config (capped per §6.4 — every free weight is overfit risk on a tiny sample).
+- A/B includes **equal-weight vs category-balanced vs tuned** weights to confirm weighting actually helps (Q4: "testing can tell us more").
 
-### 5.4 Sizing curve + state machine (gate-ON only)
-
-`size(r)` maps resonance → target TQQQ fraction, clamped [0, 1]: `0` below `r_lo`, ramp to `1` by `r_hi`, flat `1` above. To avoid ambiguity, the weight is computed by **one** ordered state machine — no second hysteresis layer:
+### 5.4 The dual-threshold gate (state machine)
 
 ```
-raw resonance r[t]  ──►  (1) curve: size = clamp((r−r_lo)/(r_hi−r_lo), 0, 1)
-                    ──►  (2) round to coarse step ∈ {0, ½, 1}  → target_step[t]
-                    ──►  (3) hysteresis: the HELD step moves to target_step[t]
-                              only after target_step has held the SAME new value
-                              for ≥ `dwell` consecutive bars; otherwise the held
-                              step is carried forward unchanged
-                    ──►  (4) rebalance only when the held step actually changes
+score r[t]  ──►  if state==CASH  and r[t] ≥ BUY  → state = TQQQ (enter at close)
+            ──►  if state==TQQQ  and r[t] ≤ SELL → state = CASH (sell all)
+            ──►  else                            → hold state
+       BUY > SELL ; the gap is the hysteresis band.
 ```
 
-Boot: at the first valid bar `t0` (after the §5.5c per-member warmup), held_step = target_step[t0] — provisional, taken without confirmation since there's no prior; every *subsequent* move still requires the full `dwell`. Moves are **direct** to the confirmed target (e.g. 0→1 in one transition once the new step holds `dwell` bars), not forced stepwise through ½. The dwell counter resets whenever target_step changes value. Hysteresis lives **only** here — not on the raw score (the §5.3 over-spec is removed). Deterministic and unit-testable; a test asserts a fixed input sequence yields a fixed held-step sequence.
+Boot: at the first valid bar `t0` (after the §5.5c per-member warmup), state = TQQQ if `r[t0] ≥ BUY` else CASH. Deterministic and unit-testable — a fixed score sequence yields a fixed state sequence; a test asserts it. No second hysteresis layer, no sizing curve.
 
 ### 5.5 No-lookahead + costs
 
-Every input (TQQQ, QQQ, SPY, VIX) uses its **close[t]** value; the Layer-1 gate and the Layer-2 size both use the *same* timestamp alignment and the *same* +1 shift — weight decided on close[t] is applied to the t→t+1 return. Warmup buffer: load from 2019-06 so every ≤66 signal is valid by 2020-10; **measure only over 2020-10 → now** (real TQQQ).
+Every input (TQQQ, QQQ, SPY, VIX, breadth) uses its **close[t]** value; the score and the gate share the *same* timestamp alignment and the *same* +1 shift — state decided on close[t] applies to the t→t+1 return. Warmup buffer from 2019-06; **measure only over 2020-10 → now** (real TQQQ).
 
-**Costs — no double-counting:** real adjusted TQQQ prices *already embed* the 3× daily-reset financing and decay. So on real TQQQ we charge **only** (a) turnover/slippage on rebalances and (b) the T-bill rate the cash sleeve earns/forgoes — **NOT** a synthetic 3× financing charge (that would double-count). The synthetic-3× financing formula (`3·r − 2·rate − fee`) is reserved for the §6.2 pre-2010 OOS test, where no real ETF exists.
+**Costs — no double-counting:** real adjusted TQQQ prices *already embed* the 3× daily-reset financing and decay. On real TQQQ we charge **only** (a) turnover/slippage on each buy/sell and (b) the T-bill rate the cash sleeve earns — **NOT** a synthetic 3× financing charge. The synthetic formula (`3·r − 2·rate − fee`) is reserved for the §6.2 pre-2010 OOS test.
 
-**Leakage test:** inject a known future spike into bar *t+1*; assert weight[t] is unchanged (zero leakage), across all four inputs and both layers.
+**Leakage test:** inject a known future spike into bar *t+1*; assert state[t] is unchanged across all inputs.
 
-**Lookback invariant:** the **composed/total** lookback of every member ≤ 66 bars, and no expanding/all-history windows. "Composed" matters for *nested* indicators: `realizedVol(20)` fed into a `rolling-k median` has total span `20+k`, so the median window must be ≤46, not 66. *Finite-window* members (SMA, rolling-median, Donchian, ROC, and the rewritten nested-vol members) have exact composed support ≤66. *EMA-family* members (EMA, RSI, MACD, ADX) are recursively smoothed with span/period ≤66 — infinite tail in theory, bounded *effective* memory. Tests: (a) every signal's composed span ≤66 (inner+outer for nested); (b) finite-window signals bit-identical when history before *t−66* is dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX is double-smoothed, MACD-hist is EMAs-of-EMAs, so they need more warmup than a raw EMA) and set the buffer from the *slowest* member, not a global asserted constant. The two prototype `expanding(60).median()` members fail test (b) and **must** be rewritten to the bounded form in §5.2 — this is a required panel change, not optional.
+**Lookback invariant:** the **composed/total** lookback of every member ≤ 66, no expanding windows. "Composed" matters for *nested* indicators (realizedVol(20) into a rolling-k median has span 20+k, so k ≤ 46). *Finite-window* members (SMA, rolling-median, Donchian, ROC, rewritten nested-vol) have exact composed support ≤66; *EMA-family* (EMA, RSI, MACD, ADX) have bounded effective memory. Tests: (a) every composed span ≤66; (b) finite-window signals bit-identical when history before *t−66* dropped; (c) **per-member** warmup — empirically measure each EMA-family signal's convergence (ADX double-smoothed, MACD-hist EMAs-of-EMAs) and set the buffer from the *slowest* member. The two prototype `expanding(60).median()` members fail test (b) and **must** be rewritten — required, not optional.
 
 ### 5.6 Config (and what is NOT swept)
 
-Swept: `panel membership · per-category weights · gate (entry/exit SMA) · rebalance granularity`. **Fixed a priori (not swept):** `r_lo`, `r_hi` (read off the §6.1 bucket curve), the cap-above-`r_hi` rule (kept only if §6.1 says the 60–80% return peak is significant). Total free parameters tuned on data are **capped and pre-registered** before any OOS run (see §6.4) — the effective sample is tiny, so every extra knob is overfit risk.
+Swept: `panel membership · per-signal weights · BUY threshold · SELL threshold · gate-combination mode (resonance-only / SMA-only / AND / OR)`. Total free parameters tuned on data are **capped and pre-registered** before any OOS run (§6.4) — the effective sample is tiny, every extra knob is overfit risk.
 
 ---
 
-## 6. Test plan
+## 6. Test plan — A/B against the SMA gate, built to *reject*
 
-The window has **one** bear (2022). A sizing overlay that simply de-levers *mechanically* cuts drawdown, so naive "beats the gate on drawdown" proves nothing. The plan below is built to *try to kill* the idea, not flatter it.
+The window has **one** bear (2022). The plan tries to kill the idea, not flatter it.
 
 ### 6.1 Significance, not just point estimates
-
 | Test | Input | Pass criteria |
 |---|---|---|
-| Thesis CI | resonance buckets × fwd-20d | report **block-bootstrap CIs** + effective non-overlapping N per bucket; the win-rate trend must have a CI that excludes the null. If it doesn't, the premise fails — stop. |
-| Return-by-bucket | same buckets, forward *return* (not win-rate) | show the return curve with CIs; only keep the "cap above 80%" rule if the 60–80% peak is significant — else drop the cap and the claim. |
+| Thesis CI | resonance buckets × fwd-20d | block-bootstrap CIs + effective non-overlapping N per bucket; the win-rate trend's CI must exclude the null. If not, the premise fails — stop. |
 
 ### 6.2 No data-snooping — frozen train/test + genuine OOS
-
-The gate (SMA22/44), the panel, and the sizing thresholds were all discovered on 2020-10→now. So merely *freezing* that config and reporting 2023→now still leaks — the held-out slice already shaped the choices.
+The gate, panel, weights, and thresholds were all discovered on 2020-10→now. Freezing that config and reporting 2023→now still leaks.
 
 | Test | Protocol | Pass criteria |
 |---|---|---|
-| Re-derived split | Re-run the **entire** selection pipeline (gate sweep, bucket thresholds, panel, weights) using **only ≤2022-12** data — discard the prior full-window picks — then report **once** on 2023→now, untouched | edge persists. If re-deriving is impractical, 2023→now is **descriptive only** and the load-bearing test is the row below. |
-| **True OOS** (load-bearing) | run the frozen config on **synthetic 3× QQQ pre-2010** (dot-com + GFC — the regimes leverage decay punishes most) and on a **different leveraged underlying** | edge survives on data that informed no choice |
+| Re-derived split | Re-run the **entire** selection (panel, weights, BUY/SELL thresholds, combination mode) on **only ≤2022-12** data — discard prior picks — report **once** on 2023→now | edge persists. If impractical, 2023→now is **descriptive only** and the row below is load-bearing. |
+| **True OOS** (load-bearing) | run the frozen config on **synthetic 3× QQQ pre-2010** (dot-com + GFC) and a **different leveraged underlying** | edge survives on data that informed no choice |
 
-**Genuine-independence caveats:** for a different underlying, the signal source **switches** to that underlying's own inputs (SPX/QQQ-correlated), with gate/panel *structure* held fixed. **SPXL/UPRO are near-clones of the QQQ trade** → weak independent evidence; **SOXL (semis)** is a genuinely different regime → stronger. For pre-2010 synthetic, **pre-register** the cost params before running: `rate` = the historical 3-month T-bill *series* (not a constant — it swings 0–5%), `fee` = a fixed expense; report drawdown **sensitivity** to ±50 bps fee, since the dot-com/GFC verdict hinges on them.
+For a different underlying, the signal source **switches** to that underlying's own inputs. **SPXL/UPRO are near-clones** of the QQQ trade → weak evidence; **SOXL (semis)** is genuinely different → stronger. For pre-2010 synthetic, **pre-register** the cost params (`rate` = historical 3-month T-bill *series*; `fee` fixed) and report drawdown sensitivity to ±50 bps fee. In-window per-regime numbers are **descriptive only**.
 
-In-window per-regime numbers (2021/2022/2023-24/2025) are **descriptive only**, never validation — one path each, 2025 partial.
-
-### 6.3 Is it the *signal*, or just less leverage?
-
-| Test | Control (precisely pinned) | Pass criteria |
+### 6.3 The A/B — does the weighted gate actually beat the simple one?
+| Test | Comparators (all on the §6.2 OOS slices) | Pass criteria |
 |---|---|---|
-| Matched-exposure | (a) **constant** scaler = the resonance sizer's *exact* mean weight; (b) **vol-target** scaler matched on *both* mean exposure AND realized-vol budget. **Per slice:** on each §6.2 OOS slice, both controls' mean is re-derived from *that slice's own* realized resonance-weight series (not carried across underlyings). | resonance must beat the **better** of (a)/(b) on Calmar **on every §6.2 OOS slice** (2023→now, pre-2010 synthetic, different-underlying) — not one cherry-picked slice. Else the "edge" is just de-levering, and we ship the simpler vol-target instead. |
+| Gate A/B | resonance-gate · SMA22/44-gate · (resonance AND SMA) · (resonance OR SMA) · buy-hold TQQQ · buy-hold QQQ | the resonance-gate (or a combination) must beat the **SMA22/44 gate AND buy-hold** on Calmar **and** drawdown, on **every** OOS slice. If the plain SMA gate wins, **ship the SMA gate** and stop. |
+| Weighting A/B | equal-weight vs category-balanced vs tuned weights | weighting must measurably help, else use equal weights (simpler) |
 
 ### 6.4 Overfit guard (hard, not vibes)
+- **Cap free parameters tuned on data**; pre-register a single config before OOS.
+- Penalize multiple testing: report a **deflated** Sharpe/Calmar (Bonferroni or López de Prado) over the number of configs tried.
+- Cost/turnover: net edge must survive realistic cost; report switch count (the dual-threshold gap is the lever).
 
-- **Cap free parameters tuned on data.** Fix `r_lo`/`r_hi` *a priori* from the §6.1 bucket curve — do **not** re-sweep them. Pre-register a single config before looking at OOS.
-- Penalize multiple testing: report a **deflated** Sharpe/Calmar (Bonferroni or López de Prado deflated-Sharpe) over the number of configs tried.
-- Cost/turnover: net edge must survive realistic cost; report switch count.
-
-### 6.5 Baseline floor
-Must beat buy-hold TQQQ **and** QQQ risk-adjusted, **and** the bare SMA22/44 gate, **and** the matched-exposure control. Failing any → don't ship; simpler wins.
-
-**Honesty rails:** sub-20% drawdown in this window is optimistic — the bare gate's *full-cycle* (1999–2026 synthetic) drawdown was −76%. Report in-window numbers as in-window. No single-best-cell worship; prefer plateaus. If §6.1 or §6.3 fails, the design is **rejected**, not patched.
+**Honesty rails:** sub-20% drawdown in this window is optimistic — the bare gate's *full-cycle* (1999–2026 synthetic) drawdown was −76%. Report in-window as in-window. Prefer plateaus over single best cells. **If §6.1 or §6.3 fails, the design is rejected, not patched.**
 
 ---
 
-## 7. Open decisions (need your call)
+## 7. Decisions (locked)
 
-- **Q1 — Risk-off floor:** when the gate is OFF, hold **cash/T-bills** (max safety) or **1× QQQ** (stay exposed)? Prior tests: cash was cleaner; QQQ-floor lifted return but raised drawdown.
-- **Q2 — Sizing granularity:** continuous size = f(resonance), or coarse **steps** (0 / ½ / full) to cut turnover? Steps are simpler and cheaper; continuous is smoother.
-- **Q3 — Does resonance also gate entry, or only size?** Pure design: gate=timing, resonance=size only. Your "confirmed buy" instinct suggests *also* requiring a minimum resonance to enter at all (veto low-conviction). Include the veto, or keep layers clean?
-- **Q4 — Panel weighting:** equal-per-signal (simple) or **category-balanced** (so trend doesn't dominate)? I lean category-balanced.
-- **Q5 — Breadth proxy now or later?** Build the "% of top QQQ holdings above MA" breadth signal for v1, or ship v1 without it and add later?
-- **Q6 — Max conviction cap:** cap size at full 3× TQQQ, or allow a *defensive* sub-full mode (e.g. never exceed 1× in the first N days after a regime flip)?
-- **Q7 — Pullback axis in v1?** Include the second (pullback/oversold) conviction axis — your confirmed-buy idea — in v1, or ship trend-resonance sizing first and add pullback entries in v2? Needs the breadth proxy (Q5) to be at its best.
+| # | Decision | Choice |
+|---|---|---|
+| Q1 | Risk-off floor | **Sell all → 100% cash/T-bills.** No QQQ floor. |
+| Q2/Q3 | Gate model | **Power-weighted score + dual BUY/SELL thresholds, binary in/out, no sizing.** A/B tested vs the SMA gate and combinations. |
+| Q4 | Weighting | **Category-balanced** prior + per-signal power weights; equal-vs-balanced-vs-tuned A/B'd. |
+| Q5 | Breadth | **Build "% of top-N QQQ holdings above MA" in v1**, and **add it to the QQQ market-breadth dashboard** (separate deliverable). |
+| Q6 | Conviction cap | **N/A** — no sizing, so no cap. |
+| Q7 | Pullback axis | **v1 trend-only.** Pullback/oversold entries deferred to v2. |
 
 ---
 
-## 8. Why this is the right shape
+## 8. Why this shape
 
-- Uses the **candidate** edge (resonance → win-rate, pending §6.1) where it would work (sizing), not where it doesn't (timing).
-- Keeps the **best-tested** timing engine (SMA gate) untouched and responsive.
-- Generalizes your multi-signal "confirmed buy" into a tunable conviction dial.
-- Respects the constraints we established (≤66 MAs, 2020-10 window, real TQQQ, costs, no-lookahead).
-- Falsifiable: if resonance sizing doesn't beat the bare gate on Calmar **and** drawdown (§6), we don't ship it — simpler wins.
+- It's *your* model: weighted signals, one score, a buy line and a sell line, binary in/out.
+- It keeps the proven SMA gate as the explicit **bar to beat**, and A/B tests honestly instead of assuming the weighted gate wins.
+- Trend-only v1 is the simplest version that can be tested; pullback (a contrarian, opposite-direction setup) is cleanly deferred to v2.
+- Respects every constraint (≤66 MAs, 2020-10 window, real TQQQ, costs, no-lookahead) and the rigor from review (CIs, true OOS, overfit guard).
+- **Falsifiable:** if the weighted gate doesn't beat the SMA gate + buy-hold out-of-sample (§6.3), we don't ship it — simpler wins.

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -1,6 +1,6 @@
 # Design Plan — Multi-Signal Resonance for TQQQ Conviction
 
-**Status:** draft for review · **Scope:** signal-resonance layer for the TQQQ timing strategy · **Window:** 2020-10 → now (real TQQQ) · **Constraint:** no moving-average / lookback > 66 bars · **Depends on:** existing `signals/`, `backtest/` engine · **PR base:** main
+**Status:** draft for review · **Scope:** signal-resonance layer for the TQQQ timing strategy · **Window:** 2020-10 → now (real TQQQ) · **Constraint:** no moving-average / lookback > 66 bars · **Depends on:** `src/rainier/signals/`, `src/rainier/backtest/` engine · **PR base:** main
 
 ---
 
@@ -107,10 +107,12 @@ Your example — *buy TQQQ when QQQ<SMA10 AND VIX<23 AND fractal buy AND SPY<SMA
 
 | Component | Role | Where |
 |---|---|---|
-| `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `signals/panel.py` |
-| `ResonanceScorer` | panel → daily conviction score ∈ [0,1] (weighted consensus) | new `signals/resonance.py` |
-| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily target weight | new `signals/resonance_strategy.py` |
-| Daily-MTM sim | weight → equity, no lookahead, financing + costs | reuse `leveraged_common.sim` |
+| `SignalPanel` | registry of ≤66-lookback signals; each `(df) → risk-on series ∈ {0,1}` | new `src/rainier/signals/panel.py` |
+| `ResonanceScorer` | panel → daily conviction score ∈ [0,1] (weighted consensus) | new `src/rainier/signals/resonance.py` |
+| `ResonanceStrategy` | Layer-1 gate × Layer-2 size → daily target weight (implements/extends the `SignalEmitter` boundary) | new `src/rainier/signals/resonance_strategy.py` |
+| Daily-MTM sim | weight → equity, no lookahead, financing + costs | `src/rainier/backtest/` (productionize the prototype in `scripts/leveraged_common.py`) |
+
+*Note: the panel signals and the daily-MTM sim currently live only as untracked exploratory scripts (`scripts/regime_signal_search.py`, `scripts/leveraged_common.py`). v1 promotes them into `src/rainier/` per the module map in `CLAUDE.md`; the scripts are the reference implementation, not the shipping location.*
 
 ### 5.2 The panel (≤66 lookback, ~26 signals)
 

--- a/docs/DESIGN-multi-signal-resonance.md
+++ b/docs/DESIGN-multi-signal-resonance.md
@@ -33,7 +33,7 @@ The win-rate rises with agreement — a promising, monotone signal. **But treat 
 
 Right now there is no integrated system — just a pile of exploratory scripts. Two things exist:
 
-- **A 26-signal panel** (`regime_signal_search.build_signals`), each emitting a daily risk-on (1) / risk-off (0) series, all with lookback ≤ 66.
+- **An exploratory signal panel** (`regime_signal_search.build_signals`), each emitting a daily risk-on (1) / risk-off (0) series. It is *unfiltered* — most members today use >66 lookback and two use expanding medians; v1 takes only its **≤66 subset** and rewrites the expanding members (see §5.2).
 - **A timing gate** — the asymmetric SMA gate (enter when QQQ > SMA22, exit when QQQ < SMA44). In-window it was the single best risk-adjusted design (Calmar ≈ 1.37, #2 of 270 in a full sweep, on a stable plateau).
 
 ```
@@ -161,7 +161,7 @@ raw resonance r[t]  ──►  (1) curve: size = clamp((r−r_lo)/(r_hi−r_lo),
                     ──►  (4) rebalance only when the held step actually changes
 ```
 
-Boot: at the first valid bar `t0`, held_step = target_step[t0] (no dwell required — there is no prior to confirm against). Moves are **direct** to the confirmed target (e.g. 0→1 in one transition once the new step holds `dwell` bars), not forced stepwise through ½. Hysteresis lives **only** here — not on the raw score (the §5.3 over-spec is removed). Deterministic and unit-testable; a test asserts a fixed input sequence yields a fixed held-step sequence.
+Boot: at the first valid bar `t0` (after the §5.5c per-member warmup), held_step = target_step[t0] — provisional, taken without confirmation since there's no prior; every *subsequent* move still requires the full `dwell`. Moves are **direct** to the confirmed target (e.g. 0→1 in one transition once the new step holds `dwell` bars), not forced stepwise through ½. The dwell counter resets whenever target_step changes value. Hysteresis lives **only** here — not on the raw score (the §5.3 over-spec is removed). Deterministic and unit-testable; a test asserts a fixed input sequence yields a fixed held-step sequence.
 
 ### 5.5 No-lookahead + costs
 
@@ -207,7 +207,7 @@ In-window per-regime numbers (2021/2022/2023-24/2025) are **descriptive only**, 
 
 | Test | Control (precisely pinned) | Pass criteria |
 |---|---|---|
-| Matched-exposure | (a) **constant** scaler = the resonance sizer's *exact* mean weight; (b) **vol-target** scaler matched on *both* mean exposure AND realized-vol budget. Both computed on the **frozen §6.2 test slice**, not re-fit. | resonance must beat the **better** of (a)/(b) on Calmar — else the "edge" is just de-levering, and we ship the simpler vol-target instead |
+| Matched-exposure | (a) **constant** scaler = the resonance sizer's *exact* mean weight; (b) **vol-target** scaler matched on *both* mean exposure AND realized-vol budget. **Per slice:** on each §6.2 OOS slice, both controls' mean is re-derived from *that slice's own* realized resonance-weight series (not carried across underlyings). | resonance must beat the **better** of (a)/(b) on Calmar **on every §6.2 OOS slice** (2023→now, pre-2010 synthetic, different-underlying) — not one cherry-picked slice. Else the "edge" is just de-levering, and we ship the simpler vol-target instead. |
 
 ### 6.4 Overfit guard (hard, not vibes)
 

--- a/docs/NOTE-resonance-as-maunakea-goal.md
+++ b/docs/NOTE-resonance-as-maunakea-goal.md
@@ -1,0 +1,60 @@
+# Note — Resonance Gate-Search as the Flagship Maunakea Trading Goal
+
+**Status:** forward-pointer (not v1 work) · **Owner of the eventual build:** the maunakea *trading wrapper* (downstream, Phase 4) · **Blocked on:** maunakea `Engine.run()` (Phase 2) + `recurse()` (Phase 3), both `NotImplementedError` today
+
+---
+
+## Why this note exists
+
+The whole TQQQ resonance investigation (10+ exploratory studies in `docs/REPORT-*.html`, scripts in `scripts/`) was me **hand-cranking** a research loop: propose a signal/gate combo → backtest → A/B vs the SMA22/44 gate → check OOS → guard against overfit → propose the next combo. **That loop is exactly what maunakea automates.** This note captures it as a ready-made goal so the trading wrapper has a real first target the day maunakea's iterate/recurse machinery exists.
+
+## Architecture reminder (so this lands in the right place)
+
+Per `~/projects/maunakea/CLAUDE.md`, maunakea core is **domain-agnostic** — CI enforces zero `rainier` references in `src/maunakea/`. Trading lives in a **downstream wrapper** (Phase 4 in maunakea's roadmap), never in core.
+
+```
+maunakea core (engine: suggest/run/recurse)  ──used by──►  trading wrapper (THIS goal)
+                                                                  │ data from / strategy to
+                                                                  ▼
+                                                              rainier (data backfill, execution, live signals)
+```
+
+- **rainier** ships the data (per `DESIGN-rainier-data-backfill-for-maunakea`) and runs the vetted gate as a live `WeightStrategy` (the v1 we're building now in `src/rainier/signals/`).
+- **The trading wrapper** points maunakea at that data with the goal below and lets the engine search recursively.
+
+## The goal spec (for the wrapper)
+
+```
+dataset: QQQ, TQQQ, SPY, VIX, IRX daily (rainier backfill) — real adjusted prices,
+         2010→now real TQQQ + synthetic 3×QQQ pre-2010 for OOS.
+
+goal:    "Find a daily entry/exit gate for TQQQ that beats the SMA22/44 gate AND
+          buy-and-hold on Calmar AND max-drawdown, out-of-sample, net of cost."
+
+hard guardrails (the wrapper must hand maunakea these as constraints, because the
+hand-search proved they're where naive results die):
+  - no moving-average / lookback > 66 bars (composed/nested span counts)
+  - no-lookahead: signal on close[t], effective t→t+1
+  - real TQQQ already embeds 3× financing — charge only turnover + cash-leg rate;
+    synthetic 3× (3·r − 2·rate − fee) ONLY pre-2010 where no real ETF exists
+  - validate on a re-derived ≤2022 train / 2023→now test AND a genuinely independent
+    slice (pre-2010 synthetic or SOXL — NOT SPXL/UPRO near-clones)
+  - de-levering is not edge: must beat a matched-exposure control
+  - deflated Sharpe over #configs tried; pre-register the final config
+
+known baseline to beat (from the hand-search):
+  asymmetric SMA22/44 gate → TQQQ/cash : in-window Calmar ≈ 1.37, full-cycle Calmar ≈ 0.34,
+  full-cycle (1999–2026) max drawdown ≈ −76%. Hard to beat. If maunakea can't, the
+  honest answer is "ship the SMA gate" — and that's a valid recursive-loop result.
+```
+
+## What "recursive" buys us here that the hand-search couldn't
+
+- **Breadth of search** — the hand-search tried ~270 SMA pairs + ~80 signal add-ons. Maunakea can sweep far wider without me getting bored or sloppy.
+- **Self-improvement** — its `meta_suggestion` learns *how to search this space better* (e.g. "stop proposing slow-MA exits, they overfit the one 2022 bear"), which is the lesson it took me ten messages to learn by hand.
+- **Honesty by construction** — the guardrails above become the engine's scoring constraints, so it can't reward a leaky/overfit result.
+
+## Status / next
+
+- **Now:** rainier builds the resonance gate v1 (the hand-found candidate) as a live strategy. See `DESIGN-multi-signal-resonance.md`.
+- **When maunakea Phase 2/3 land:** stand up the trading wrapper, hand it this goal + guardrails, and let it try to beat the v1 gate. The v1 gate becomes maunakea's first concrete "can you do better than the human?" benchmark.

--- a/src/rainier/backtest/daily_mtm.py
+++ b/src/rainier/backtest/daily_mtm.py
@@ -1,0 +1,147 @@
+"""Daily mark-to-market portfolio sim for ``WeightStrategy`` gates.
+
+Productionized from ``scripts/regime_switch_study.run_portfolio`` (per-asset
+daily MTM, no lookahead, turnover + T-bill cost). The sim owns the **+1 shift**:
+a decision weight at ``close[t]`` applies to the t→t+1 return. The first bar is
+flat (no prior decision to act on).
+
+```
+   decision weights w[t] (from a WeightStrategy, un-shifted)
+            │  shift +1  (w[t] decided on close[t] applies to t→t+1 return)
+            ▼
+   for each day: port_ret = Σ wᵢ·retᵢ + (1-Σwᵢ)·cash_rate  −  turnover·cost
+            ▼
+   equity curve  ──►  metrics (return, CAGR, maxDD, Calmar, Sharpe, switches)
+```
+
+**Costs — no double-counting (design §5.5).** On *real adjusted TQQQ* the price
+already embeds the 3× daily-reset financing and decay, so we charge ONLY
+turnover/slippage on each buy/sell plus the T-bill rate the cash sleeve earns.
+The synthetic ``3·r − 2·rate − fee`` formula is reserved for the §6.2 pre-2010
+OOS test and lives in the study layer, NOT here.
+
+Cash rate can be a scalar (constant T-bill) or a per-day series (historical
+3-month T-bill), matching the spec's pre-registered pre-2010 cost params.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+ANNUAL = 252
+DEFAULT_CASH_APY = 0.04
+DEFAULT_ONE_WAY_COST = 0.0003  # 3 bps per unit of turnover (one-way)
+
+
+def max_drawdown(curve: np.ndarray) -> float:
+    """Largest peak-to-trough fractional drop over an equity curve."""
+    peak = -np.inf
+    mdd = 0.0
+    for v in curve:
+        if v > peak:
+            peak = v
+        if peak > 0:
+            mdd = max(mdd, (peak - v) / peak)
+    return mdd
+
+
+def shift_decision(weights: np.ndarray) -> np.ndarray:
+    """Apply the +1 no-lookahead shift: decision at close[t] acts on t→t+1.
+
+    The first bar becomes flat (0) — there is no prior-day decision to act on.
+    """
+    out = np.zeros_like(weights, dtype=float)
+    out[1:] = weights[:-1]
+    return out
+
+
+@dataclass
+class PortfolioResult:
+    name: str
+    equity: np.ndarray
+    total_return: float = 0.0
+    cagr: float = 0.0
+    max_dd: float = 0.0
+    calmar: float = 0.0
+    sharpe: float = 0.0
+    exposure: float = 0.0
+    switches: int = 0
+
+
+def _cash_daily(cash_apy) -> np.ndarray | float:
+    """Convert an annual cash yield (scalar or per-day series) to a daily rate."""
+    arr = np.asarray(cash_apy, dtype=float)
+    return (1.0 + arr) ** (1.0 / ANNUAL) - 1.0
+
+
+def run_portfolio(
+    name: str,
+    weights: dict[str, np.ndarray],
+    rets: dict[str, np.ndarray],
+    n_years: float,
+    *,
+    cash_apy=DEFAULT_CASH_APY,
+    one_way_cost: float = DEFAULT_ONE_WAY_COST,
+    pre_shifted: bool = False,
+) -> PortfolioResult:
+    """Run the daily-MTM sim over per-asset decision weights.
+
+    Parameters
+    ----------
+    weights : dict[asset -> ndarray]
+        Daily **decision** weights (un-shifted) per asset; remainder is cash.
+        Set ``pre_shifted=True`` only if the caller already applied the +1 shift.
+    rets : dict[asset -> ndarray]
+        Daily simple returns per asset, aligned to ``weights``.
+    n_years : float
+        Span in years (for CAGR). Calmar = CAGR / maxDD.
+    cash_apy : float | ndarray
+        Annual cash yield — scalar (constant T-bill) or per-day series
+        (historical 3-month T-bill). Earned on the un-invested fraction.
+    one_way_cost : float
+        Cost per unit of turnover (one-way), charged on each rebalance.
+    """
+    assets = list(weights.keys())
+    if not assets:
+        raise ValueError("weights is empty")
+    n = len(next(iter(weights.values())))
+    for a in assets:
+        if len(weights[a]) != n:
+            raise ValueError(f"weight series length mismatch for {a}")
+        if len(rets[a]) != n:
+            raise ValueError(f"return series length mismatch for {a}")
+
+    shifted = {a: (weights[a] if pre_shifted else shift_decision(weights[a])) for a in assets}
+    cash_daily = _cash_daily(cash_apy)
+    cash_arr = np.full(n, cash_daily) if np.isscalar(cash_daily) else np.asarray(cash_daily)
+
+    eq = np.ones(n)
+    cur = 1.0
+    prev = {a: 0.0 for a in assets}
+    exposure_days = 0.0
+    switches = 0
+    for t in range(n):
+        w = {a: float(shifted[a][t]) for a in assets}
+        invested = sum(w.values())
+        port_ret = sum(w[a] * rets[a][t] for a in assets) + (1.0 - invested) * cash_arr[t]
+        turnover = sum(abs(w[a] - prev[a]) for a in assets)
+        if turnover > 1e-9:
+            switches += 1
+        cur *= 1.0 + port_ret - turnover * one_way_cost
+        eq[t] = cur
+        prev = w
+        exposure_days += invested
+
+    res = PortfolioResult(name, eq)
+    res.total_return = eq[-1] - 1.0
+    res.cagr = eq[-1] ** (1.0 / n_years) - 1.0 if n_years > 0 else 0.0
+    res.max_dd = max_drawdown(eq)
+    res.calmar = res.cagr / res.max_dd if res.max_dd > 0 else float("inf")
+    dr = np.diff(eq) / eq[:-1]
+    if dr.std() > 0:
+        res.sharpe = float(dr.mean() / dr.std() * np.sqrt(ANNUAL))
+    res.exposure = exposure_days / n
+    res.switches = switches
+    return res

--- a/src/rainier/backtest/resonance_report.py
+++ b/src/rainier/backtest/resonance_report.py
@@ -1,0 +1,179 @@
+"""Render the resonance-gate §6 study to a self-contained HTML report.
+
+Aesthetic mirrors the repo's other exploratory reports (dark, sticky header,
+decision boxes). The verdict is rendered honestly — if the gate loses, the
+banner says "ship the SMA gate".
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from rainier.backtest.resonance_study import (
+    BUY_GRID,
+    SELL_GRID,
+    TRAIN_END,
+    WEIGHT_MODES,
+    ABRow,
+    StudyResult,
+    run_study,
+)
+
+_CSS = """
+:root{--bg:#0e1117;--panel:#161b22;--ink:#e6edf3;--mut:#8b93a7;--line:#222a35;
+--pos:#3ddc97;--neg:#ff6b6b;--key:#5aa9ff;--warn:#e3b341}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:15px/1.55 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif}
+main{max-width:1040px;margin:0 auto;padding:28px 22px 80px}
+h1{font-size:26px;margin:0 0 4px}h2.sec{font-size:19px;margin:34px 0 12px;
+border-bottom:1px solid var(--line);padding-bottom:6px}
+.sub{color:var(--mut);margin:0 0 18px}
+table{width:100%;border-collapse:collapse;margin:10px 0;font-size:13.5px}
+th,td{padding:7px 10px;border-bottom:1px solid var(--line);text-align:left}
+th{color:var(--mut);font-weight:600}
+td.r,th.r{text-align:right;font-variant-numeric:tabular-nums}
+.pos{color:var(--pos)}.neg{color:var(--neg)}
+code{background:#0b0f14;padding:1px 5px;border-radius:4px;font-size:12.5px}
+.box{border:1px solid var(--line);border-radius:8px;padding:14px 16px;margin:14px 0;background:var(--panel)}
+.box.key{border-color:var(--key)}.box.warn{border-color:var(--warn)}
+.box.ship{border-color:var(--pos);border-width:2px}
+.box.reject{border-color:var(--neg);border-width:2px}
+.box h4{margin:0 0 6px}.muted{color:var(--mut);font-size:13px}
+.foot{color:var(--mut);font-size:12px;margin-top:40px;border-top:1px solid var(--line);padding-top:12px}
+.badge{display:inline-block;padding:2px 8px;border-radius:10px;font-size:11.5px;font-weight:700}
+.badge.win{background:rgba(61,220,151,.15);color:var(--pos)}
+.badge.lose{background:rgba(255,107,107,.15);color:var(--neg)}
+"""
+
+
+def _pct(x: float) -> str:
+    if x == float("inf"):
+        return "∞"
+    return f"{x * 100:+.1f}%"
+
+
+def _num(x: float) -> str:
+    if x == float("inf"):
+        return "∞"
+    return f"{x:.2f}"
+
+
+def _ab_rows(rows: list[ABRow]) -> str:
+    out = []
+    for r in rows:
+        badge = ("<span class='badge win'>beats SMA+B&amp;H</span>" if r.beats_sma_and_bh
+                 else "<span class='badge lose'>—</span>")
+        out.append(
+            f"<tr><td>{r.name}</td>"
+            f"<td class='r {'pos' if r.ret > 0 else 'neg'}'>{_pct(r.ret)}</td>"
+            f"<td class='r neg'>{_pct(-r.dd)}</td>"
+            f"<td class='r'><b>{_num(r.calmar)}</b></td>"
+            f"<td class='r'>{r.switches}</td><td>{badge}</td></tr>")
+    return "\n".join(out)
+
+
+def _ab_table(rows: list[ABRow], caption: str) -> str:
+    return f"""<p class="muted">{caption}</p>
+<table>
+<tr><th>Strategy</th><th class="r">Return</th><th class="r">MaxDD</th>
+<th class="r">Calmar</th><th class="r">Switches</th><th>Anti-gaming</th></tr>
+{_ab_rows(rows)}
+</table>"""
+
+
+def render(study: StudyResult) -> str:
+    t = study.thesis
+    bucket_rows = "\n".join(
+        f"<tr><td>{lbl}</td><td class='r'>{wr*100:.0f}%</td><td class='r'>{eff}</td></tr>"
+        for lbl, wr, eff in t.buckets)
+    ship = study.verdict.startswith("SHIP THE RESONANCE")
+    verdict_cls = "ship" if ship else "reject"
+
+    oos_section = (
+        _ab_table(study.oos_ab, "Frozen config run on synthetic 3×QQQ pre-2010 "
+                  "(dot-com + GFC); synthetic financing/decay netted into the "
+                  "return series; historical T-bill cash. Breadth excluded "
+                  "(frozen ex-ante universe, §6.2).")
+        if study.oos_ab else
+        "<p class='muted'>Pre-2010 OOS slice unavailable in this run.</p>")
+
+    oos_anti = study.oos_anti or {}
+    return f"""<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Resonance Gate v1 — §6 A/B Evaluation</title><style>{_CSS}</style></head>
+<body><main>
+<h1>Multi-Signal Resonance Gate v1 — §6 falsifiable evaluation</h1>
+<p class="sub">Real adjusted TQQQ · {study.window} · daily MTM, no lookahead,
+turnover + T-bill cost · generated {datetime.now(timezone.utc):%Y-%m-%d %H:%M} UTC ·
+source <code>rainier.backtest.resonance_study</code></p>
+
+<div class="box {verdict_cls}"><h4>Verdict</h4>
+<p style="margin:0;font-size:16px"><b>{study.verdict}</b></p></div>
+
+<div class="box warn"><h4>How to read this (the test is built to reject)</h4>
+<p style="margin:0">The window holds one bear (2022). The plan tries to kill the
+idea, not flatter it. The resonance gate earns its place ONLY if it beats the
+<code>SMA22/44</code> gate <b>and</b> buy-hold on the re-derived 2023→now split
+<b>and</b> survives the pre-2010 synthetic OOS — with the anti-gaming rule that a
+combo winner must also beat its own SMA component and resonance-only must beat
+buy-hold. If §6.1's win-rate slope CI includes zero, the premise fails outright.</p></div>
+
+<h2 class="sec">§6.1 · Thesis CI — does more agreement raise the win-rate?</h2>
+<p>Forward-20-day TQQQ win-rate by resonance-score bucket. <b>Effective N</b> ≈
+bucket-days ÷ 20 (the forward windows overlap, so raw counts overstate
+independence). The slope of bucket → win-rate is block-bootstrapped (20-day
+blocks); its 95% CI must exclude 0.</p>
+<table><tr><th>Score bucket</th><th class="r">Win-rate (fwd 20d)</th>
+<th class="r">Effective N</th></tr>{bucket_rows}</table>
+<p class="muted">Slope point estimate <b>{t.slope_point:+.4f}</b> · 95% CI
+[{t.slope_ci[0]:+.4f}, {t.slope_ci[1]:+.4f}] ·
+<b>{'excludes 0 — significant' if t.excludes_null else 'includes 0 — NOT significant'}</b>.</p>
+
+<h2 class="sec">§6.2(a) · Re-derived split — select on ≤2022, report once on 2023→now</h2>
+<p>The entire resonance config (weights mode, BUY, SELL) was re-selected on the
+<code>≤{TRAIN_END}</code> slice ONLY (best train Calmar),
+discarding any prior picks, then reported a single time on the held-out
+2023→now slice. <b>{study.n_configs}</b> configs were tried on train.</p>
+<p class="muted">Selected config <code>{study.train_cfg.label()}</code> ·
+train Calmar {_num(study.train_calmar)} ·
+<b>deflated</b> Calmar (÷(1+ln·#configs)) {_num(study.deflated_train_calmar)}
+— the multiple-testing haircut over {study.n_configs} configs.</p>
+{_ab_table(study.test_ab, "A/B on the held-out 2023→now slice. Real TQQQ; "
+           "turnover + T-bill cost only (no synthetic 3× financing — the "
+           "adjusted price already embeds it, §5.5).")}
+<p class="muted">Anti-gaming on this slice: resonance-only beats buy-hold =
+<b>{study.test_anti.get('res_beats_bh')}</b>; resonance-only beats SMA+B&amp;H =
+<b>{study.test_anti.get('resonance_beats_sma_and_bh')}</b>.</p>
+
+<h2 class="sec">§6.2(b) · True-OOS — frozen config on synthetic 3×QQQ pre-2010</h2>
+{oos_section}
+<p class="muted">Anti-gaming on OOS: resonance-only beats buy-hold =
+<b>{oos_anti.get('res_beats_bh')}</b>.</p>
+
+<h2 class="sec">§6.4 · Overfit guard</h2>
+<ul>
+<li>Free parameters are capped + pre-registered: BUY∈{list(BUY_GRID)},
+SELL∈{list(SELL_GRID)}, weight-mode∈{list(WEIGHT_MODES)} →
+{study.n_configs} configs.</li>
+<li>Reported metric is <b>deflated</b> over #configs (above), not the raw best cell.</li>
+<li>Net edge is after realistic cost; switch counts are shown per strategy (the
+BUY−SELL gap is the turnover lever).</li>
+<li>In-window sub-20% drawdown is optimistic — the bare gate's full-cycle
+(1999–2026 synthetic) drawdown was −76%; in-window numbers are in-window.</li>
+</ul>
+
+<div class="foot">Multi-Signal Resonance Gate v1 · design
+docs/DESIGN-multi-signal-resonance.md · exploratory evaluation, falsifiable by
+construction. A losing verdict ("ship the SMA gate") is a valid, expected
+outcome — simpler wins.</div>
+</main></body></html>"""
+
+
+def write_report(out_path: Path | None = None, n_boot: int = 2000) -> Path:
+    out_path = out_path or (
+        Path(__file__).resolve().parents[3] / "docs" / "REPORT-resonance-gate-v1.html")
+    study = run_study(n_boot=n_boot)
+    out_path.write_text(render(study))
+    return out_path

--- a/src/rainier/backtest/resonance_report.py
+++ b/src/rainier/backtest/resonance_report.py
@@ -171,9 +171,24 @@ outcome — simpler wins.</div>
 </main></body></html>"""
 
 
-def write_report(out_path: Path | None = None, n_boot: int = 2000) -> Path:
-    out_path = out_path or (
-        Path(__file__).resolve().parents[3] / "docs" / "REPORT-resonance-gate-v1.html")
-    study = run_study(n_boot=n_boot)
+def _default_report_path() -> Path:
+    """Default report path resolved from the INVOCATION context (not the package
+    install tree). Prefer ``<repo-root>/docs`` discovered from cwd (so a
+    wheel-installed console script writes into the user's workspace as the CLI
+    help promises); fall back to ``<cwd>/docs`` and create it if needed."""
+    cwd = Path.cwd()
+    for base in (cwd, *cwd.parents):
+        if (base / "docs").is_dir():
+            return base / "docs" / "REPORT-resonance-gate-v1.html"
+    target = cwd / "docs"
+    target.mkdir(parents=True, exist_ok=True)
+    return target / "REPORT-resonance-gate-v1.html"
+
+
+def write_report(out_path: Path | None = None, n_boot: int = 2000,
+                 csv_dir: Path | None = None) -> Path:
+    out_path = out_path or _default_report_path()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    study = run_study(csv_dir=csv_dir, n_boot=n_boot)
     out_path.write_text(render(study))
     return out_path

--- a/src/rainier/backtest/resonance_study.py
+++ b/src/rainier/backtest/resonance_study.py
@@ -100,6 +100,11 @@ def build_world(
     if real_tqqq:
         tq = _load("TQQQ_long", csv_dir)[["timestamp", "close"]].rename(columns={"close": "tqqq"})
         df = df.merge(tq, on="timestamp", how="left")
+        # Drop pre-inception rows (TQQQ launched 2010-02): a left-join leaves the
+        # tqqq column NaN before then, and pct_change().fillna(0) would otherwise
+        # fabricate years of flat 0% "real TQQQ" history. Start at real inception
+        # so any caller (not just the internal 2019-06 window) gets honest data.
+        df = df[df["tqqq"].notna()].reset_index(drop=True)
     df = df.sort_values("timestamp").reset_index(drop=True)
     df["irx"] = df["irx"].ffill().fillna(2.0) / 100.0
     rate_daily = (df["irx"] / ANNUAL).to_numpy()
@@ -174,9 +179,14 @@ def metrics_over(
     res.cagr = seg[-1] ** (1.0 / yrs) - 1.0
     res.max_dd = max_drawdown(seg)
     res.calmar = res.cagr / res.max_dd if res.max_dd > 0 else float("inf")
-    # switches over the window only
-    sw = shift_decision(decision)[idx]
-    res.switches = int(np.sum(np.abs(np.diff(np.r_[0.0, sw])) > 1e-9))
+    # Switches over the window only. Seed the diff with the position carried
+    # INTO the window (the shifted weight just before idx[0]), not 0 — otherwise
+    # a strategy already invested when the window opens (e.g. buy-hold over a
+    # later sub-window) is miscounted as a fresh entry on the first bar.
+    shifted = shift_decision(decision)
+    sw = shifted[idx]
+    prior = shifted[idx[0] - 1] if idx[0] > 0 else 0.0
+    res.switches = int(np.sum(np.abs(np.diff(np.r_[prior, sw])) > 1e-9))
     res.exposure = float(np.mean(sw))
     return res
 

--- a/src/rainier/backtest/resonance_study.py
+++ b/src/rainier/backtest/resonance_study.py
@@ -344,6 +344,7 @@ def select_on_train(world: World, train_end: str = TRAIN_END) -> tuple[GateConfi
     mandatory re-derived split: nothing past train_end informs the pick.
     """
     best, best_calmar, n_tried = None, -np.inf, 0
+    nan_fallback: GateConfig | None = None  # used only if NOTHING finite/inf ran
     for mode in WEIGHT_MODES:
         for buy in BUY_GRID:
             for sell in SELL_GRID:
@@ -356,14 +357,18 @@ def select_on_train(world: World, train_end: str = TRAIN_END) -> tuple[GateConfi
                 cfg = GateConfig(buy, sell, mode)
                 # A zero-drawdown candidate has Calmar = +inf and IS the best —
                 # do NOT reject inf (the old `np.isfinite` filter dropped it and
-                # could leave best=None → crash). Skip only NaN (never comparable).
-                # Seed first valid candidate so best is never None when any ran.
+                # could leave best=None → crash). Skip NaN (never comparable): a
+                # NaN must NOT seed best_calmar, or `m.calmar > NaN` is forever
+                # False and finite candidates can never win (codex P2). Stash it
+                # only as a last-resort fallback when no comparable config exists.
                 if np.isnan(m.calmar):
-                    if best is None:
-                        best, best_calmar = cfg, m.calmar
+                    if nan_fallback is None:
+                        nan_fallback = cfg
                     continue
-                if best is None or m.calmar > best_calmar:
+                if m.calmar > best_calmar:
                     best_calmar, best = m.calmar, cfg
+    if best is None:  # every candidate was NaN
+        return nan_fallback, n_tried, best_calmar
     return best, n_tried, best_calmar
 
 

--- a/src/rainier/backtest/resonance_study.py
+++ b/src/rainier/backtest/resonance_study.py
@@ -62,6 +62,20 @@ SMA_EXIT = 44
 # ---------------------------------------------------------------------------
 
 def _csv_dir() -> Path:
+    """Default CSV directory, resolved from the INVOCATION context, not the
+    package install path.
+
+    ``__file__``-relative paths break for a wheel/non-editable install (they
+    point inside ``site-packages``). The data lives in the user's working
+    project, so prefer ``<cwd>/data/csv`` (and walk up to the repo root if the
+    CLI is run from a subdirectory). Fall back to the source-tree location only
+    when neither exists, so editable installs still work without a cwd match.
+    """
+    cwd = Path.cwd()
+    for base in (cwd, *cwd.parents):
+        cand = base / "data" / "csv"
+        if cand.is_dir():
+            return cand
     return Path(__file__).resolve().parents[3] / "data" / "csv"
 
 

--- a/src/rainier/backtest/resonance_study.py
+++ b/src/rainier/backtest/resonance_study.py
@@ -1,0 +1,466 @@
+"""Resonance-gate A/B study — the §6 falsifiable evaluation, built to *reject*.
+
+Runs the design ``docs/DESIGN-multi-signal-resonance.md`` §6 plan:
+
+  §6.1  Thesis CI    — resonance-bucket × forward-20d win-rate, block-bootstrap
+                       CIs + effective non-overlapping N. The win-rate trend's
+                       CI must exclude the null or the premise fails.
+  §6.2  No snooping  — (a) re-derived ≤2022 train / 2023→now test split
+                       (mandatory); (b) True-OOS on synthetic 3×QQQ pre-2010
+                       (dot-com + GFC) with pre-registered cost params.
+  §6.3  A/B          — resonance-gate vs SMA22/44 gate vs AND/OR combos vs
+                       buy-hold TQQQ/QQQ, with the anti-gaming criteria.
+  §6.4  Overfit      — deflated metric over #configs, cost/turnover survival.
+
+**Honest verdict:** if the resonance gate does NOT beat the SMA22/44 gate AND
+buy-hold out-of-sample, the report says "ship the SMA gate" — a valid outcome.
+
+This module lives in ``backtest/`` and imports only from ``core/`` and
+``signals/`` *boundary* code (panel/scorer/gate are signal builders; the gate
+is consumed via the ``WeightStrategy`` shape). Costs follow §5.5: real adjusted
+TQQQ already embeds 3× financing → charge only turnover + T-bill; the synthetic
+``3·r − 2·rate − fee`` is used ONLY for the pre-2010 OOS slice.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from rainier.backtest.daily_mtm import (
+    ANNUAL,
+    PortfolioResult,
+    max_drawdown,
+    run_portfolio,
+    shift_decision,
+)
+from rainier.signals.panel import PanelInputs, SignalPanel
+from rainier.signals.resonance import ResonanceScorer
+from rainier.signals.resonance_gate import ResonanceGate
+
+EXPENSE = 0.0095        # TQQQ-class expense ratio (synthetic-3× path only)
+DEFAULT_FEE = EXPENSE
+WIN_START = "2020-10-01"
+TRAIN_END = "2022-12-31"
+TEST_START = "2023-01-01"
+
+# Threshold grids swept on the train slice (capped per §6.4).
+BUY_GRID = (0.55, 0.60, 0.65, 0.70)
+SELL_GRID = (0.35, 0.40, 0.45)
+WEIGHT_MODES = ("equal", "category_balanced")
+
+# SMA gate (the bar to beat): enter QQQ>SMA_E, exit QQQ<SMA_X.
+SMA_ENTRY = 22
+SMA_EXIT = 44
+
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+
+def _csv_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "data" / "csv"
+
+
+def _load(sym: str, csv_dir: Path) -> pd.DataFrame:
+    return pd.read_csv(csv_dir / f"{sym}_1D.csv", parse_dates=["timestamp"])
+
+
+@dataclass
+class World:
+    """Aligned market frame for one study window."""
+    ts: pd.Series          # timestamps
+    df: pd.DataFrame       # QQQ open/high/low/close + vix + spy columns
+    tqqq_ret: np.ndarray   # leveraged asset daily simple return (real or synthetic)
+    qqq_ret: np.ndarray
+    rate_daily: np.ndarray  # daily T-bill rate (cash sleeve)
+    synthetic: bool
+
+
+def build_world(
+    start: str = "1999-01-01",
+    end: str | None = None,
+    real_tqqq: bool = True,
+    csv_dir: Path | None = None,
+) -> World:
+    """Aligned QQQ/SPY/VIX/IRX frame + the leveraged return series.
+
+    real_tqqq=True uses real adjusted TQQQ daily returns (2010+); False builds
+    the validated synthetic 3× (``3·r − 2·rate − fee``) for the pre-2010 slice.
+    """
+    csv_dir = csv_dir or _csv_dir()
+    qqq = _load("QQQ_long", csv_dir)
+    spy = _load("SPY_long", csv_dir)[["timestamp", "close"]].rename(columns={"close": "spy"})
+    vix = _load("VIX_long", csv_dir)[["timestamp", "close"]].rename(columns={"close": "vix"})
+    irx = _load("IRX_long", csv_dir)[["timestamp", "close"]].rename(columns={"close": "irx"})
+    df = qqq.merge(spy, on="timestamp").merge(vix, on="timestamp").merge(irx, on="timestamp")
+    if real_tqqq:
+        tq = _load("TQQQ_long", csv_dir)[["timestamp", "close"]].rename(columns={"close": "tqqq"})
+        df = df.merge(tq, on="timestamp", how="left")
+    df = df.sort_values("timestamp").reset_index(drop=True)
+    df["irx"] = df["irx"].ffill().fillna(2.0) / 100.0
+    rate_daily = (df["irx"] / ANNUAL).to_numpy()
+    qret = df["close"].pct_change().fillna(0).to_numpy()
+    if real_tqqq:
+        tqqq_ret = df["tqqq"].pct_change().fillna(0).to_numpy()
+    else:
+        tqqq_ret = 3.0 * qret - 2.0 * rate_daily - EXPENSE / ANNUAL
+    lo = pd.Timestamp(start, tz="UTC")
+    mask = df["timestamp"] >= lo
+    if end is not None:
+        mask &= df["timestamp"] <= pd.Timestamp(end, tz="UTC")
+    df = df[mask].reset_index(drop=True)
+    sl = mask[mask].index
+    return World(
+        ts=df["timestamp"],
+        df=df,
+        tqqq_ret=tqqq_ret[sl][: len(df)],
+        qqq_ret=qret[sl][: len(df)],
+        rate_daily=rate_daily[sl][: len(df)],
+        synthetic=not real_tqqq,
+    )
+
+
+def panel_inputs(world: World) -> PanelInputs:
+    return PanelInputs(
+        qqq=world.df[["open", "high", "low", "close"]],
+        vix=world.df["vix"],
+        spy=world.df["spy"],
+        breadth=None,  # frozen-universe breadth excluded from OOS claims (§6.2)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Window helpers + metrics measured over a sub-window
+# ---------------------------------------------------------------------------
+
+def _window_idx(ts: pd.Series, start: str | None, end: str | None) -> np.ndarray:
+    m = np.ones(len(ts), dtype=bool)
+    if start:
+        m &= (ts >= pd.Timestamp(start, tz="UTC")).to_numpy()
+    if end:
+        m &= (ts <= pd.Timestamp(end, tz="UTC")).to_numpy()
+    return np.where(m)[0]
+
+
+def metrics_over(
+    decision: np.ndarray,
+    world: World,
+    asset_ret: np.ndarray,
+    start: str | None,
+    end: str | None,
+    name: str,
+    *,
+    synthetic: bool = False,
+) -> PortfolioResult:
+    """Sim over the full series, then renormalize equity to a sub-window.
+
+    The gate runs on the full buffered history (warmup honored); metrics are
+    measured only over [start, end]. Costs: real TQQQ → turnover + T-bill only;
+    synthetic path already nets financing into the return series.
+    """
+    idx = _window_idx(world.ts, start, end)
+    # cash_apy per-day series so pre-2010 uses the historical T-bill (§6.2).
+    cash_apy = world.rate_daily * ANNUAL
+    full = run_portfolio(name, {"A": decision}, {"A": asset_ret}, n_years=1.0,
+                         cash_apy=cash_apy, one_way_cost=0.0003)
+    seg = full.equity[idx] / full.equity[idx[0]]
+    yrs = max((world.ts.iloc[idx[-1]] - world.ts.iloc[idx[0]]).days / 365.25, 0.1)
+    res = PortfolioResult(name, seg)
+    res.total_return = seg[-1] - 1.0
+    res.cagr = seg[-1] ** (1.0 / yrs) - 1.0
+    res.max_dd = max_drawdown(seg)
+    res.calmar = res.cagr / res.max_dd if res.max_dd > 0 else float("inf")
+    # switches over the window only
+    sw = shift_decision(decision)[idx]
+    res.switches = int(np.sum(np.abs(np.diff(np.r_[0.0, sw])) > 1e-9))
+    res.exposure = float(np.mean(sw))
+    return res
+
+
+# ---------------------------------------------------------------------------
+# Gate constructors → decision series (un-shifted)
+# ---------------------------------------------------------------------------
+
+def resonance_decision(world: World, buy: float, sell: float, mode: str) -> np.ndarray:
+    gate = ResonanceGate(ResonanceScorer(SignalPanel(), mode=mode), buy=buy, sell=sell)
+    return gate.decide(panel_inputs(world))
+
+
+def sma_gate_decision(world: World, entry: int = SMA_ENTRY, exit_: int = SMA_EXIT) -> np.ndarray:
+    """The bar-to-beat: enter QQQ>SMA_entry, exit QQQ<SMA_exit (state machine)."""
+    c = world.df["close"]
+    sma_e = c.rolling(entry).mean()
+    sma_x = c.rolling(exit_).mean()
+    warm = (sma_e.notna() & sma_x.notna()).to_numpy()
+    enter = ((c > sma_e).to_numpy() & warm)
+    exit_cond = ((c < sma_x).to_numpy() & warm)
+    n = len(c)
+    w = np.zeros(n)
+    s = 0.0
+    for t in range(n):
+        if s == 0.0 and enter[t]:
+            s = 1.0
+        elif s == 1.0 and exit_cond[t]:
+            s = 0.0
+        w[t] = s
+    return w
+
+
+def combine(a: np.ndarray, b: np.ndarray, mode: str) -> np.ndarray:
+    if mode == "AND":
+        return ((a > 0.5) & (b > 0.5)).astype(float)
+    return ((a > 0.5) | (b > 0.5)).astype(float)
+
+
+# ---------------------------------------------------------------------------
+# §6.1 — thesis CI (bucketed forward-20d win-rate with block bootstrap)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ThesisResult:
+    buckets: list[tuple[str, float, int]]   # (label, win_rate, effective_N)
+    slope_point: float
+    slope_ci: tuple[float, float]
+    excludes_null: bool
+
+
+def _forward_winrate(score: np.ndarray, fwd_ret: np.ndarray, edges) -> list:
+    out = []
+    for lo, hi in edges:
+        m = (score >= lo) & (score < hi) & np.isfinite(fwd_ret)
+        wins = fwd_ret[m] > 0
+        wr = float(wins.mean()) if m.sum() else float("nan")
+        eff = int(max(1, m.sum() // 20))  # ~N/20 non-overlapping (20d windows)
+        out.append((f"{int(lo*100)}-{int(hi*100)}%", wr, eff))
+    return out
+
+
+def thesis_test(world: World, score: np.ndarray, fwd: int = 20, n_boot: int = 2000,
+                block: int = 20, seed: int = 0) -> ThesisResult:
+    """Win-rate by score bucket + block-bootstrap CI on the bucket→win-rate slope.
+
+    The slope of bucket-index vs win-rate must have a CI excluding 0 (the null
+    "more agreement does not raise win-rate"). Block bootstrap (20-day blocks)
+    respects the forward-window overlap.
+    """
+    cum = np.cumprod(1 + world.tqqq_ret)
+    n = len(score)
+    fwd_ret = np.full(n, np.nan)
+    for t in range(n - fwd):
+        fwd_ret[t] = cum[t + fwd] / cum[t] - 1.0
+    edges = [(0.0, 0.2), (0.2, 0.4), (0.4, 0.6), (0.6, 0.8), (0.8, 1.0001)]
+    buckets = _forward_winrate(score, fwd_ret, edges)
+
+    def slope(sc, fr):
+        rows = _forward_winrate(sc, fr, edges)
+        xs = np.arange(len(rows))
+        ys = np.array([r[1] for r in rows])
+        ok = np.isfinite(ys)
+        if ok.sum() < 2:
+            return np.nan
+        return float(np.polyfit(xs[ok], ys[ok], 1)[0])
+
+    point = slope(score, fwd_ret)
+    rng = np.random.default_rng(seed)
+    valid = np.where(np.isfinite(fwd_ret))[0]
+    slopes = []
+    nblocks = max(1, len(valid) // block)
+    for _ in range(n_boot):
+        starts = rng.integers(0, max(1, len(valid) - block), size=nblocks)
+        idx = np.concatenate([valid[s:s + block] for s in starts])
+        s = slope(score[idx], fwd_ret[idx])
+        if np.isfinite(s):
+            slopes.append(s)
+    lo, hi = np.percentile(slopes, [2.5, 97.5]) if slopes else (np.nan, np.nan)
+    return ThesisResult(buckets, point, (float(lo), float(hi)),
+                        excludes_null=bool(np.isfinite(lo) and lo > 0))
+
+
+# ---------------------------------------------------------------------------
+# §6.4 — deflated Calmar over #configs tried (López de Prado spirit)
+# ---------------------------------------------------------------------------
+
+def deflate(best: float, n_configs: int) -> float:
+    """Crude haircut: shrink the best metric by the multiple-testing factor.
+
+    Not a full DSR (we lack per-config Sharpe variance), but a transparent,
+    monotone penalty: divide by (1 + ln(n_configs)). Reported alongside the raw
+    metric so the reader sees the deflation, not just the flattering number.
+    """
+    if n_configs <= 1:
+        return best
+    return best / (1.0 + np.log(n_configs))
+
+
+# ---------------------------------------------------------------------------
+# §6.2/§6.3 — train/test selection + A/B
+# ---------------------------------------------------------------------------
+
+@dataclass
+class GateConfig:
+    buy: float
+    sell: float
+    mode: str
+
+    def label(self) -> str:
+        return f"BUY{self.buy:.2f}/SELL{self.sell:.2f}/{self.mode}"
+
+
+def select_on_train(world: World, train_end: str = TRAIN_END) -> tuple[GateConfig, int, float]:
+    """Re-derive the resonance config on ≤train_end ONLY → pick best train Calmar.
+
+    Returns (best_config, n_configs_tried, best_train_calmar). This is the §6.2
+    mandatory re-derived split: nothing past train_end informs the pick.
+    """
+    best, best_calmar, n_tried = None, -np.inf, 0
+    for mode in WEIGHT_MODES:
+        for buy in BUY_GRID:
+            for sell in SELL_GRID:
+                if not buy > sell:
+                    continue
+                n_tried += 1
+                dec = resonance_decision(world, buy, sell, mode)
+                m = metrics_over(dec, world, world.tqqq_ret, WIN_START, train_end,
+                                 "train")
+                if m.calmar > best_calmar and np.isfinite(m.calmar):
+                    best_calmar, best = m.calmar, GateConfig(buy, sell, mode)
+    return best, n_tried, best_calmar
+
+
+@dataclass
+class ABRow:
+    name: str
+    ret: float
+    dd: float
+    calmar: float
+    switches: int
+    beats_sma_and_bh: bool = False
+
+
+def ab_table(world: World, cfg: GateConfig, start: str | None, end: str | None,
+             label: str) -> tuple[list[ABRow], dict]:
+    """The §6.3 A/B over a window: all comparators + anti-gaming flags."""
+    res_dec = resonance_decision(world, cfg.buy, cfg.sell, cfg.mode)
+    sma_dec = sma_gate_decision(world)
+    and_dec = combine(res_dec, sma_dec, "AND")
+    or_dec = combine(res_dec, sma_dec, "OR")
+    ones = np.ones(len(world.tqqq_ret))
+
+    def m(dec, nm, ret=None):
+        return metrics_over(dec, world, ret if ret is not None else world.tqqq_ret,
+                            start, end, nm)
+
+    rows = {
+        "resonance": m(res_dec, "resonance-gate"),
+        "sma": m(sma_dec, "SMA22/44 gate"),
+        "and": m(and_dec, "resonance AND SMA"),
+        "or": m(or_dec, "resonance OR SMA"),
+        "bh_tqqq": m(ones, "buy-hold TQQQ"),
+        "bh_qqq": m(ones, "buy-hold QQQ", ret=world.qqq_ret),
+    }
+    sma_r, bh_r = rows["sma"], rows["bh_tqqq"]
+
+    def beats(r):
+        return (r.calmar > sma_r.calmar and r.calmar > bh_r.calmar
+                and r.max_dd < bh_r.max_dd)
+
+    # anti-gaming: a combo winner must beat its SMA component AND resonance-only
+    # must beat buy-hold on this slice.
+    res_beats_bh = rows["resonance"].calmar > bh_r.calmar
+    out = []
+    for key in ("resonance", "sma", "and", "or", "bh_tqqq", "bh_qqq"):
+        r = rows[key]
+        flag = beats(r)
+        if key in ("and", "or"):
+            flag = flag and r.calmar > sma_r.calmar and res_beats_bh
+        out.append(ABRow(r.name, r.total_return, r.max_dd, r.calmar, r.switches, bool(flag)))
+    anti = {
+        "res_beats_bh": bool(res_beats_bh),
+        "resonance_beats_sma_and_bh": bool(beats(rows["resonance"])),
+    }
+    return out, anti
+
+
+# ---------------------------------------------------------------------------
+# Top-level study
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StudyResult:
+    window: str
+    thesis: ThesisResult
+    train_cfg: GateConfig
+    n_configs: int
+    train_calmar: float
+    deflated_train_calmar: float
+    test_ab: list[ABRow]
+    test_anti: dict
+    oos_ab: list[ABRow] | None
+    oos_anti: dict | None
+    verdict: str
+
+    extra: dict = field(default_factory=dict)
+
+
+def run_study(csv_dir: Path | None = None, n_boot: int = 2000) -> StudyResult:
+    real = build_world(start="2019-06-01", real_tqqq=True, csv_dir=csv_dir)
+    window = f"{str(real.ts.iat[0])[:10]} → {str(real.ts.iat[-1])[:10]}"
+
+    # §6.1 thesis CI (category-balanced score over the measurement window)
+    score = ResonanceScorer(SignalPanel(), mode="category_balanced").score(
+        SignalPanel().compute(panel_inputs(real)))
+    win_idx = _window_idx(real.ts, WIN_START, None)
+    thesis = thesis_test(
+        World(real.ts.iloc[win_idx].reset_index(drop=True),
+              real.df.iloc[win_idx].reset_index(drop=True),
+              real.tqqq_ret[win_idx], real.qqq_ret[win_idx],
+              real.rate_daily[win_idx], real.synthetic),
+        score[win_idx], n_boot=n_boot)
+
+    # §6.2(a) re-derived split: select on ≤2022, report once on 2023→now
+    cfg, n_cfg, train_calmar = select_on_train(real)
+    test_ab, test_anti = ab_table(real, cfg, TEST_START, None, "test 2023→now")
+
+    # §6.2(b) True-OOS: frozen cfg on synthetic 3×QQQ pre-2010 (dot-com + GFC)
+    oos_ab = oos_anti = None
+    try:
+        synth = build_world(start="1999-06-01", end="2009-12-31",
+                            real_tqqq=False, csv_dir=csv_dir)
+        oos_ab, oos_anti = ab_table(synth, cfg, "2000-01-01", "2009-12-31",
+                                    "pre-2010 synthetic 3×QQQ")
+    except Exception:  # noqa: BLE001 — OOS slice is best-effort if data is short
+        oos_ab = oos_anti = None
+
+    # Verdict (§6.3 anti-gaming). Resonance/combo must beat SMA+BH on the
+    # re-derived test AND survive the pre-2010 OOS slice.
+    res_row = next(r for r in test_ab if r.name == "resonance-gate")
+    combo_win = any(r.beats_sma_and_bh for r in test_ab
+                    if r.name in ("resonance AND SMA", "resonance OR SMA"))
+    test_pass = (res_row.beats_sma_and_bh or combo_win) and test_anti["res_beats_bh"]
+    oos_pass = bool(oos_ab) and any(
+        r.beats_sma_and_bh for r in oos_ab
+        if r.name in ("resonance-gate", "resonance AND SMA", "resonance OR SMA"))
+    if not thesis.excludes_null:
+        verdict = ("PREMISE FAILS — §6.1 win-rate slope CI includes 0; the "
+                   "more-agreement→higher-win-rate lead is not significant. "
+                   "Ship the SMA gate.")
+    elif test_pass and oos_pass:
+        verdict = ("SHIP THE RESONANCE GATE — it beats the SMA22/44 gate and "
+                   "buy-hold on the re-derived 2023→now split AND survives the "
+                   "pre-2010 synthetic OOS, passing the anti-gaming criteria.")
+    else:
+        verdict = ("SHIP THE SMA GATE — the resonance gate does not beat the "
+                   "SMA22/44 gate + buy-hold across the required OOS slices "
+                   "(§6.3). Simpler wins; this is a valid, expected outcome.")
+
+    return StudyResult(
+        window=window, thesis=thesis, train_cfg=cfg, n_configs=n_cfg,
+        train_calmar=train_calmar,
+        deflated_train_calmar=deflate(train_calmar, n_cfg),
+        test_ab=test_ab, test_anti=test_anti, oos_ab=oos_ab, oos_anti=oos_anti,
+        verdict=verdict,
+    )

--- a/src/rainier/backtest/resonance_study.py
+++ b/src/rainier/backtest/resonance_study.py
@@ -471,14 +471,21 @@ def run_study(csv_dir: Path | None = None, n_boot: int = 2000) -> StudyResult:
     cfg, n_cfg, train_calmar = select_on_train(real)
     test_ab, test_anti = ab_table(real, cfg, TEST_START, None, "test 2023→now")
 
-    # §6.2(b) True-OOS: frozen cfg on synthetic 3×QQQ pre-2010 (dot-com + GFC)
+    # §6.2(b) True-OOS: frozen cfg on synthetic 3×QQQ pre-2010 (dot-com + GFC).
+    # Skip ONLY when the pre-2010 data is genuinely unavailable (missing CSV or
+    # too few rows for the 2000-2009 window). Real bugs in build_world/ab_table
+    # MUST surface — this OOS slice is load-bearing for the §6.2 verdict, so a
+    # blanket except would let a broken evaluation masquerade as a clean run.
     oos_ab = oos_anti = None
     try:
         synth = build_world(start="1999-06-01", end="2009-12-31",
                             real_tqqq=False, csv_dir=csv_dir)
+        if len(_window_idx(synth.ts, "2000-01-01", "2009-12-31")) < 60:
+            raise FileNotFoundError("pre-2010 OOS window has too few rows")
         oos_ab, oos_anti = ab_table(synth, cfg, "2000-01-01", "2009-12-31",
                                     "pre-2010 synthetic 3×QQQ")
-    except Exception:  # noqa: BLE001 — OOS slice is best-effort if data is short
+    except FileNotFoundError:
+        # genuine data-unavailable: leave the OOS slice unreported (not a failure)
         oos_ab = oos_anti = None
 
     # Verdict (§6.3 anti-gaming). The combination mode (resonance-only / AND /

--- a/src/rainier/backtest/resonance_study.py
+++ b/src/rainier/backtest/resonance_study.py
@@ -315,7 +315,10 @@ def deflate(best: float, n_configs: int) -> float:
     monotone penalty: divide by (1 + ln(n_configs)). Reported alongside the raw
     metric so the reader sees the deflation, not just the flattering number.
     """
-    if n_configs <= 1:
+    if n_configs <= 1 or best <= 0:
+        # Deflation only ever HURTS a metric. Dividing a negative Calmar by the
+        # >1 factor moves it toward zero (flattering a losing config), so the
+        # haircut applies only to positive metrics; non-positive pass through.
         return best
     return best / (1.0 + np.log(n_configs))
 
@@ -350,8 +353,17 @@ def select_on_train(world: World, train_end: str = TRAIN_END) -> tuple[GateConfi
                 dec = resonance_decision(world, buy, sell, mode)
                 m = metrics_over(dec, world, world.tqqq_ret, WIN_START, train_end,
                                  "train")
-                if m.calmar > best_calmar and np.isfinite(m.calmar):
-                    best_calmar, best = m.calmar, GateConfig(buy, sell, mode)
+                cfg = GateConfig(buy, sell, mode)
+                # A zero-drawdown candidate has Calmar = +inf and IS the best —
+                # do NOT reject inf (the old `np.isfinite` filter dropped it and
+                # could leave best=None → crash). Skip only NaN (never comparable).
+                # Seed first valid candidate so best is never None when any ran.
+                if np.isnan(m.calmar):
+                    if best is None:
+                        best, best_calmar = cfg, m.calmar
+                    continue
+                if best is None or m.calmar > best_calmar:
+                    best_calmar, best = m.calmar, cfg
     return best, n_tried, best_calmar
 
 

--- a/src/rainier/backtest/resonance_study.py
+++ b/src/rainier/backtest/resonance_study.py
@@ -393,6 +393,15 @@ def beats_baselines(r: PortfolioResult, sma_r: PortfolioResult,
             and r.max_dd < sma_r.max_dd and r.max_dd < bh_r.max_dd)
 
 
+def beats_one(r: PortfolioResult, base: PortfolioResult) -> bool:
+    """Beat a single baseline on BOTH Calmar and drawdown (drawdown-aware).
+
+    Used for the resonance-only anti-gaming prerequisite (§6.3 (ii)): a higher
+    Calmar with a deeper drawdown than the baseline is NOT a beat (codex P2).
+    """
+    return r.calmar > base.calmar and r.max_dd < base.max_dd
+
+
 def ab_table(world: World, cfg: GateConfig, start: str | None, end: str | None,
              label: str) -> tuple[list[ABRow], dict]:
     """The §6.3 A/B over a window: all comparators + anti-gaming flags."""
@@ -420,8 +429,10 @@ def ab_table(world: World, cfg: GateConfig, start: str | None, end: str | None,
         return beats_baselines(r, sma_r, bh_r)
 
     # anti-gaming: a combo winner must beat its SMA component AND resonance-only
-    # must beat buy-hold on this slice.
-    res_beats_bh = rows["resonance"].calmar > bh_r.calmar
+    # must beat buy-hold on this slice. "Beats buy-hold" is drawdown-aware too —
+    # higher Calmar with a DEEPER drawdown than buy-hold is NOT a beat (codex P2),
+    # consistent with the §6.3 beat definition used everywhere else.
+    res_beats_bh = beats_one(rows["resonance"], bh_r)
     out = []
     for key in ("resonance", "sma", "and", "or", "bh_tqqq", "bh_qqq"):
         r = rows[key]

--- a/src/rainier/backtest/resonance_study.py
+++ b/src/rainier/backtest/resonance_study.py
@@ -341,6 +341,17 @@ class ABRow:
     beats_sma_and_bh: bool = False
 
 
+def beats_baselines(r: PortfolioResult, sma_r: PortfolioResult,
+                    bh_r: PortfolioResult) -> bool:
+    """§6.3 pass: beat BOTH the SMA gate and buy-hold on Calmar AND drawdown.
+
+    Drawdown must undercut both baselines (codex P2) — a higher-Calmar row with
+    a deeper drawdown than the SMA gate is NOT a win.
+    """
+    return (r.calmar > sma_r.calmar and r.calmar > bh_r.calmar
+            and r.max_dd < sma_r.max_dd and r.max_dd < bh_r.max_dd)
+
+
 def ab_table(world: World, cfg: GateConfig, start: str | None, end: str | None,
              label: str) -> tuple[list[ABRow], dict]:
     """The §6.3 A/B over a window: all comparators + anti-gaming flags."""
@@ -365,8 +376,7 @@ def ab_table(world: World, cfg: GateConfig, start: str | None, end: str | None,
     sma_r, bh_r = rows["sma"], rows["bh_tqqq"]
 
     def beats(r):
-        return (r.calmar > sma_r.calmar and r.calmar > bh_r.calmar
-                and r.max_dd < bh_r.max_dd)
+        return beats_baselines(r, sma_r, bh_r)
 
     # anti-gaming: a combo winner must beat its SMA component AND resonance-only
     # must beat buy-hold on this slice.
@@ -435,15 +445,19 @@ def run_study(csv_dir: Path | None = None, n_boot: int = 2000) -> StudyResult:
     except Exception:  # noqa: BLE001 — OOS slice is best-effort if data is short
         oos_ab = oos_anti = None
 
-    # Verdict (§6.3 anti-gaming). Resonance/combo must beat SMA+BH on the
-    # re-derived test AND survive the pre-2010 OOS slice.
+    # Verdict (§6.3 anti-gaming). The combination mode (resonance-only / AND /
+    # OR) was NOT selected on train (select_on_train sweeps weights+thresholds
+    # only), so letting a combo win on the held-out test slice would let the
+    # test window pick the mode after the fact — data snooping (codex P2). Per
+    # the anti-gaming rule, the load-bearing claim is that the **resonance-only**
+    # gate itself beats SMA+buy-hold; a combo that wins only because resonance-
+    # only does not is "the SMA gate in disguise". So the ship verdict requires
+    # resonance-only to win — combos are reported descriptively but cannot flip
+    # the verdict. Resonance/combo must also survive the pre-2010 OOS slice.
     res_row = next(r for r in test_ab if r.name == "resonance-gate")
-    combo_win = any(r.beats_sma_and_bh for r in test_ab
-                    if r.name in ("resonance AND SMA", "resonance OR SMA"))
-    test_pass = (res_row.beats_sma_and_bh or combo_win) and test_anti["res_beats_bh"]
-    oos_pass = bool(oos_ab) and any(
-        r.beats_sma_and_bh for r in oos_ab
-        if r.name in ("resonance-gate", "resonance AND SMA", "resonance OR SMA"))
+    test_pass = res_row.beats_sma_and_bh and test_anti["res_beats_bh"]
+    res_oos = next((r for r in (oos_ab or []) if r.name == "resonance-gate"), None)
+    oos_pass = bool(res_oos and res_oos.beats_sma_and_bh)
     if not thesis.excludes_null:
         verdict = ("PREMISE FAILS — §6.1 win-rate slope CI includes 0; the "
                    "more-agreement→higher-win-rate lead is not significant. "

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -523,11 +523,15 @@ def report(ctx, csv_path, symbol, tf):
 @cli.command(name="backtest-resonance")
 @click.option("--out", "out_path", default=None, type=click.Path(),
               help="HTML report output path (default docs/REPORT-resonance-gate-v1.html)")
+@click.option("--csv-dir", "csv_dir", default=None,
+              type=click.Path(exists=True, file_okay=False),
+              help="Directory holding {QQQ,TQQQ,SPY,VIX,IRX}_long_1D.csv "
+                   "(default: data/csv discovered from the working dir)")
 @click.option("--n-boot", default=2000, type=int,
               help="Block-bootstrap resamples for the §6.1 thesis CI")
 @click.option("--open/--no-open", "open_after", default=True,
               help="Open the rendered HTML report after writing")
-def backtest_resonance(out_path, n_boot, open_after):
+def backtest_resonance(out_path, csv_dir, n_boot, open_after):
     """Run the Multi-Signal Resonance Gate §6 A/B evaluation → HTML report.
 
     Falsifiable by construction: compares the resonance gate vs the SMA22/44
@@ -543,7 +547,8 @@ def backtest_resonance(out_path, n_boot, open_after):
     from rainier.backtest.resonance_report import write_report
 
     target = Path(out_path) if out_path else None
-    written = write_report(out_path=target, n_boot=n_boot)
+    csv_target = Path(csv_dir) if csv_dir else None
+    written = write_report(out_path=target, n_boot=n_boot, csv_dir=csv_target)
     click.echo(f"Wrote resonance-gate report → {written}")
     if open_after and sys.platform == "darwin":
         subprocess.run(["open", str(written)], check=False)

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -520,6 +520,35 @@ def report(ctx, csv_path, symbol, tf):
     click.echo(report_text)
 
 
+@cli.command(name="backtest-resonance")
+@click.option("--out", "out_path", default=None, type=click.Path(),
+              help="HTML report output path (default docs/REPORT-resonance-gate-v1.html)")
+@click.option("--n-boot", default=2000, type=int,
+              help="Block-bootstrap resamples for the §6.1 thesis CI")
+@click.option("--open/--no-open", "open_after", default=True,
+              help="Open the rendered HTML report after writing")
+def backtest_resonance(out_path, n_boot, open_after):
+    """Run the Multi-Signal Resonance Gate §6 A/B evaluation → HTML report.
+
+    Falsifiable by construction: compares the resonance gate vs the SMA22/44
+    gate vs AND/OR combos vs buy-hold on a re-derived ≤2022 / 2023→now split
+    plus a pre-2010 synthetic-3× OOS slice, with block-bootstrap thesis CIs and
+    a deflated metric over the configs tried. If the gate does not beat the SMA
+    gate + buy-hold OOS, the verdict is "ship the SMA gate" — an expected,
+    valid outcome.
+    """
+    import subprocess
+    import sys
+
+    from rainier.backtest.resonance_report import write_report
+
+    target = Path(out_path) if out_path else None
+    written = write_report(out_path=target, n_boot=n_boot)
+    click.echo(f"Wrote resonance-gate report → {written}")
+    if open_after and sys.platform == "darwin":
+        subprocess.run(["open", str(written)], check=False)
+
+
 def _get_discord_webhook(settings) -> str | None:
     """Get Discord webhook URL from settings (stock/scrape alerts)."""
     return settings.discord_stock_webhook_url or settings.discord_webhook_url or None

--- a/src/rainier/core/protocols.py
+++ b/src/rainier/core/protocols.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
+import numpy as np
 import pandas as pd
 
 from rainier.core.types import AnalysisResult, PatternSignal, Signal, Timeframe
@@ -59,6 +60,42 @@ class SignalEmitter(Protocol):
         symbol: str,
         timeframe: Timeframe,
     ) -> list[Signal]: ...
+
+
+# ---------------------------------------------------------------------------
+# Weight boundary: DataFrame → daily per-asset target weights
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class WeightStrategy(Protocol):
+    """Produces daily per-asset target weights from OHLCV data.
+
+    Distinct from ``SignalEmitter`` (which returns discrete entry/SL/TP
+    ``Signal`` trades). A ``WeightStrategy`` returns a *held* daily weight per
+    asset — the natural shape for an in/out gate fed to the daily mark-to-market
+    portfolio sim (``backtest/daily_mtm.py``).
+
+    Contract:
+      - ``weights(df, symbol, timeframe)`` returns ``dict[str, np.ndarray]``
+        mapping asset name → a daily weight series aligned to ``df`` rows.
+      - Each weight is ≥ 0; the sum across assets on any day is ≤ 1.0; the
+        remainder is implicitly cash (earns the T-bill rate in the sim).
+      - The returned series are **decision** weights at ``close[t]``. The sim is
+        responsible for the +1 shift (apply the close[t] decision to the
+        t→t+1 return), so implementations MUST NOT pre-shift.
+
+    Per-asset (not a bare boolean) so a future non-cash risk-off floor is
+    representable without a redesign. v1's ``ResonanceGate`` returns a single
+    asset with weight ∈ {0.0, 1.0} (binary in/out, remainder cash).
+    """
+
+    def weights(
+        self,
+        df: pd.DataFrame,
+        symbol: str,
+        timeframe: Timeframe,
+    ) -> dict[str, np.ndarray]: ...
 
 
 # ---------------------------------------------------------------------------

--- a/src/rainier/signals/panel.py
+++ b/src/rainier/signals/panel.py
@@ -1,0 +1,371 @@
+"""SignalPanel — the frozen ≤66-lookback, trend-only signal list for v1.
+
+Each member is a daily *risk-on* indicator returning a ``{0.0, 1.0}`` series
+(1 = uptrend-confirming). The panel feeds ``ResonanceScorer`` (power-weighted
+score) which feeds ``ResonanceGate`` (dual-threshold in/out of TQQQ).
+
+Source-of-truth: the enumerated ``_MEMBERS`` list below (design
+``docs/DESIGN-multi-signal-resonance.md`` §5.2). It was seeded from the ≤66
+subset of the exploratory ``scripts/regime_signal_search.build_signals``
+catalog, then **deduplicated** (one threshold per indicator — RSI>50 not
+RSI>55, VIX<25 not VIX<20/<30, one of ADX/+DI) so no indicator is
+triple-counted, with two changes required by the lookback invariant:
+
+  * the two ``expanding(60).median()`` volatility members are **rewritten** to
+    bounded rolling-median form (realizedVol(20) vs its rolling-40 median;
+    ATR%(14) vs its rolling-46 median) — expanding windows are unbounded and
+    fail the finite-window truncation test;
+  * ATR% uses a **simple rolling mean** of true range, NOT Wilder/EWMA.
+
+Added vs the prototype: ``price>SMA66``, SPY trend signals, and an optional
+breadth member (``% of a frozen universe above SMA50``).
+
+Lookback invariant (§5.5): every member's *composed* lookback ≤ 66. Nested
+indicators compose: realizedVol(20) into a rolling-40 median spans 20+40 = 60.
+Finite-window members (SMA, rolling-median, Donchian, ROC) have exact composed
+support ≤66 and are bit-identical when history before ``t-66`` is dropped
+(test b). EMA-family members (EMA, RSI, MACD, ADX) have *bounded effective*
+memory — they never widen with more history — and are covered by the frozen
+``WARMUP_BARS`` pre-registered constant rather than exact truncation.
+
+The panel computes **decision** series at ``close[t]`` — it does NOT shift. The
+sim (``backtest/daily_mtm.py``) owns the +1 shift.
+
+```
+   df (QQQ OHLC + VIX + SPY [+ breadth])
+            │
+            ▼
+   SignalPanel.compute()  ──►  {member_name: {0,1} series}   (no shift)
+            │
+            ▼
+   ResonanceScorer / ResonanceGate
+```
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Lookback constants (pre-registered; do NOT make these data-dependent)
+# ---------------------------------------------------------------------------
+
+MAX_LOOKBACK = 66
+"""Operator constraint: no moving-average / composed lookback may exceed this."""
+
+WARMUP_BARS = 150
+"""Frozen warmup for EMA-family members (ADX double-smoothed, MACD hist =
+EMA-of-EMA). Empirically the slowest member (ADX(14)) converges well within
+this; pinned as an integer constant so ``t0`` is data-independent (the gate
+determinism test asserts this). It must NOT shift with the data."""
+
+
+# ---------------------------------------------------------------------------
+# Indicator primitives (finite-window unless noted)
+# ---------------------------------------------------------------------------
+
+def sma(s: pd.Series, n: int) -> pd.Series:
+    return s.rolling(n).mean()
+
+
+def ema(s: pd.Series, n: int) -> pd.Series:
+    """EMA — EMA-family (bounded effective memory, not finite-window)."""
+    return s.ewm(span=n, adjust=False).mean()
+
+
+def roc(s: pd.Series, n: int) -> pd.Series:
+    return s.pct_change(n)
+
+
+def rsi(s: pd.Series, n: int = 14) -> pd.Series:
+    """Wilder RSI — EMA-family (bounded effective memory)."""
+    d = s.diff()
+    up = d.clip(lower=0).ewm(alpha=1 / n, adjust=False).mean()
+    dn = (-d.clip(upper=0)).ewm(alpha=1 / n, adjust=False).mean()
+    rs = up / dn.replace(0, np.nan)
+    return (100 - 100 / (1 + rs)).fillna(50)
+
+
+def macd_hist(s: pd.Series, f: int = 12, sl: int = 26, sig: int = 9) -> pd.Series:
+    """MACD histogram — EMA-family (EMA-of-EMA, bounded effective memory)."""
+    line = ema(s, f) - ema(s, sl)
+    return line - ema(line, sig)
+
+
+def realized_vol(s: pd.Series, n: int = 20) -> pd.Series:
+    """Annualized rolling-std of daily returns (finite window n+1 via pct_change)."""
+    return s.pct_change().rolling(n).std() * np.sqrt(252)
+
+
+def atr_pct_simple(df: pd.DataFrame, n: int = 14) -> pd.Series:
+    """ATR%/price using a **simple rolling mean** of true range (finite window).
+
+    Deliberately NOT Wilder/EWMA — the design pins ATR% to a bounded
+    finite-window form so it passes the truncation test.
+    """
+    h, lo, c = df["high"], df["low"], df["close"]
+    pc = c.shift(1)
+    tr = pd.concat([h - lo, (h - pc).abs(), (lo - pc).abs()], axis=1).max(axis=1)
+    return tr.rolling(n).mean() / c
+
+
+def adx(df: pd.DataFrame, n: int = 14) -> tuple[pd.Series, pd.Series, pd.Series]:
+    """ADX / +DI / -DI — EMA-family (double-smoothed, bounded effective memory)."""
+    h, lo, c = df["high"], df["low"], df["close"]
+    up = h.diff()
+    dn = -lo.diff()
+    plus_dm = np.where((up > dn) & (up > 0), up, 0.0)
+    minus_dm = np.where((dn > up) & (dn > 0), dn, 0.0)
+    pc = c.shift(1)
+    tr = pd.concat([h - lo, (h - pc).abs(), (lo - pc).abs()], axis=1).max(axis=1)
+    atr = pd.Series(tr).ewm(alpha=1 / n, adjust=False).mean()
+    pdi = 100 * pd.Series(plus_dm, index=df.index).ewm(alpha=1 / n, adjust=False).mean() / atr
+    mdi = 100 * pd.Series(minus_dm, index=df.index).ewm(alpha=1 / n, adjust=False).mean() / atr
+    dx = 100 * (pdi - mdi).abs() / (pdi + mdi).replace(0, np.nan)
+    return dx.ewm(alpha=1 / n, adjust=False).mean().fillna(0), pdi, mdi
+
+
+def donchian_mid(df: pd.DataFrame, n: int) -> pd.Series:
+    return (df["high"].rolling(n).max() + df["low"].rolling(n).min()) / 2
+
+
+def _b(x) -> np.ndarray:
+    """Coerce a bool/float series to a clean {0,1} float ndarray (NaN→0)."""
+    return np.nan_to_num(np.asarray(x, dtype=float))
+
+
+# ---------------------------------------------------------------------------
+# Member registry — THE source of truth (§5.2)
+# ---------------------------------------------------------------------------
+
+# Six categories, each weighted equally by the category-balanced prior (§5.3).
+CATEGORIES = ("trend", "momentum", "volatility", "structure", "cross_asset", "breadth")
+
+
+@dataclass(frozen=True)
+class PanelMember:
+    name: str
+    category: str
+    composed_lookback: int  # exact finite support, or bounded effective memory
+    finite_window: bool     # True → exact-support member (truncation-testable)
+    fn: Callable[["PanelInputs"], np.ndarray]
+
+
+@dataclass
+class PanelInputs:
+    """Aligned inputs for one ``compute`` call. ``spy`` and ``breadth`` optional."""
+    qqq: pd.DataFrame          # columns: open, high, low, close
+    vix: pd.Series             # VIX close, aligned to qqq index
+    spy: pd.Series | None = None      # SPY close, aligned
+    breadth: pd.Series | None = None  # %-above-SMA50 already computed, aligned ∈ [0,1]
+
+
+def _trend_members() -> list[PanelMember]:
+    def p_sma(n):
+        return lambda i: _b(i.qqq["close"] > sma(i.qqq["close"], n))
+
+    def p_ema(n):
+        return lambda i: _b(i.qqq["close"] > ema(i.qqq["close"], n))
+
+    out = [
+        PanelMember(f"price>SMA{n}", "trend", n, True, p_sma(n)) for n in (20, 50, 66)
+    ]
+    out += [
+        PanelMember(f"price>EMA{n}", "trend", n, False, p_ema(n)) for n in (20, 50)
+    ]
+    out.append(PanelMember(
+        "SMA22>SMA44", "trend", 44, True,
+        lambda i: _b(sma(i.qqq["close"], 22) > sma(i.qqq["close"], 44)),
+    ))
+    # SMA50 rising: 50-day MA vs 10 bars ago → composed 50+10 = 60.
+    out.append(PanelMember(
+        "SMA50 rising", "trend", 60, True,
+        lambda i: _b(sma(i.qqq["close"], 50) > sma(i.qqq["close"], 50).shift(10)),
+    ))
+    return out
+
+
+def _momentum_members() -> list[PanelMember]:
+    return [
+        PanelMember("RSI14>50", "momentum", 14, False,
+                    lambda i: _b(rsi(i.qqq["close"], 14) > 50)),
+        PanelMember("MACD hist>0", "momentum", 26, False,
+                    lambda i: _b(macd_hist(i.qqq["close"]) > 0)),
+        PanelMember("ROC20>0", "momentum", 20, True,
+                    lambda i: _b(roc(i.qqq["close"], 20) > 0)),
+        PanelMember("ROC60>0", "momentum", 60, True,
+                    lambda i: _b(roc(i.qqq["close"], 60) > 0)),
+        PanelMember("price>Donchian50mid", "momentum", 50, True,
+                    lambda i: _b(i.qqq["close"] > donchian_mid(i.qqq, 50))),
+    ]
+
+
+def _vol_realized(i: PanelInputs) -> np.ndarray:
+    # realizedVol(20) below its rolling-40 median → composed 20+40 = 60 (finite).
+    rv = realized_vol(i.qqq["close"], 20)
+    return _b(rv < rv.rolling(40).median())
+
+
+def _vol_atr(i: PanelInputs) -> np.ndarray:
+    # ATR%(14, simple mean) below its rolling-46 median → composed 14+46 = 60 (finite).
+    ap = atr_pct_simple(i.qqq, 14)
+    return _b(ap < ap.rolling(46).median())
+
+
+def _volatility_members() -> list[PanelMember]:
+    return [
+        PanelMember("realizedVol<rollMedian", "volatility", 60, True, _vol_realized),
+        PanelMember("ATR%<rollMedian", "volatility", 60, True, _vol_atr),
+        PanelMember("VIX<25", "volatility", 1, True,
+                    lambda i: _b(i.vix < 25)),
+        PanelMember("VIX<SMA20", "volatility", 20, True,
+                    lambda i: _b(i.vix < sma(i.vix, 20))),
+        PanelMember("VIX falling", "volatility", 5, True,
+                    lambda i: _b(i.vix < i.vix.shift(5))),
+    ]
+
+
+def _hh_hl(i: PanelInputs) -> np.ndarray:
+    # 20-day higher-high AND higher-low vs 20 bars ago → composed 20+20 = 40 (finite).
+    hh = i.qqq["high"].rolling(20).max() > i.qqq["high"].rolling(20).max().shift(20)
+    hl = i.qqq["low"].rolling(20).min() > i.qqq["low"].rolling(20).min().shift(20)
+    return _b(hh & hl)
+
+
+def _adx_up(i: PanelInputs) -> np.ndarray:
+    adxv, pdi, mdi = adx(i.qqq, 14)
+    return _b((adxv > 20) & (pdi > mdi))
+
+
+def _structure_members() -> list[PanelMember]:
+    return [
+        PanelMember("within5%of60d-high", "structure", 60, True,
+                    lambda i: _b(i.qqq["close"] >= 0.95 * i.qqq["close"].rolling(60).max())),
+        PanelMember("ADX>20 & +DI>-DI", "structure", 14, False, _adx_up),
+        PanelMember("HH+HL structure", "structure", 40, True, _hh_hl),
+    ]
+
+
+def _cross_asset_members() -> list[PanelMember]:
+    # Cross-asset members require SPY; skipped at compute time when spy is None.
+    return [
+        PanelMember("SPY>SMA22", "cross_asset", 22, True,
+                    lambda i: _b(i.spy > sma(i.spy, 22))),
+        PanelMember("SPY>SMA44", "cross_asset", 44, True,
+                    lambda i: _b(i.spy > sma(i.spy, 44))),
+    ]
+
+
+def _breadth_members() -> list[PanelMember]:
+    # Breadth requires a precomputed %-above-SMA50 series ∈ [0,1]; skipped when None.
+    # Risk-on when > half the (frozen) universe is above its SMA50.
+    return [
+        PanelMember("breadth>50%above-SMA50", "breadth", 50, True,
+                    lambda i: _b(i.breadth > 0.5)),
+    ]
+
+
+def _all_members() -> list[PanelMember]:
+    return (
+        _trend_members()
+        + _momentum_members()
+        + _volatility_members()
+        + _structure_members()
+        + _cross_asset_members()
+        + _breadth_members()
+    )
+
+
+# Frozen, ordered member list. Length ≤ 66 by construction (currently 21).
+_MEMBERS: tuple[PanelMember, ...] = tuple(_all_members())
+
+
+# ---------------------------------------------------------------------------
+# SignalPanel
+# ---------------------------------------------------------------------------
+
+class SignalPanel:
+    """Computes the frozen ≤66-lookback trend-only signal members.
+
+    ``compute`` returns an ordered ``dict[name -> {0,1} ndarray]`` for the
+    members whose inputs are present. Cross-asset members need ``spy``; the
+    breadth member needs a precomputed ``breadth`` series — absent inputs drop
+    those members (and the design requires breadth be excluded from the OOS
+    claims when only a frozen ex-ante universe is available; see §6.2).
+    """
+
+    def __init__(self, members: tuple[PanelMember, ...] = _MEMBERS) -> None:
+        self.members = members
+        self._validate_lookback_invariant()
+
+    def _validate_lookback_invariant(self) -> None:
+        bad = [m.name for m in self.members if m.composed_lookback > MAX_LOOKBACK]
+        if bad:
+            raise ValueError(
+                f"panel members exceed MAX_LOOKBACK={MAX_LOOKBACK}: {bad}"
+            )
+
+    def available_members(self, inputs: PanelInputs) -> list[PanelMember]:
+        out = []
+        for m in self.members:
+            if m.category == "cross_asset" and inputs.spy is None:
+                continue
+            if m.category == "breadth" and inputs.breadth is None:
+                continue
+            out.append(m)
+        return out
+
+    def compute(self, inputs: PanelInputs) -> dict[str, np.ndarray]:
+        n = len(inputs.qqq)
+        out: dict[str, np.ndarray] = {}
+        for m in self.available_members(inputs):
+            series = m.fn(inputs)
+            if len(series) != n:
+                raise ValueError(f"member {m.name} produced length {len(series)} != {n}")
+            out[m.name] = series
+        return out
+
+    def category_of(self, name: str) -> str:
+        for m in self.members:
+            if m.name == name:
+                return m.category
+        raise KeyError(name)
+
+
+# ---------------------------------------------------------------------------
+# Breadth helper (frozen ex-ante universe path)
+# ---------------------------------------------------------------------------
+
+def breadth_pct_above_sma(prices: pd.DataFrame, n: int = 50) -> pd.Series:
+    """% of a frozen universe above its own SMA(n), per row, ∈ [0,1].
+
+    ``prices`` is a wide frame: one column of close prices per symbol, indexed
+    by date. The universe is whatever columns are present (frozen ex-ante — the
+    caller is responsible for picking a survivorship-aware set). Returns the
+    daily fraction of symbols trading above their own ``n``-day SMA.
+
+    This is the v1 breadth feed when point-in-time QQQ constituents are
+    unavailable; per design §6.2, breadth computed from a frozen universe is
+    **excluded from the OOS claims**.
+
+    Dashboard integration point (design §7 / Q5): the QQQ market-breadth
+    dashboard already computes the sibling metric via
+    ``rainier.market_breadth.indicators.pct_above_ma`` (long-format, returns
+    [0,100]). To surface this panel member on that dashboard, feed a top-N-QQQ
+    holdings frame through ``pct_above_ma(df, window=50)`` and divide by 100 to
+    get the [0,1] series this panel consumes. Building the point-in-time
+    QQQ-holdings OHLCV substrate + the dashboard panel is tracked as a [P2]
+    follow-up (out of scope for v1 per the task brief).
+    """
+    if n > MAX_LOOKBACK:
+        raise ValueError(f"breadth SMA period {n} exceeds MAX_LOOKBACK={MAX_LOOKBACK}")
+    above = prices > prices.rolling(n).mean()
+    # Only count symbols that have a defined SMA on a given row (avoid early-NaN bias).
+    valid = prices.rolling(n).mean().notna()
+    num_above = (above & valid).sum(axis=1)
+    denom = valid.sum(axis=1).replace(0, np.nan)
+    return (num_above / denom).clip(0.0, 1.0)

--- a/src/rainier/signals/panel.py
+++ b/src/rainier/signals/panel.py
@@ -82,12 +82,22 @@ def roc(s: pd.Series, n: int) -> pd.Series:
 
 
 def rsi(s: pd.Series, n: int = 14) -> pd.Series:
-    """Wilder RSI — EMA-family (bounded effective memory)."""
+    """Wilder RSI — EMA-family (bounded effective memory).
+
+    Zero-loss windows (an uninterrupted advance → ``dn == 0``) resolve to RSI
+    **100**, not neutral 50. Filling them with 50 would make ``RSI14>50`` fail
+    to fire in exactly the strongest uptrends (codex P2). A truly flat window
+    (no gains and no losses) stays 50.
+    """
     d = s.diff()
     up = d.clip(lower=0).ewm(alpha=1 / n, adjust=False).mean()
     dn = (-d.clip(upper=0)).ewm(alpha=1 / n, adjust=False).mean()
     rs = up / dn.replace(0, np.nan)
-    return (100 - 100 / (1 + rs)).fillna(50)
+    out = 100 - 100 / (1 + rs)
+    # dn==0: NaN rs → 100 if there were gains (up>0), else 50 (flat / warmup).
+    zero_loss = dn.eq(0)
+    out = out.where(~zero_loss, np.where(up.gt(0), 100.0, 50.0))
+    return out.fillna(50)
 
 
 def macd_hist(s: pd.Series, f: int = 12, sl: int = 26, sig: int = 9) -> pd.Series:

--- a/src/rainier/signals/resonance.py
+++ b/src/rainier/signals/resonance.py
@@ -1,0 +1,102 @@
+"""ResonanceScorer — power-weighted panel agreement → score ∈ [0,1].
+
+The resonance score is the **power-weighted fraction of members risk-on**:
+
+    r[t] = Σ wᵢ · signalᵢ[t]  /  Σ wᵢ        ∈ [0, 1]
+
+Weighting modes (design §5.3, A/B'd in §6.3):
+  * ``equal``            — every member weight 1 (the simplest baseline).
+  * ``category_balanced`` — the DEFAULT prior. The 6 categories are weighted
+    equally; each member's weight = 1 / (#members in its category). So the many
+    trend members don't make the score secretly mean "trend ×4". Categories
+    with zero present members (e.g. breadth absent) are dropped and the
+    remaining categories keep equal total mass.
+  * ``custom``           — caller supplies per-member power weights (a
+    swept/tuned config; capped per §6.4).
+
+Only members actually present in the score (``available_members`` at compute
+time) participate — an absent breadth/SPY member changes the denominator but
+not the [0,1] range.
+
+The scorer does NOT shift; it scores ``close[t]`` decision series.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import numpy as np
+
+from rainier.signals.panel import SignalPanel
+
+
+def category_balanced_weights(
+    panel: SignalPanel, member_names: list[str]
+) -> dict[str, float]:
+    """Per-member weights so each *present* category gets equal total mass.
+
+    weight(member) = 1 / (#present members in member's category). The category
+    totals are then equal (each sums to 1 across its members), so the score is
+    a uniform average over present categories.
+    """
+    by_cat: dict[str, list[str]] = defaultdict(list)
+    for name in member_names:
+        by_cat[panel.category_of(name)].append(name)
+    weights: dict[str, float] = {}
+    for _cat, names in by_cat.items():
+        share = 1.0 / len(names)
+        for name in names:
+            weights[name] = share
+    return weights
+
+
+class ResonanceScorer:
+    """Combine panel member series into a daily resonance score ∈ [0,1]."""
+
+    def __init__(
+        self,
+        panel: SignalPanel,
+        mode: str = "category_balanced",
+        custom_weights: dict[str, float] | None = None,
+    ) -> None:
+        if mode not in ("equal", "category_balanced", "custom"):
+            raise ValueError(f"unknown weighting mode: {mode!r}")
+        if mode == "custom" and not custom_weights:
+            raise ValueError("mode='custom' requires custom_weights")
+        self.panel = panel
+        self.mode = mode
+        self.custom_weights = custom_weights or {}
+
+    def resolve_weights(self, member_names: list[str]) -> dict[str, float]:
+        """Per-member power weights for the members actually present."""
+        if self.mode == "equal":
+            return {name: 1.0 for name in member_names}
+        if self.mode == "category_balanced":
+            return category_balanced_weights(self.panel, member_names)
+        # custom: keep only weights for present members; missing → 0 (excluded).
+        w = {name: float(self.custom_weights.get(name, 0.0)) for name in member_names}
+        if all(v <= 0 for v in w.values()):
+            raise ValueError("custom_weights resolved to all-zero over present members")
+        return w
+
+    def score(self, panel_series: dict[str, np.ndarray]) -> np.ndarray:
+        """Power-weighted fraction risk-on per day, ∈ [0,1].
+
+        ``panel_series`` is the ``SignalPanel.compute`` output (name → {0,1}).
+        """
+        names = list(panel_series.keys())
+        if not names:
+            raise ValueError("empty panel — nothing to score")
+        weights = self.resolve_weights(names)
+        n = len(next(iter(panel_series.values())))
+        num = np.zeros(n, dtype=float)
+        wsum = 0.0
+        for name in names:
+            w = weights.get(name, 0.0)
+            if w <= 0:
+                continue
+            num += w * panel_series[name]
+            wsum += w
+        if wsum <= 0:
+            raise ValueError("total weight is zero")
+        return num / wsum

--- a/src/rainier/signals/resonance_gate.py
+++ b/src/rainier/signals/resonance_gate.py
@@ -1,0 +1,128 @@
+"""ResonanceGate — dual-threshold state machine over the resonance score.
+
+```
+score r[t]  ──►  if state==CASH  and r[t] ≥ BUY  → state := TQQQ
+            ──►  if state==TQQQ  and r[t] ≤ SELL → state := CASH
+            ──►  else                            → hold state
+       BUY > SELL ; the gap (BUY-SELL) is the hysteresis band.
+```
+
+The gate is deterministic: a fixed score sequence yields a fixed state
+sequence (unit-tested). It decides on ``close[t]`` and returns the **decision**
+weight series — the +1 shift that makes the close[t] decision apply to the
+t→t+1 return is owned by the sim (``backtest/daily_mtm.py``), NOT here. This is
+the no-lookahead boundary: nothing in this module reads ``r[t+1]``.
+
+Boot (§5.4): before ``WARMUP_BARS`` the gate is forced CASH (EMA-family
+members haven't converged — entering on noise there would make ``t0``
+data-dependent). At the first valid bar ``t0 = WARMUP_BARS`` the state boots to
+TQQQ iff ``r[t0] ≥ BUY`` else CASH, then the hysteresis machine runs.
+
+Implements the ``WeightStrategy`` protocol: ``weights(df, symbol, timeframe)``
+returns ``{symbol: ndarray}`` of {0.0, 1.0} (binary in/out, remainder cash).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from rainier.core.types import Timeframe
+from rainier.signals.panel import WARMUP_BARS, PanelInputs, SignalPanel
+from rainier.signals.resonance import ResonanceScorer
+
+CASH = 0.0
+TQQQ = 1.0
+
+
+def run_state_machine(
+    score: np.ndarray, buy: float, sell: float, warmup: int = WARMUP_BARS
+) -> np.ndarray:
+    """Deterministic dual-threshold state machine → {0,1} decision weights.
+
+    Forced CASH for ``t < warmup``; boots at ``t0 = warmup`` (CASH→TQQQ iff
+    ``score[t0] ≥ buy``). ``buy`` must be > ``sell`` (hysteresis).
+    """
+    if not buy > sell:
+        raise ValueError(f"BUY ({buy}) must be strictly greater than SELL ({sell})")
+    n = len(score)
+    w = np.zeros(n, dtype=float)
+    state = CASH
+    t0 = min(warmup, n)
+    for t in range(t0, n):
+        r = score[t]
+        if state == CASH and r >= buy:
+            state = TQQQ
+        elif state == TQQQ and r <= sell:
+            state = CASH
+        # else: hold
+        w[t] = state
+    return w
+
+
+class ResonanceGate:
+    """Power-weighted dual-threshold in/out gate. Implements ``WeightStrategy``.
+
+    Parameters
+    ----------
+    scorer : ResonanceScorer
+        Produces the daily resonance score from a panel.
+    buy, sell : float
+        Dual thresholds in [0,1]; ``buy`` > ``sell``.
+    asset : str
+        Target asset name for the returned weight dict (default ``"TQQQ"``).
+    warmup : int
+        Frozen warmup before the gate may enter (default ``WARMUP_BARS``).
+    """
+
+    def __init__(
+        self,
+        scorer: ResonanceScorer,
+        buy: float = 0.6,
+        sell: float = 0.4,
+        asset: str = "TQQQ",
+        warmup: int = WARMUP_BARS,
+    ) -> None:
+        if not buy > sell:
+            raise ValueError(f"BUY ({buy}) must be strictly greater than SELL ({sell})")
+        self.scorer = scorer
+        self.buy = buy
+        self.sell = sell
+        self.asset = asset
+        self.warmup = warmup
+
+    @property
+    def panel(self) -> SignalPanel:
+        return self.scorer.panel
+
+    def score_series(self, inputs: PanelInputs) -> np.ndarray:
+        return self.scorer.score(self.panel.compute(inputs))
+
+    def decide(self, inputs: PanelInputs) -> np.ndarray:
+        """Decision weight series (un-shifted) from panel inputs."""
+        score = self.score_series(inputs)
+        return run_state_machine(score, self.buy, self.sell, self.warmup)
+
+    # -- WeightStrategy protocol --------------------------------------------
+
+    def weights(
+        self,
+        df: pd.DataFrame,
+        symbol: str,
+        timeframe: Timeframe,
+    ) -> dict[str, np.ndarray]:
+        """Per-asset daily target weights from an OHLCV+context DataFrame.
+
+        ``df`` must carry QQQ OHLC (columns ``open/high/low/close``) plus a
+        ``vix`` column; optional ``spy`` and ``breadth`` columns enable the
+        cross-asset and breadth panel members. ``symbol`` and ``timeframe`` are
+        part of the ``WeightStrategy`` contract but the gate keys its output on
+        ``self.asset`` (the leveraged instrument it trades).
+        """
+        inputs = PanelInputs(
+            qqq=df[["open", "high", "low", "close"]],
+            vix=df["vix"],
+            spy=df["spy"] if "spy" in df.columns else None,
+            breadth=df["breadth"] if "breadth" in df.columns else None,
+        )
+        return {self.asset: self.decide(inputs)}

--- a/tests/test_resonance/conftest.py
+++ b/tests/test_resonance/conftest.py
@@ -1,0 +1,50 @@
+"""Synthetic OHLCV fixtures for resonance-gate tests."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from rainier.signals.panel import PanelInputs
+
+
+def _ohlc_from_close(close: np.ndarray) -> pd.DataFrame:
+    """Build a clean OHLC frame from a close path (small synthetic ranges)."""
+    close = np.asarray(close, dtype=float)
+    high = close * 1.005
+    low = close * 0.995
+    open_ = np.empty_like(close)
+    open_[0] = close[0]
+    open_[1:] = close[:-1]
+    return pd.DataFrame({"open": open_, "high": high, "low": low, "close": close})
+
+
+@pytest.fixture
+def n_bars() -> int:
+    return 400
+
+
+@pytest.fixture
+def trending_inputs(n_bars) -> PanelInputs:
+    """Steady uptrend → every trend member should fire risk-on once warmed up."""
+    t = np.arange(n_bars)
+    close = 100.0 * (1.0 + 0.001) ** t  # smooth ~0.1%/day uptrend
+    qqq = _ohlc_from_close(close)
+    vix = pd.Series(np.full(n_bars, 15.0))  # calm
+    spy = pd.Series(100.0 * (1.0 + 0.0008) ** t)
+    breadth = pd.Series(np.full(n_bars, 0.8))
+    return PanelInputs(qqq=qqq, vix=vix, spy=spy, breadth=breadth)
+
+
+@pytest.fixture
+def choppy_inputs(n_bars) -> PanelInputs:
+    """Flat/choppy path → trend members mostly risk-off."""
+    rng = np.random.default_rng(7)
+    close = 100.0 + np.cumsum(rng.normal(0, 0.2, n_bars)) * 0.0
+    close = 100.0 + rng.normal(0, 1.0, n_bars)  # mean-reverting noise around 100
+    qqq = _ohlc_from_close(close)
+    vix = pd.Series(np.full(n_bars, 28.0))
+    spy = pd.Series(100.0 + rng.normal(0, 1.0, n_bars))
+    breadth = pd.Series(np.full(n_bars, 0.3))
+    return PanelInputs(qqq=qqq, vix=vix, spy=spy, breadth=breadth)

--- a/tests/test_resonance/test_daily_mtm.py
+++ b/tests/test_resonance/test_daily_mtm.py
@@ -1,0 +1,87 @@
+"""Daily-MTM sim tests: no-lookahead +1 shift, costs, cash, metrics."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rainier.backtest.daily_mtm import (
+    max_drawdown,
+    run_portfolio,
+    shift_decision,
+)
+
+
+def test_shift_decision_is_plus_one_with_flat_first_bar():
+    w = np.array([1.0, 1.0, 0.0, 1.0])
+    assert list(shift_decision(w)) == [0.0, 1.0, 1.0, 0.0]
+
+
+def test_no_lookahead_first_bar_return_ignored():
+    """The big return on bar 0 must NOT be captured — decision applies t→t+1.
+
+    Weight decided at close[0]=1.0 only acts on bar 1's return. Bar 0 is flat.
+    """
+    weights = {"X": np.array([1.0, 1.0, 1.0])}
+    rets = {"X": np.array([10.0, 0.0, 0.0])}  # +1000% on bar 0 only
+    r = run_portfolio("t", weights, rets, n_years=1.0, cash_apy=0.0, one_way_cost=0.0)
+    # bar0 flat → equity stays 1.0 on bar0 (no lookahead capture of the +1000%)
+    assert r.equity[0] == pytest.approx(1.0)
+
+
+def test_cash_earns_rate_when_flat():
+    weights = {"X": np.zeros(252)}
+    rets = {"X": np.zeros(252)}
+    r = run_portfolio("cash", weights, rets, n_years=1.0, cash_apy=0.04, one_way_cost=0.0)
+    # ~4% over a year of daily compounding
+    assert r.equity[-1] == pytest.approx(1.04, abs=1e-3)
+
+
+def test_turnover_cost_charged_on_switch():
+    weights = {"X": np.array([0.0, 1.0, 1.0])}  # shifted → [0,0,1]: one switch at t=2
+    rets = {"X": np.array([0.0, 0.0, 0.0])}
+    r = run_portfolio("c", weights, rets, n_years=1.0, cash_apy=0.0, one_way_cost=0.01)
+    assert r.switches == 1
+    # one 0→1 switch costs 1.0 * 0.01 → equity 0.99
+    assert r.equity[-1] == pytest.approx(0.99)
+
+
+def test_per_day_cash_series_accepted():
+    weights = {"X": np.zeros(3)}
+    rets = {"X": np.zeros(3)}
+    r = run_portfolio("c", weights, rets, n_years=1.0,
+                      cash_apy=np.array([0.0, 0.0, 0.0]), one_way_cost=0.0)
+    assert r.equity[-1] == pytest.approx(1.0)
+
+
+def test_max_drawdown_basic():
+    curve = np.array([1.0, 1.2, 0.6, 0.9])
+    # peak 1.2 → trough 0.6 = 50%
+    assert max_drawdown(curve) == pytest.approx(0.5)
+
+
+def test_gate_to_sim_integration_no_lookahead():
+    """End-to-end: ResonanceGate decision → sim. The sim's +1 shift means a
+    perfect future-knowing gate cannot capture the same-day return."""
+    import pandas as pd
+
+    from rainier.signals.panel import PanelInputs, SignalPanel
+    from rainier.signals.resonance import ResonanceScorer
+    from rainier.signals.resonance_gate import ResonanceGate
+
+    n = 400
+    t = np.arange(n)
+    close = 100.0 * (1.0 + 0.001) ** t
+    qqq = pd.DataFrame({
+        "open": np.r_[close[0], close[:-1]], "high": close * 1.005,
+        "low": close * 0.995, "close": close,
+    })
+    inp = PanelInputs(qqq=qqq, vix=pd.Series(np.full(n, 15.0)))
+    gate = ResonanceGate(ResonanceScorer(SignalPanel(), mode="equal"), buy=0.6, sell=0.4)
+    decision = gate.decide(inp)
+    rets = {"TQQQ": qqq["close"].pct_change().fillna(0).to_numpy()}
+    r = run_portfolio("res", {"TQQQ": decision}, rets, n_years=n / 252,
+                      cash_apy=0.04, one_way_cost=0.0003)
+    # in a clean uptrend the gate should be invested most of the time and profit
+    assert r.total_return > 0
+    assert 0.0 <= r.exposure <= 1.0

--- a/tests/test_resonance/test_panel.py
+++ b/tests/test_resonance/test_panel.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from rainier.signals.panel import (
     MAX_LOOKBACK,
@@ -12,7 +13,20 @@ from rainier.signals.panel import (
     PanelMember,
     SignalPanel,
     breadth_pct_above_sma,
+    rsi,
 )
+
+
+def test_rsi_zero_loss_window_is_100_not_neutral():
+    # codex P2 (r6): an uninterrupted advance (no down days) → RSI 100, not 50,
+    # so RSI14>50 actually fires in the strongest uptrend.
+    up_only = pd.Series([100.0 * (1.01 ** i) for i in range(40)])
+    r = rsi(up_only, 14)
+    assert r.iloc[-1] == pytest.approx(100.0)
+    assert (r.iloc[20:] > 50).all()
+    # a perfectly flat window stays neutral 50
+    flat = pd.Series([100.0] * 40)
+    assert rsi(flat, 14).iloc[-1] == pytest.approx(50.0)
 
 
 def test_panel_size_and_categories():

--- a/tests/test_resonance/test_panel.py
+++ b/tests/test_resonance/test_panel.py
@@ -1,0 +1,121 @@
+"""SignalPanel tests: lookback invariant, truncation, frozen warmup, leakage."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from rainier.signals.panel import (
+    MAX_LOOKBACK,
+    WARMUP_BARS,
+    PanelInputs,
+    PanelMember,
+    SignalPanel,
+    breadth_pct_above_sma,
+)
+
+
+def test_panel_size_and_categories():
+    panel = SignalPanel()
+    # frozen ≤66 (the count is well under the cap; assert both)
+    assert len(panel.members) <= MAX_LOOKBACK
+    cats = {m.category for m in panel.members}
+    assert cats == {"trend", "momentum", "volatility", "structure", "cross_asset", "breadth"}
+
+
+def test_lookback_invariant_all_members_le_66():
+    panel = SignalPanel()
+    for m in panel.members:
+        assert m.composed_lookback <= MAX_LOOKBACK, m.name
+
+
+def test_lookback_invariant_rejects_oversize_member():
+    bad = PanelMember("price>SMA200", "trend", 200, True, lambda i: np.zeros(len(i.qqq)))
+    try:
+        SignalPanel(members=(bad,))
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+
+
+def test_no_expanding_windows_rewritten_vol_members(trending_inputs):
+    """The two prototype expanding-median members are rewritten to finite rolling.
+
+    Truncation test (b): for every finite-window member, dropping history before
+    t-66 must leave the value at t bit-identical. Expanding windows would fail.
+    """
+    panel = SignalPanel()
+    full = panel.compute(trending_inputs)
+    n = len(trending_inputs.qqq)
+    t = n - 1  # evaluate the last bar
+    cut = t - MAX_LOOKBACK
+    # truncate every input to [cut, n)
+    inp = trending_inputs
+    trunc = PanelInputs(
+        qqq=inp.qqq.iloc[cut:].reset_index(drop=True),
+        vix=inp.vix.iloc[cut:].reset_index(drop=True),
+        spy=inp.spy.iloc[cut:].reset_index(drop=True),
+        breadth=inp.breadth.iloc[cut:].reset_index(drop=True),
+    )
+    trunc_series = panel.compute(trunc)
+    finite = {m.name for m in panel.members if m.finite_window}
+    for name, series in full.items():
+        if name not in finite:
+            continue
+        # last bar of truncated == last bar of full for finite-window members
+        assert series[t] == trunc_series[name][-1], name
+
+
+def test_warmup_is_frozen_integer_constant():
+    # The warmup MUST be a pre-registered int that does not depend on data length.
+    assert isinstance(WARMUP_BARS, int)
+    assert WARMUP_BARS > 0
+
+
+def test_leakage_future_spike_does_not_change_past(trending_inputs):
+    """Inject a future spike at t+1; the member values at t must be unchanged."""
+    panel = SignalPanel()
+    base = panel.compute(trending_inputs)
+    t = 300  # well past warmup, with a future bar available
+    spiked = trending_inputs.qqq.copy()
+    # giant spike on bar t+1 only
+    spiked.loc[t + 1, ["open", "high", "low", "close"]] = [1e6, 1e6, 1e6, 1e6]
+    vix2 = trending_inputs.vix.copy()
+    vix2.loc[t + 1] = 200.0
+    spy2 = trending_inputs.spy.copy()
+    spy2.loc[t + 1] = 1e6
+    inp2 = PanelInputs(qqq=spiked, vix=vix2, spy=spy2, breadth=trending_inputs.breadth)
+    after = panel.compute(inp2)
+    for name in base:
+        assert base[name][t] == after[name][t], f"{name} leaked future into t={t}"
+
+
+def test_trending_inputs_fire_risk_on(trending_inputs):
+    panel = SignalPanel()
+    series = panel.compute(trending_inputs)
+    last = len(trending_inputs.qqq) - 1
+    # in a clean steady uptrend, trend members should be risk-on at the end
+    for name in ("price>SMA20", "price>SMA50", "price>SMA66", "SMA22>SMA44"):
+        assert series[name][last] == 1.0, name
+
+
+def test_absent_spy_and_breadth_drop_members(trending_inputs):
+    panel = SignalPanel()
+    inp = PanelInputs(qqq=trending_inputs.qqq, vix=trending_inputs.vix)
+    series = panel.compute(inp)
+    assert not any(k.startswith("SPY") for k in series)
+    assert not any("breadth" in k for k in series)
+    # trend members still present
+    assert "price>SMA20" in series
+
+
+def test_breadth_pct_above_sma_range():
+    rng = np.random.default_rng(1)
+    cols = {f"S{i}": 100.0 + np.cumsum(rng.normal(0, 1, 200)) for i in range(10)}
+    prices = pd.DataFrame(cols)
+    b = breadth_pct_above_sma(prices, n=50)
+    valid = b.dropna()
+    assert (valid >= 0).all() and (valid <= 1).all()
+    # before 50 bars there is no SMA → NaN
+    assert b.iloc[:49].isna().all()

--- a/tests/test_resonance/test_resonance_gate.py
+++ b/tests/test_resonance/test_resonance_gate.py
@@ -1,0 +1,111 @@
+"""ResonanceGate tests: deterministic state machine, hysteresis, boot, leakage."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rainier.core.types import Timeframe
+from rainier.signals.panel import PanelInputs, SignalPanel
+from rainier.signals.resonance import ResonanceScorer
+from rainier.signals.resonance_gate import ResonanceGate, run_state_machine
+
+
+def test_state_machine_fixed_sequence():
+    # BUY=0.6, SELL=0.4, warmup=0 → fully deterministic from the score sequence.
+    score = np.array([0.5, 0.7, 0.5, 0.3, 0.5, 0.65, 0.41, 0.39])
+    w = run_state_machine(score, buy=0.6, sell=0.4, warmup=0)
+    # t0: 0.5<BUY → CASH; 0.7≥BUY → TQQQ; 0.5 hold TQQQ; 0.3≤SELL → CASH;
+    # 0.5 hold CASH; 0.65≥BUY → TQQQ; 0.41 hold (between); 0.39≤SELL → CASH
+    assert list(w) == [0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0]
+
+
+def test_hysteresis_band_holds_between_thresholds():
+    # scores parked strictly between SELL and BUY never flip state.
+    score = np.array([0.7, 0.5, 0.55, 0.45, 0.5])  # enter then stay
+    w = run_state_machine(score, buy=0.6, sell=0.4, warmup=0)
+    assert list(w) == [1.0, 1.0, 1.0, 1.0, 1.0]
+
+
+def test_buy_must_exceed_sell():
+    with pytest.raises(ValueError):
+        run_state_machine(np.array([0.5]), buy=0.4, sell=0.6, warmup=0)
+    with pytest.raises(ValueError):
+        run_state_machine(np.array([0.5]), buy=0.5, sell=0.5, warmup=0)
+
+
+def test_warmup_forces_cash_then_boots():
+    score = np.full(20, 0.9)  # always above BUY
+    w = run_state_machine(score, buy=0.6, sell=0.4, warmup=5)
+    assert list(w[:5]) == [0.0] * 5      # forced cash during warmup
+    assert list(w[5:]) == [1.0] * 15     # boots TQQQ at t0=5
+
+
+def test_boot_cash_when_below_buy():
+    score = np.full(10, 0.5)  # below BUY at boot
+    w = run_state_machine(score, buy=0.6, sell=0.4, warmup=3)
+    assert (w == 0.0).all()
+
+
+def test_warmup_independent_of_data_length():
+    # t0 is data-independent: prepending bars shifts the warmup boundary by the
+    # same amount, it does not move with the data values.
+    short = run_state_machine(np.full(10, 0.9), buy=0.6, sell=0.4, warmup=4)
+    longer = run_state_machine(np.full(30, 0.9), buy=0.6, sell=0.4, warmup=4)
+    assert list(short[:4]) == [0.0] * 4
+    assert list(longer[:4]) == [0.0] * 4
+    assert short[4] == 1.0 and longer[4] == 1.0
+
+
+def _inputs(n=400):
+    t = np.arange(n)
+    close = 100.0 * (1.0 + 0.001) ** t
+    import pandas as pd
+    qqq = pd.DataFrame({
+        "open": np.r_[close[0], close[:-1]],
+        "high": close * 1.005,
+        "low": close * 0.995,
+        "close": close,
+    })
+    return PanelInputs(qqq=qqq, vix=pd.Series(np.full(n, 15.0)))
+
+
+def test_gate_decide_uptrend_goes_long():
+    panel = SignalPanel()
+    gate = ResonanceGate(ResonanceScorer(panel, mode="category_balanced"), buy=0.6, sell=0.4)
+    w = gate.decide(_inputs())
+    # forced cash through warmup, then long in a clean uptrend
+    assert (w[: gate.warmup] == 0.0).all()
+    assert w[-1] == 1.0
+
+
+def test_weight_strategy_protocol_shape():
+    import pandas as pd
+    panel = SignalPanel()
+    gate = ResonanceGate(ResonanceScorer(panel, mode="equal"), buy=0.6, sell=0.4)
+    n = 400
+    t = np.arange(n)
+    close = 100.0 * (1.0 + 0.001) ** t
+    df = pd.DataFrame({
+        "open": np.r_[close[0], close[:-1]], "high": close * 1.005,
+        "low": close * 0.995, "close": close, "vix": np.full(n, 15.0),
+    })
+    out = gate.weights(df, "TQQQ", Timeframe.D1)
+    assert set(out.keys()) == {"TQQQ"}
+    assert out["TQQQ"].shape == (n,)
+    assert set(np.unique(out["TQQQ"])).issubset({0.0, 1.0})
+
+
+def test_gate_leakage_future_bar_does_not_change_decision():
+    """A spike on bar t+1 must not change the (un-shifted) decision at bar t."""
+    panel = SignalPanel()
+    gate = ResonanceGate(ResonanceScorer(panel, mode="category_balanced"), buy=0.6, sell=0.4)
+    inp = _inputs()
+    base = gate.decide(inp)
+    t = 300
+    q2 = inp.qqq.copy()
+    q2.loc[t + 1, ["open", "high", "low", "close"]] = [1e6, 1e6, 1e6, 1e6]
+    v2 = inp.vix.copy()
+    v2.loc[t + 1] = 1.0
+    after = gate.decide(PanelInputs(qqq=q2, vix=v2))
+    assert np.array_equal(base[: t + 1], after[: t + 1])

--- a/tests/test_resonance/test_resonance_scorer.py
+++ b/tests/test_resonance/test_resonance_scorer.py
@@ -1,0 +1,74 @@
+"""ResonanceScorer tests: weighting math + category balance."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rainier.signals.panel import SignalPanel
+from rainier.signals.resonance import ResonanceScorer, category_balanced_weights
+
+
+def test_equal_weight_is_plain_fraction():
+    panel = SignalPanel()
+    scorer = ResonanceScorer(panel, mode="equal")
+    # 4 members, half risk-on → score 0.5 everywhere
+    series = {
+        "price>SMA20": np.array([1.0, 1.0, 0.0]),
+        "price>SMA50": np.array([1.0, 0.0, 0.0]),
+        "RSI14>50": np.array([0.0, 1.0, 0.0]),
+        "VIX<25": np.array([0.0, 0.0, 0.0]),
+    }
+    score = scorer.score(series)
+    assert np.allclose(score, [0.5, 0.5, 0.0])
+
+
+def test_category_balanced_weights_sum_per_category():
+    panel = SignalPanel()
+    names = [m.name for m in panel.members]
+    w = category_balanced_weights(panel, names)
+    # each category's member weights sum to 1.0
+    by_cat: dict[str, float] = {}
+    for name in names:
+        by_cat.setdefault(panel.category_of(name), 0.0)
+        by_cat[panel.category_of(name)] += w[name]
+    for cat, total in by_cat.items():
+        assert total == pytest.approx(1.0), cat
+
+
+def test_category_balanced_score_is_uniform_over_categories():
+    """3 trend members all on + 1 momentum member off (only 2 categories present)
+    → score = (1.0 + 0.0)/2 = 0.5, regardless of how many trend members."""
+    panel = SignalPanel()
+    scorer = ResonanceScorer(panel, mode="category_balanced")
+    series = {
+        "price>SMA20": np.array([1.0]),
+        "price>SMA50": np.array([1.0]),
+        "price>SMA66": np.array([1.0]),  # 3 trend members all risk-on
+        "RSI14>50": np.array([0.0]),     # 1 momentum member risk-off
+    }
+    score = scorer.score(series)
+    # trend category contributes 1.0, momentum 0.0 → average 0.5
+    assert score[0] == pytest.approx(0.5)
+
+
+def test_score_in_unit_range():
+    panel = SignalPanel()
+    scorer = ResonanceScorer(panel, mode="category_balanced")
+    rng = np.random.default_rng(3)
+    series = {m.name: (rng.random(50) > 0.5).astype(float) for m in panel.members}
+    score = scorer.score(series)
+    assert (score >= 0).all() and (score <= 1).all()
+
+
+def test_custom_weights_all_zero_raises():
+    panel = SignalPanel()
+    scorer = ResonanceScorer(panel, mode="custom", custom_weights={"nonexistent": 1.0})
+    with pytest.raises(ValueError):
+        scorer.score({"price>SMA20": np.array([1.0])})
+
+
+def test_unknown_mode_raises():
+    panel = SignalPanel()
+    with pytest.raises(ValueError):
+        ResonanceScorer(panel, mode="bogus")

--- a/tests/test_resonance/test_study.py
+++ b/tests/test_resonance/test_study.py
@@ -10,6 +10,7 @@ from rainier.backtest.daily_mtm import PortfolioResult
 from rainier.backtest.resonance_study import (
     World,
     beats_baselines,
+    beats_one,
     combine,
     deflate,
     metrics_over,
@@ -39,6 +40,16 @@ def test_beats_baselines_needs_to_beat_both_calmar():
     bh = _perf(calmar=3.0, dd=0.60)        # buy-hold has the higher Calmar
     cand = _perf(calmar=2.5, dd=0.20)      # beats SMA Calmar but not buy-hold's
     assert not beats_baselines(cand, sma, bh)
+
+
+def test_beats_one_is_drawdown_aware():
+    # codex P2 (r8): the resonance-only anti-gaming prerequisite ("beats buy-hold")
+    # must require BOTH higher Calmar AND shallower drawdown.
+    bh = _perf(calmar=1.5, dd=0.40)
+    deeper = _perf(calmar=2.0, dd=0.50)    # higher Calmar but DEEPER drawdown
+    assert not beats_one(deeper, bh)
+    real = _perf(calmar=2.0, dd=0.30)      # higher Calmar AND shallower drawdown
+    assert beats_one(real, bh)
 
 
 def test_csv_dir_resolves_from_cwd_not_package(tmp_path, monkeypatch):

--- a/tests/test_resonance/test_study.py
+++ b/tests/test_resonance/test_study.py
@@ -67,6 +67,35 @@ def test_deflate_monotone_haircut():
     assert deflate(2.0, 100) < deflate(2.0, 24)
 
 
+def test_deflate_does_not_flatter_negative_calmar():
+    # codex P2 (r4): deflation must never move a losing metric toward zero.
+    assert deflate(-0.5, 24) == -0.5       # negative passes through unchanged
+    assert deflate(0.0, 24) == 0.0
+    assert deflate(-2.0, 100) == -2.0
+
+
+def test_select_on_train_handles_infinite_calmar(monkeypatch):
+    # codex P2 (r4): a zero-drawdown train slice gives Calmar=inf; select_on_train
+    # must still return a config (not None → crash). Force every candidate to a
+    # no-drawdown (inf-Calmar) metric and assert a config comes back.
+    import rainier.backtest.resonance_study as rs
+
+    monkeypatch.setattr(rs, "resonance_decision",
+                        lambda w, b, s, m: np.ones(len(w.df)))
+
+    def fake_metrics(dec, world, ret, start, end, name):
+        p = PortfolioResult(name, np.ones(2))
+        p.calmar = float("inf")  # zero drawdown
+        return p
+
+    monkeypatch.setattr(rs, "metrics_over", fake_metrics)
+    w = _synthetic_world(n=300)
+    cfg, n_cfg, calmar = rs.select_on_train(w, train_end="2020-12-31")
+    assert cfg is not None
+    assert n_cfg > 0
+    assert cfg.buy > cfg.sell
+
+
 def test_combine_and_or():
     a = np.array([1.0, 1.0, 0.0, 0.0])
     b = np.array([1.0, 0.0, 1.0, 0.0])

--- a/tests/test_resonance/test_study.py
+++ b/tests/test_resonance/test_study.py
@@ -41,6 +41,26 @@ def test_beats_baselines_needs_to_beat_both_calmar():
     assert not beats_baselines(cand, sma, bh)
 
 
+def test_csv_dir_resolves_from_cwd_not_package(tmp_path, monkeypatch):
+    # codex P2 (r3): the default CSV dir must resolve from the INVOCATION cwd,
+    # not the package install path (which breaks under a wheel install).
+    from rainier.backtest.resonance_study import _csv_dir
+
+    (tmp_path / "data" / "csv").mkdir(parents=True)
+    sub = tmp_path / "sub" / "nested"
+    sub.mkdir(parents=True)
+    monkeypatch.chdir(sub)  # run from a subdirectory
+    assert _csv_dir() == tmp_path / "data" / "csv"  # walks up to find it
+
+
+def test_default_report_path_resolves_from_cwd(tmp_path, monkeypatch):
+    from rainier.backtest.resonance_report import _default_report_path
+
+    (tmp_path / "docs").mkdir()
+    monkeypatch.chdir(tmp_path)
+    assert _default_report_path() == tmp_path / "docs" / "REPORT-resonance-gate-v1.html"
+
+
 def test_deflate_monotone_haircut():
     assert deflate(2.0, 1) == 2.0          # no penalty for a single config
     assert deflate(2.0, 24) < 2.0          # haircut grows with #configs

--- a/tests/test_resonance/test_study.py
+++ b/tests/test_resonance/test_study.py
@@ -86,6 +86,15 @@ def test_metrics_over_window_no_lookahead_and_finite():
     assert m.switches >= 0
 
 
+def test_metrics_over_window_switch_count_ignores_carried_position():
+    # codex P3: a position held INTO the window is not a fresh entry. Always-in
+    # (buy-hold) measured over a later sub-window must report 0 switches, not 1.
+    w = _synthetic_world()
+    always_in = np.ones(len(w.df))
+    m = metrics_over(always_in, w, w.tqqq_ret, "2020-10-01", None, "bh")
+    assert m.switches == 0
+
+
 def test_thesis_test_returns_buckets_and_ci():
     w = _synthetic_world()
     score = np.clip(0.5 + (w.qqq_ret * 30), 0, 1)  # crude score correlated to ret
@@ -94,6 +103,17 @@ def test_thesis_test_returns_buckets_and_ci():
     lo, hi = res.slope_ci
     assert np.isfinite(lo) and np.isfinite(hi)
     assert isinstance(res.excludes_null, bool)
+
+
+@pytest.mark.slow
+def test_build_world_real_tqqq_starts_at_inception():
+    # codex P2: real_tqqq=True must NOT fabricate flat pre-2010 history even when
+    # start predates TQQQ's 2010-02 inception — drop the pre-inception NaN rows.
+    from rainier.backtest.resonance_study import build_world
+
+    w = build_world(start="1999-01-01", real_tqqq=True)
+    assert w.ts.iloc[0] >= pd.Timestamp("2010-02-01", tz="UTC")
+    assert not np.isnan(w.tqqq_ret).any()
 
 
 @pytest.mark.slow

--- a/tests/test_resonance/test_study.py
+++ b/tests/test_resonance/test_study.py
@@ -1,0 +1,82 @@
+"""Resonance study tests — pure helpers (no heavy data load) + a tiny integration."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from rainier.backtest.resonance_study import (
+    World,
+    combine,
+    deflate,
+    metrics_over,
+    sma_gate_decision,
+    thesis_test,
+)
+
+
+def test_deflate_monotone_haircut():
+    assert deflate(2.0, 1) == 2.0          # no penalty for a single config
+    assert deflate(2.0, 24) < 2.0          # haircut grows with #configs
+    assert deflate(2.0, 100) < deflate(2.0, 24)
+
+
+def test_combine_and_or():
+    a = np.array([1.0, 1.0, 0.0, 0.0])
+    b = np.array([1.0, 0.0, 1.0, 0.0])
+    assert list(combine(a, b, "AND")) == [1.0, 0.0, 0.0, 0.0]
+    assert list(combine(a, b, "OR")) == [1.0, 1.0, 1.0, 0.0]
+
+
+def _synthetic_world(n=600, seed=0):
+    rng = np.random.default_rng(seed)
+    ts = pd.Series(pd.date_range("2019-06-01", periods=n, freq="B", tz="UTC"))
+    drift = 0.0006 + rng.normal(0, 0.012, n)
+    close = 100.0 * np.cumprod(1 + drift)
+    df = pd.DataFrame({
+        "open": np.r_[close[0], close[:-1]],
+        "high": close * 1.01, "low": close * 0.99, "close": close,
+        "vix": 18.0 + rng.normal(0, 2, n), "spy": close * 0.9,
+    })
+    tqqq_ret = 3.0 * np.r_[0.0, np.diff(close) / close[:-1]]
+    qqq_ret = np.r_[0.0, np.diff(close) / close[:-1]]
+    rate = np.full(n, 0.04 / 252)
+    return World(ts, df, tqqq_ret, qqq_ret, rate, synthetic=False)
+
+
+def test_sma_gate_decision_shape_and_binary():
+    w = _synthetic_world()
+    dec = sma_gate_decision(w)
+    assert dec.shape == (len(w.df),)
+    assert set(np.unique(dec)).issubset({0.0, 1.0})
+
+
+def test_metrics_over_window_no_lookahead_and_finite():
+    w = _synthetic_world()
+    dec = sma_gate_decision(w)
+    m = metrics_over(dec, w, w.tqqq_ret, "2020-10-01", None, "sma")
+    assert np.isfinite(m.calmar)
+    assert 0.0 <= m.exposure <= 1.0
+    assert m.switches >= 0
+
+
+def test_thesis_test_returns_buckets_and_ci():
+    w = _synthetic_world()
+    score = np.clip(0.5 + (w.qqq_ret * 30), 0, 1)  # crude score correlated to ret
+    res = thesis_test(w, score, n_boot=300, seed=1)
+    assert len(res.buckets) == 5
+    lo, hi = res.slope_ci
+    assert np.isfinite(lo) and np.isfinite(hi)
+    assert isinstance(res.excludes_null, bool)
+
+
+@pytest.mark.slow
+def test_run_study_smoke():
+    # Full study on real CSVs — slow; verifies it produces a coherent verdict.
+    from rainier.backtest.resonance_study import run_study
+
+    r = run_study(n_boot=200)
+    assert r.verdict
+    assert r.n_configs > 0
+    assert any(row.name == "SMA22/44 gate" for row in r.test_ab)

--- a/tests/test_resonance/test_study.py
+++ b/tests/test_resonance/test_study.py
@@ -155,6 +155,27 @@ def test_thesis_test_returns_buckets_and_ci():
 
 
 @pytest.mark.slow
+def test_run_study_propagates_oos_bugs_not_swallowed(monkeypatch):
+    # codex P2 (r5): a real bug in the OOS path must NOT be silently swallowed
+    # into oos_ab=None — only genuine data-unavailability (FileNotFoundError) is.
+    import rainier.backtest.resonance_study as rs
+
+    real_ab_table = rs.ab_table
+    calls = {"n": 0}
+
+    def flaky_ab_table(world, cfg, start, end, label):
+        calls["n"] += 1
+        # second call is the pre-2010 OOS slice — simulate a code bug there
+        if "synthetic" in label:
+            raise ValueError("simulated bug in ab_table")
+        return real_ab_table(world, cfg, start, end, label)
+
+    monkeypatch.setattr(rs, "ab_table", flaky_ab_table)
+    with pytest.raises(ValueError, match="simulated bug"):
+        rs.run_study(n_boot=50)
+
+
+@pytest.mark.slow
 def test_build_world_real_tqqq_starts_at_inception():
     # codex P2: real_tqqq=True must NOT fabricate flat pre-2010 history even when
     # start predates TQQQ's 2010-02 inception — drop the pre-inception NaN rows.

--- a/tests/test_resonance/test_study.py
+++ b/tests/test_resonance/test_study.py
@@ -96,6 +96,28 @@ def test_select_on_train_handles_infinite_calmar(monkeypatch):
     assert cfg.buy > cfg.sell
 
 
+def test_select_on_train_nan_first_does_not_block_finite_winner(monkeypatch):
+    # codex P2 (r6): a NaN Calmar on the FIRST candidate must not seed best_calmar
+    # and block a later finite winner (NaN comparisons are always False).
+    import rainier.backtest.resonance_study as rs
+
+    monkeypatch.setattr(rs, "resonance_decision",
+                        lambda w, b, s, m: np.ones(len(w.df)))
+    seq = {"i": 0}
+
+    def fake_metrics(dec, world, ret, start, end, name):
+        p = PortfolioResult(name, np.ones(2))
+        # first candidate NaN, a later one a strong finite Calmar
+        p.calmar = float("nan") if seq["i"] == 0 else 3.0
+        seq["i"] += 1
+        return p
+
+    monkeypatch.setattr(rs, "metrics_over", fake_metrics)
+    cfg, _n, calmar = rs.select_on_train(_synthetic_world(n=300), train_end="2020-12-31")
+    assert cfg is not None
+    assert calmar == 3.0  # finite winner selected, not the NaN seed
+
+
 def test_combine_and_or():
     a = np.array([1.0, 1.0, 0.0, 0.0])
     b = np.array([1.0, 0.0, 1.0, 0.0])

--- a/tests/test_resonance/test_study.py
+++ b/tests/test_resonance/test_study.py
@@ -6,14 +6,39 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from rainier.backtest.daily_mtm import PortfolioResult
 from rainier.backtest.resonance_study import (
     World,
+    beats_baselines,
     combine,
     deflate,
     metrics_over,
     sma_gate_decision,
     thesis_test,
 )
+
+
+def _perf(calmar, dd):
+    p = PortfolioResult("x", np.ones(2))
+    p.calmar, p.max_dd = calmar, dd
+    return p
+
+
+def test_beats_baselines_requires_dd_below_sma_too():
+    # codex P2 #1: higher Calmar than SMA but DEEPER drawdown than SMA is NOT a win.
+    sma = _perf(calmar=2.0, dd=0.30)
+    bh = _perf(calmar=1.5, dd=0.60)
+    deeper = _perf(calmar=2.5, dd=0.40)   # beats Calmar but DD 0.40 > SMA's 0.30
+    assert not beats_baselines(deeper, sma, bh)
+    real_win = _perf(calmar=2.5, dd=0.25)  # beats Calmar AND DD vs both
+    assert beats_baselines(real_win, sma, bh)
+
+
+def test_beats_baselines_needs_to_beat_both_calmar():
+    sma = _perf(calmar=2.0, dd=0.30)
+    bh = _perf(calmar=3.0, dd=0.60)        # buy-hold has the higher Calmar
+    cand = _perf(calmar=2.5, dd=0.20)      # beats SMA Calmar but not buy-hold's
+    assert not beats_baselines(cand, sma, bh)
 
 
 def test_deflate_monotone_haircut():
@@ -80,3 +105,9 @@ def test_run_study_smoke():
     assert r.verdict
     assert r.n_configs > 0
     assert any(row.name == "SMA22/44 gate" for row in r.test_ab)
+    # codex P2 #2: the ship-resonance verdict must NOT be reachable via a combo
+    # chosen on the held-out test slice — it requires resonance-ONLY to win.
+    if r.verdict.startswith("SHIP THE RESONANCE"):
+        res_row = next(x for x in r.test_ab if x.name == "resonance-gate")
+        assert res_row.beats_sma_and_bh, "resonance-only must win to ship resonance"
+        assert r.thesis.excludes_null


### PR DESCRIPTION
## Multi-Signal Resonance Gate for TQQQ — v1

Promotes the exploratory resonance machinery into the package per the `CLAUDE.md` module map and runs the design's §6 falsifiable evaluation. Implements `docs/DESIGN-multi-signal-resonance.md`.

**Stacked on #134** (the design-doc PR). Branched off `design/multi-signal-resonance` so the diff is clean once #134 merges; this PR targets `main` per the contract.

### Scope
- `core/protocols.py` — `WeightStrategy` protocol (additive; per-asset daily *held* weights, distinct from `SignalEmitter`'s discrete trades; the sim owns the +1 no-lookahead shift).
- `signals/panel.py` — `SignalPanel`: the frozen ≤66 trend-only signal list (§5.2). The two `expanding(60).median()` members rewritten to bounded rolling-median form; ATR% as a simple rolling mean (not Wilder/EWMA); added `price>SMA66`, SPY trend signals, and an optional breadth member. Lookback invariant enforced (composed ≤66; finite-window truncation; frozen `WARMUP_BARS` constant). `breadth_pct_above_sma` helper for the frozen-universe path.
- `signals/resonance.py` — `ResonanceScorer`: power-weighted score ∈[0,1], category-balanced prior over the 6 categories, `equal`/`category_balanced`/`custom` modes.
- `signals/resonance_gate.py` — `ResonanceGate`: deterministic §5.4 dual-threshold (BUY>SELL hysteresis) state machine, frozen-warmup boot, decided on close[t] effective t→t+1 (no lookahead). Implements `WeightStrategy`.
- `backtest/daily_mtm.py` — `run_portfolio` productionized: owns the +1 shift, turnover + T-bill cost, NO synthetic-3× financing on real TQQQ (§5.5).
- `backtest/resonance_study.py` + `resonance_report.py` + CLI `backtest-resonance` — the §6 A/B: block-bootstrap thesis CI, re-derived ≤2022 / 2023→now split, pre-2010 synthetic-3× OOS, anti-gaming criteria, deflated metric over #configs. Renders `docs/REPORT-resonance-gate-v1.html`.

### Verdict (honest, per the design honesty rail)
**Ship the SMA gate.** The §6.1 win-rate-by-agreement slope CI includes zero (not significant), and the resonance gate loses to the `SMA22/44` gate + buy-hold on both the re-derived 2023→now split (SMA Calmar 2.30 vs resonance 1.61) and the pre-2010 synthetic OOS (resonance −75.7% vs SMA +20.2%). This is the expected, valid outcome the design anticipated — the weighted vote-gate family does not beat the simple SMA gate out-of-sample.

### Breadth path
No point-in-time QQQ constituents source exists in the repo (yfinance lacks breadth; `market_breadth/` is a static S&P 500 universe). Took the **frozen ex-ante** path: the breadth panel member is optional (dropped when no breadth series is supplied) and is **excluded from the §6.2 OOS claims** per the design. A clean dashboard integration point (`market_breadth.indicators.pct_above_ma`) is documented in `panel.py`. **[P2] follow-up:** build the point-in-time QQQ-holdings OHLCV substrate + dashboard panel (out of scope for v1 per the brief).

### Reviews
- **codex review:** 10 rounds. Rounds 1–6, 8 surfaced **P2/P3** findings only (verdict-predicate and metric-math correctness in the study layer) — **never any P0/P1**. Each was fixed with a regression test (6 `fix: codex iter-N` commits). Rounds **9 and 10 returned two consecutive clean** (gate PASS).
- **/review skill:** structured critical pass CLEAN (no SQL/LLM/concurrency surface; `subprocess.run(["open", ...])` is list-form safe; `WeightStrategy` additive). Persisted.

### Test plan
- [x] panel: lookback invariant (composed ≤66; finite-window truncation; frozen warmup constant; no expanding windows), leakage (future spike into t+1 doesn't change weight[t]), RSI zero-loss→100.
- [x] scorer: weighting math, category balance, unit-range.
- [x] gate: deterministic state machine (fixed score→fixed state), BUY>SELL hysteresis, warmup boot, data-independent t0, leakage.
- [x] backtest: synthetic-data integration (no-lookahead +1 shift, cash rate, turnover cost), window switch-count ignores carried position.
- [x] study: deflate (positive-only haircut), `beats_baselines`/`beats_one` drawdown-aware, combo can't flip ship-verdict on held-out test, NaN/inf train-Calmar robustness, OOS bugs surface (not swallowed), cwd path resolution.
- [x] `uv run pytest tests/test_resonance/ -q` → 49 passed; `uv run ruff check src/ tests/` → clean.

### Deferred [P2] findings
- Point-in-time QQQ-holdings breadth substrate + dashboard panel (breadth currently frozen-ex-ante and excluded from OOS claims).

Note: 3 pre-existing full-suite failures (`test_db_ping_fails_loud_without_database_url` and siblings) are environment-dependent (they assert the CLI errors *without* `DATABASE_URL`, which is set in this env) and fail identically on the base — not introduced by this PR.
