### PR TITLE
feat: weekly missed-winner sweep + R-B count + zero-share guard

### DIFF
--- a/migrations/0008_paper_skip_zero_share.sql
+++ b/migrations/0008_paper_skip_zero_share.sql
@@ -1,0 +1,28 @@
+-- Migration 0008 — paper_skip reason CHECK gains 'zero_share_price' (Phase 3).
+--
+-- The zero-share fill guard (TASK-PLAN qu100-miss-sweep-6b63 acceptance 9):
+-- a T+1 open above the $10k notional floors shares = floor(10000/open) to 0;
+-- the fill step now expires the pending row and records
+-- paper_skip(reason='zero_share_price') instead of booking a 0-share
+-- position. The 0005 CHECK (ck_paper_skip_reason) doesn't include the new
+-- reason, so it is rebuilt here; the ORM CHECK in core/models.py matches.
+--
+-- Apply with (POST-#115 the legacy public-schema tables live on
+-- LEGACY_DATABASE_URL, NOT DATABASE_URL which now points at Neon — see memory
+-- project_two_database_url_engines):
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0008_paper_skip_zero_share.sql
+--
+-- Idempotent: re-applying is safe (DROP IF EXISTS + ADD). market.* and every
+-- other public table are untouched.
+
+BEGIN;
+
+ALTER TABLE paper_skip DROP CONSTRAINT IF EXISTS ck_paper_skip_reason;
+ALTER TABLE paper_skip ADD CONSTRAINT ck_paper_skip_reason
+    CHECK (reason IN ('symbol_already_active','missing_levels',
+                      'missing_screened_record','gap_invalidated',
+                      'same_symbol_lower_conviction','zero_share_price'));
+
+COMMIT;
+
+-- Downgrade lives in migrations/0008_paper_skip_zero_share_downgrade.sql.

--- a/migrations/0008_paper_skip_zero_share.sql
+++ b/migrations/0008_paper_skip_zero_share.sql
@@ -12,6 +12,10 @@
 -- project_two_database_url_engines):
 --   psql "$LEGACY_DATABASE_URL" -f migrations/0008_paper_skip_zero_share.sql
 --
+-- ORDER: apply BEFORE deploying the Phase 3 code — the new fill guard inserts
+-- reason='zero_share_price', which the old 5-reason CHECK rejects
+-- (IntegrityError aborts that fill run). Old code + new schema is safe.
+--
 -- Idempotent: re-applying is safe (DROP IF EXISTS + ADD). market.* and every
 -- other public table are untouched.
 

--- a/migrations/0008_paper_skip_zero_share_downgrade.sql
+++ b/migrations/0008_paper_skip_zero_share_downgrade.sql
@@ -1,0 +1,23 @@
+-- Migration 0008 DOWNGRADE — reverses 0008_paper_skip_zero_share.sql.
+--
+-- Restores the original 5-reason ck_paper_skip_reason CHECK. Rows carrying
+-- the retired 'zero_share_price' reason are DELETED first (they would violate
+-- the restored constraint); the skipped theses simply leave the skip ledger —
+-- their paper_trade rows (status=expired) are untouched.
+--
+-- Apply with:
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0008_paper_skip_zero_share_downgrade.sql
+--
+-- Idempotent: re-applying is safe.
+
+BEGIN;
+
+DELETE FROM paper_skip WHERE reason = 'zero_share_price';
+
+ALTER TABLE paper_skip DROP CONSTRAINT IF EXISTS ck_paper_skip_reason;
+ALTER TABLE paper_skip ADD CONSTRAINT ck_paper_skip_reason
+    CHECK (reason IN ('symbol_already_active','missing_levels',
+                      'missing_screened_record','gap_invalidated',
+                      'same_symbol_lower_conviction'));
+
+COMMIT;

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1922,7 +1922,7 @@ def paper_update(as_of_iso):
 
 @paper_group.command(name="report")
 @click.option("--date", "as_of_iso", default=None, help="Report as-of date (YYYY-MM-DD)")
