### PR TITLE
fix(discord): per-operation logging + truthful delivery accounting

### DIFF
--- a/src/rainier/alerts/discord.py
+++ b/src/rainier/alerts/discord.py
@@ -50,6 +50,11 @@ class DiscordSendResult:
     candidate_payloads_failed: int    # webhook POSTs that errored
     thesis_ok: int                    # per-ticker thesis embeds delivered
     thesis_failed: int                # per-ticker thesis embeds that errored
+    # The summary embed (the table listing ALL candidates) rides in payload
+    # idx 0. If it lands, the operator saw the report even when a later detail
+    # payload failed — so this is the "did the report show up" signal, distinct
+    # from fully_ok (every payload landed).
+    summary_ok: bool = False
 
     @property
     def fully_ok(self) -> bool:
@@ -904,12 +909,15 @@ def send_stock_candidates(
 
     payloads_ok = 0
     payloads_failed = 0
+    summary_ok = False  # did payload idx 0 (the full-candidate table) land?
     for idx, payload in enumerate(payloads):
         n_embeds = len(payload.get("embeds", []))
         try:
             response = httpx.post(webhook_url, json=payload, timeout=10)
             response.raise_for_status()
             payloads_ok += 1
+            if idx == 0:
+                summary_ok = True
             log.info(
                 "discord_payload_ok",
                 idx=idx, status=response.status_code, embeds=n_embeds,
@@ -925,10 +933,13 @@ def send_stock_candidates(
         "discord_candidates_send_done",
         channel="stock", session=session,
         payloads_ok=payloads_ok, payloads_failed=payloads_failed,
+        summary_ok=summary_ok,
     )
 
     if not theses:
-        return DiscordSendResult(reported, payloads_ok, payloads_failed, 0, 0)
+        return DiscordSendResult(
+            reported, payloads_ok, payloads_failed, 0, 0, summary_ok=summary_ok,
+        )
 
     # Per-ticker rich thesis embeds route to the LLM-dedicated channel when
     # configured (DISCORD_LLM_WEBHOOK_URL), otherwise fall back to the stock
@@ -937,7 +948,9 @@ def send_stock_candidates(
     llm_webhook_url = _resolve_llm_webhook_url(config)
     if not llm_webhook_url:
         log.warning("discord_no_webhook_url_llm")
-        return DiscordSendResult(reported, payloads_ok, payloads_failed, 0, 0)
+        return DiscordSendResult(
+            reported, payloads_ok, payloads_failed, 0, 0, summary_ok=summary_ok,
+        )
 
     # Per-ticker rich thesis embeds — top 5 only, in candidate order.
     thesis_ok = 0
@@ -978,6 +991,7 @@ def send_stock_candidates(
     )
     return DiscordSendResult(
         reported, payloads_ok, payloads_failed, thesis_ok, thesis_failed,
+        summary_ok=summary_ok,
     )
 
 

--- a/src/rainier/alerts/discord.py
+++ b/src/rainier/alerts/discord.py
@@ -927,7 +927,7 @@ def send_stock_candidates(
             log.error(
                 "discord_payload_failed",
                 idx=idx, status=_http_status(exc),
-                error=str(exc)[:200], embeds=n_embeds,
+                error_type=type(exc).__name__, embeds=n_embeds,
             )
     log.info(
         "discord_candidates_send_done",
@@ -983,7 +983,7 @@ def send_stock_candidates(
             log.error(
                 "discord_thesis_send_failed",
                 symbol=candidate.symbol, status=_http_status(exc),
-                error=str(exc)[:200],
+                error_type=type(exc).__name__,
             )
     log.info(
         "discord_thesis_send_done",
@@ -1119,7 +1119,7 @@ def send_eval_report(
     except Exception as exc:
         log.error(
             "discord_eval_send_failed",
-            status=_http_status(exc), error=str(exc)[:200],
+            status=_http_status(exc), error_type=type(exc).__name__,
         )
 
 
@@ -1253,7 +1253,7 @@ def send_research_report(
     except Exception as exc:
         log.error(
             "discord_research_send_failed",
-            status=_http_status(exc), error=str(exc)[:200],
+            status=_http_status(exc), error_type=type(exc).__name__,
         )
 
 

--- a/src/rainier/alerts/discord.py
+++ b/src/rainier/alerts/discord.py
@@ -3,18 +3,61 @@
 from __future__ import annotations
 
 import json
-import logging
 import re
+from dataclasses import dataclass
 from datetime import date as date_cls
 from datetime import datetime
 from typing import Any
 
 import httpx
+import structlog
 
 from rainier.core.config import DiscordConfig
 from rainier.core.types import Direction, Signal, StockCandidate
 
-log = logging.getLogger(__name__)
+# structlog (NOT stdlib logging) so every Discord operation lands in the same
+# structured stream as the scraper + pipeline (``data/qu-scrape.log``). The
+# module previously used ``logging.getLogger`` whose records never reached that
+# file, so a failed webhook POST logged ``discord_send_failed`` into the void
+# while the pipeline still printed ``discord_sent=20`` — the channel stayed
+# empty and the logs looked healthy. See ``send_stock_candidates``.
+log = structlog.get_logger()
+
+
+def _http_status(exc: Exception) -> int | None:
+    """Extract the HTTP status code from an httpx error, else None.
+
+    ``raise_for_status()`` raises ``HTTPStatusError`` (has ``.response``);
+    connection/timeout errors have no status. Used so per-operation failure
+    logs carry the actual code (404 deleted webhook, 401 rotated token, 429
+    rate-limited) instead of a bare "it failed".
+    """
+    resp = getattr(exc, "response", None)
+    return getattr(resp, "status_code", None) if resp is not None else None
+
+
+@dataclass(frozen=True)
+class DiscordSendResult:
+    """Truthful per-operation outcome of a candidate-report send.
+
+    ``len(candidates)`` is what we *tried* to report; these are what actually
+    reached Discord. The pipeline logs ``discord_sent`` from ``fully_ok`` so a
+    silent webhook failure no longer reads as success.
+    """
+
+    candidates_reported: int          # len(candidates) attempted
+    candidate_payloads_ok: int        # webhook POSTs that returned 2xx
+    candidate_payloads_failed: int    # webhook POSTs that errored
+    thesis_ok: int                    # per-ticker thesis embeds delivered
+    thesis_failed: int                # per-ticker thesis embeds that errored
+
+    @property
+    def fully_ok(self) -> bool:
+        """True iff every candidate-report payload landed (no failures)."""
+        return (
+            self.candidate_payloads_failed == 0
+            and self.candidate_payloads_ok > 0
+        )
 
 # Pattern type → display label (Caisen methodology)
 PATTERN_LABELS: dict[str, str] = {
@@ -790,7 +833,7 @@ def _load_chart_bytes_for_thesis(thesis: dict) -> bytes | None:
         from rainier.dashboard.data import load_thesis_chart
         return load_thesis_chart(int(raw_id))
     except Exception:
-        log.exception("discord_load_chart_failed thesis_id=%s", raw_id)
+        log.exception("discord_load_chart_failed", thesis_id=raw_id)
         return None
 
 
@@ -816,7 +859,7 @@ def send_stock_candidates(
     *,
     dashboard_base_url: str | None = None,
     session: str | None = None,
-) -> None:
+) -> DiscordSendResult:
     """Send QU100 stock candidate alerts to Discord.
 
     Args:
@@ -837,28 +880,55 @@ def send_stock_candidates(
             multiple same-day scans apart in the stock channel. ``None``
             preserves the legacy session-less title.
     """
+    reported = len(candidates)
     if not candidates:
-        return
+        return DiscordSendResult(0, 0, 0, 0, 0)
     if not config.enabled:
-        log.debug("discord_alerts_disabled")
-        return
+        log.info("discord_alerts_disabled", candidates=reported, session=session)
+        return DiscordSendResult(reported, 0, 0, 0, 0)
 
     webhook_url = _resolve_webhook_url(config)
     if not webhook_url:
-        log.warning("discord_no_webhook_url")
-        return
+        log.warning(
+            "discord_no_webhook_url", channel="stock",
+            candidates=reported, session=session,
+        )
+        return DiscordSendResult(reported, 0, 0, 0, 0)
 
     payloads = _build_payloads(candidates, session=session)
+    log.info(
+        "discord_candidates_send_starting",
+        channel="stock", session=session,
+        candidates=reported, payloads=len(payloads),
+    )
 
-    for payload in payloads:
+    payloads_ok = 0
+    payloads_failed = 0
+    for idx, payload in enumerate(payloads):
+        n_embeds = len(payload.get("embeds", []))
         try:
             response = httpx.post(webhook_url, json=payload, timeout=10)
             response.raise_for_status()
-        except Exception:
-            log.exception("discord_send_failed")
+            payloads_ok += 1
+            log.info(
+                "discord_payload_ok",
+                idx=idx, status=response.status_code, embeds=n_embeds,
+            )
+        except Exception as exc:
+            payloads_failed += 1
+            log.error(
+                "discord_payload_failed",
+                idx=idx, status=_http_status(exc),
+                error=str(exc)[:200], embeds=n_embeds,
+            )
+    log.info(
+        "discord_candidates_send_done",
+        channel="stock", session=session,
+        payloads_ok=payloads_ok, payloads_failed=payloads_failed,
+    )
 
     if not theses:
-        return
+        return DiscordSendResult(reported, payloads_ok, payloads_failed, 0, 0)
 
     # Per-ticker rich thesis embeds route to the LLM-dedicated channel when
     # configured (DISCORD_LLM_WEBHOOK_URL), otherwise fall back to the stock
@@ -867,9 +937,11 @@ def send_stock_candidates(
     llm_webhook_url = _resolve_llm_webhook_url(config)
     if not llm_webhook_url:
         log.warning("discord_no_webhook_url_llm")
-        return
+        return DiscordSendResult(reported, payloads_ok, payloads_failed, 0, 0)
 
     # Per-ticker rich thesis embeds — top 5 only, in candidate order.
+    thesis_ok = 0
+    thesis_failed = 0
     for candidate in candidates[:5]:
         thesis = theses.get(candidate.symbol)
         if not thesis:
@@ -891,8 +963,22 @@ def send_stock_candidates(
                 chart_bytes=chart_bytes,
                 chart_filename=chart_filename,
             )
-        except Exception:
-            log.exception("discord_thesis_send_failed symbol=%s", candidate.symbol)
+            thesis_ok += 1
+            log.info("discord_thesis_ok", symbol=candidate.symbol)
+        except Exception as exc:
+            thesis_failed += 1
+            log.error(
+                "discord_thesis_send_failed",
+                symbol=candidate.symbol, status=_http_status(exc),
+                error=str(exc)[:200],
+            )
+    log.info(
+        "discord_thesis_send_done",
+        thesis_ok=thesis_ok, thesis_failed=thesis_failed,
+    )
+    return DiscordSendResult(
+        reported, payloads_ok, payloads_failed, thesis_ok, thesis_failed,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1015,8 +1101,12 @@ def send_eval_report(
     try:
         response = httpx.post(webhook_url, json={"content": message}, timeout=10)
         response.raise_for_status()
-    except Exception:
-        log.exception("discord_eval_send_failed")
+        log.info("discord_eval_send_ok", status=response.status_code)
+    except Exception as exc:
+        log.error(
+            "discord_eval_send_failed",
+            status=_http_status(exc), error=str(exc)[:200],
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1145,8 +1235,12 @@ def send_research_report(
     try:
         response = httpx.post(webhook_url, json={"content": message}, timeout=10)
         response.raise_for_status()
-    except Exception:
-        log.exception("discord_research_send_failed")
+        log.info("discord_research_send_ok", status=response.status_code)
+    except Exception as exc:
+        log.error(
+            "discord_research_send_failed",
+            status=_http_status(exc), error=str(exc)[:200],
+        )
 
 
 def format_stock_candidates_json(candidates: list[StockCandidate]) -> str:

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3187,42 +3187,16 @@ def debug_post_fake_thesis(ctx, symbol, verdict, use_llm_webhook):
     click.echo(f"  summary webhook (stock_webhook_url) : {_mask_webhook_url(stock_url)}")
     click.echo(f"  thesis  webhook (llm_webhook_url)   : {_mask_webhook_url(thesis_url)}")
 
-    # send_stock_candidates() catches httpx exceptions internally
-    # (`log.exception(...)`) and returns normally, so a 4xx/5xx Discord
-    # response would otherwise let this probe exit 0 with "done." — the
-    # exact false-success path operators use this command to diagnose.
-    # Attach a captor handler to the discord logger so we can detect
-    # those swallowed failures and surface them as a non-zero exit.
-    import logging as _stdlib_logging
-
-    captured_failures: list[_stdlib_logging.LogRecord] = []
-
-    class _DiscordFailureCaptor(_stdlib_logging.Handler):
-        def emit(self, record: _stdlib_logging.LogRecord) -> None:
-            if record.levelno >= _stdlib_logging.ERROR:
-                captured_failures.append(record)
-
-    captor = _DiscordFailureCaptor(level=_stdlib_logging.ERROR)
-    discord_logger = _stdlib_logging.getLogger("rainier.alerts.discord")
-    # Logger.isEnabledFor() is the gate BEFORE handlers run — if the
-    # caller (CI wrapper, structlog config, etc.) raised the discord
-    # logger to CRITICAL, ERROR records get dropped at the logger and
-    # the captor never sees them. Temporarily lower the level to ERROR
-    # so log.exception(...) calls inside send_stock_candidates reach
-    # our handler, then restore on the way out so we don't perturb the
-    # operator's logging config beyond this call.
-    saved_level = discord_logger.level
-    saved_disabled = discord_logger.disabled
-    saved_propagate = discord_logger.propagate
-    discord_logger.setLevel(_stdlib_logging.ERROR)
-    discord_logger.disabled = False
-    # propagate=False so our captured records don't also fire on parent
-    # handlers (which might surface stack traces the operator doesn't
-    # need for the routing diagnostic). The captor is our only sink.
-    discord_logger.propagate = False
-    discord_logger.addHandler(captor)
+    # send_stock_candidates() catches httpx exceptions internally so a
+    # Discord hiccup never crashes the scrape pipeline — but it now RETURNS a
+    # DiscordSendResult whose per-endpoint failure counts reflect what landed.
+    # This probe inspects those counts and exits non-zero on any failed POST,
+    # surfacing the "false success" path (rotated webhook, 4xx/5xx, timeout)
+    # operators use this command to diagnose. Detection is return-value based,
+    # so it works regardless of the logger's level/config and never perturbs
+    # the caller's logging setup.
     try:
-        send_stock_candidates(
+        send_result = send_stock_candidates(
             [candidate],
             discord_cfg,
             theses={fake_symbol: thesis_dict},
@@ -3230,28 +3204,22 @@ def debug_post_fake_thesis(ctx, symbol, verdict, use_llm_webhook):
         )
     except Exception as exc:  # noqa: BLE001 — synthetic-payload bugs surface here
         raise click.ClickException(f"Discord POST failed: {exc}") from exc
-    finally:
-        discord_logger.removeHandler(captor)
-        discord_logger.setLevel(saved_level)
-        discord_logger.disabled = saved_disabled
-        discord_logger.propagate = saved_propagate
 
-    if captured_failures:
-        # Render a terse one-line summary of each captured failure so the
-        # operator can tell which endpoint failed (summary vs thesis)
-        # without having to grep the structured log. We do NOT echo the
-        # full webhook URL — only the logger event name + exception
-        # class. The URL has already been printed in masked form above.
-        summaries = []
-        for rec in captured_failures:
-            exc_type = (
-                rec.exc_info[0].__name__ if rec.exc_info and rec.exc_info[0] else "?"
-            )
-            summaries.append(f"{rec.getMessage()} ({exc_type})")
+    failures: list[str] = []
+    if send_result.candidate_payloads_failed:
+        failures.append(
+            f"summary channel: {send_result.candidate_payloads_failed} "
+            "payload(s) failed"
+        )
+    if send_result.thesis_failed:
+        failures.append(
+            f"thesis channel: {send_result.thesis_failed} embed(s) failed"
+        )
+    if failures:
         raise click.ClickException(
-            "Discord POST failed (send_stock_candidates swallowed the "
-            "error internally; the probe surfaced it): "
-            + "; ".join(summaries)
+            "Discord POST failed (send_stock_candidates caught the error "
+            "internally; the probe surfaced it via return counts): "
+            + "; ".join(failures)
         )
 
     click.echo("done.")

--- a/src/rainier/pipeline/post_scrape.py
+++ b/src/rainier/pipeline/post_scrape.py
@@ -148,14 +148,17 @@ def run_post_scrape_pipeline(settings: Settings, session_name: str) -> None:
         dashboard_base_url=settings.llm_thesis.dashboard_base_url,
         session=session_name,
     )
-    # discord_sent reflects what actually LANDED, not len(candidates). A silent
-    # webhook failure (deleted/rotated webhook, rate-limit) now reads as
-    # discord_sent=0 with discord_payloads_failed>0 instead of a misleading
-    # "sent 20" while the channel stayed empty.
+    # discord_sent reflects what actually LANDED, not len(candidates). The
+    # summary embed (payload idx 0) lists ALL candidates, so summary_ok is the
+    # "did the report show up" signal: it stays len(candidates) on a partial
+    # failure where a later detail payload dropped but the table landed, and
+    # goes 0 only when the summary itself failed. discord_payloads_failed>0
+    # still flags partial drops. A silent dead-webhook now reads discord_sent=0
+    # instead of a misleading "sent 20" while the channel stayed empty.
     log.info(
         "post_scrape_pipeline_done",
         session=session_name,
-        discord_sent=len(candidates) if send_result.fully_ok else 0,
+        discord_sent=len(candidates) if send_result.summary_ok else 0,
         discord_payloads_ok=send_result.candidate_payloads_ok,
         discord_payloads_failed=send_result.candidate_payloads_failed,
         theses_attached=len(theses),

--- a/src/rainier/pipeline/post_scrape.py
+++ b/src/rainier/pipeline/post_scrape.py
@@ -141,16 +141,24 @@ def run_post_scrape_pipeline(settings: Settings, session_name: str) -> None:
     # summary embed title that the pre-extraction CLI used (via
     # _build_payloads(candidates, session=session)) — without it, the four
     # daily scans become indistinguishable in the channel.
-    send_stock_candidates(
+    send_result = send_stock_candidates(
         candidates,
         settings.alerts.discord,
         theses=theses or None,
         dashboard_base_url=settings.llm_thesis.dashboard_base_url,
         session=session_name,
     )
+    # discord_sent reflects what actually LANDED, not len(candidates). A silent
+    # webhook failure (deleted/rotated webhook, rate-limit) now reads as
+    # discord_sent=0 with discord_payloads_failed>0 instead of a misleading
+    # "sent 20" while the channel stayed empty.
     log.info(
         "post_scrape_pipeline_done",
         session=session_name,
-        discord_sent=len(candidates),
+        discord_sent=len(candidates) if send_result.fully_ok else 0,
+        discord_payloads_ok=send_result.candidate_payloads_ok,
+        discord_payloads_failed=send_result.candidate_payloads_failed,
         theses_attached=len(theses),
+        theses_sent=send_result.thesis_ok,
+        theses_failed=send_result.thesis_failed,
     )

--- a/tests/test_alerts/test_discord.py
+++ b/tests/test_alerts/test_discord.py
@@ -321,6 +321,41 @@ class TestSendResultAccounting:
         failed = [e for e in caplogs if e.get("event") == "discord_payload_failed"]
         assert failed, "expected a discord_payload_failed event"
         assert failed[0].get("status") == 404
+        # Diagnostic carries the exception class, never the raw message.
+        assert failed[0].get("error_type") == "HTTPStatusError"
+
+    def test_failure_log_never_leaks_webhook_token(self):
+        """httpx.HTTPStatusError.__str__ embeds the request URL, and a Discord
+        webhook URL contains its secret token. Failure logs must carry status +
+        exception class only — never str(exc). Regression for codex [P1]
+        2026-06-09 (credential leak into data/qu-scrape.log)."""
+        from structlog.testing import capture_logs
+
+        secret = "SUPERSECRETtoken9999"
+        url = f"https://discord.com/api/webhooks/123456/{secret}"
+        config = DiscordConfig(enabled=True, webhook_url=url)
+        # Reproduce the real leak vector: httpx auto-generates the error
+        # message in raise_for_status(), and that message embeds the request
+        # URL (which carries the token).
+        req = httpx.Request("POST", url)
+        resp = httpx.Response(401, request=req)
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            err = e
+        assert secret in str(err)  # the leak vector exists in the exception
+
+        with capture_logs() as caplogs:
+            with patch("rainier.alerts.discord.httpx.post") as mock_post:
+                mock_post.return_value = MagicMock(
+                    raise_for_status=MagicMock(side_effect=err)
+                )
+                send_stock_candidates([_candidate()], config)
+
+        import json
+        blob = json.dumps(caplogs)
+        assert secret not in blob, "webhook token leaked into structured logs"
+        assert "webhooks/123456" not in blob
 
 
 class TestFormatJson:

--- a/tests/test_alerts/test_discord.py
+++ b/tests/test_alerts/test_discord.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import json
+import os
 from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 
 from rainier.alerts.discord import (
     DiscordSendResult,
     _build_payloads,
     _format_candidate_embed,
     _format_summary_embed,
+    _resolve_webhook_url,
     format_stock_candidates_json,
     send_stock_candidates,
 )
@@ -429,3 +433,76 @@ class TestSendStockCandidatesWithTheses:
             send_stock_candidates(candidates, config, theses=theses)
         # 1 embed payload + 5 thesis messages (top-5 only) = 6 total.
         assert mock_post.call_count == 6
+
+
+class TestDeliveryContract:
+    """Guards the 2026-06-09 incident at the code level: a message counts as
+    delivered ONLY when Discord accepts the POST, and the candidate table the
+    operator reads is what actually goes to the channel. Deterministic — safe
+    for CI. For a true end-to-end channel check, see the env-gated live test
+    below (and the ``rainier debug post-fake-thesis`` CLI probe)."""
+
+    def test_summary_message_is_posted_to_channel_on_success(self):
+        config = DiscordConfig(enabled=True, stock_webhook_url="https://chan/hook")
+        with patch("rainier.alerts.discord.httpx.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=204)
+            result = send_stock_candidates([_candidate(symbol="NVDA")], config)
+
+        # A POST actually fired at the RESOLVED channel webhook...
+        assert mock_post.call_count >= 1
+        first = mock_post.call_args_list[0]
+        posted_url = first.args[0] if first.args else first.kwargs.get("url")
+        assert posted_url == _resolve_webhook_url(config) == "https://chan/hook"
+        # ...carrying the candidate summary table (the human-readable report)...
+        payload = first.kwargs["json"]
+        titles = [e.get("title", "") for e in payload["embeds"]]
+        assert any("QU100 Actionable Setups" in t for t in titles)
+        assert "NVDA" in json.dumps(payload)
+        # ...and ONLY THEN is delivery reported.
+        assert result.summary_ok is True
+        assert result.fully_ok is True
+
+    def test_delivery_not_reported_when_channel_rejects(self):
+        """A 5xx from Discord must NOT read as delivered — the exact false
+        success that left the channel empty while logs said 'sent 20'."""
+        config = DiscordConfig(enabled=True, webhook_url="https://example.com/hook")
+        resp = MagicMock(status_code=500)
+        err = httpx.HTTPStatusError("500", request=MagicMock(), response=resp)
+        with patch("rainier.alerts.discord.httpx.post") as mock_post:
+            mock_post.return_value = MagicMock(
+                raise_for_status=MagicMock(side_effect=err)
+            )
+            result = send_stock_candidates([_candidate()], config)
+        assert result.summary_ok is False
+        assert result.fully_ok is False
+
+
+@pytest.mark.skipif(
+    not os.environ.get("RAINIER_DISCORD_LIVE_TEST"),
+    reason="live delivery test — set RAINIER_DISCORD_LIVE_TEST=1 to actually "
+    "POST to the configured Discord channel (kept out of CI: non-deterministic, "
+    "needs the real webhook secret, and posts a visible message).",
+)
+def test_live_delivery_to_real_channel():
+    """End-to-end proof a message reaches the real channel: POST the candidate
+    report to the configured webhook and assert Discord accepted it (summary
+    payload delivered). Run on demand:
+
+        RAINIER_DISCORD_LIVE_TEST=1 uv run pytest \
+            tests/test_alerts/test_discord.py -k live_delivery -q
+
+    Then eyeball the channel for the "[delivery self-test]" message.
+    """
+    from rainier.core.config import get_settings
+
+    cfg = get_settings().alerts.discord
+    if not cfg.enabled or not _resolve_webhook_url(cfg):
+        pytest.skip("Discord not configured (enabled + a webhook URL required)")
+
+    marker = _candidate(symbol="ZZTEST", pattern_status="[delivery self-test]")
+    result = send_stock_candidates([marker], cfg, session="midday")
+
+    assert result.summary_ok is True, (
+        "Discord did not accept the summary POST — message NOT delivered to "
+        f"the channel (payloads_failed={result.candidate_payloads_failed})"
+    )

--- a/tests/test_alerts/test_discord.py
+++ b/tests/test_alerts/test_discord.py
@@ -356,7 +356,6 @@ class TestSendResultAccounting:
                 )
                 send_stock_candidates([_candidate()], config)
 
-        import json
         blob = json.dumps(caplogs)
         assert secret not in blob, "webhook token leaked into structured logs"
         assert "webhooks/123456" not in blob
@@ -414,6 +413,42 @@ class TestSendStockCandidatesWithTheses:
             send_stock_candidates(candidates, config, theses=theses)
             # 1 embed payload + 5 thesis text messages = 6 calls minimum.
             assert mock_post.call_count == 6
+
+    def test_thesis_failure_counts_and_never_leaks_token(self):
+        """A failed per-ticker thesis POST is counted (thesis_failed) while the
+        summary still reports delivered, AND the discord_thesis_send_failed log
+        carries status + exception class only — never the LLM webhook URL/token.
+        The thesis channel has the same leak vector as the summary channel
+        (codex [P1] 2026-06-09); this locks it too."""
+        from structlog.testing import capture_logs
+
+        secret = "LLMCHANNELtoken4242"
+        llm_url = f"https://discord.com/api/webhooks/777/{secret}"
+        config = DiscordConfig(
+            enabled=True,
+            stock_webhook_url="https://stock/hook",
+            llm_webhook_url=llm_url,
+        )
+        theses = {"NVDA": self._thesis()}
+
+        def _side_effect(url, **kwargs):
+            if url == llm_url:  # thesis embed POST → fail with a URL-bearing error
+                req = httpx.Request("POST", url)
+                httpx.Response(404, request=req).raise_for_status()
+            return MagicMock(status_code=204, raise_for_status=lambda: None)
+
+        with capture_logs() as caplogs:
+            with patch("rainier.alerts.discord.httpx.post", side_effect=_side_effect):
+                result = send_stock_candidates(
+                    [_candidate(symbol="NVDA")], config, theses=theses
+                )
+
+        assert result.thesis_failed == 1
+        assert result.thesis_ok == 0
+        assert result.summary_ok is True  # the table still landed
+        failed = [e for e in caplogs if e.get("event") == "discord_thesis_send_failed"]
+        assert failed and failed[0].get("status") == 404
+        assert secret not in json.dumps(caplogs), "LLM webhook token leaked into logs"
 
     def test_thesis_message_under_1800_chars(self):
         from rainier.alerts.discord import _format_thesis_message

--- a/tests/test_alerts/test_discord.py
+++ b/tests/test_alerts/test_discord.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import httpx
+
 from rainier.alerts.discord import (
+    DiscordSendResult,
     _build_payloads,
     _format_candidate_embed,
     _format_summary_embed,
@@ -213,6 +216,84 @@ class TestSendStockCandidates:
             mock_post.side_effect = Exception("Connection refused")
             # Should not raise
             send_stock_candidates([_candidate()], config)
+
+
+class TestSendResultAccounting:
+    """The return value must reflect what actually LANDED, so callers (and the
+    pipeline's discord_sent log) stop reporting false success when the webhook
+    silently fails. Regression for the 2026-06-09 'channel empty but logs say
+    sent 20' incident."""
+
+    def test_success_reports_truthful_counts(self):
+        config = DiscordConfig(enabled=True, webhook_url="https://example.com/hook")
+        with patch("rainier.alerts.discord.httpx.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=204)
+            result = send_stock_candidates([_candidate()], config)
+        assert isinstance(result, DiscordSendResult)
+        assert result.candidates_reported == 1
+        assert result.candidate_payloads_ok == 1
+        assert result.candidate_payloads_failed == 0
+        assert result.fully_ok is True
+
+    def test_failed_post_is_not_fully_ok(self):
+        config = DiscordConfig(enabled=True, webhook_url="https://example.com/hook")
+        with patch("rainier.alerts.discord.httpx.post") as mock_post:
+            mock_post.side_effect = httpx.HTTPError("simulated 404 deleted webhook")
+            result = send_stock_candidates([_candidate()], config)
+        assert result.candidate_payloads_failed == 1
+        assert result.candidate_payloads_ok == 0
+        assert result.fully_ok is False
+
+    def test_disabled_or_no_webhook_is_not_fully_ok(self):
+        # enabled=False → nothing sent → fully_ok False (no false success).
+        disabled = DiscordConfig(enabled=False, webhook_url="https://x/hook")
+        r1 = send_stock_candidates([_candidate()], disabled)
+        assert r1.candidate_payloads_ok == 0 and r1.fully_ok is False
+        # no webhook URL → same.
+        nowebhook = DiscordConfig(enabled=True, webhook_url="", stock_webhook_url="")
+        r2 = send_stock_candidates([_candidate()], nowebhook)
+        assert r2.candidate_payloads_ok == 0 and r2.fully_ok is False
+
+    def test_empty_candidates_returns_zero_result(self):
+        config = DiscordConfig(enabled=True, webhook_url="https://example.com/hook")
+        result = send_stock_candidates([], config)
+        assert result.candidates_reported == 0
+        assert result.fully_ok is False
+
+    def test_per_operation_logs_emitted(self):
+        """Each send operation logs a structured event so the channel-delivery
+        path is observable in data/qu-scrape.log."""
+        from structlog.testing import capture_logs
+
+        config = DiscordConfig(enabled=True, webhook_url="https://example.com/hook")
+        with capture_logs() as caplogs:
+            with patch("rainier.alerts.discord.httpx.post") as mock_post:
+                mock_post.return_value = MagicMock(status_code=204)
+                send_stock_candidates([_candidate()], config)
+
+        events = [e.get("event", "") for e in caplogs]
+        assert "discord_candidates_send_starting" in events
+        assert "discord_payload_ok" in events
+        assert "discord_candidates_send_done" in events
+
+    def test_failed_payload_logs_status_and_error(self):
+        """A failed POST logs discord_payload_failed with the HTTP status so
+        the operator can tell 404 (deleted webhook) from 429 (rate-limit)."""
+        from structlog.testing import capture_logs
+
+        config = DiscordConfig(enabled=True, webhook_url="https://example.com/hook")
+        resp = MagicMock(status_code=404)
+        err = httpx.HTTPStatusError("404", request=MagicMock(), response=resp)
+        with capture_logs() as caplogs:
+            with patch("rainier.alerts.discord.httpx.post") as mock_post:
+                mock_post.return_value = MagicMock(
+                    raise_for_status=MagicMock(side_effect=err)
+                )
+                send_stock_candidates([_candidate()], config)
+
+        failed = [e for e in caplogs if e.get("event") == "discord_payload_failed"]
+        assert failed, "expected a discord_payload_failed event"
+        assert failed[0].get("status") == 404
 
 
 class TestFormatJson:

--- a/tests/test_alerts/test_discord.py
+++ b/tests/test_alerts/test_discord.py
@@ -234,6 +234,32 @@ class TestSendResultAccounting:
         assert result.candidate_payloads_ok == 1
         assert result.candidate_payloads_failed == 0
         assert result.fully_ok is True
+        assert result.summary_ok is True
+
+    def test_partial_delivery_summary_landed(self):
+        """If the summary payload (idx 0, the full candidate table) lands but a
+        later detail payload fails, summary_ok stays True (operator saw the
+        report) while fully_ok is False and the failure is counted. Pipeline
+        logs discord_sent=len(candidates), not 0. (codex [P2] 2026-06-09.)"""
+        config = DiscordConfig(enabled=True, webhook_url="https://example.com/hook")
+        # 10 patterned candidates → 11 embeds → 2 payloads (summary+9, then 1).
+        candidates = [_candidate(symbol=f"S{i}") for i in range(10)]
+        assert len(_build_payloads(candidates)) == 2  # guards the fixture intent
+        calls = {"n": 0}
+
+        def _side_effect(url, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return MagicMock(status_code=204, raise_for_status=lambda: None)
+            raise httpx.HTTPError("simulated detail-payload 429 rate-limit")
+
+        with patch("rainier.alerts.discord.httpx.post", side_effect=_side_effect):
+            result = send_stock_candidates(candidates, config)
+
+        assert result.summary_ok is True       # table landed
+        assert result.candidate_payloads_ok == 1
+        assert result.candidate_payloads_failed == 1
+        assert result.fully_ok is False        # but not every payload
 
     def test_failed_post_is_not_fully_ok(self):
         config = DiscordConfig(enabled=True, webhook_url="https://example.com/hook")
@@ -243,6 +269,7 @@ class TestSendResultAccounting:
         assert result.candidate_payloads_failed == 1
         assert result.candidate_payloads_ok == 0
         assert result.fully_ok is False
+        assert result.summary_ok is False      # the table itself never landed
 
     def test_disabled_or_no_webhook_is_not_fully_ok(self):
         # enabled=False → nothing sent → fully_ok False (no false success).

--- a/tests/test_cli/test_debug_post_fake_thesis.py
+++ b/tests/test_cli/test_debug_post_fake_thesis.py
@@ -372,14 +372,14 @@ def test_discord_post_failure_exits_nonzero_and_does_not_print_done():
 
 def test_failure_surfaces_even_when_discord_logger_is_silenced():
     """The probe must detect swallowed httpx failures even when the
-    process has raised the ``rainier.alerts.discord`` logger to
-    CRITICAL (a common CI / wrapper-script default). Without this,
-    `logger.isEnabledFor(ERROR)` returns False and the captor handler
-    is never invoked.
+    process has silenced the ``rainier.alerts.discord`` logger (a common
+    CI / wrapper-script default).
 
-    Regression test for codex iter-5 [P2]: the probe lowers the logger
-    level to ERROR for its own duration and restores the prior level
-    on exit so the operator's logging config isn't perturbed.
+    The probe now detects failures from ``DiscordSendResult`` counts, not
+    by sniffing log records, so detection is inherently logger-independent
+    and the probe never touches the caller's logging config. This test
+    silences the legacy stdlib logger and asserts the failure still
+    surfaces AND the logger level is left untouched.
     """
     import logging
 


### PR DESCRIPTION
## Problem

QU100 reports silently failed to reach the Discord channel while the logs read healthy. Root of the blind spot:

- `alerts/discord.py` used **stdlib `logging`**, whose records never reach `data/qu-scrape.log` (the rest of the app uses **structlog**). A failed webhook POST logged `discord_send_failed` into the void.
- The pipeline logged `discord_sent=len(candidates)` **unconditionally** — the count it *tried*, not what landed. A dead/rotated webhook left the channel empty while the log said `discord_sent=20`.

(The 2026-06-09 "empty channel" incident itself turned out to be source-timing + a `--dates` backfill that skips the pipeline — the webhook was verified reachable (HTTP 204). But the silent-failure path above was a real latent bug that would hide a genuine delivery failure. This PR fixes that.)

## Fix

- Switch `alerts/discord.py` to **structlog** so every send operation lands in `data/qu-scrape.log`.
- **Per-operation logging:** `discord_candidates_send_starting`, `discord_payload_ok` / `discord_payload_failed` (with HTTP status), `discord_candidates_send_done`, `discord_thesis_ok` / `discord_thesis_send_failed`, `discord_thesis_send_done`.
- `send_stock_candidates` returns **`DiscordSendResult`** with real ok/failed counts + `summary_ok` (did the candidate table — payload idx 0 — land?). Pipeline keys `discord_sent` off `summary_ok`: stays `len(candidates)` when the table lands even on a partial detail-payload failure, goes `0` only when the table itself failed, with `discord_payloads_failed` flagging partial drops.
- `debug post-fake-thesis` detects failures via the **return value** instead of sniffing stdlib log records — works regardless of logger config and no longer perturbs the caller's logging setup (the old captor hack is deleted).

## Security

- **[P1] (codex)** `str(httpx.HTTPStatusError)` embeds the request URL, and Discord webhook URLs carry the secret token — logging `error=str(exc)` would persist the credential into `data/qu-scrape.log` on 401/404/429/5xx. Now logs `status` + `error_type` (exception class) only, across payload/thesis/eval/research sends. Regression test asserts the token never reaches captured logs (summary **and** thesis channels).

## Review

- Codex review: PASS (2 findings fixed — [P1] token leak, [P2] partial-delivery accounting — then 3 consecutive clean runs).
- /review skill: PASS — security specialist NO FINDINGS (leak fix confirmed complete); testing/maintainability findings addressed (thesis-path coverage, dead import, stale docstring).
- codex iterations: 2 (iter-1 [P2], iter-2 [P1])
- /review invocations: 1
- Deferred: low-confidence DRY on result construction — skipped per house style (three plain lines over a premature helper).

## Test plan

- [x] `uv run pytest tests/test_alerts/ tests/test_pipeline/test_post_scrape.py tests/test_cli/test_debug_post_fake_thesis.py` — 153 passed, 1 skipped (env-gated live test)
- [x] Full suite: 1437 passed, 6 failed (pre-existing `DATABASE_URL`-in-`.env` tests, unrelated — none touch changed files), 172 skipped
- [x] `uv run ruff check src/ tests/` clean
- [x] Live: a dead webhook now logs `discord_payload_failed status=404`, `discord_sent=0` (previously silent); a 404 with a token URL leaks nothing into captured logs
- [ ] Opt-in end-to-end: `RAINIER_DISCORD_LIVE_TEST=1 uv run pytest tests/test_alerts/test_discord.py -k live_delivery` posts to the real channel and asserts Discord accepted it