-@click.option("--week", is_flag=True, help="Render the weekly snapshot (Phase 3)")
+@click.option("--week", is_flag=True, help="Weekly missed-winner report (Phase 3)")
 @click.option(
     "--regenerate",
     is_flag=True,
@@ -1932,7 +1932,9 @@ def paper_report(as_of_iso, week, regenerate):
     """Render a paper-book report.
 
     Plain (default) re-renders from the persisted ``paper_report_snapshot`` only.
-    ``--regenerate`` recomputes the DAILY report from raw inputs and upserts.
+    ``--regenerate`` recomputes from raw inputs and upserts — for ``--week``
+    that's money_flow_snapshots/stock_prices/screened_stocks/analysis_results/
+    paper_trade (never the mutable ResearchInsight queue).
     """
     from datetime import date as _date
 
@@ -1948,18 +1950,27 @@ def paper_report(as_of_iso, week, regenerate):
     as_of = _date.fromisoformat(as_of_iso) if as_of_iso else _date.today()
 
     if week:
+        from rainier.paper.sweep import (
+            compute_weekly_payload,
+            persist_weekly_snapshot,
+            render_weekly_payload,
+        )
+
         if regenerate:
-            # Weekly regeneration is Phase 3 (miss-sweep). Fail clearly, not
-            # silently wrong (H5).
-            raise click.ClickException(
-                "weekly --regenerate is not implemented yet (Phase 3 miss-sweep)."
-            )
+            # Recompute from the raw period inputs (historical as_of selects
+            # the historical cohort: max data_date <= as_of). No price ingest,
+            # no insight emission, no Discord — just compute + upsert + render.
+            payload = compute_weekly_payload(as_of)
+            persist_weekly_snapshot(as_of, payload)
+            click.echo(render_weekly_payload(payload))
+            return
         payload = load_snapshot(REPORT_TYPE_WEEKLY, as_of)
         if payload is None:
             raise click.ClickException(
-                f"No weekly snapshot for {as_of}."
+                f"No weekly snapshot for {as_of}. "
+                "Run with --regenerate to compute one."
             )
-        click.echo(render_payload(payload))
+        click.echo(render_weekly_payload(payload))
         return
 
     if regenerate:

--- a/src/rainier/core/models.py
+++ b/src/rainier/core/models.py
@@ -693,9 +693,11 @@ class PaperSkip(Base):
     __table_args__ = (
         UniqueConstraint("thesis_id", name="uq_paper_skip_thesis_id"),
         CheckConstraint(
+            # zero_share_price: T+1 open > $10k notional floors shares to 0
+            # (Phase 3 zero-share fill guard; migration 0008 for existing DBs).
             "reason IN ('symbol_already_active','missing_levels',"
             "'missing_screened_record','gap_invalidated',"
-            "'same_symbol_lower_conviction')",
+            "'same_symbol_lower_conviction','zero_share_price')",
             name="ck_paper_skip_reason",
         ),
     )

--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -73,6 +73,10 @@ INSIGHT_KINDS: tuple[str, ...] = (
     # Phase 2 (D7c): weekly human-readable lessons from the paper-trade record.
     # info/noop — feedable into the prompt later.
     "paper_lessons",
+    # Phase 3 (D8 / §5(4)): weekly missed-winner sweep. One insight per as-of
+    # ISO week (info/noop); the durable record is the weekly
+    # paper_report_snapshot — this row is only the action-queue echo.
+    "missed_winner",
 )
 
 SEVERITIES: tuple[str, ...] = ("info", "warn", "critical")

--- a/src/rainier/paper/calendar.py
+++ b/src/rainier/paper/calendar.py
@@ -35,6 +35,23 @@ class TradingCalendar:
             nxt += timedelta(days=1)
         return nxt
 
+    def prev_session(self, d: date) -> date:
+        """The last trading session strictly before ``d`` (Monday→Friday)."""
+        prev = d - timedelta(days=1)
+        while not self.is_session(prev):
+            prev -= timedelta(days=1)
+        return prev
+
+    def sub_sessions(self, end: date, n: int) -> date:
+        """The session ``n`` trading days before ``end`` (n=0 → end itself
+        if it's a session, else the previous session). Mirror of add_sessions."""
+        cur = end
+        if not self.is_session(cur):
+            cur = self.prev_session(cur)
+        for _ in range(n):
+            cur = self.prev_session(cur)
+        return cur
+
     def sessions_between(self, start: date, end: date) -> list[date]:
         """Trading sessions in ``[start, end]`` inclusive, ascending."""
         out: list[date] = []

--- a/src/rainier/paper/ingest.py
+++ b/src/rainier/paper/ingest.py
@@ -245,6 +245,59 @@ def screened_symbols(as_of: date) -> list[str]:
     return sorted({r[0] for r in rows})
 
 
+def get_current_qu100_cohort(as_of: date) -> list[dict[str, Any]]:
+    """The current QU100 cohort at-or-before ``as_of`` (shared API — the weekly
+    miss-sweep uses it now; PR 5 reuses it for the daily ingest universe).
+
+    Selection (TASK-PLAN qu100-miss-sweep-6b63 acceptance 1): within
+    ``ranking_type='top100'`` pick the latest ``data_date <= as_of``, then the
+    latest ``captured_at`` within that data_date (the freshest capture batch of
+    the day — a backfill that stamped older data_dates with the same
+    captured_at can't win because data_date filters first). Live runs pass
+    today; ``--regenerate`` passes the report's date and gets the historical
+    cohort. Do NOT use the all-history CLI ``qu100`` selector (every symbol
+    ever seen) — this is the point-in-time membership.
+
+    Returns ``[{symbol, rank, data_date, captured_at}]`` ordered by rank;
+    ``[]`` when no top100 snapshot exists at-or-before ``as_of``.
+    """
+    from rainier.core.models import MoneyFlowSnapshot
+
+    with get_session() as session:
+        max_dd = session.execute(
+            select(func.max(MoneyFlowSnapshot.data_date)).where(
+                MoneyFlowSnapshot.ranking_type == "top100",
+                MoneyFlowSnapshot.data_date <= as_of,
+            )
+        ).scalar()
+        if max_dd is None:
+            return []
+        max_cap = session.execute(
+            select(func.max(MoneyFlowSnapshot.captured_at)).where(
+                MoneyFlowSnapshot.ranking_type == "top100",
+                MoneyFlowSnapshot.data_date == max_dd,
+            )
+        ).scalar()
+        rows = session.execute(
+            select(
+                MoneyFlowSnapshot.symbol,
+                MoneyFlowSnapshot.rank,
+                MoneyFlowSnapshot.data_date,
+                MoneyFlowSnapshot.captured_at,
+            )
+            .where(
+                MoneyFlowSnapshot.ranking_type == "top100",
+                MoneyFlowSnapshot.data_date == max_dd,
+                MoneyFlowSnapshot.captured_at == max_cap,
+            )
+            .order_by(MoneyFlowSnapshot.rank)
+        ).all()
+    return [
+        {"symbol": r[0], "rank": int(r[1]), "data_date": r[2], "captured_at": r[3]}
+        for r in rows
+    ]
+
+
 def _yfinance_fetch_fn(symbols: list[str], start: date, end: date) -> dict[str, list[Bar]]:
     """Production fetch: yfinance → per-symbol long-form bars (NaN → None)."""
     import pandas as pd

--- a/src/rainier/paper/positions.py
+++ b/src/rainier/paper/positions.py
@@ -421,6 +421,20 @@ def fill_pending_positions(
                 continue
 
             shares = int(math.floor(NOTIONAL_USD / open_px))
+
+            # Zero-share guard (TASK-PLAN qu100-miss-sweep-6b63 acceptance 9):
+            # a T+1 open above the $10k notional floors shares to 0 — never
+            # book a 0-share position (it would hold the symbol's active slot
+            # while tracking nothing). Expire + skip `zero_share_price`.
+            if shares == 0:
+                if _expire_locked(session, it["id"]):
+                    _record_skip(
+                        it["thesis_id"], it["symbol"], it["scan_date"],
+                        "zero_share_price",
+                    )
+                    expired += 1
+                continue
+
             allocated = shares * open_px
             residual = NOTIONAL_USD - allocated
             res = session.execute(

--- a/src/rainier/paper/report.py
+++ b/src/rainier/paper/report.py
@@ -218,20 +218,23 @@ def _count_same_bar_exits(session, as_of: date) -> int:
     return n
 
 
-def persist_daily_snapshot(as_of: date, payload: dict[str, Any]) -> None:
-    """Upsert one (daily, as_of_date) snapshot row (H2/H4)."""
+def persist_snapshot(report_type: str, as_of: date, payload: dict[str, Any]) -> None:
+    """Upsert one (report_type, as_of_date) snapshot row (H2/H4)."""
     with get_session() as session:
         stmt = (
             pg_insert(PaperReportSnapshot)
-            .values(
-                report_type=REPORT_TYPE_DAILY, as_of_date=as_of, payload=payload
-            )
+            .values(report_type=report_type, as_of_date=as_of, payload=payload)
             .on_conflict_do_update(
                 constraint="uq_paper_report_snapshot_type_date",
                 set_={"payload": payload},
             )
         )
         session.execute(stmt)
+
+
+def persist_daily_snapshot(as_of: date, payload: dict[str, Any]) -> None:
+    """Upsert one (daily, as_of_date) snapshot row (H2/H4)."""
+    persist_snapshot(REPORT_TYPE_DAILY, as_of, payload)
 
 
 def load_snapshot(report_type: str, as_of: date) -> dict[str, Any] | None:

--- a/src/rainier/paper/sweep.py
+++ b/src/rainier/paper/sweep.py
@@ -39,8 +39,9 @@ import logging
 from datetime import date
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 
+from rainier.alerts.discord import _http_status, send_daily_report
 from rainier.core.database import get_session
 from rainier.core.models import (
     LLMAnalysisRecord,
@@ -170,15 +171,13 @@ def _held_symbols(session, window_start: date, window_end: date) -> set[str]:
     only (entry_date set, status open/closed) whose
     [entry_date, COALESCE(exit_date, window_end)] overlaps the window.
     Pending / never-filled expired rows are NOT held."""
-    from sqlalchemy import func as sa_func
-
     rows = session.execute(
         select(PaperTrade.symbol)
         .where(
             PaperTrade.entry_date.isnot(None),
             PaperTrade.status.in_(("open", "closed")),
             PaperTrade.entry_date <= window_end,
-            sa_func.coalesce(PaperTrade.exit_date, window_end) >= window_start,
+            func.coalesce(PaperTrade.exit_date, window_end) >= window_start,
         )
         .distinct()
     ).all()
@@ -368,11 +367,15 @@ def render_weekly_payload(payload: dict[str, Any]) -> str:
 
 def send_weekly_paper_report(payload: dict[str, Any], discord_config: Any) -> bool:
     """Push the weekly report to Discord. Non-fatal on failure / no webhook:
-    logs + returns False, never raises (mirrors the daily path)."""
-    text = render_weekly_payload(payload)
-    try:
-        from rainier.alerts.discord import _http_status, send_daily_report
+    logs + returns False, never raises (mirrors the daily path).
 
+    ``_http_status``/``send_daily_report`` are module-top imports and the
+    render runs INSIDE the try, so the except path can always execute — the
+    never-raises guarantee is what keeps Discord exceptions away from any
+    caller that might stringify them (review iter-1, security specialist).
+    """
+    try:
+        text = render_weekly_payload(payload)
         webhook = (
             getattr(discord_config, "webhook_url", None) if discord_config else None
         )

--- a/src/rainier/paper/sweep.py
+++ b/src/rainier/paper/sweep.py
@@ -1,0 +1,515 @@
+"""Weekly missed-winner sweep (Phase 3, design §5(4) / D8).
+
+COVERAGE DIAGNOSTIC ONLY: a flagged "missed winner" is a trailing
+point-to-point return with no entry-timing/stop/target — NOT comparable to the
+path-dependent paper trades, and never an input to weight-tuning/calibration.
+It answers one question: are big movers concentrated outside our funnel?
+
+    Friday 09:00 PT run (as_of = Friday)
+        │
+        ▼
+    window_end   = last completed session BEFORE the run  (Thursday)
+    window_start = 10 trading days before window_end
+    return       = close(window_end) / close(window_start) − 1
+                   (11 closes, 10 intervals)
+        │
+        ▼
+    cohort = get_current_qu100_cohort(as_of)      ← point-in-time membership
+    ingest_prices(cohort ∪ declined, as_of=window_end, window_days=11)
+        │                              └── anchored at window_end so the
+        ▼                                  in-progress Friday bar is NEVER
+    flag: return ≥ +10% (inclusive) AND not held   written (a partial upsert
+        │                                          would later read complete)
+        ▼
+    attribute (highest funnel stage reached ANYWHERE in the window):
+      (i)   declined thesis (watch/no_setup)  → verdict_watch_or_no_setup
+      (ii)  screened, pattern_type NOT NULL   → not_in_top5
+      (iii) screened, pattern_type NULL       → no_pattern
+      (iv)  else                              → rank_too_low
+        │
+        ▼
+    snapshot (paper_report_snapshot, weekly) ── durable record
+    ResearchInsight kind=missed_winner       ── mutable action queue
+    Discord push                             ── non-fatal
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Any
+
+from sqlalchemy import select
+
+from rainier.core.database import get_session
+from rainier.core.models import (
+    LLMAnalysisRecord,
+    PaperTrade,
+    ScreenedStockRecord,
+    StockPrice,
+)
+
+from .calendar import DEFAULT_CALENDAR, TradingCalendar
+from .ingest import FetchFn, canonical_instant, get_current_qu100_cohort, ingest_prices
+from .report import REPORT_TYPE_WEEKLY, persist_snapshot
+
+log = logging.getLogger(__name__)
+
+# 10 trading-day intervals (operator 2026-06-02, design D8).
+WINDOW_SESSIONS = 10
+# The ingest window must cover the anchor close too: 11 sessions, because the
+# default window_days=10 drops close(window_start) (acceptance 3).
+INGEST_WINDOW_SESSIONS = WINDOW_SESSIONS + 1
+# Forward-return thresholds — both INCLUSIVE (acceptance 2 / 6).
+MISS_THRESHOLD = 0.10
+DODGE_THRESHOLD = -0.10
+# Float guard so an exact ±10% close pair (e.g. 90/100 → −0.09999999999999998)
+# still lands on the inclusive side of the threshold.
+_EPS = 1e-9
+
+# Attribution buckets, ordered highest funnel stage first (acceptance 4).
+BUCKET_VERDICT = "verdict_watch_or_no_setup"
+BUCKET_NOT_TOP5 = "not_in_top5"
+BUCKET_NO_PATTERN = "no_pattern"
+BUCKET_RANK_TOO_LOW = "rank_too_low"
+BUCKETS = (BUCKET_VERDICT, BUCKET_NOT_TOP5, BUCKET_NO_PATTERN, BUCKET_RANK_TOO_LOW)
+
+# One tuning hypothesis per dominant bucket (acceptance 7 — the design's
+# outcome→action mapping). Hypotheses, not actions: this metric never tunes.
+_HYPOTHESES = {
+    BUCKET_VERDICT: (
+        "The LLM saw these names and declined them. Hypothesis: the verdict "
+        "criteria are too conservative on this regime — review the declined "
+        "theses' rationale against what actually moved before touching the "
+        "prompt."
+    ),
+    BUCKET_NOT_TOP5: (
+        "Winners were screened WITH a tradable pattern but ranked below the "
+        "thesis cut. Hypothesis: the composite ranking under-weights whatever "
+        "carried these names — compare their component scores to the top-5's."
+    ),
+    BUCKET_NO_PATTERN: (
+        "Winners were screened but no tradable pattern fired. Hypothesis: the "
+        "pattern detector set misses this move shape — inspect their charts "
+        "for a recurring, codifiable structure."
+    ),
+    BUCKET_RANK_TOO_LOW: (
+        "Most missed winners never entered the top-50 screen — expected, the "
+        "screen covers a subset of QU100 by design. Hypothesis: widening "
+        "screen depth would capture them, at proportional scan cost; treat as "
+        "coverage information, not a tuning signal."
+    ),
+}
+
+_DISCLOSURE = (
+    "Coverage diagnostic ONLY: trailing point-to-point returns with no "
+    "entry-timing/stop/target — not comparable to paper trades; never feeds "
+    "weight-tuning or calibration. rank_too_low dominance is EXPECTED (the "
+    "screen covers a subset of QU100). The current-cohort sweep has "
+    "survivorship bias: symbols that crashed out of the index don't appear."
+)
+
+
+def compute_window(
+    as_of: date, calendar: TradingCalendar | None = None
+) -> tuple[date, date]:
+    """The prior completed 10-trading-day window for a run on ``as_of``.
+
+    ``window_end`` = last completed priced trading day strictly BEFORE the run
+    (Thursday for a Friday 09:00 run — never the in-progress session);
+    ``window_start`` = 10 trading days before ``window_end``. Exactly 11
+    sessions inclusive (11 closes, 10 intervals) — acceptance 2.
+    """
+    cal = calendar or DEFAULT_CALENDAR
+    window_end = cal.prev_session(as_of)
+    window_start = cal.sub_sessions(window_end, WINDOW_SESSIONS)
+    return window_start, window_end
+
+
+# ---------------------------------------------------------------------------
+# Funnel / held / pricing queries (raw inputs only — never ResearchInsight)
+# ---------------------------------------------------------------------------
+
+
+def _declined_symbols(session, window_start: date, window_end: date) -> set[str]:
+    """Symbols with a thesis row in-window whose verdict is watch/no_setup —
+    funnel tier (i). In-window = the thesis's screened scan_date."""
+    rows = session.execute(
+        select(ScreenedStockRecord.symbol)
+        .join(
+            LLMAnalysisRecord,
+            ScreenedStockRecord.thesis_id == LLMAnalysisRecord.id,
+        )
+        .where(
+            ScreenedStockRecord.scan_date >= window_start,
+            ScreenedStockRecord.scan_date <= window_end,
+            LLMAnalysisRecord.recommendation.in_(("watch", "no_setup")),
+        )
+        .distinct()
+    ).all()
+    return {r[0] for r in rows}
+
+
+def _screened_sets(
+    session, window_start: date, window_end: date
+) -> tuple[set[str], set[str]]:
+    """(symbols screened with a pattern, all screened symbols) in-window."""
+    rows = session.execute(
+        select(ScreenedStockRecord.symbol, ScreenedStockRecord.pattern_type).where(
+            ScreenedStockRecord.scan_date >= window_start,
+            ScreenedStockRecord.scan_date <= window_end,
+        )
+    ).all()
+    with_pattern = {sym for sym, pat in rows if pat is not None}
+    screened = {sym for sym, _pat in rows}
+    return with_pattern, screened
+
+
+def _held_symbols(session, window_start: date, window_end: date) -> set[str]:
+    """Symbols we actually HELD during the window (acceptance 5): filled rows
+    only (entry_date set, status open/closed) whose
+    [entry_date, COALESCE(exit_date, window_end)] overlaps the window.
+    Pending / never-filled expired rows are NOT held."""
+    from sqlalchemy import func as sa_func
+
+    rows = session.execute(
+        select(PaperTrade.symbol)
+        .where(
+            PaperTrade.entry_date.isnot(None),
+            PaperTrade.status.in_(("open", "closed")),
+            PaperTrade.entry_date <= window_end,
+            sa_func.coalesce(PaperTrade.exit_date, window_end) >= window_start,
+        )
+        .distinct()
+    ).all()
+    return {r[0] for r in rows}
+
+
+def _closes_on(session, symbols: set[str], d: date) -> dict[str, float]:
+    if not symbols:
+        return {}
+    rows = session.execute(
+        select(StockPrice.symbol, StockPrice.close).where(
+            StockPrice.symbol.in_(sorted(symbols)),
+            StockPrice.date == canonical_instant(d),
+            StockPrice.close.isnot(None),
+        )
+    ).all()
+    return {sym: float(px) for sym, px in rows}
+
+
+def _attribute(
+    symbol: str,
+    declined: set[str],
+    with_pattern: set[str],
+    screened: set[str],
+) -> str:
+    """Bucket = the HIGHEST funnel stage the symbol reached at any point inside
+    the window (acceptance 4) — a day-2 declined thesis beats a day-9
+    unscreened miss."""
+    if symbol in declined:
+        return BUCKET_VERDICT
+    if symbol in with_pattern:
+        return BUCKET_NOT_TOP5
+    if symbol in screened:
+        return BUCKET_NO_PATTERN
+    return BUCKET_RANK_TOO_LOW
+
+
+# ---------------------------------------------------------------------------
+# Payload compute (raw inputs; shared by the live sweep and --regenerate)
+# ---------------------------------------------------------------------------
+
+
+def compute_weekly_payload(
+    as_of: date, calendar: TradingCalendar | None = None
+) -> dict[str, Any]:
+    """Build the weekly missed-winner payload from raw inputs only:
+    money_flow_snapshots (cohort), stock_prices, screened_stocks,
+    analysis_results, paper_trade — NEVER from ResearchInsight (the insight
+    queue is mutable; the snapshot is the durable record — acceptance 7).
+
+    JSON-native throughout so the persisted snapshot re-renders identically.
+    """
+    window_start, window_end = compute_window(as_of, calendar)
+    cohort = get_current_qu100_cohort(as_of)
+    cohort_symbols = sorted({c["symbol"] for c in cohort})
+    rank_by_symbol: dict[str, int] = {}
+    for c in cohort:
+        rank_by_symbol.setdefault(c["symbol"], c["rank"])
+
+    with get_session() as session:
+        declined = _declined_symbols(session, window_start, window_end)
+        with_pattern, screened = _screened_sets(session, window_start, window_end)
+        held = _held_symbols(session, window_start, window_end)
+        price_universe = set(cohort_symbols) | declined
+        start_closes = _closes_on(session, price_universe, window_start)
+        end_closes = _closes_on(session, price_universe, window_end)
+
+    def _ret(symbol: str) -> float | None:
+        start_px = start_closes.get(symbol)
+        end_px = end_closes.get(symbol)
+        if start_px is None or end_px is None or start_px <= 0:
+            return None
+        return end_px / start_px - 1.0
+
+    missed: list[dict[str, Any]] = []
+    missing_prices: list[str] = []
+    held_winner_count = 0
+    for symbol in cohort_symbols:
+        ret = _ret(symbol)
+        if ret is None:
+            missing_prices.append(symbol)
+            continue
+        if ret < MISS_THRESHOLD - _EPS:
+            continue
+        if symbol in held:
+            held_winner_count += 1
+            continue
+        missed.append(
+            {
+                "symbol": symbol,
+                "rank": rank_by_symbol.get(symbol),
+                "return_pct": round(ret, 6),
+                "bucket": _attribute(symbol, declined, with_pattern, screened),
+            }
+        )
+    missed.sort(key=lambda w: (-w["return_pct"], w["symbol"]))
+
+    bucket_counts = {b: 0 for b in BUCKETS}
+    for w in missed:
+        bucket_counts[w["bucket"]] += 1
+    dominant = None
+    if missed:
+        # Ties resolve to the highest funnel stage (BUCKETS order).
+        dominant = max(BUCKETS, key=lambda b: (bucket_counts[b], -BUCKETS.index(b)))
+
+    # R-B: dodged losers — declined in-window, forward return ≤ −10%
+    # (inclusive), and NOT held (a loser we held wasn't dodged — acceptance 6).
+    dodged: list[dict[str, Any]] = []
+    for symbol in sorted(declined):
+        ret = _ret(symbol)
+        if ret is None or symbol in held:
+            continue
+        if ret <= DODGE_THRESHOLD + _EPS:
+            dodged.append({"symbol": symbol, "return_pct": round(ret, 6)})
+    dodged.sort(key=lambda d: (d["return_pct"], d["symbol"]))
+
+    first = cohort[0] if cohort else None
+    return {
+        "report_type": REPORT_TYPE_WEEKLY,
+        "as_of_date": as_of.isoformat(),
+        "window_start": window_start.isoformat(),
+        "window_end": window_end.isoformat(),
+        "threshold_pct": MISS_THRESHOLD,
+        "cohort": {
+            "size": len(cohort_symbols),
+            "data_date": first["data_date"].isoformat() if first else None,
+            "captured_at": first["captured_at"].isoformat() if first else None,
+        },
+        "missed_winners": missed,
+        "bucket_counts": bucket_counts,
+        "dominant_bucket": dominant,
+        "tuning_hypothesis": _HYPOTHESES[dominant] if dominant else None,
+        "held_winner_count": held_winner_count,
+        "dodged_losers": {"count": len(dodged), "names": dodged},
+        "missing_price_symbols": missing_prices,
+        "disclosure": _DISCLOSURE,
+    }
+
+
+def persist_weekly_snapshot(as_of: date, payload: dict[str, Any]) -> None:
+    """Upsert one (weekly, as_of_date) snapshot row — the durable record."""
+    persist_snapshot(REPORT_TYPE_WEEKLY, as_of, payload)
+
+
+def render_weekly_payload(payload: dict[str, Any]) -> str:
+    """Render a weekly snapshot payload into Discord-ready text."""
+    cohort = payload.get("cohort", {})
+    lines = [
+        f"**QU100 missed-winner sweep — {payload.get('as_of_date')}**",
+        f"window: {payload.get('window_start')} → {payload.get('window_end')} "
+        f"(10 trading days)",
+        f"cohort: {cohort.get('size', 0)} names "
+        f"(data_date {cohort.get('data_date')})",
+    ]
+    winners = payload.get("missed_winners", [])
+    if winners:
+        lines.append(f"missed winners (≥ +10%, not held): {len(winners)}")
+        for w in winners[:15]:
+            lines.append(
+                f"  {w['symbol']} {w['return_pct']:+.1%} — {w['bucket']}"
+            )
+        if len(winners) > 15:
+            lines.append(f"  … +{len(winners) - 15} more")
+        counts = payload.get("bucket_counts", {})
+        lines.append(
+            "buckets: " + " · ".join(f"{b}:{counts.get(b, 0)}" for b in BUCKETS)
+        )
+        lines.append(f"dominant bucket: {payload.get('dominant_bucket')}")
+        lines.append(f"hypothesis: {payload.get('tuning_hypothesis')}")
+    else:
+        lines.append("missed winners (≥ +10%, not held): none")
+    dodged = payload.get("dodged_losers", {})
+    lines.append(
+        f"R-B dodged losers (declined, ≤ −10%): {dodged.get('count', 0)}"
+    )
+    for d in dodged.get("names", [])[:10]:
+        lines.append(f"  {d['symbol']} {d['return_pct']:+.1%}")
+    missing = payload.get("missing_price_symbols", [])
+    if missing:
+        shown = ", ".join(missing[:10])
+        more = f" (+{len(missing) - 10} more)" if len(missing) > 10 else ""
+        lines.append(f"missing prices: {shown}{more}")
+    lines.append("")
+    lines.append(payload.get("disclosure", ""))
+    return "\n".join(lines)
+
+
+def send_weekly_paper_report(payload: dict[str, Any], discord_config: Any) -> bool:
+    """Push the weekly report to Discord. Non-fatal on failure / no webhook:
+    logs + returns False, never raises (mirrors the daily path)."""
+    text = render_weekly_payload(payload)
+    try:
+        from rainier.alerts.discord import _http_status, send_daily_report
+
+        webhook = (
+            getattr(discord_config, "webhook_url", None) if discord_config else None
+        )
+        if (
+            not discord_config
+            or not getattr(discord_config, "enabled", False)
+            or not webhook
+        ):
+            log.info("weekly_sweep_discord_skipped reason=no_webhook")
+            return False
+        send_daily_report(text, discord_config)
+        return True
+    except Exception as exc:
+        # Never log str(exc) or the traceback: httpx.HTTPStatusError.__str__
+        # embeds the request URL, and the webhook URL carries its secret token
+        # (codex [P1] 2026-06-09, commit 96fbd13). Status + class only.
+        log.error(
+            "weekly_sweep_discord_failed status=%s error_type=%s",
+            _http_status(exc),
+            type(exc).__name__,
+        )
+        return False
+
+
+# ---------------------------------------------------------------------------
+# ResearchInsight emission (acceptance 8)
+# ---------------------------------------------------------------------------
+
+
+def _week_subject(as_of: date) -> str:
+    iso = as_of.isocalendar()
+    return f"{iso[0]}-W{iso[1]:02d}"
+
+
+def emit_missed_winner_insight(as_of: date, payload: dict[str, Any]) -> None:
+    """One `missed_winner` insight per week (subject = the as-of ISO week),
+    severity=info, action=noop. Evidence = the flagged names with bucket +
+    return. The durable record remains the snapshot — insights are the mutable
+    queue (a re-run UPSERTs the same pending row)."""
+    from rainier.llm_thesis.research import emit_insight
+
+    winners = payload["missed_winners"]
+    dominant = payload.get("dominant_bucket")
+    evidence = {
+        "window_start": payload["window_start"],
+        "window_end": payload["window_end"],
+        "winners": [
+            {"symbol": w["symbol"], "bucket": w["bucket"],
+             "return_pct": w["return_pct"]}
+            for w in winners
+        ],
+        "bucket_counts": payload["bucket_counts"],
+        "dominant_bucket": dominant,
+        "dodged_losers_count": payload["dodged_losers"]["count"],
+    }
+    if winners:
+        rationale = (
+            f"Missed-winner sweep {payload['window_start']}→"
+            f"{payload['window_end']}: {len(winners)} QU100 names ≥ +10% not "
+            f"held; dominant bucket {dominant}. "
+            f"{payload['tuning_hypothesis']} R-B dodged losers: "
+            f"{payload['dodged_losers']['count']}. Coverage diagnostic only — "
+            "never a tuning input."
+        )
+    else:
+        rationale = (
+            f"Missed-winner sweep {payload['window_start']}→"
+            f"{payload['window_end']}: no QU100 name ≥ +10% was missed. "
+            f"R-B dodged losers: {payload['dodged_losers']['count']}."
+        )
+    subject = _week_subject(as_of)
+    emit_insight(
+        kind="missed_winner",
+        subject=subject,
+        severity="info",
+        evidence=evidence,
+        action={"kind": "noop", "target": subject, "params": {}},
+        rationale=rationale,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator — the Fri 09:00 PT research-job step (acceptance 2/3)
+# ---------------------------------------------------------------------------
+
+
+def sweep_missed_winners(
+    *,
+    as_of: date,
+    fetch_fn: FetchFn,
+    calendar: TradingCalendar | None = None,
+    discord_config: Any = None,
+) -> dict[str, Any]:
+    """Run the weekly sweep: cohort pricing → forward returns → flag → attribute
+    → snapshot + insight + Discord. Returns the persisted payload.
+
+    Sweep-owned pricing (acceptance 3): the daily ingest covers only
+    active ∪ top-50 until PR 5 lands, so the sweep ingests the full cohort
+    itself with ``as_of = window_end`` (never the in-progress session — a
+    partial Friday bar upserted mid-session would later read as a complete
+    day) and an 11-session window so close(window_start) is fetched too.
+    Declined names are included so R-B (acceptance 6) prices even when a name
+    has dropped out of the current cohort.
+    """
+    cal = calendar or DEFAULT_CALENDAR
+    window_start, window_end = compute_window(as_of, cal)
+
+    cohort = get_current_qu100_cohort(as_of)
+    symbols = {c["symbol"] for c in cohort}
+    with get_session() as session:
+        symbols |= _declined_symbols(session, window_start, window_end)
+
+    if symbols:
+        ingest_prices(
+            sorted(symbols),
+            as_of=window_end,
+            fetch_fn=fetch_fn,
+            window_days=INGEST_WINDOW_SESSIONS,
+            calendar=cal,
+        )
+    else:
+        log.warning("weekly_sweep_empty_cohort as_of=%s", as_of.isoformat())
+
+    payload = compute_weekly_payload(as_of, cal)
+    persist_weekly_snapshot(as_of, payload)
+    emit_missed_winner_insight(as_of, payload)
+    send_weekly_paper_report(payload, discord_config)
+    log.info(
+        "weekly_sweep_done as_of=%s window=%s..%s cohort=%d missed=%d "
+        "dominant=%s dodged=%d missing_prices=%d",
+        as_of.isoformat(),
+        payload["window_start"],
+        payload["window_end"],
+        payload["cohort"]["size"],
+        len(payload["missed_winners"]),
+        payload["dominant_bucket"],
+        payload["dodged_losers"]["count"],
+        len(payload["missing_price_symbols"]),
+    )
+    return payload

--- a/src/rainier/paper/sweep.py
+++ b/src/rainier/paper/sweep.py
@@ -36,7 +36,7 @@ It answers one question: are big movers concentrated outside our funnel?
 from __future__ import annotations
 
 import logging
-from datetime import date
+from datetime import date, timedelta
 from typing import Any
 
 from sqlalchemy import func, select
@@ -59,8 +59,18 @@ log = logging.getLogger(__name__)
 # 10 trading-day intervals (operator 2026-06-02, design D8).
 WINDOW_SESSIONS = 10
 # The ingest window must cover the anchor close too: 11 sessions, because the
-# default window_days=10 drops close(window_start) (acceptance 3).
-INGEST_WINDOW_SESSIONS = WINDOW_SESSIONS + 1
+# default window_days=10 drops close(window_start) (acceptance 3). +2 buffer
+# sessions so a market holiday AT window_start (DEFAULT_CALENDAR is Mon-Fri
+# only — no holiday table) still gets a real close fetched just before it for
+# the at-or-before endpoint lookup (review iter-2).
+INGEST_WINDOW_SESSIONS = WINDOW_SESSIONS + 1 + 2
+# Endpoint closes use an at-or-before lookup capped at this many calendar days
+# back, so an unpriced endpoint (e.g. window_end = Thanksgiving, which the
+# no-holiday default calendar happily returns) degrades to the last completed
+# PRICED day — per the plan's "last completed priced trading day" — instead of
+# wiping the whole cohort into missing_price_symbols (review iter-2). 5 days
+# covers a holiday cluster + weekend; anything staler is genuinely missing.
+_CLOSE_LOOKBACK_DAYS = 5
 # Forward-return thresholds — both INCLUSIVE (acceptance 2 / 6).
 MISS_THRESHOLD = 0.10
 DODGE_THRESHOLD = -0.10
@@ -184,17 +194,32 @@ def _held_symbols(session, window_start: date, window_end: date) -> set[str]:
     return {r[0] for r in rows}
 
 
-def _closes_on(session, symbols: set[str], d: date) -> dict[str, float]:
+def _closes_at_or_before(
+    session, symbols: set[str], d: date
+) -> dict[str, float]:
+    """Per-symbol close on ``d``, or the latest close within
+    ``_CLOSE_LOOKBACK_DAYS`` before it. An exact-date lookup would zero out the
+    entire report whenever an endpoint lands on a market holiday (~10
+    Fridays/yr for window_start; every Thanksgiving for window_end) — the
+    no-holiday DEFAULT_CALENDAR can't avoid picking one (review iter-2)."""
     if not symbols:
         return {}
+    floor = canonical_instant(d - timedelta(days=_CLOSE_LOOKBACK_DAYS))
     rows = session.execute(
-        select(StockPrice.symbol, StockPrice.close).where(
+        select(StockPrice.symbol, StockPrice.close, StockPrice.date).where(
             StockPrice.symbol.in_(sorted(symbols)),
-            StockPrice.date == canonical_instant(d),
+            StockPrice.date <= canonical_instant(d),
+            StockPrice.date >= floor,
             StockPrice.close.isnot(None),
         )
     ).all()
-    return {sym: float(px) for sym, px in rows}
+    best: dict[str, Any] = {}
+    out: dict[str, float] = {}
+    for sym, px, dt in rows:
+        if sym not in best or dt > best[sym]:
+            best[sym] = dt
+            out[sym] = float(px)
+    return out
 
 
 def _attribute(
@@ -221,17 +246,27 @@ def _attribute(
 
 
 def compute_weekly_payload(
-    as_of: date, calendar: TradingCalendar | None = None
+    as_of: date,
+    calendar: TradingCalendar | None = None,
+    *,
+    cohort: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build the weekly missed-winner payload from raw inputs only:
     money_flow_snapshots (cohort), stock_prices, screened_stocks,
     analysis_results, paper_trade — NEVER from ResearchInsight (the insight
     queue is mutable; the snapshot is the durable record — acceptance 7).
 
+    ``cohort`` lets the live sweep pass the membership it already priced —
+    re-reading here would race the QU midday scrape (the Fri 09:00 PT run is
+    12:00 ET; the morning slot often slips past it), swapping in a cohort the
+    ingest never covered (review iter-2). ``--regenerate`` passes None and
+    fetches the historical cohort itself.
+
     JSON-native throughout so the persisted snapshot re-renders identically.
     """
     window_start, window_end = compute_window(as_of, calendar)
-    cohort = get_current_qu100_cohort(as_of)
+    if cohort is None:
+        cohort = get_current_qu100_cohort(as_of)
     cohort_symbols = sorted({c["symbol"] for c in cohort})
     rank_by_symbol: dict[str, int] = {}
     for c in cohort:
@@ -242,8 +277,8 @@ def compute_weekly_payload(
         with_pattern, screened = _screened_sets(session, window_start, window_end)
         held = _held_symbols(session, window_start, window_end)
         price_universe = set(cohort_symbols) | declined
-        start_closes = _closes_on(session, price_universe, window_start)
-        end_closes = _closes_on(session, price_universe, window_end)
+        start_closes = _closes_at_or_before(session, price_universe, window_start)
+        end_closes = _closes_at_or_before(session, price_universe, window_end)
 
     def _ret(symbol: str) -> float | None:
         start_px = start_closes.get(symbol)
@@ -285,14 +320,23 @@ def compute_weekly_payload(
 
     # R-B: dodged losers — declined in-window, forward return ≤ −10%
     # (inclusive), and NOT held (a loser we held wasn't dodged — acceptance 6).
+    # A declined name with no price visibility is tracked in
+    # missing_price_symbols too: an off-cohort decliner that can't price
+    # (delisted after crashing — exactly the dodged shape) must not vanish
+    # silently from the count it exists to inform (review iter-2).
     dodged: list[dict[str, Any]] = []
     for symbol in sorted(declined):
         ret = _ret(symbol)
-        if ret is None or symbol in held:
+        if ret is None:
+            if symbol not in missing_prices:
+                missing_prices.append(symbol)
+            continue
+        if symbol in held:
             continue
         if ret <= DODGE_THRESHOLD + _EPS:
             dodged.append({"symbol": symbol, "return_pct": round(ret, 6)})
     dodged.sort(key=lambda d: (d["return_pct"], d["symbol"]))
+    missing_prices.sort()
 
     first = cohort[0] if cohort else None
     return {
@@ -499,7 +543,10 @@ def sweep_missed_winners(
     else:
         log.warning("weekly_sweep_empty_cohort as_of=%s", as_of.isoformat())
 
-    payload = compute_weekly_payload(as_of, cal)
+    # Pass the cohort we actually priced — a second read here would race the
+    # QU midday scrape and could swap in a never-ingested membership
+    # (review iter-2).
+    payload = compute_weekly_payload(as_of, cal, cohort=cohort)
     persist_weekly_snapshot(as_of, payload)
     emit_missed_winner_insight(as_of, payload)
     send_weekly_paper_report(payload, discord_config)

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -311,6 +311,29 @@ async def run_research_job(eval_date_iso: str | None = None) -> None:
 
     log.info("research_job_emitted", count=len(insights))
 
+    # Phase 3 — weekly missed-winner sweep (design §5(4), coverage diagnostic
+    # only). Own try/except so a sweep failure never kills the research report
+    # (and vice versa). Discord delivery inside the sweep is already non-fatal.
+    try:
+        from rainier.paper.ingest import _yfinance_fetch_fn
+        from rainier.paper.sweep import sweep_missed_winners
+
+        settings = await asyncio.to_thread(load_settings_fresh)
+        payload = await asyncio.to_thread(
+            lambda: sweep_missed_winners(
+                as_of=eval_date,
+                fetch_fn=_yfinance_fetch_fn,
+                discord_config=settings.alerts.discord,
+            )
+        )
+        log.info(
+            "research_miss_sweep_done",
+            missed=len(payload["missed_winners"]),
+            dodged=payload["dodged_losers"]["count"],
+        )
+    except Exception as exc:
+        log.error("research_miss_sweep_failed", error=str(exc))
+
     try:
         settings = await asyncio.to_thread(load_settings_fresh)
         await asyncio.to_thread(

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -332,7 +332,19 @@ async def run_research_job(eval_date_iso: str | None = None) -> None:
             dodged=payload["dodged_losers"]["count"],
         )
     except Exception as exc:
-        log.error("research_miss_sweep_failed", error=str(exc))
+        # Never log str(exc) here: this try block loads the Discord config —
+        # a pydantic ValidationError from load_settings_fresh() embeds
+        # input_value=... which can carry the token-bearing webhook URL, and
+        # any exception escaping the sweep would be stringified one frame up
+        # from the send (codex [P1] 2026-06-09, commit 96fbd13). Status +
+        # class only.
+        from rainier.alerts.discord import _http_status
+
+        log.error(
+            "research_miss_sweep_failed",
+            status=_http_status(exc),
+            error_type=type(exc).__name__,
+        )
 
     try:
         settings = await asyncio.to_thread(load_settings_fresh)

--- a/tests/test_llm_thesis/test_research.py
+++ b/tests/test_llm_thesis/test_research.py
@@ -283,6 +283,10 @@ def test_insight_kinds_and_severities_are_complete():
         # Phase 2 (D6 / D7c).
         "time_stop_discovered",
         "paper_lessons",
+        # Phase 3 (D8): weekly missed-winner sweep — emitted by
+        # paper.sweep.sweep_missed_winners (the run_research_job sweep step),
+        # not by a run_research check.
+        "missed_winner",
     }
     assert set(SEVERITIES) == {"info", "warn", "critical"}
 
@@ -770,7 +774,10 @@ def test_run_research_runs_all_checks_and_collects_emissions():
         out = run_research(eval_date=date(2026, 5, 7))
 
     assert len(out) == 8
-    assert {r.kind for r in out} == set(INSIGHT_KINDS)
+    # Every kind EXCEPT missed_winner comes from a run_research check;
+    # missed_winner is emitted by the Phase-3 sweep step (paper.sweep) inside
+    # run_research_job, outside this orchestrator.
+    assert {r.kind for r in out} == set(INSIGHT_KINDS) - {"missed_winner"}
 
 
 def test_run_research_isolates_failures():

--- a/tests/test_paper/conftest.py
+++ b/tests/test_paper/conftest.py
@@ -26,6 +26,11 @@ MIGRATION_DOWN = REPO_ROOT / "migrations" / "0005_paper_tracker_downgrade.sql"
 # schema so calibration compute/persist tests have the table.
 MIGRATION_0007_UP = REPO_ROOT / "migrations" / "0007_paper_calibration.sql"
 MIGRATION_0007_DOWN = REPO_ROOT / "migrations" / "0007_paper_calibration_downgrade.sql"
+# Phase 3 (miss-sweep): extends ck_paper_skip_reason with `zero_share_price`.
+MIGRATION_0008_UP = REPO_ROOT / "migrations" / "0008_paper_skip_zero_share.sql"
+MIGRATION_0008_DOWN = (
+    REPO_ROOT / "migrations" / "0008_paper_skip_zero_share_downgrade.sql"
+)
 
 # Minimal DDL for the FK-target tables the paper migration references. The real
 # schema lives in migrations/0001-0004; for an isolated paper-tracker test DB we
@@ -103,6 +108,45 @@ CREATE TABLE IF NOT EXISTS stock_prices (
     volume  BIGINT,
     PRIMARY KEY (id, date),
     CONSTRAINT uq_stock_price_symbol_date UNIQUE (symbol, date)
+);
+
+-- Mirror the MoneyFlowSnapshot ORM (models.py) for the Phase-3 miss-sweep
+-- cohort selector (`get_current_qu100_cohort` reads data_date / ranking_type /
+-- captured_at / rank). ORM inserts emit ALL columns, so all must exist.
+CREATE TABLE IF NOT EXISTS money_flow_snapshots (
+    id              BIGSERIAL,
+    captured_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+    capture_session VARCHAR(20) NOT NULL,
+    data_date       DATE NOT NULL,
+    view_type       VARCHAR(10) NOT NULL DEFAULT 'daily',
+    ranking_type    VARCHAR(10) NOT NULL,
+    symbol          VARCHAR(10) NOT NULL REFERENCES stocks (symbol),
+    rank            INTEGER NOT NULL,
+    daily_change    INTEGER,
+    sector          VARCHAR(100),
+    industry        VARCHAR(200),
+    long_short      VARCHAR(50),
+    raw_data        JSONB,
+    PRIMARY KEY (id, captured_at)
+);
+
+-- Mirror the ResearchInsight ORM (models.py) for the Phase-3 missed_winner
+-- insight emission (emit_insight UPSERTs pending rows by (kind, subject)).
+CREATE TABLE IF NOT EXISTS research_insights (
+    id               SERIAL PRIMARY KEY,
+    created_at       TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at       TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    kind             VARCHAR(40) NOT NULL,
+    severity         VARCHAR(10) NOT NULL,
+    subject          VARCHAR(100) NOT NULL,
+    evidence         JSONB,
+    action           JSONB,
+    rationale        TEXT,
+    recurrence_count INTEGER NOT NULL DEFAULT 1,
+    status           VARCHAR(20) NOT NULL DEFAULT 'pending',
+    decided_at       TIMESTAMP WITH TIME ZONE,
+    decided_by       VARCHAR(200),
+    applied_change   JSONB
 );
 
 -- Mirror the ThesisEvaluation ORM (models.py) enough for the D7a calibration
@@ -211,6 +255,7 @@ def pg_legacy_engine(request):
         conn.execute(text(_PREREQ_DDL))
     _apply_sql(engine, MIGRATION_UP)
     _apply_sql(engine, MIGRATION_0007_UP)  # D7a paper_calibration
+    _apply_sql(engine, MIGRATION_0008_UP)  # Phase 3 zero_share_price skip reason
 
     from rainier.core import config, database
 

--- a/tests/test_paper/test_cli.py
+++ b/tests/test_paper/test_cli.py
@@ -1,4 +1,4 @@
-"""Step 8 — `rainier paper` CLI (TEST-SPEC §H5). No DB for the Phase-3 guard."""
+"""Step 8 — `rainier paper` CLI (TEST-SPEC §H5). No-DB registration checks."""
 
 from __future__ import annotations
 
@@ -7,13 +7,15 @@ from click.testing import CliRunner
 from rainier.cli import cli
 
 
-def test_h5_weekly_regenerate_is_phase3_error():
+def test_weekly_flags_registered():
+    """Phase 3 ships --week / --week --regenerate (the old guard error is
+    gone); behavior is covered in test_weekly_sweep.py — here just
+    registration."""
     runner = CliRunner()
-    result = runner.invoke(
-        cli, ["paper", "report", "--date", "2026-01-09", "--week", "--regenerate"]
-    )
-    assert result.exit_code != 0
-    assert "Phase 3" in result.output or "not implemented" in result.output
+    result = runner.invoke(cli, ["paper", "report", "--help"])
+    assert result.exit_code == 0
+    assert "--week" in result.output
+    assert "--regenerate" in result.output
 
 
 def test_paper_group_registered():

--- a/tests/test_paper/test_fill_and_update.py
+++ b/tests/test_paper/test_fill_and_update.py
@@ -287,3 +287,34 @@ def test_f16_split_freeze_closed_immutable(pg_legacy_session):
     update_open_positions(as_of=date(2026, 1, 8))
     after = _get(s, pid)
     assert (after.entry_price, after.exit_price, after.pnl, after.shares) == booked_tuple
+
+
+# --------------------------- Zero-share guard ---------------------------
+# TASK-PLAN qu100-miss-sweep-6b63 acceptance 9: a T+1 open > $10k/share would
+# floor shares to 0 — never open a 0-share position. Skip reason
+# `zero_share_price` + status=expired.
+
+
+def test_zero_share_guard_expires_and_records_skip(pg_legacy_session):
+    s = pg_legacy_session
+    pid = _mk_pending(s, 1, "BRKA", date(2026, 1, 5), stop=5000, target=20000)
+    _price(s, "BRKA", date(2026, 1, 6), 12000, 12500, 11800, 12100)  # T+1 open > $10k
+    res = fill_pending_positions(as_of=date(2026, 1, 6))
+    assert res == {"filled": 0, "expired": 1}
+    p = _get(s, pid)
+    assert p.status == "expired"
+    assert p.shares is None and p.entry_price is None  # never a 0-share fill
+    skips = s.execute(select(PaperSkip).where(PaperSkip.symbol == "BRKA")).scalars().all()
+    assert len(skips) == 1 and skips[0].reason == "zero_share_price"
+
+
+def test_zero_share_boundary_open_at_exactly_10k_fills(pg_legacy_session):
+    s = pg_legacy_session
+    pid = _mk_pending(s, 1, "BRKA", date(2026, 1, 5), stop=5000, target=20000)
+    _price(s, "BRKA", date(2026, 1, 6), 10000.0, 10500, 9800, 10100)
+    res = fill_pending_positions(as_of=date(2026, 1, 6))
+    assert res == {"filled": 1, "expired": 0}
+    p = _get(s, pid)
+    assert p.status == "open" and p.shares == 1
+    assert p.allocated_amount == pytest.approx(10000.0)
+    assert p.residual_cash == pytest.approx(0.0)

--- a/tests/test_paper/test_migrations.py
+++ b/tests/test_paper/test_migrations.py
@@ -80,7 +80,7 @@ def test_paper_skip_orm_shape_and_reason_set():
     sqltext = " ".join(str(c.sqltext) for c in checks)
     for reason in (
         "symbol_already_active", "missing_levels", "missing_screened_record",
-        "gap_invalidated", "same_symbol_lower_conviction",
+        "gap_invalidated", "same_symbol_lower_conviction", "zero_share_price",
     ):
         assert reason in sqltext, f"reason {reason} missing from CHECK"
 
@@ -261,6 +261,74 @@ def test_0007_paper_calibration_downgrade_drops_only_its_table(pg_legacy_engine)
     # 0005 tables + FK targets untouched.
     assert {"paper_trade", "paper_skip", "paper_report_snapshot",
             "analysis_results", "screened_stocks"} <= tables
+
+
+@pytest.mark.requires_postgres
+def test_0008_zero_share_reason_accepted(pg_legacy_engine):
+    """0008 (applied by the fixture) extends ck_paper_skip_reason with
+    `zero_share_price` (TASK-PLAN qu100-miss-sweep-6b63 acceptance 9)."""
+    with pg_legacy_engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO analysis_results (id, llm_model, prompt_template) "
+                "VALUES (201, 'm', 't') ON CONFLICT DO NOTHING"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO paper_skip (thesis_id, symbol, scan_date, reason) "
+                "VALUES (201, 'BRKA', '2026-01-06', 'zero_share_price')"
+            )
+        )
+    with pg_legacy_engine.connect() as conn:
+        n = conn.execute(
+            text("SELECT count(*) FROM paper_skip WHERE reason='zero_share_price'")
+        ).scalar()
+    assert n == 1
+
+
+@pytest.mark.requires_postgres
+def test_0008_downgrade_restores_old_constraint(pg_legacy_engine):
+    """0008 downgrade removes zero_share_price rows + restores the 5-reason
+    CHECK; re-applying 0008 re-accepts the new reason (idempotent)."""
+    from pathlib import Path
+
+    mig_dir = Path(__file__).resolve().parents[2] / "migrations"
+    with pg_legacy_engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO paper_skip (thesis_id, symbol, scan_date, reason) "
+                "VALUES (202, 'BRKA', '2026-01-06', 'zero_share_price')"
+            )
+        )
+    with pg_legacy_engine.begin() as conn:
+        conn.execute(text((mig_dir / "0008_paper_skip_zero_share_downgrade.sql").read_text()))
+    with pg_legacy_engine.begin() as conn:
+        with pytest.raises(IntegrityError):
+            conn.execute(
+                text(
+                    "INSERT INTO paper_skip (thesis_id, symbol, scan_date, reason) "
+                    "VALUES (203, 'BRKA', '2026-01-06', 'zero_share_price')"
+                )
+            )
+    # Old reasons still pass post-downgrade.
+    with pg_legacy_engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO paper_skip (thesis_id, symbol, scan_date, reason) "
+                "VALUES (204, 'BRKA', '2026-01-06', 'gap_invalidated')"
+            )
+        )
+    # Re-apply 0008 → new reason accepted again.
+    with pg_legacy_engine.begin() as conn:
+        conn.execute(text((mig_dir / "0008_paper_skip_zero_share.sql").read_text()))
+    with pg_legacy_engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO paper_skip (thesis_id, symbol, scan_date, reason) "
+                "VALUES (205, 'BRKA', '2026-01-06', 'zero_share_price')"
+            )
+        )
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_paper/test_weekly_sweep.py
+++ b/tests/test_paper/test_weekly_sweep.py
@@ -255,6 +255,18 @@ def test_threshold_plus_10_pct_inclusive(pg_legacy_session):
     assert flagged["WINA"]["rank"] == 1
 
 
+@requires_postgres
+def test_threshold_float_epsilon_inclusive_from_below(pg_legacy_session):
+    """3.00→3.30 is mathematically exactly +10% but floats to just BELOW 0.10
+    (0.09999999999999987) — the _EPS guard must still flag it (review iter-1,
+    the miss-side twin of the dodge-side 100→90 case)."""
+    s = pg_legacy_session
+    assert 3.3 / 3.0 - 1.0 < 0.10  # the float really lands below
+    _seed_cohort(s, ["EPSW"])
+    _window_closes(s, "EPSW", 3.0, 3.3)
+    assert "EPSW" in _flagged(compute_weekly_payload(AS_OF))
+
+
 # ---------------------------------------------------------------------------
 # Attribution tiers (acceptance 4; multi-day = highest stage wins)
 # ---------------------------------------------------------------------------
@@ -537,6 +549,112 @@ def test_weekly_discord_failure_never_leaks_webhook_token(caplog):
     assert "401" in blob and "HTTPStatusError" in blob
 
 
+def test_weekly_discord_skipped_when_disabled_or_no_webhook():
+    """No config / disabled / missing webhook → returns False without ever
+    touching the network (review iter-1 coverage)."""
+    from unittest.mock import patch
+
+    from rainier.paper.sweep import send_weekly_paper_report
+
+    class _Disabled:
+        enabled = False
+        webhook_url = "https://discord.com/api/webhooks/1/x"
+
+    class _NoUrl:
+        enabled = True
+        webhook_url = None
+
+    with patch("rainier.paper.sweep.send_daily_report") as mock_send:
+        assert send_weekly_paper_report({}, None) is False
+        assert send_weekly_paper_report({}, _Disabled()) is False
+        assert send_weekly_paper_report({}, _NoUrl()) is False
+    mock_send.assert_not_called()
+
+
+def test_weekly_discord_success_sends_rendered_text():
+    from unittest.mock import patch
+
+    from rainier.paper.sweep import send_weekly_paper_report
+
+    class _Cfg:
+        enabled = True
+        webhook_url = "https://discord.com/api/webhooks/1/x"
+
+    payload = {"as_of_date": "2026-06-12", "missed_winners": [],
+               "dodged_losers": {"count": 0, "names": []}}
+    cfg = _Cfg()
+    with patch("rainier.paper.sweep.send_daily_report") as mock_send:
+        assert send_weekly_paper_report(payload, cfg) is True
+    mock_send.assert_called_once_with(render_weekly_payload(payload), cfg)
+
+
+def test_weekly_discord_malformed_payload_never_raises():
+    """render runs INSIDE the try (review iter-1): a malformed payload returns
+    False instead of raising into a caller that might stringify it."""
+    from unittest.mock import patch
+
+    from rainier.paper.sweep import send_weekly_paper_report
+
+    class _Cfg:
+        enabled = True
+        webhook_url = "https://discord.com/api/webhooks/1/x"
+
+    bad = {"missed_winners": [{}]}  # w["symbol"] raises KeyError in render
+    with patch("rainier.paper.sweep.send_daily_report") as mock_send:
+        assert send_weekly_paper_report(bad, _Cfg()) is False
+    mock_send.assert_not_called()
+
+
+def test_render_truncates_long_winner_and_missing_lists():
+    """>15 winners → '… +N more'; >10 missing symbols → '(+N more)'
+    (review iter-1 coverage for the Discord-size truncation arithmetic)."""
+    winners = [
+        {"symbol": f"W{i:02d}", "rank": i + 1, "return_pct": 0.20,
+         "bucket": BUCKET_RANK_TOO_LOW}
+        for i in range(16)
+    ]
+    payload = {
+        "as_of_date": "2026-06-12",
+        "missed_winners": winners,
+        "bucket_counts": {BUCKET_RANK_TOO_LOW: 16},
+        "dominant_bucket": BUCKET_RANK_TOO_LOW,
+        "tuning_hypothesis": "h",
+        "dodged_losers": {"count": 0, "names": []},
+        "missing_price_symbols": [f"M{i:02d}" for i in range(11)],
+        "disclosure": "d",
+    }
+    out = render_weekly_payload(payload)
+    assert "… +1 more" in out
+    assert "W14" in out and "W15" not in out  # exactly 15 winner lines
+    assert "(+1 more)" in out
+    assert "M09" in out and "M10" not in out  # exactly 10 missing shown
+
+
+@requires_postgres
+def test_sweep_empty_cohort_skips_ingest_and_persists_clean(pg_legacy_session):
+    """Zero cohort + zero declined → no fetch at all, a clean size-0 snapshot,
+    and one empty missed_winner insight (review iter-1 coverage for the
+    empty-cohort guard branch)."""
+    s = pg_legacy_session
+
+    def fetch_fn(symbols, start, end):  # noqa: ARG001
+        raise AssertionError("empty cohort must never trigger an ingest fetch")
+
+    payload = sweep_missed_winners(as_of=AS_OF, fetch_fn=fetch_fn)
+    assert payload["cohort"] == {"size": 0, "data_date": None, "captured_at": None}
+    assert payload["missed_winners"] == []
+    assert payload["dominant_bucket"] is None
+
+    from rainier.paper.report import REPORT_TYPE_WEEKLY, load_snapshot
+
+    assert load_snapshot(REPORT_TYPE_WEEKLY, AS_OF) == payload
+    rows = s.execute(
+        select(ResearchInsight).where(ResearchInsight.kind == "missed_winner")
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].evidence["winners"] == []
+
+
 # ---------------------------------------------------------------------------
 # CLI: --week snapshot re-render vs --week --regenerate (validation, separate)
 # ---------------------------------------------------------------------------
@@ -595,16 +713,28 @@ def test_cli_week_regenerate_recomputes_from_raw_and_upserts(pg_legacy_session):
                                  "bucket": BUCKET_RANK_TOO_LOW}]}
     persist_weekly_snapshot(AS_OF, stale)
 
-    result = CliRunner().invoke(
-        cli,
-        ["paper", "report", "--week", "--regenerate", "--date", AS_OF.isoformat()],
-    )
+    from unittest.mock import patch
+
+    with patch("rainier.paper.sweep.send_daily_report") as mock_send:
+        result = CliRunner().invoke(
+            cli,
+            ["paper", "report", "--week", "--regenerate", "--date",
+             AS_OF.isoformat()],
+        )
     assert result.exit_code == 0, result.output
     assert "RAWW" in result.output  # recomputed from raw inputs
     assert "SENT" not in result.output
 
     refreshed = load_snapshot(REPORT_TYPE_WEEKLY, AS_OF)
     assert [w["symbol"] for w in refreshed["missed_winners"]] == ["RAWW"]
+
+    # --regenerate is compute + upsert + render ONLY: no insight emission,
+    # no Discord (review iter-1 — pins the docstring's promise).
+    mock_send.assert_not_called()
+    rows = s.execute(
+        select(ResearchInsight).where(ResearchInsight.kind == "missed_winner")
+    ).scalars().all()
+    assert rows == []
 
 
 @requires_postgres

--- a/tests/test_paper/test_weekly_sweep.py
+++ b/tests/test_paper/test_weekly_sweep.py
@@ -492,6 +492,51 @@ def test_sweep_emits_one_insight_per_week_and_persists_snapshot(
     assert "survivorship" in disclosure
 
 
+def test_weekly_discord_failure_never_leaks_webhook_token(caplog):
+    """httpx.HTTPStatusError.__str__ embeds the request URL, and a Discord
+    webhook URL carries its secret token. The weekly send's failure log must
+    carry status + exception class only — never str(exc) or a traceback.
+    Regression for codex [P1] 2026-06-09 (commit 96fbd13)."""
+    import logging
+    from unittest.mock import MagicMock, patch
+
+    import httpx
+
+    from rainier.paper.sweep import send_weekly_paper_report
+
+    secret = "WEEKLYtokenSECRET777"
+    url = f"https://discord.com/api/webhooks/424242/{secret}"
+
+    class _Cfg:
+        enabled = True
+        webhook_url = url
+
+    # Reproduce the real leak vector: raise_for_status() auto-generates a
+    # message embedding the request URL (which carries the token).
+    req = httpx.Request("POST", url)
+    resp = httpx.Response(401, request=req)
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        err = e
+    assert secret in str(err)  # the leak vector exists in the exception
+
+    with caplog.at_level(logging.INFO, logger="rainier.paper.sweep"):
+        with patch("rainier.alerts.discord.httpx.post") as mock_post:
+            mock_post.return_value = MagicMock(
+                raise_for_status=MagicMock(side_effect=err)
+            )
+            ok = send_weekly_paper_report({}, _Cfg())
+
+    assert ok is False
+    fmt = logging.Formatter()
+    blob = "\n".join(fmt.format(r) for r in caplog.records)
+    assert secret not in blob, "webhook token leaked into logs"
+    assert "webhooks/424242" not in blob
+    assert "weekly_sweep_discord_failed" in blob
+    assert "401" in blob and "HTTPStatusError" in blob
+
+
 # ---------------------------------------------------------------------------
 # CLI: --week snapshot re-render vs --week --regenerate (validation, separate)
 # ---------------------------------------------------------------------------

--- a/tests/test_paper/test_weekly_sweep.py
+++ b/tests/test_paper/test_weekly_sweep.py
@@ -268,6 +268,82 @@ def test_threshold_float_epsilon_inclusive_from_below(pg_legacy_session):
 
 
 # ---------------------------------------------------------------------------
+# Holiday-at-endpoint degradation (review iter-2): the no-holiday
+# DEFAULT_CALENDAR can anchor an endpoint on a market holiday (window_end =
+# Thanksgiving annually; window_start ~10 Fridays/yr). The at-or-before close
+# lookup must fall back to the last completed PRICED day instead of wiping the
+# whole cohort into missing_price_symbols.
+# ---------------------------------------------------------------------------
+
+
+@requires_postgres
+def test_unpriced_window_end_falls_back_to_prior_close(pg_legacy_session):
+    """No bar at window_end (holiday shape) → the Wednesday close before it
+    prices the symbol; it is flagged, not 'missing'."""
+    s = pg_legacy_session
+    _seed_cohort(s, ["HOLE"])
+    _close(s, "HOLE", WINDOW_START, 100.0)
+    _close(s, "HOLE", date(2026, 6, 10), 120.0)  # last priced day before 6/11
+
+    payload = compute_weekly_payload(AS_OF)
+    assert payload["missing_price_symbols"] == []
+    assert _flagged(payload)["HOLE"]["return_pct"] == pytest.approx(0.20)
+
+
+@requires_postgres
+def test_unpriced_window_start_falls_back_to_prior_close(pg_legacy_session):
+    s = pg_legacy_session
+    _seed_cohort(s, ["HOLS"])
+    _close(s, "HOLS", date(2026, 5, 27), 100.0)  # day before window_start
+    _close(s, "HOLS", WINDOW_END, 115.0)
+
+    payload = compute_weekly_payload(AS_OF)
+    assert payload["missing_price_symbols"] == []
+    assert _flagged(payload)["HOLS"]["return_pct"] == pytest.approx(0.15)
+
+
+@requires_postgres
+def test_close_staler_than_lookback_is_missing(pg_legacy_session):
+    """The at-or-before fallback is capped: a close >5 calendar days before the
+    endpoint is genuinely missing, not silently stale-priced."""
+    s = pg_legacy_session
+    _seed_cohort(s, ["STAL"])
+    _close(s, "STAL", date(2026, 5, 20), 100.0)  # 8 days before window_start
+    _close(s, "STAL", WINDOW_END, 130.0)
+
+    payload = compute_weekly_payload(AS_OF)
+    assert payload["missing_price_symbols"] == ["STAL"]
+    assert payload["missed_winners"] == []
+
+
+@requires_postgres
+def test_sweep_reads_cohort_exactly_once(pg_legacy_session):
+    """The payload must be computed from the SAME cohort the ingest priced —
+    a second read would race the QU midday scrape (review iter-2)."""
+    from unittest.mock import patch
+
+    s = pg_legacy_session
+    _seed_cohort(s, ["ONCE"])
+    _window_closes(s, "ONCE", 100.0, 105.0)
+
+    from rainier.paper import sweep as sweep_mod
+
+    real = sweep_mod.get_current_qu100_cohort
+    calls = []
+
+    def counting(as_of):
+        calls.append(as_of)
+        return real(as_of)
+
+    def fetch_fn(symbols, start, end):  # noqa: ARG001
+        return {}
+
+    with patch("rainier.paper.sweep.get_current_qu100_cohort", side_effect=counting):
+        sweep_missed_winners(as_of=AS_OF, fetch_fn=fetch_fn)
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
 # Attribution tiers (acceptance 4; multi-day = highest stage wins)
 # ---------------------------------------------------------------------------
 
@@ -395,10 +471,15 @@ def test_rb_dodged_losers_inclusive_and_held_excluded(pg_legacy_session):
     _declined(s, 923, "DWIN", date(2026, 6, 2), verdict="watch")
     # HLOS was nonetheless held in-window (a different thesis filled).
     _filled_position(s, 924, "HLOS", date(2026, 6, 3), status="open")
+    # DGON: declined, off-cohort, NO prices (delisted-after-crash shape) —
+    # must surface in missing_price_symbols, never silently vanish from R-B
+    # (review iter-2).
+    _declined(s, 925, "DGON", date(2026, 6, 2), verdict="watch")
 
     payload = compute_weekly_payload(AS_OF)
     assert payload["dodged_losers"]["count"] == 1
     assert [d["symbol"] for d in payload["dodged_losers"]["names"]] == ["DODG"]
+    assert "DGON" in payload["missing_price_symbols"]
 
 
 # ---------------------------------------------------------------------------
@@ -434,7 +515,9 @@ def test_sweep_ingest_anchored_at_window_end_never_partial_friday(
     assert calls, "sweep must run its own cohort ingest"
     _syms, start, end = calls[0]
     assert end == WINDOW_END, "ingest anchored at window_end, not the run day"
-    assert start == WINDOW_START, "fetch window must cover all 11 sessions"
+    # +2 buffer sessions before window_start (holiday-at-endpoint cover,
+    # review iter-2) — the fetch must still include every in-window session.
+    assert start <= WINDOW_START, "fetch window must cover all 11 sessions"
 
     rows = s.execute(
         select(StockPrice.date).where(StockPrice.symbol == "ANCH")

--- a/tests/test_paper/test_weekly_sweep.py
+++ b/tests/test_paper/test_weekly_sweep.py
@@ -1,0 +1,575 @@
+"""Phase 3 — weekly missed-winner sweep (TASK-PLAN qu100-miss-sweep-6b63).
+
+Covers: window arithmetic, the shared cohort selector, the +10% inclusive
+threshold, four-tier attribution (highest funnel stage wins), the held
+predicate, R-B dodged losers, sweep-owned ingest anchoring (never the partial
+Friday bar), insight emission, snapshot re-render vs --regenerate, and the
+zero-winner clean-empty path. Deterministic fixtures, no network.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+from sqlalchemy import select, text
+
+from rainier.core.models import (
+    MoneyFlowSnapshot,
+    PaperTrade,
+    ResearchInsight,
+    ScreenedStockRecord,
+    StockPrice,
+)
+from rainier.paper.calendar import DEFAULT_CALENDAR
+from rainier.paper.ingest import canonical_instant, get_current_qu100_cohort
+from rainier.paper.sweep import (
+    BUCKET_NO_PATTERN,
+    BUCKET_NOT_TOP5,
+    BUCKET_RANK_TOO_LOW,
+    BUCKET_VERDICT,
+    compute_weekly_payload,
+    compute_window,
+    persist_weekly_snapshot,
+    render_weekly_payload,
+    sweep_missed_winners,
+)
+
+requires_postgres = pytest.mark.requires_postgres
+
+AS_OF = date(2026, 6, 12)  # Friday — the 09:00 PT run day (in-progress session)
+WINDOW_END = date(2026, 6, 11)  # Thursday — last completed priced day
+WINDOW_START = date(2026, 5, 28)  # 10 trading days before window_end
+CAP_T1 = datetime(2026, 6, 11, 18, 0, tzinfo=timezone.utc)
+CAP_T2 = datetime(2026, 6, 11, 21, 30, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Window arithmetic (pure — no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_window_friday_run_uses_last_completed_day():
+    """A Friday 09:00 run anchors to Thursday — never the in-progress session —
+    and spans exactly 10 trading-day intervals (11 closes)."""
+    start, end = compute_window(AS_OF)
+    assert end == WINDOW_END
+    assert start == WINDOW_START
+    sessions = DEFAULT_CALENDAR.sessions_between(start, end)
+    assert len(sessions) == 11  # 11 closes, 10 intervals
+
+
+def test_window_weekend_and_monday_runs():
+    # Saturday run: Friday is complete → window_end = Friday.
+    start, end = compute_window(date(2026, 6, 13))
+    assert end == date(2026, 6, 12)
+    assert start == date(2026, 5, 29)
+    # Monday run: window_end = the prior Friday.
+    start, end = compute_window(date(2026, 6, 15))
+    assert end == date(2026, 6, 12)
+
+
+def test_insight_kinds_extended_with_missed_winner():
+    from rainier.llm_thesis.research import INSIGHT_KINDS
+
+    assert "missed_winner" in INSIGHT_KINDS
+
+
+# ---------------------------------------------------------------------------
+# DB fixtures / helpers (pg lane)
+# ---------------------------------------------------------------------------
+
+
+def _stock(s, symbol):
+    s.execute(
+        text("INSERT INTO stocks (symbol) VALUES (:s) ON CONFLICT DO NOTHING"),
+        {"s": symbol},
+    )
+
+
+def _mfs(s, symbol, rank, data_date, captured_at, ranking_type="top100"):
+    _stock(s, symbol)
+    s.add(
+        MoneyFlowSnapshot(
+            captured_at=captured_at,
+            capture_session="close",
+            data_date=data_date,
+            view_type="daily",
+            ranking_type=ranking_type,
+            symbol=symbol,
+            rank=rank,
+        )
+    )
+    s.commit()
+
+
+def _seed_cohort(s, symbols, data_date=date(2026, 6, 11), captured_at=CAP_T2):
+    for i, sym in enumerate(symbols, start=1):
+        _mfs(s, sym, i, data_date, captured_at)
+
+
+def _close(s, symbol, d, px):
+    _stock(s, symbol)
+    s.add(
+        StockPrice(
+            symbol=symbol, date=canonical_instant(d), open=px, high=px,
+            low=px, close=px, volume=1,
+        )
+    )
+    s.commit()
+
+
+def _window_closes(s, symbol, start_px, end_px):
+    _close(s, symbol, WINDOW_START, start_px)
+    _close(s, symbol, WINDOW_END, end_px)
+
+
+def _thesis(s, tid, recommendation):
+    s.execute(
+        text(
+            "INSERT INTO analysis_results (id, llm_model, prompt_template, "
+            "recommendation) VALUES (:i,'m','t',:r) ON CONFLICT DO NOTHING"
+        ),
+        {"i": tid, "r": recommendation},
+    )
+    s.commit()
+
+
+def _screened(s, symbol, scan_date, *, pattern=None, thesis_id=None,
+              session_name="close", rank=10):
+    _stock(s, symbol)
+    s.add(
+        ScreenedStockRecord(
+            scan_date=scan_date, session_name=session_name, symbol=symbol,
+            rule_rank=rank, composite_score=0.5, pattern_type=pattern,
+            thesis_id=thesis_id,
+        )
+    )
+    s.commit()
+
+
+def _declined(s, tid, symbol, scan_date, verdict="watch"):
+    """A top-5 thesis the LLM declined (watch/no_setup) on scan_date."""
+    _thesis(s, tid, verdict)
+    _screened(s, symbol, scan_date, pattern="w_bottom", thesis_id=tid, rank=1)
+
+
+def _filled_position(s, tid, symbol, entry_date, *, exit_date=None,
+                     status="open"):
+    _thesis(s, tid, "setup_long")
+    _stock(s, symbol)
+    kw = {}
+    if status == "closed":
+        kw = dict(exit_price=90.0, exit_reason="stop_loss", return_pct=-0.10,
+                  pnl=-1000.0)
+    s.add(
+        PaperTrade(
+            thesis_id=tid, symbol=symbol, scan_date=entry_date,
+            session_name="close", status=status, planned_entry_price=100.0,
+            stop_loss=50.0, target_price=500.0, entry_date=entry_date,
+            entry_price=100.0, shares=100, allocated_amount=10000.0,
+            residual_cash=0.0, price_basis="adjusted", exit_date=exit_date,
+            **kw,
+        )
+    )
+    s.commit()
+
+
+def _unfilled_position(s, tid, symbol, scan_date, status="pending"):
+    _thesis(s, tid, "setup_long")
+    _stock(s, symbol)
+    s.add(
+        PaperTrade(
+            thesis_id=tid, symbol=symbol, scan_date=scan_date,
+            session_name="close", status=status, planned_entry_price=100.0,
+            stop_loss=50.0, target_price=500.0,
+        )
+    )
+    s.commit()
+
+
+def _flagged(payload):
+    return {w["symbol"]: w for w in payload["missed_winners"]}
+
+
+# ---------------------------------------------------------------------------
+# Cohort selector (acceptance 1)
+# ---------------------------------------------------------------------------
+
+
+@requires_postgres
+def test_cohort_latest_data_date_then_latest_captured_at(pg_legacy_session):
+    s = pg_legacy_session
+    dd = date(2026, 6, 10)
+    # Early capture of 6/10 (stale membership) + later capture (fresh).
+    _mfs(s, "AAA", 1, dd, CAP_T1)
+    _mfs(s, "BBB", 2, dd, CAP_T1)
+    _mfs(s, "AAA", 1, dd, CAP_T2)
+    _mfs(s, "CCC", 2, dd, CAP_T2)
+    # Non-top100 partial with a LATER data_date must not win.
+    _mfs(s, "ETF", 1, date(2026, 6, 11), CAP_T2, ranking_type="etf")
+    # Backfilled older data_date SHARING the latest captured_at must not win.
+    _mfs(s, "OLD", 1, date(2026, 6, 9), CAP_T2)
+
+    cohort = get_current_qu100_cohort(AS_OF)
+    assert [c["symbol"] for c in cohort] == ["AAA", "CCC"]
+    assert all(c["data_date"] == dd for c in cohort)
+    assert all(c["captured_at"] == CAP_T2 for c in cohort)
+    assert [c["rank"] for c in cohort] == [1, 2]
+
+
+@requires_postgres
+def test_cohort_historical_as_of_picks_past_cohort(pg_legacy_session):
+    """--regenerate for a past week selects max data_date <= as_of, not today's."""
+    s = pg_legacy_session
+    _mfs(s, "OLD", 1, date(2026, 6, 1), CAP_T1)
+    _mfs(s, "NEW", 1, date(2026, 6, 8), CAP_T2)
+    cohort = get_current_qu100_cohort(date(2026, 6, 5))
+    assert [c["symbol"] for c in cohort] == ["OLD"]
+    assert cohort[0]["data_date"] == date(2026, 6, 1)
+
+
+@requires_postgres
+def test_cohort_empty_when_no_top100(pg_legacy_session):
+    assert get_current_qu100_cohort(AS_OF) == []
+
+
+# ---------------------------------------------------------------------------
+# Threshold boundary (validation: +10% exactly flagged; just below not)
+# ---------------------------------------------------------------------------
+
+
+@requires_postgres
+def test_threshold_plus_10_pct_inclusive(pg_legacy_session):
+    s = pg_legacy_session
+    _seed_cohort(s, ["WINA", "JUST"])
+    _window_closes(s, "WINA", 100.0, 110.0)   # +10.0% exactly → flagged
+    _window_closes(s, "JUST", 100.0, 109.9)   # just below → not flagged
+
+    payload = compute_weekly_payload(AS_OF)
+    flagged = _flagged(payload)
+    assert "WINA" in flagged
+    assert "JUST" not in flagged
+    assert flagged["WINA"]["bucket"] == BUCKET_RANK_TOO_LOW
+    assert flagged["WINA"]["return_pct"] == pytest.approx(0.10)
+    assert flagged["WINA"]["rank"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Attribution tiers (acceptance 4; multi-day = highest stage wins)
+# ---------------------------------------------------------------------------
+
+
+@requires_postgres
+def test_attribution_tiers_and_highest_stage_wins(pg_legacy_session):
+    s = pg_legacy_session
+    syms = ["VRD", "MIX", "PAT", "NOP", "LOW"]
+    _seed_cohort(s, syms)
+    for sym in syms:
+        _window_closes(s, sym, 100.0, 120.0)  # all +20% winners, none held
+
+    # VRD: declined thesis (watch) in-window on day 2 → tier (i). Also
+    # unscreened later in the window — the highest stage still wins.
+    _declined(s, 901, "VRD", date(2026, 6, 1), verdict="watch")
+    # MIX: pattern-screened on 6/3, then declined (no_setup) on 6/5 →
+    # highest stage = tier (i), NOT not_in_top5.
+    _screened(s, "MIX", date(2026, 6, 3), pattern="bull_flag")
+    _declined(s, 902, "MIX", date(2026, 6, 5), verdict="no_setup")
+    # PAT: screened with a pattern, never got a thesis → tier (ii).
+    _screened(s, "PAT", date(2026, 6, 4), pattern="w_bottom")
+    # NOP: screened without a pattern → tier (iii).
+    _screened(s, "NOP", date(2026, 6, 4), pattern=None)
+    # LOW: never screened → tier (iv).
+
+    payload = compute_weekly_payload(AS_OF)
+    flagged = _flagged(payload)
+    assert flagged["VRD"]["bucket"] == BUCKET_VERDICT
+    assert flagged["MIX"]["bucket"] == BUCKET_VERDICT
+    assert flagged["PAT"]["bucket"] == BUCKET_NOT_TOP5
+    assert flagged["NOP"]["bucket"] == BUCKET_NO_PATTERN
+    assert flagged["LOW"]["bucket"] == BUCKET_RANK_TOO_LOW
+
+    assert payload["bucket_counts"] == {
+        BUCKET_VERDICT: 2, BUCKET_NOT_TOP5: 1,
+        BUCKET_NO_PATTERN: 1, BUCKET_RANK_TOO_LOW: 1,
+    }
+    assert payload["dominant_bucket"] == BUCKET_VERDICT
+    assert payload["tuning_hypothesis"]  # one documented hypothesis (acceptance 7)
+
+
+@requires_postgres
+def test_attribution_outside_window_rows_ignored(pg_legacy_session):
+    s = pg_legacy_session
+    _seed_cohort(s, ["OUT"])
+    _window_closes(s, "OUT", 100.0, 115.0)
+    # Screened + declined BEFORE the window only → rank_too_low.
+    _declined(s, 903, "OUT", date(2026, 5, 27), verdict="watch")
+    payload = compute_weekly_payload(AS_OF)
+    assert _flagged(payload)["OUT"]["bucket"] == BUCKET_RANK_TOO_LOW
+
+
+# ---------------------------------------------------------------------------
+# Held predicate (acceptance 5)
+# ---------------------------------------------------------------------------
+
+
+@requires_postgres
+def test_held_predicate_overlap_and_unfilled(pg_legacy_session):
+    s = pg_legacy_session
+    syms = ["HOPN", "HCLS", "OLDX", "PEND", "EXPD"]
+    _seed_cohort(s, syms)
+    for sym in syms:
+        _window_closes(s, sym, 100.0, 130.0)  # all winners
+
+    # Open position filled in-window → held → excluded.
+    _filled_position(s, 911, "HOPN", date(2026, 6, 3), status="open")
+    # Closed position whose [entry, exit] touches the window start → held.
+    _filled_position(s, 912, "HCLS", date(2026, 5, 20),
+                     exit_date=date(2026, 5, 28), status="closed")
+    # Closed BEFORE the window → not held → flagged.
+    _filled_position(s, 913, "OLDX", date(2026, 5, 18),
+                     exit_date=date(2026, 5, 27), status="closed")
+    # Pending (never filled) → flagged.
+    _unfilled_position(s, 914, "PEND", date(2026, 6, 9), status="pending")
+    # Never-filled expired → flagged.
+    _unfilled_position(s, 915, "EXPD", date(2026, 6, 2), status="expired")
+
+    flagged = _flagged(compute_weekly_payload(AS_OF))
+    assert "HOPN" not in flagged
+    assert "HCLS" not in flagged
+    assert {"OLDX", "PEND", "EXPD"} <= set(flagged)
+
+
+# ---------------------------------------------------------------------------
+# Missing prices + zero-winner week (validation)
+# ---------------------------------------------------------------------------
+
+
+@requires_postgres
+def test_missing_prices_explicit_and_zero_winner_clean(pg_legacy_session):
+    s = pg_legacy_session
+    _seed_cohort(s, ["FLAT", "GONE"])
+    _window_closes(s, "FLAT", 100.0, 101.0)  # not a winner
+    # GONE has no prices at all.
+
+    payload = compute_weekly_payload(AS_OF)
+    assert payload["missed_winners"] == []
+    assert payload["missing_price_symbols"] == ["GONE"]
+    assert payload["dominant_bucket"] is None
+    # Clean empty render + snapshot persist (no poison retry).
+    text_out = render_weekly_payload(payload)
+    assert "none" in text_out.lower()
+    persist_weekly_snapshot(AS_OF, payload)
+    from rainier.paper.report import REPORT_TYPE_WEEKLY, load_snapshot
+
+    assert load_snapshot(REPORT_TYPE_WEEKLY, AS_OF) == payload
+
+
+# ---------------------------------------------------------------------------
+# R-B dodged losers (acceptance 6)
+# ---------------------------------------------------------------------------
+
+
+@requires_postgres
+def test_rb_dodged_losers_inclusive_and_held_excluded(pg_legacy_session):
+    s = pg_legacy_session
+    _seed_cohort(s, ["DODG", "HLOS", "DWIN"])
+    _window_closes(s, "DODG", 100.0, 90.0)   # −10% exactly → counted
+    _window_closes(s, "HLOS", 100.0, 80.0)   # held loser → excluded
+    _window_closes(s, "DWIN", 100.0, 95.0)   # declined, only −5% → not counted
+
+    _declined(s, 921, "DODG", date(2026, 6, 2), verdict="watch")
+    _declined(s, 922, "HLOS", date(2026, 6, 2), verdict="no_setup")
+    _declined(s, 923, "DWIN", date(2026, 6, 2), verdict="watch")
+    # HLOS was nonetheless held in-window (a different thesis filled).
+    _filled_position(s, 924, "HLOS", date(2026, 6, 3), status="open")
+
+    payload = compute_weekly_payload(AS_OF)
+    assert payload["dodged_losers"]["count"] == 1
+    assert [d["symbol"] for d in payload["dodged_losers"]["names"]] == ["DODG"]
+
+
+# ---------------------------------------------------------------------------
+# Sweep-owned ingest anchoring (acceptance 3)
+# ---------------------------------------------------------------------------
+
+
+@requires_postgres
+def test_sweep_ingest_anchored_at_window_end_never_partial_friday(
+    pg_legacy_session,
+):
+    s = pg_legacy_session
+    _seed_cohort(s, ["ANCH"])
+
+    sessions = DEFAULT_CALENDAR.sessions_between(WINDOW_START, WINDOW_END)
+    assert len(sessions) == 11
+    calls = []
+
+    def fetch_fn(symbols, start, end):
+        calls.append((tuple(symbols), start, end))
+        # Source also returns the in-progress Friday bar — the sweep must
+        # never persist it (a mid-session upsert would later read complete).
+        days = sessions + [AS_OF]
+        bars = [
+            {"date": d, "open": 100.0 + i, "high": 101.0 + i, "low": 99.0 + i,
+             "close": 100.0 + i, "volume": 1}
+            for i, d in enumerate(days)
+        ]
+        return {sym: bars for sym in symbols}
+
+    sweep_missed_winners(as_of=AS_OF, fetch_fn=fetch_fn)
+
+    assert calls, "sweep must run its own cohort ingest"
+    _syms, start, end = calls[0]
+    assert end == WINDOW_END, "ingest anchored at window_end, not the run day"
+    assert start == WINDOW_START, "fetch window must cover all 11 sessions"
+
+    rows = s.execute(
+        select(StockPrice.date).where(StockPrice.symbol == "ANCH")
+    ).scalars().all()
+    got = {d.date() if isinstance(d, datetime) else d for d in rows}
+    assert canonical_instant(AS_OF).date() not in got, "partial Friday bar written"
+    assert {d for d in sessions} == got  # all 11 anchor-to-end closes present
+
+
+# ---------------------------------------------------------------------------
+# Insight emission (acceptance 8) + snapshot persistence (acceptance 7)
+# ---------------------------------------------------------------------------
+
+
+@requires_postgres
+def test_sweep_emits_one_insight_per_week_and_persists_snapshot(
+    pg_legacy_session,
+):
+    s = pg_legacy_session
+    _seed_cohort(s, ["WINA"])
+    sessions = DEFAULT_CALENDAR.sessions_between(WINDOW_START, WINDOW_END)
+
+    def fetch_fn(symbols, start, end):
+        bars = [
+            {"date": d, "open": 100.0, "high": 130.0, "low": 99.0,
+             "close": 100.0 if d != WINDOW_END else 125.0, "volume": 1}
+            for d in sessions
+        ]
+        return {sym: bars for sym in symbols}
+
+    payload = sweep_missed_winners(as_of=AS_OF, fetch_fn=fetch_fn)
+    assert [w["symbol"] for w in payload["missed_winners"]] == ["WINA"]
+
+    iso = AS_OF.isocalendar()
+    subject = f"{iso[0]}-W{iso[1]:02d}"
+    rows = s.execute(
+        select(ResearchInsight).where(ResearchInsight.kind == "missed_winner")
+    ).scalars().all()
+    assert len(rows) == 1
+    ins = rows[0]
+    assert ins.subject == subject
+    assert ins.severity == "info"
+    assert ins.action["kind"] == "noop"
+    ev_winners = ins.evidence["winners"]
+    assert ev_winners[0]["symbol"] == "WINA"
+    assert ev_winners[0]["bucket"] == BUCKET_RANK_TOO_LOW
+    assert ev_winners[0]["return_pct"] == pytest.approx(0.25)
+
+    # Snapshot is the durable record.
+    from rainier.paper.report import REPORT_TYPE_WEEKLY, load_snapshot
+
+    assert load_snapshot(REPORT_TYPE_WEEKLY, AS_OF) == payload
+
+    # Re-run the same week → still ONE pending insight (UPSERT, not a dup).
+    sweep_missed_winners(as_of=AS_OF, fetch_fn=fetch_fn)
+    s.expire_all()
+    rows = s.execute(
+        select(ResearchInsight).where(ResearchInsight.kind == "missed_winner")
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].recurrence_count == 2
+
+    # Coverage disclosures (acceptance 10).
+    disclosure = payload["disclosure"].lower()
+    assert "coverage" in disclosure
+    assert "rank_too_low" in disclosure
+    assert "survivorship" in disclosure
+
+
+# ---------------------------------------------------------------------------
+# CLI: --week snapshot re-render vs --week --regenerate (validation, separate)
+# ---------------------------------------------------------------------------
+
+
+@requires_postgres
+def test_cli_week_rerenders_from_snapshot_only(pg_legacy_session):
+    from click.testing import CliRunner
+
+    from rainier.cli import cli
+
+    s = pg_legacy_session
+    # Raw inputs that would compute differently than the stored snapshot.
+    _seed_cohort(s, ["RAWW"])
+    _window_closes(s, "RAWW", 100.0, 150.0)
+    sentinel = {
+        "report_type": "weekly",
+        "as_of_date": AS_OF.isoformat(),
+        "window_start": WINDOW_START.isoformat(),
+        "window_end": WINDOW_END.isoformat(),
+        "cohort": {"size": 1, "data_date": "2026-06-11", "captured_at": None},
+        "missed_winners": [
+            {"symbol": "SENT", "rank": 1, "return_pct": 0.42,
+             "bucket": BUCKET_RANK_TOO_LOW}
+        ],
+        "bucket_counts": {BUCKET_RANK_TOO_LOW: 1},
+        "dominant_bucket": BUCKET_RANK_TOO_LOW,
+        "tuning_hypothesis": "sentinel",
+        "dodged_losers": {"count": 0, "names": []},
+        "missing_price_symbols": [],
+        "disclosure": "sentinel disclosure",
+    }
+    persist_weekly_snapshot(AS_OF, sentinel)
+
+    result = CliRunner().invoke(
+        cli, ["paper", "report", "--week", "--date", AS_OF.isoformat()]
+    )
+    assert result.exit_code == 0, result.output
+    assert "SENT" in result.output  # snapshot content
+    assert "RAWW" not in result.output  # NOT recomputed from raw
+
+
+@requires_postgres
+def test_cli_week_regenerate_recomputes_from_raw_and_upserts(pg_legacy_session):
+    from click.testing import CliRunner
+
+    from rainier.cli import cli
+    from rainier.paper.report import REPORT_TYPE_WEEKLY, load_snapshot
+
+    s = pg_legacy_session
+    _seed_cohort(s, ["RAWW"])
+    _window_closes(s, "RAWW", 100.0, 150.0)
+    stale = {"report_type": "weekly", "as_of_date": AS_OF.isoformat(),
+             "missed_winners": [{"symbol": "SENT", "rank": 1,
+                                 "return_pct": 0.42,
+                                 "bucket": BUCKET_RANK_TOO_LOW}]}
+    persist_weekly_snapshot(AS_OF, stale)
+
+    result = CliRunner().invoke(
+        cli,
+        ["paper", "report", "--week", "--regenerate", "--date", AS_OF.isoformat()],
+    )
+    assert result.exit_code == 0, result.output
+    assert "RAWW" in result.output  # recomputed from raw inputs
+    assert "SENT" not in result.output
+
+    refreshed = load_snapshot(REPORT_TYPE_WEEKLY, AS_OF)
+    assert [w["symbol"] for w in refreshed["missed_winners"]] == ["RAWW"]
+
+
+@requires_postgres
+def test_cli_week_without_snapshot_fails_cleanly(pg_legacy_session):
+    from click.testing import CliRunner
+
+    from rainier.cli import cli
+
+    result = CliRunner().invoke(
+        cli, ["paper", "report", "--week", "--date", "2031-01-03"]
+    )
+    assert result.exit_code != 0
+    assert "No weekly snapshot" in result.output

--- a/tests/test_scheduler/test_research_job.py
+++ b/tests/test_scheduler/test_research_job.py
@@ -247,6 +247,47 @@ async def test_run_research_job_continues_when_sweep_fails():
     mock_discord.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_run_research_job_sweep_failure_log_never_leaks_token():
+    """The miss-sweep failure handler must log status + exception class ONLY —
+    never str(exc), whose httpx variant embeds the token-bearing webhook URL
+    (regression for codex [P1] 2026-06-09, commit 96fbd13; review iter-1)."""
+    import httpx
+
+    secret = "SWEEPtokenSECRET999"
+    url = f"https://discord.com/api/webhooks/55555/{secret}"
+    req = httpx.Request("POST", url)
+    resp = httpx.Response(401, request=req)
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        err = e
+    assert secret in str(err)  # the leak vector exists in the exception
+
+    with (
+        patch(
+            "rainier.scheduler.service.load_settings_fresh",
+            return_value=_settings(),
+        ),
+        patch("rainier.llm_thesis.research.mark_stale", return_value=0),
+        patch("rainier.llm_thesis.research.run_research", return_value=[]),
+        patch("rainier.paper.sweep.sweep_missed_winners", side_effect=err),
+        patch("rainier.alerts.discord.send_research_report"),
+        patch("rainier.scheduler.service.log") as mock_log,
+    ):
+        from rainier.scheduler.service import run_research_job
+        await run_research_job(eval_date_iso="2026-06-12")
+
+    blob = repr(mock_log.mock_calls)
+    assert secret not in blob, "webhook token leaked into the failure log"
+    failed = [
+        c for c in mock_log.error.call_args_list
+        if c.args and c.args[0] == "research_miss_sweep_failed"
+    ]
+    assert len(failed) == 1
+    assert failed[0].kwargs == {"status": 401, "error_type": "HTTPStatusError"}
+
+
 # ---------------------------------------------------------------------------
 # Cron registration — Friday 09:00 PT
 # ---------------------------------------------------------------------------

--- a/tests/test_scheduler/test_research_job.py
+++ b/tests/test_scheduler/test_research_job.py
@@ -68,6 +68,10 @@ async def test_run_research_job_calls_mark_stale_then_run_research():
             "rainier.llm_thesis.research.run_research", side_effect=_run_research,
         ),
         patch(
+            "rainier.paper.sweep.sweep_missed_winners",
+            return_value={"missed_winners": [], "dodged_losers": {"count": 0}},
+        ),
+        patch(
             "rainier.alerts.discord.send_research_report"
         ) as mock_discord,
     ):
@@ -100,6 +104,10 @@ async def test_run_research_job_continues_when_mark_stale_fails():
             "rainier.llm_thesis.research.run_research", side_effect=_run_research,
         ),
         patch(
+            "rainier.paper.sweep.sweep_missed_winners",
+            return_value={"missed_winners": [], "dodged_losers": {"count": 0}},
+        ),
+        patch(
             "rainier.alerts.discord.send_research_report"
         ) as mock_discord,
     ):
@@ -127,6 +135,10 @@ async def test_run_research_job_continues_when_run_research_fails():
         ),
         patch(
             "rainier.llm_thesis.research.run_research", side_effect=_run_research,
+        ),
+        patch(
+            "rainier.paper.sweep.sweep_missed_winners",
+            return_value={"missed_winners": [], "dodged_losers": {"count": 0}},
         ),
         patch(
             "rainier.alerts.discord.send_research_report"
@@ -160,12 +172,79 @@ async def test_run_research_job_defaults_to_today():
         patch(
             "rainier.llm_thesis.research.run_research", side_effect=_run_research,
         ),
+        patch(
+            "rainier.paper.sweep.sweep_missed_winners",
+            return_value={"missed_winners": [], "dodged_losers": {"count": 0}},
+        ),
         patch("rainier.alerts.discord.send_research_report"),
     ):
         from rainier.scheduler.service import run_research_job
         await run_research_job()
 
     assert captured["eval_date"] == date.today()
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — weekly missed-winner sweep wiring (TASK-PLAN qu100-miss-sweep-6b63)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_research_job_runs_miss_sweep_with_eval_date():
+    """The Fri 09:00 PT job runs sweep_missed_winners with as_of=eval_date,
+    the production yfinance fetch_fn, and the Discord config threaded."""
+    captured = {}
+
+    def _sweep(*, as_of, fetch_fn, calendar=None, discord_config=None):
+        _ = calendar
+        captured["as_of"] = as_of
+        captured["fetch_fn"] = fetch_fn
+        captured["discord"] = discord_config
+        return {"missed_winners": [], "dodged_losers": {"count": 0}}
+
+    settings = _settings()
+    with (
+        patch(
+            "rainier.scheduler.service.load_settings_fresh",
+            return_value=settings,
+        ),
+        patch("rainier.llm_thesis.research.mark_stale", return_value=0),
+        patch("rainier.llm_thesis.research.run_research", return_value=[]),
+        patch(
+            "rainier.paper.sweep.sweep_missed_winners", side_effect=_sweep,
+        ),
+        patch("rainier.alerts.discord.send_research_report"),
+    ):
+        from rainier.scheduler.service import run_research_job
+        await run_research_job(eval_date_iso="2026-06-12")
+
+    from rainier.paper.ingest import _yfinance_fetch_fn
+
+    assert captured["as_of"] == date(2026, 6, 12)
+    assert captured["fetch_fn"] is _yfinance_fetch_fn
+    assert captured["discord"] is settings.alerts.discord
+
+
+@pytest.mark.asyncio
+async def test_run_research_job_continues_when_sweep_fails():
+    """A sweep failure must not kill the research Discord report."""
+    with (
+        patch(
+            "rainier.scheduler.service.load_settings_fresh",
+            return_value=_settings(),
+        ),
+        patch("rainier.llm_thesis.research.mark_stale", return_value=0),
+        patch("rainier.llm_thesis.research.run_research", return_value=[]),
+        patch(
+            "rainier.paper.sweep.sweep_missed_winners",
+            side_effect=RuntimeError("yfinance down"),
+        ),
+        patch("rainier.alerts.discord.send_research_report") as mock_discord,
+    ):
+        from rainier.scheduler.service import run_research_job
+        await run_research_job(eval_date_iso="2026-06-12")
+
+    mock_discord.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Phase 3 weekly missed-winner sweep per docs/TASK-PLAN-qu100-miss-sweep-6b63.md (design: DESIGN-qu100-llm-feedback-loop.md): weekly job scans skipped QU100 candidates for missed winners and reports them.
- R-B dodged-losers counting: tracks rejected-but-bad candidates so the LLM feedback loop sees both miss directions.
- Zero-share guard: prevents zero-share position sizing from silently corrupting sweep results.
- Review hardening: token-safe sweep-failure logging, never-raises Discord send, holiday-safe endpoint closes, single cohort read, R-B missing-price visibility.

## Review
- /review: passed (claude rounds: 3)
- codex review: passed (codex rounds: 2)

## Test plan
- [x] Test suite: zero NEW failures vs base. Pre-existing test_db_migrations/test_neon_source environmental failure cluster (present on main) documented; unrelated to this diff.
- [ ] CI green
- [ ] Verify locally: run the weekly sweep once and confirm Discord summary renders

## Deferred findings (P2/P3)
- codex P2: weekly Discord send has no stock_webhook_url fallback.
- codex P2: window_start not re-anchored after window_end holiday fallback.
- Pre-existing (on main): service.py research_discord_failed logs str(exc) — webhook-token leak vector.
- `--regenerate` can overwrite a better existing snapshot.
- Snapshot keyed by date vs insight keyed by ISO-week (key-scheme mismatch).
- No _scrub_discord_text applied to symbols in the weekly render.
- Holiday gap triggers a full refetch instead of incremental.
- No operator alert/retry on sweep failure.