### PR TITLE
feat(paper): R-A post-exit reflections — schema CHECK embargo, daily generation, last-K prompt injection

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -168,9 +168,10 @@ llm_thesis:
   enabled: true
   model: "claude-sonnet-4-6"
   max_usd_per_scan: 1.0
-  # v2: D7a calibration block. This runtime value is what builds the Tier-1
-  # cache key (not prompt.PROMPT_VERSION) — keep it == the module constant.
-  prompt_version: "v2"
+  # v2: D7a calibration block. v3: R-A last-K reflections block. This runtime
+  # value is what builds the Tier-1 cache key (not prompt.PROMPT_VERSION) —
+  # keep it == the module constant.
+  prompt_version: "v3"
   enabled_sessions:
     - afternoon
     - close

--- a/migrations/0009_paper_reflection.sql
+++ b/migrations/0009_paper_reflection.sql
@@ -1,0 +1,36 @@
+-- Migration 0009 — R-A per-trade post-exit LLM reflections
+-- (design DESIGN-qu100-llm-feedback-loop Appendix B, task qu100-ra-reflections)
+--
+-- Adds (on the LEGACY local-TimescaleDB engine — NOT Neon, see memory
+-- project_two_database_url_engines):
+--   * paper_trade.reflection TEXT — the LLM's 2–3 sentence post-mortem,
+--     written once per closed trade by the daily job (paper/reflection.py)
+--     AFTER step (v) (the report/chart-capture step). The last K=10 feed the
+--     thesis prompt's calibration section.
+--   * CHECK ck_paper_trade_reflection_after_exit — the outcome embargo at the
+--     schema level: a reflection may only exist once the trade has resolved
+--     (exit_reason set). No interim/open-position reflections, ever.
+--
+-- Apply with (POST-#115 the legacy public-schema tables live on
+-- LEGACY_DATABASE_URL, NOT DATABASE_URL which now points at Neon):
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0009_paper_reflection.sql
+--
+-- Idempotent: re-applying is safe (IF NOT EXISTS / duplicate_object guard).
+-- Additive only: no existing row or column is touched.
+
+BEGIN;
+
+ALTER TABLE paper_trade ADD COLUMN IF NOT EXISTS reflection TEXT;
+
+DO $$
+BEGIN
+    ALTER TABLE paper_trade
+        ADD CONSTRAINT ck_paper_trade_reflection_after_exit
+        CHECK (reflection IS NULL OR exit_reason IS NOT NULL);
+EXCEPTION
+    WHEN duplicate_object THEN NULL;  -- already applied
+END $$;
+
+COMMIT;
+
+-- Downgrade lives in migrations/0009_paper_reflection_downgrade.sql.

--- a/migrations/0009_paper_reflection_downgrade.sql
+++ b/migrations/0009_paper_reflection_downgrade.sql
@@ -1,0 +1,17 @@
+-- Migration 0009 DOWNGRADE — reverses 0009_paper_reflection.sql.
+--
+-- Drops EXACTLY: paper_trade.reflection + its CHECK constraint. Every other
+-- column/row of paper_trade (and every other table) is untouched.
+--
+-- Apply with:
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0009_paper_reflection_downgrade.sql
+--
+-- Idempotent: re-applying is safe (IF EXISTS).
+
+BEGIN;
+
+ALTER TABLE paper_trade
+    DROP CONSTRAINT IF EXISTS ck_paper_trade_reflection_after_exit;
+ALTER TABLE paper_trade DROP COLUMN IF EXISTS reflection;
+
+COMMIT;

--- a/migrations/0009_paper_reflection_downgrade.sql
+++ b/migrations/0009_paper_reflection_downgrade.sql
@@ -15,3 +15,10 @@ ALTER TABLE paper_trade
 ALTER TABLE paper_trade DROP COLUMN IF EXISTS reflection;
 
 COMMIT;
+
+-- DATA LOSS WARNING: dropping the column destroys all LLM-generated
+-- reflection text permanently. Re-applying 0008 only regenerates trades
+-- exited within the trailing 30-day generation window (and at fresh LLM
+-- cost); older reflections are unrecoverable. To snapshot first:
+--   \copy (SELECT id, reflection FROM paper_trade WHERE reflection IS NOT NULL)
+--     TO 'paper_trade_reflection_backup.csv' CSV HEADER

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -303,12 +303,13 @@ class LLMThesisConfig(BaseModel):
     enabled: bool = True
     model: str = "claude-sonnet-4-6"
     max_usd_per_scan: float = 1.0
-    # Bumped v1->v2 with the D7a calibration block. The Tier-1 cache key is built
-    # from THIS runtime value (service.generate_thesis reads
-    # settings.llm_thesis.prompt_version), so it must track prompt.PROMPT_VERSION
-    # — the module constant alone never busts the cache. Keep the two in lockstep
+    # Bumped v1->v2 with the D7a calibration block, v2->v3 with the R-A
+    # reflections block. The Tier-1 cache key is built from THIS runtime value
+    # (service.generate_thesis reads settings.llm_thesis.prompt_version), so it
+    # must track prompt.PROMPT_VERSION — the module constant alone never busts
+    # the cache. Keep the two (plus settings.yaml) in lockstep
     # (test_prompt_version_config_tracks_module guards the invariant).
-    prompt_version: str = "v2"
+    prompt_version: str = "v3"
     enabled_sessions: list[str] = Field(
         default_factory=lambda: ["afternoon", "close"]
     )

--- a/src/rainier/core/models.py
+++ b/src/rainier/core/models.py
@@ -649,6 +649,13 @@ class PaperTrade(Base):
     return_pct: Mapped[float | None] = mapped_column(Float)
     pnl: Mapped[float | None] = mapped_column(Float)
 
+    # R-A (design DESIGN-qu100-llm-feedback-loop Appendix B): post-exit LLM
+    # post-mortem. The CHECK below is the outcome embargo at the schema level —
+    # a reflection can only exist once the trade has resolved (exit_reason set).
+    # Written once by paper/reflection.py (NULL-only update, idempotent); the
+    # last K feed the thesis prompt's calibration section.
+    reflection: Mapped[str | None] = mapped_column(Text)
+
     __table_args__ = (
         UniqueConstraint("thesis_id", name="uq_paper_trade_thesis_id"),
         CheckConstraint(
@@ -659,6 +666,11 @@ class PaperTrade(Base):
             "exit_reason IS NULL OR exit_reason IN "
             "('stop_loss','target','time_stop','manual')",
             name="ck_paper_trade_exit_reason",
+        ),
+        # R-A outcome embargo: reflections only exist for resolved trades.
+        CheckConstraint(
+            "reflection IS NULL OR exit_reason IS NOT NULL",
+            name="ck_paper_trade_reflection_after_exit",
         ),
         # Partial unique index — one pending/open position per symbol (design
         # D1). Closed/expired rows fall out, so a symbol can be re-traded later.

--- a/src/rainier/llm_thesis/prompt.py
+++ b/src/rainier/llm_thesis/prompt.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 # calibration text is INVISIBLE to compute_input_hash (it hashes only the
 # EvidencePack + image), so the Tier-1 cache — keyed on prompt_version — would
 # otherwise serve a pre-calibration thesis. Bumping the version busts Tier-1.
-PROMPT_VERSION = "v2"
+# v3 (R-A): the rolling last-K=10 post-exit trade reflections are appended to
+# the calibration section — same Tier-1-bust rationale. Bump IN LOCKSTEP with
+# core/config.py LLMThesisConfig.prompt_version and settings.yaml
+# llm_thesis.prompt_version (the runtime cache key uses the config value).
+PROMPT_VERSION = "v3"
 
 OUTPUT_SCHEMA = """{
   "verdict": "setup_long" | "watch" | "no_setup",
@@ -97,11 +101,13 @@ def build_user_message(
     `signal_renders` is the list of `signal.render_for_prompt(value)` strings for
     every enabled signal that produced a non-None value. Order is REGISTRY order.
 
-    `calibration_section` (D7a) is a bounded, pre-rendered block describing how
-    prior theses graded out (unbiased fixed-horizon headline + labeled realized
-    supplementary). Empty string = nothing to inject (Phase-0 / fresh DB). NOTE:
-    this text does NOT enter `compute_input_hash` (Tier-2), so PROMPT_VERSION is
-    bumped to bust the Tier-1 cache whenever this block's shape changes.
+    `calibration_section` (D7a + R-A) is a bounded, pre-rendered block describing
+    how prior theses graded out (unbiased fixed-horizon headline + labeled
+    realized supplementary), followed by the last K=10 post-exit trade
+    reflections (R-A). Empty string = nothing to inject (Phase-0 / fresh DB).
+    NOTE: this text does NOT enter `compute_input_hash` (Tier-2), so
+    PROMPT_VERSION is bumped to bust the Tier-1 cache whenever this block's
+    shape changes.
     """
     body = (
         f"Symbol: {symbol}\n"

--- a/src/rainier/llm_thesis/service.py
+++ b/src/rainier/llm_thesis/service.py
@@ -374,6 +374,25 @@ async def generate_thesis(
     except Exception:
         log.warning("thesis_calibration_load_failed symbol=%s", symbol, exc_info=True)
 
+    # R-A: append the rolling last-K post-exit reflections to the calibration
+    # section. Same strictly-before discipline (a reflection for a trade exited
+    # on day D is written end-of-day D — a day-D scan must not see it) and the
+    # same best-effort isolation: a load failure costs the block, not the
+    # thesis. Like the calibration text this is invisible to compute_input_hash,
+    # so PROMPT_VERSION ("v3") busts the Tier-1 cache instead.
+    try:
+        from rainier.paper.reflection import reflection_prompt_section
+
+        reflections_block = reflection_prompt_section(scan_date)
+        if reflections_block:
+            calibration_section = (
+                f"{calibration_section}\n\n{reflections_block}"
+                if calibration_section
+                else reflections_block
+            )
+    except Exception:
+        log.warning("thesis_reflections_load_failed symbol=%s", symbol, exc_info=True)
+
     user_prompt = build_user_message(
         symbol=symbol,
         scan_date=pack.scan_date,

--- a/src/rainier/paper/reflection.py
+++ b/src/rainier/paper/reflection.py
@@ -209,8 +209,8 @@ def _fmt(v: Any, spec: str = "") -> str:
 def _build_reflection_prompt(t: dict[str, Any]) -> str:
     """Per-trade user prompt: the booked facts + the original thesis case."""
     thesis = (t.get("thesis_reasoning") or "").strip()
-    if len(thesis) > 600:
-        thesis = thesis[:600] + "…"
+    if len(thesis) > REFLECTION_THESIS_EXCERPT_CHARS:
+        thesis = thesis[:REFLECTION_THESIS_EXCERPT_CHARS] + "…"
     return_pct = t.get("return_pct")
     lines = [
         f"Symbol: {t['symbol']}",
@@ -322,10 +322,13 @@ def generate_reflections(
                 raise ValueError("empty reflection from LLM")
             # NULL-only update: never rewrites, race-safe, and the schema CHECK
             # (exit_reason IS NOT NULL) backstops the embargo.
+            # updated_at is set explicitly: the ORM-level onupdate does not
+            # fire for raw-SQL UPDATEs, and change-detection consumers read it.
             with _get_session() as session:
                 result = session.execute(
                     sql_text(
-                        "UPDATE paper_trade SET reflection = :r "
+                        "UPDATE paper_trade "
+                        "SET reflection = :r, updated_at = NOW() "
                         "WHERE id = :id AND reflection IS NULL "
                         "  AND exit_reason IS NOT NULL"
                     ),
@@ -400,9 +403,12 @@ def render_reflections_section(rows: list[dict[str, Any]]) -> str:
     """Bounded, labeled prompt block. "" when there is nothing to show."""
     if not rows:
         return ""
+    # "reflected closed trades", not "closed trades": trades whose reflection
+    # generation permanently failed (or aged out of the lookback window) are
+    # absent, so the sample the model sees is reflected-only — say so.
     lines = [
-        f"--- Recent trade reflections (last {len(rows)} closed trades, "
-        "post-exit post-mortems) ---"
+        f"--- Recent trade reflections (last {len(rows)} reflected closed "
+        "trades, post-exit post-mortems) ---"
     ]
     for r in rows:
         body = (r.get("reflection") or "").replace("\n", " ").strip()

--- a/src/rainier/paper/reflection.py
+++ b/src/rainier/paper/reflection.py
@@ -1,0 +1,377 @@
+"""R-A — per-trade post-exit LLM reflections (design Appendix B, task plan
+qu100-ra-reflections-587f).
+
+WHAT THIS IS
+------------
+When a paper trade closes, the LLM writes a 2–3 sentence post-mortem — the
+pattern that triggered entry, what price actually did versus the plan, and
+whether the entry reasoning was validated (the FinAgent two-part framing).
+The text is stored on the trade row (`paper_trade.reflection`); the last K=10
+reflections are injected into the daily thesis prompt's calibration section so
+written lessons — not just numbers — reach the model.
+
+OUTCOME EMBARGO
+---------------
+Reflections only ever exist for RESOLVED trades. The schema enforces it:
+`CHECK (reflection IS NULL OR exit_reason IS NOT NULL)` (migration 0009), and
+the writer is a NULL-only UPDATE, so a reflection is written at most once and
+never rewritten.
+
+GENERATION CONTRACT (daily job, AFTER step (v) — scheduler/service.py)
+----------------------------------------------------------------------
+* Selection: all CLOSED trades with `reflection IS NULL` and
+  `exit_date <= as_of`, bounded to the trailing 30 days — a failed generation
+  is naturally retried on the next run, and the bound keeps a cold-started
+  backlog from burning unbounded LLM spend.
+* One LLM call per trade. A failure on one trade logs, leaves the reflection
+  NULL, and moves on — it never blocks the pipeline or the batch.
+* Chart attachment is FEATURE-DETECTED: when the `paper_trade.chart_id`
+  column exists (chart-archive PR landed) and is set, the archived close-side
+  PNG rides along as image input; otherwise the call is text-only. This module
+  must work on a pre-chart-archive schema with zero crashes.
+
+All reads/writes go through the LEGACY local-TimescaleDB engine
+(`core.database.get_session`) — never Neon (memory:
+project_two_database_url_engines).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import Any, Protocol
+
+from sqlalchemy import text as sql_text
+
+from rainier.core.database import get_session
+
+log = logging.getLogger(__name__)
+
+# Rolling number of reflections injected into the thesis prompt (task plan K).
+REFLECTION_PROMPT_K = 10
+# Generation selection window: closed trades exited within the trailing N days.
+REFLECTION_LOOKBACK_DAYS = 30
+# Hard cap on the stored reflection text (the prompt asks for 2–3 sentences;
+# this is the defensive bound, not the target length).
+REFLECTION_MAX_CHARS = 1000
+# Per-reflection cap when rendering into the prompt section (keeps the whole
+# K=10 block bounded at a few KB).
+REFLECTION_RENDER_CHARS = 280
+
+REFLECTION_SYSTEM_PROMPT = """You are reviewing ONE closed paper trade after the fact.
+Write a 2-3 sentence post-mortem in plain text (no JSON, no preamble, no headers):
+1. What price actually did after entry versus the planned entry/stop/target — name the
+   pattern that triggered the entry.
+2. Whether the entry reasoning was validated by the outcome (did the thesis hold?), and
+   the one lesson worth carrying forward.
+Be concrete and terse. No hedging filler."""
+
+
+class LLMFn(Protocol):
+    def __call__(
+        self,
+        *,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        image_bytes: bytes | None,
+    ) -> str: ...
+
+
+def _default_llm_fn(
+    *,
+    model: str,
+    system_prompt: str,
+    user_prompt: str,
+    image_bytes: bytes | None,
+) -> str:
+    """Single LiteLLM completion returning the text content.
+
+    Local twin of llm_thesis.service._call_llm (kept separate so paper/ does
+    not import llm_thesis internals); lazy import so tests never load LiteLLM.
+    """
+    import base64
+
+    import litellm
+
+    content_parts: list[dict[str, Any]] = [{"type": "text", "text": user_prompt}]
+    if image_bytes:
+        b64 = base64.b64encode(image_bytes).decode("ascii")
+        content_parts.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{b64}"},
+            }
+        )
+    resp = litellm.completion(
+        model=model,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": content_parts},
+        ],
+        temperature=0.2,
+    )
+    return resp["choices"][0]["message"]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Feature detection + chart fetch (R-D integration point)
+# ---------------------------------------------------------------------------
+
+
+def _chart_id_column_exists(session) -> bool:
+    """True iff `paper_trade.chart_id` exists in the connected database.
+
+    Resolves `paper_trade` through the connection's search_path (pg_attribute
+    + regclass), so a test schema and production `public` both work. Any
+    failure (non-Postgres dialect, missing table) degrades to False — the
+    text-only path, never a crash.
+    """
+    try:
+        return bool(
+            session.execute(
+                sql_text(
+                    "SELECT 1 FROM pg_attribute "
+                    "WHERE attrelid = 'paper_trade'::regclass "
+                    "AND attname = 'chart_id' AND NOT attisdropped"
+                )
+            ).scalar()
+        )
+    except Exception:
+        return False
+
+
+def _load_chart_bytes(session, trade_id: int, has_chart_col: bool) -> bytes | None:
+    """Archived close-side chart PNG for the trade, when available.
+
+    Best-effort: any failure returns None (text-only reflection). Raw SQL on
+    purpose — `chart_id` is not on the ORM model until the chart-archive PR
+    merges, and `image_bytes` is read by id only.
+    """
+    if not has_chart_col:
+        return None
+    try:
+        chart_id = session.execute(
+            sql_text("SELECT chart_id FROM paper_trade WHERE id = :id"),
+            {"id": trade_id},
+        ).scalar()
+        if chart_id is None:
+            return None
+        raw = session.execute(
+            sql_text("SELECT image_bytes FROM chart_images WHERE id = :cid"),
+            {"cid": chart_id},
+        ).scalar()
+        return bytes(raw) if raw is not None else None
+    except Exception:
+        log.warning(
+            "reflection_chart_fetch_failed trade_id=%s — falling back to text-only",
+            trade_id,
+            exc_info=True,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+
+def _fmt(v: Any, spec: str = "") -> str:
+    return format(v, spec) if v is not None else "n/a"
+
+
+def _build_reflection_prompt(t: dict[str, Any]) -> str:
+    """Per-trade user prompt: the booked facts + the original thesis case."""
+    thesis = (t.get("thesis_reasoning") or "").strip()
+    if len(thesis) > 600:
+        thesis = thesis[:600] + "…"
+    return_pct = t.get("return_pct")
+    lines = [
+        f"Symbol: {t['symbol']}",
+        f"Pattern that triggered entry: {t.get('pattern_type') or 'unknown'}",
+        f"Verdict / confidence at entry: {t.get('verdict') or 'n/a'} / "
+        f"{t.get('llm_confidence') if t.get('llm_confidence') is not None else 'n/a'}",
+        f"Plan: entry {_fmt(t.get('planned_entry_price'), '.2f')}, "
+        f"stop {_fmt(t.get('stop_loss'), '.2f')}, "
+        f"target {_fmt(t.get('target_price'), '.2f')}",
+        f"Actual: filled {t.get('entry_date')} @ {_fmt(t.get('entry_price'), '.2f')}, "
+        f"exited {t.get('exit_date')} @ {_fmt(t.get('exit_price'), '.2f')} "
+        f"via {t.get('exit_reason')}",
+        f"Outcome: return {_fmt(return_pct, '+.2%')}, "
+        f"P&L ${_fmt(t.get('pnl'), ',.2f')}",
+    ]
+    if thesis:
+        lines.append(f"Original entry thesis: {thesis}")
+    if t.get("has_chart"):
+        lines.append(
+            "A chart of the trade window (entry/stop/target/exit marked) is attached."
+        )
+    lines.append("Write the 2-3 sentence post-mortem now.")
+    return "\n".join(lines)
+
+
+def select_reflection_candidates(as_of: date) -> list[dict[str, Any]]:
+    """Closed, reflection-less trades with exit_date <= as_of, trailing 30 days.
+
+    Materialized scalar rows (never live ORM entities) — session-scope safe.
+    Oldest exit first so a backlog drains deterministically.
+    """
+    cutoff = as_of - timedelta(days=REFLECTION_LOOKBACK_DAYS)
+    with get_session() as session:
+        rows = session.execute(
+            sql_text(
+                "SELECT pt.id, pt.symbol, pt.pattern_type, pt.verdict, "
+                "       pt.llm_confidence, pt.planned_entry_price, pt.stop_loss, "
+                "       pt.target_price, pt.entry_date, pt.entry_price, "
+                "       pt.exit_date, pt.exit_price, pt.exit_reason, "
+                "       pt.return_pct, pt.pnl, ar.reasoning AS thesis_reasoning "
+                "FROM paper_trade pt "
+                "LEFT JOIN analysis_results ar ON ar.id = pt.thesis_id "
+                "WHERE pt.status = 'closed' "
+                "  AND pt.reflection IS NULL "
+                "  AND pt.exit_reason IS NOT NULL "
+                "  AND pt.exit_date IS NOT NULL "
+                "  AND pt.exit_date <= :as_of "
+                "  AND pt.exit_date >= :cutoff "
+                "ORDER BY pt.exit_date ASC, pt.id ASC"
+            ),
+            {"as_of": as_of, "cutoff": cutoff},
+        ).mappings().all()
+    return [dict(r) for r in rows]
+
+
+def generate_reflections(
+    as_of: date,
+    *,
+    model: str,
+    llm_fn: LLMFn | None = None,
+) -> dict[str, int]:
+    """Write a post-exit reflection for every eligible closed trade.
+
+    Idempotent: the selection (`reflection IS NULL`) plus the NULL-only UPDATE
+    mean a re-run never re-calls the LLM for an already-reflected trade and
+    never rewrites text. A per-trade failure logs and continues — the trade is
+    naturally retried on the next run.
+
+    Returns {"candidates", "written", "failed"} counts.
+    """
+    fn = llm_fn or _default_llm_fn
+    candidates = select_reflection_candidates(as_of)
+    written = 0
+    failed = 0
+
+    # One feature probe per run (schema doesn't change mid-batch).
+    with get_session() as session:
+        has_chart_col = _chart_id_column_exists(session)
+
+    for t in candidates:
+        trade_id = int(t["id"])
+        try:
+            with get_session() as session:
+                image_bytes = _load_chart_bytes(session, trade_id, has_chart_col)
+            t["has_chart"] = image_bytes is not None
+            reply = fn(
+                model=model,
+                system_prompt=REFLECTION_SYSTEM_PROMPT,
+                user_prompt=_build_reflection_prompt(t),
+                image_bytes=image_bytes,
+            )
+            reflection = (reply or "").strip()[:REFLECTION_MAX_CHARS]
+            if not reflection:
+                raise ValueError("empty reflection from LLM")
+            # NULL-only update: never rewrites, race-safe, and the schema CHECK
+            # (exit_reason IS NOT NULL) backstops the embargo.
+            with get_session() as session:
+                result = session.execute(
+                    sql_text(
+                        "UPDATE paper_trade SET reflection = :r "
+                        "WHERE id = :id AND reflection IS NULL "
+                        "  AND exit_reason IS NOT NULL"
+                    ),
+                    {"r": reflection, "id": trade_id},
+                )
+            written += int(result.rowcount or 0)
+        except Exception:
+            failed += 1
+            log.warning(
+                "reflection_generation_failed trade_id=%s symbol=%s — stays NULL, "
+                "retried next run",
+                trade_id,
+                t.get("symbol"),
+                exc_info=True,
+            )
+
+    log.info(
+        "reflections_generated as_of=%s candidates=%s written=%s failed=%s",
+        as_of.isoformat(),
+        len(candidates),
+        written,
+        failed,
+    )
+    return {"candidates": len(candidates), "written": written, "failed": failed}
+
+
+# ---------------------------------------------------------------------------
+# Prompt injection (consumed by llm_thesis.service.generate_thesis)
+# ---------------------------------------------------------------------------
+
+
+def load_recent_reflections(
+    as_of: date, *, k: int = REFLECTION_PROMPT_K
+) -> list[dict[str, Any]]:
+    """Last `k` reflections from trades exited STRICTLY BEFORE `as_of`.
+
+    Strictly-before mirrors the calibration block's no-hindsight contract: a
+    scan on day D must never see a reflection for a trade that exited on day D
+    (it is written end-of-day D, after the scan).
+    """
+    with get_session() as session:
+        rows = session.execute(
+            sql_text(
+                "SELECT symbol, exit_date, exit_reason, return_pct, reflection "
+                "FROM paper_trade "
+                "WHERE reflection IS NOT NULL "
+                "  AND exit_date IS NOT NULL AND exit_date < :as_of "
+                "ORDER BY exit_date DESC, id DESC "
+                "LIMIT :k"
+            ),
+            {"as_of": as_of, "k": k},
+        ).all()
+    return [
+        {
+            "symbol": symbol,
+            "exit_date": exit_date.isoformat() if exit_date else None,
+            "exit_reason": exit_reason,
+            "return_pct": float(return_pct) if return_pct is not None else None,
+            "reflection": reflection,
+        }
+        for symbol, exit_date, exit_reason, return_pct, reflection in rows
+    ]
+
+
+def render_reflections_section(rows: list[dict[str, Any]]) -> str:
+    """Bounded, labeled prompt block. "" when there is nothing to show."""
+    if not rows:
+        return ""
+    lines = [
+        f"--- Recent trade reflections (last {len(rows)} closed trades, "
+        "post-exit post-mortems) ---"
+    ]
+    for r in rows:
+        body = (r.get("reflection") or "").replace("\n", " ").strip()
+        if len(body) > REFLECTION_RENDER_CHARS:
+            body = body[: REFLECTION_RENDER_CHARS - 1] + "…"
+        ret = r.get("return_pct")
+        ret_s = f"{ret:+.2%}" if ret is not None else "n/a"
+        lines.append(
+            f"{r['symbol']} {r.get('exit_date') or '?'} "
+            f"{r.get('exit_reason') or '?'} {ret_s}: {body}"
+        )
+    return "\n".join(lines)
+
+
+def reflection_prompt_section(
+    scan_date: date, *, k: int = REFLECTION_PROMPT_K
+) -> str:
+    """Convenience: load + render in one call (used by generate_thesis)."""
+    return render_reflections_section(load_recent_reflections(scan_date, k=k))

--- a/src/rainier/paper/reflection.py
+++ b/src/rainier/paper/reflection.py
@@ -70,6 +70,17 @@ REFLECTION_MAX_CHARS = 1000
 # Per-reflection cap when rendering into the prompt section (keeps the whole
 # K=10 block bounded at a few KB).
 REFLECTION_RENDER_CHARS = 280
+# Per-run cap on LLM calls — bounds a cold-start backlog (30-day window x N
+# trades/day) to a fixed nightly spend; the overflow drains on later runs
+# (selection is oldest-first + reflection-IS-NULL, so nothing is lost).
+REFLECTION_MAX_PER_RUN = 25
+# Original-thesis excerpt bound in the per-trade prompt.
+REFLECTION_THESIS_EXCERPT_CHARS = 600
+# Completion bounds: 2-3 sentences fit comfortably in 300 tokens; the timeout
+# keeps one hung provider call from stalling the nightly pipeline (which runs
+# the batch serially before step (vi) calibration).
+REFLECTION_LLM_MAX_TOKENS = 300
+REFLECTION_LLM_TIMEOUT_S = 120
 
 REFLECTION_SYSTEM_PROMPT = """You are reviewing ONE closed paper trade after the fact.
 Write a 2-3 sentence post-mortem in plain text (no JSON, no preamble, no headers):
@@ -123,6 +134,8 @@ def _default_llm_fn(
             {"role": "user", "content": content_parts},
         ],
         temperature=0.2,
+        max_tokens=REFLECTION_LLM_MAX_TOKENS,
+        timeout=REFLECTION_LLM_TIMEOUT_S,
     )
     return resp["choices"][0]["message"]["content"]
 
@@ -258,6 +271,7 @@ def generate_reflections(
     *,
     model: str,
     llm_fn: LLMFn | None = None,
+    max_per_run: int = REFLECTION_MAX_PER_RUN,
 ) -> dict[str, int]:
     """Write a post-exit reflection for every eligible closed trade.
 
@@ -266,10 +280,24 @@ def generate_reflections(
     never rewrites text. A per-trade failure logs and continues — the trade is
     naturally retried on the next run.
 
-    Returns {"candidates", "written", "failed"} counts.
+    `max_per_run` caps LLM spend per invocation: a cold-start backlog is
+    processed oldest-first, `max_per_run` per night, until drained (deferred
+    trades stay reflection-IS-NULL so they are re-selected next run).
+
+    Returns {"candidates", "written", "failed", "deferred"} counts.
     """
     fn = llm_fn or _default_llm_fn
     candidates = select_reflection_candidates(as_of)
+    deferred = max(0, len(candidates) - max_per_run)
+    if deferred:
+        log.info(
+            "reflections_capped as_of=%s candidates=%s max_per_run=%s deferred=%s",
+            as_of.isoformat(),
+            len(candidates),
+            max_per_run,
+            deferred,
+        )
+        candidates = candidates[:max_per_run]
     written = 0
     failed = 0
 
@@ -315,13 +343,19 @@ def generate_reflections(
             )
 
     log.info(
-        "reflections_generated as_of=%s candidates=%s written=%s failed=%s",
+        "reflections_generated as_of=%s candidates=%s written=%s failed=%s deferred=%s",
         as_of.isoformat(),
         len(candidates),
         written,
         failed,
+        deferred,
     )
-    return {"candidates": len(candidates), "written": written, "failed": failed}
+    return {
+        "candidates": len(candidates),
+        "written": written,
+        "failed": failed,
+        "deferred": deferred,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/src/rainier/paper/reflection.py
+++ b/src/rainier/paper/reflection.py
@@ -43,9 +43,22 @@ from typing import Any, Protocol
 
 from sqlalchemy import text as sql_text
 
-from rainier.core.database import get_session
+from rainier.core import database
 
 log = logging.getLogger(__name__)
+
+
+def _get_session():
+    """Late-bound `core.database.get_session`.
+
+    Resolved at CALL time through the module attribute, never captured at
+    import time: this module is imported lazily from `generate_thesis`, so its
+    first import can happen inside a test's
+    `patch("rainier.core.database.get_session")` window — a `from ... import
+    get_session` would freeze that ephemeral mock into this namespace forever
+    (observed as cross-suite test pollution).
+    """
+    return database.get_session()
 
 # Rolling number of reflections injected into the thesis prompt (task plan K).
 REFLECTION_PROMPT_K = 10
@@ -217,7 +230,7 @@ def select_reflection_candidates(as_of: date) -> list[dict[str, Any]]:
     Oldest exit first so a backlog drains deterministically.
     """
     cutoff = as_of - timedelta(days=REFLECTION_LOOKBACK_DAYS)
-    with get_session() as session:
+    with _get_session() as session:
         rows = session.execute(
             sql_text(
                 "SELECT pt.id, pt.symbol, pt.pattern_type, pt.verdict, "
@@ -261,13 +274,13 @@ def generate_reflections(
     failed = 0
 
     # One feature probe per run (schema doesn't change mid-batch).
-    with get_session() as session:
+    with _get_session() as session:
         has_chart_col = _chart_id_column_exists(session)
 
     for t in candidates:
         trade_id = int(t["id"])
         try:
-            with get_session() as session:
+            with _get_session() as session:
                 image_bytes = _load_chart_bytes(session, trade_id, has_chart_col)
             t["has_chart"] = image_bytes is not None
             reply = fn(
@@ -281,7 +294,7 @@ def generate_reflections(
                 raise ValueError("empty reflection from LLM")
             # NULL-only update: never rewrites, race-safe, and the schema CHECK
             # (exit_reason IS NOT NULL) backstops the embargo.
-            with get_session() as session:
+            with _get_session() as session:
                 result = session.execute(
                     sql_text(
                         "UPDATE paper_trade SET reflection = :r "
@@ -325,7 +338,7 @@ def load_recent_reflections(
     scan on day D must never see a reflection for a trade that exited on day D
     (it is written end-of-day D, after the scan).
     """
-    with get_session() as session:
+    with _get_session() as session:
         rows = session.execute(
             sql_text(
                 "SELECT symbol, exit_date, exit_reason, return_pct, reflection "

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -213,13 +213,19 @@ async def run_daily_eval(eval_date_iso: str | None = None) -> None:
     # the trailing 30 days that has none yet. Runs AFTER step (v) (the report/
     # chart-capture step) so the close-side chart exists by reflection time once
     # the chart-archive lands; pre-archive schemas take the text-only path.
+    # Gated on the operator's LLM kill switch (`llm_thesis.enabled`): the whole
+    # feedback loop spends through that one flag, so flipping it off must stop
+    # reflection LLM calls too, not just thesis generation.
     # Non-fatal: a failure leaves reflections NULL, retried tomorrow.
-    try:
-        await asyncio.to_thread(
-            run_paper_reflections, eval_date, settings.llm_thesis.model
-        )
-    except Exception as exc:
-        log.error("daily_paper_reflections_failed", error=str(exc))
+    if settings.llm_thesis.enabled:
+        try:
+            await asyncio.to_thread(
+                run_paper_reflections, eval_date, settings.llm_thesis.model
+            )
+        except Exception as exc:
+            log.error("daily_paper_reflections_failed", error=str(exc))
+    else:
+        log.info("daily_paper_reflections_skipped reason=llm_thesis_disabled")
 
     # Step (vi): D7a calibration block — compute the unbiased fixed-horizon
     # headline + labeled realized supplementary and persist it for tomorrow's

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -209,6 +209,18 @@ async def run_daily_eval(eval_date_iso: str | None = None) -> None:
     except Exception as exc:
         log.error("daily_paper_report_failed", error=str(exc))
 
+    # R-A: post-exit reflections — one LLM post-mortem per trade closed within
+    # the trailing 30 days that has none yet. Runs AFTER step (v) (the report/
+    # chart-capture step) so the close-side chart exists by reflection time once
+    # the chart-archive lands; pre-archive schemas take the text-only path.
+    # Non-fatal: a failure leaves reflections NULL, retried tomorrow.
+    try:
+        await asyncio.to_thread(
+            run_paper_reflections, eval_date, settings.llm_thesis.model
+        )
+    except Exception as exc:
+        log.error("daily_paper_reflections_failed", error=str(exc))
+
     # Step (vi): D7a calibration block — compute the unbiased fixed-horizon
     # headline + labeled realized supplementary and persist it for tomorrow's
     # thesis prompt. Runs AFTER the daily report (it reuses the report's
@@ -254,6 +266,17 @@ def run_paper_daily_report(eval_date, discord_config) -> None:
     payload = compute_daily_payload(eval_date)
     persist_daily_snapshot(eval_date, payload)
     send_daily_paper_report(payload, discord_config)
+
+
+def run_paper_reflections(eval_date, model: str) -> None:
+    """R-A: write post-exit reflections for newly closed trades.
+
+    Selection is DB-driven (`reflection IS NULL`, trailing 30 days), so a
+    failed day is naturally retried on the next run. Idempotent.
+    """
+    from rainier.paper.reflection import generate_reflections
+
+    generate_reflections(eval_date, model=model)
 
 
 def run_paper_calibration(eval_date) -> None:

--- a/tests/test_paper/conftest.py
+++ b/tests/test_paper/conftest.py
@@ -31,6 +31,10 @@ MIGRATION_0008_UP = REPO_ROOT / "migrations" / "0008_paper_skip_zero_share.sql"
 MIGRATION_0008_DOWN = (
     REPO_ROOT / "migrations" / "0008_paper_skip_zero_share_downgrade.sql"
 )
+# R-A: paper_trade.reflection + outcome-embargo CHECK. Applied on top of 0005 so
+# full-entity PaperTrade ORM reads (positions.py et al) see the column.
+MIGRATION_0009_UP = REPO_ROOT / "migrations" / "0009_paper_reflection.sql"
+MIGRATION_0009_DOWN = REPO_ROOT / "migrations" / "0009_paper_reflection_downgrade.sql"
 
 # Minimal DDL for the FK-target tables the paper migration references. The real
 # schema lives in migrations/0001-0004; for an isolated paper-tracker test DB we
@@ -256,6 +260,7 @@ def pg_legacy_engine(request):
     _apply_sql(engine, MIGRATION_UP)
     _apply_sql(engine, MIGRATION_0007_UP)  # D7a paper_calibration
     _apply_sql(engine, MIGRATION_0008_UP)  # Phase 3 zero_share_price skip reason
+    _apply_sql(engine, MIGRATION_0009_UP)  # R-A paper_trade.reflection
 
     from rainier.core import config, database
 

--- a/tests/test_paper/test_daily_wiring.py
+++ b/tests/test_paper/test_daily_wiring.py
@@ -78,18 +78,30 @@ def test_g1_daily_eval_runs_steps_in_order(monkeypatch):
         "rainier.paper.calibration.persist_calibration", lambda *a, **k: None
     )
 
+    # R-A reflections — run AFTER step (v) (the report/chart-capture step), so
+    # the close-side chart exists by reflection time once chart-archive lands.
+    def fake_reflections(as_of, **kw):
+        calls.append("reflections")
+        return {"written": 0, "failed": 0}
+
+    monkeypatch.setattr(
+        "rainier.paper.reflection.generate_reflections", fake_reflections
+    )
+
     # Avoid the yesterday-rows DB fetch.
     monkeypatch.setattr(service, "load_settings_fresh", lambda: _FakeSettings())
 
     asyncio.run(service.run_daily_eval("2026-01-09"))
 
     # ingest precedes fill (G2); fill precedes update; update precedes horizon
-    # eval; horizon precedes the paper report; report precedes calibration
-    # (step vi reuses the report's MTM figure — G1 authoritative order).
+    # eval; horizon precedes the paper report; report precedes reflections
+    # (R-A runs after step (v)); report precedes calibration (step vi reuses
+    # the report's MTM figure — G1 authoritative order).
     assert calls.index("ingest") < calls.index("fill")
     assert calls.index("fill") < calls.index("update")
     assert calls.index("update") < calls.index("horizon")
     assert calls.index("horizon") < calls.index("report")
+    assert calls.index("report") < calls.index("reflections")
     assert calls.index("report") < calls.index("calibration")
 
 
@@ -104,6 +116,7 @@ class _FakeAlerts:
 
 class _FakeLLMThesis:
     learned_time_stop_days = None
+    model = "test-model"
 
 
 class _FakeSettings:
@@ -150,6 +163,9 @@ def test_g3_horizon_eval_still_runs(monkeypatch):
     )
     monkeypatch.setattr(
         "rainier.paper.calibration.persist_calibration", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "rainier.paper.reflection.generate_reflections", lambda *a, **k: {}
     )
     monkeypatch.setattr(service, "load_settings_fresh", lambda: _FakeSettings())
 

--- a/tests/test_paper/test_daily_wiring.py
+++ b/tests/test_paper/test_daily_wiring.py
@@ -102,7 +102,7 @@ def test_g1_daily_eval_runs_steps_in_order(monkeypatch):
     assert calls.index("update") < calls.index("horizon")
     assert calls.index("horizon") < calls.index("report")
     assert calls.index("report") < calls.index("reflections")
-    assert calls.index("report") < calls.index("calibration")
+    assert calls.index("reflections") < calls.index("calibration")
 
 
 class _FakeDiscord:
@@ -117,6 +117,8 @@ class _FakeAlerts:
 class _FakeLLMThesis:
     learned_time_stop_days = None
     model = "test-model"
+    # The operator's LLM kill switch — reflections (R-A) gate on it too.
+    enabled = True
 
 
 class _FakeSettings:
@@ -124,9 +126,16 @@ class _FakeSettings:
     llm_thesis = _FakeLLMThesis()
 
 
-def test_g3_horizon_eval_still_runs(monkeypatch):
-    ran = {"horizon": False}
+class _FakeLLMThesisDisabled(_FakeLLMThesis):
+    enabled = False
 
+
+class _FakeSettingsLLMOff(_FakeSettings):
+    llm_thesis = _FakeLLMThesisDisabled()
+
+
+def _patch_daily_eval_steps(monkeypatch, *, settings=None) -> None:
+    """Stub every run_daily_eval step except reflections/calibration tracking."""
     monkeypatch.setattr("rainier.paper.ingest.ingest_prices", lambda *a, **k: {})
     monkeypatch.setattr("rainier.paper.ingest.active_symbols", lambda: [])
     monkeypatch.setattr("rainier.paper.ingest.screened_symbols", lambda d: [])
@@ -136,13 +145,8 @@ def test_g3_horizon_eval_still_runs(monkeypatch):
     monkeypatch.setattr(
         "rainier.paper.positions.update_open_positions", lambda **k: {}
     )
-
-    def fake_evaluate_horizon(eval_date, horizon):
-        ran["horizon"] = True
-        return 0
-
     monkeypatch.setattr(
-        "rainier.llm_thesis.eval.evaluate_horizon", fake_evaluate_horizon
+        "rainier.llm_thesis.eval.evaluate_horizon", lambda *a, **k: 0
     )
     monkeypatch.setattr(
         "rainier.llm_thesis.eval.compute_verdict_hit_rate", lambda *a, **k: {}
@@ -165,9 +169,70 @@ def test_g3_horizon_eval_still_runs(monkeypatch):
         "rainier.paper.calibration.persist_calibration", lambda *a, **k: None
     )
     monkeypatch.setattr(
+        service, "load_settings_fresh", lambda: settings or _FakeSettings()
+    )
+
+
+def test_g3_horizon_eval_still_runs(monkeypatch):
+    ran = {"horizon": False}
+
+    _patch_daily_eval_steps(monkeypatch)
+
+    def fake_evaluate_horizon(eval_date, horizon):
+        ran["horizon"] = True
+        return 0
+
+    monkeypatch.setattr(
+        "rainier.llm_thesis.eval.evaluate_horizon", fake_evaluate_horizon
+    )
+    monkeypatch.setattr(
         "rainier.paper.reflection.generate_reflections", lambda *a, **k: {}
     )
-    monkeypatch.setattr(service, "load_settings_fresh", lambda: _FakeSettings())
 
     asyncio.run(service.run_daily_eval("2026-01-09"))
     assert ran["horizon"] is True
+
+
+def test_reflections_skipped_when_llm_thesis_disabled(monkeypatch):
+    """R-A spend gate: `llm_thesis.enabled = false` (the operator's LLM kill
+    switch) must stop reflection LLM calls, not just thesis generation."""
+    _patch_daily_eval_steps(monkeypatch, settings=_FakeSettingsLLMOff())
+
+    called = {"reflections": False}
+
+    def fake_reflections(*a, **kw):
+        called["reflections"] = True
+        return {}
+
+    monkeypatch.setattr(
+        "rainier.paper.reflection.generate_reflections", fake_reflections
+    )
+
+    asyncio.run(service.run_daily_eval("2026-01-09"))
+    assert called["reflections"] is False
+
+
+def test_reflections_failure_does_not_block_calibration(monkeypatch):
+    """A raising reflections step is non-fatal: step (vi) calibration still
+    runs (the daily eval's per-step isolation contract)."""
+    _patch_daily_eval_steps(monkeypatch)
+
+    ran = {"calibration": False}
+
+    def fake_calib_compute(as_of):
+        ran["calibration"] = True
+        return {}
+
+    monkeypatch.setattr(
+        "rainier.paper.calibration.compute_calibration_payload", fake_calib_compute
+    )
+
+    def broken_reflections(*a, **kw):
+        raise RuntimeError("reflections blew up")
+
+    monkeypatch.setattr(
+        "rainier.paper.reflection.generate_reflections", broken_reflections
+    )
+
+    asyncio.run(service.run_daily_eval("2026-01-09"))
+    assert ran["calibration"] is True

--- a/tests/test_paper/test_reflections.py
+++ b/tests/test_paper/test_reflections.py
@@ -3,7 +3,7 @@
 Covers (TASK-PLAN acceptance):
   1. Schema: `paper_trade.reflection TEXT` + CHECK (reflection IS NULL OR
      exit_reason IS NOT NULL) — the outcome embargo at the schema level.
-     Additive migration 0008 on $LEGACY_DATABASE_URL.
+     Additive migration 0009 on $LEGACY_DATABASE_URL.
   2. Generation: closed trades with reflection IS NULL and exit_date <= as_of,
      bounded to the trailing 30 days; one LLM call per trade; idempotent;
      LLM failure -> reflection stays NULL (retried next run, never blocks).
@@ -29,9 +29,9 @@ from sqlalchemy.exc import IntegrityError
 from rainier.core.models import PaperTrade
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-MIGRATION_0008_UP = REPO_ROOT / "migrations" / "0008_paper_reflection.sql"
-MIGRATION_0008_DOWN = (
-    REPO_ROOT / "migrations" / "0008_paper_reflection_downgrade.sql"
+MIGRATION_0009_UP = REPO_ROOT / "migrations" / "0009_paper_reflection.sql"
+MIGRATION_0009_DOWN = (
+    REPO_ROOT / "migrations" / "0009_paper_reflection_downgrade.sql"
 )
 
 
@@ -122,7 +122,7 @@ def _mk_trade(
 
 
 # ---------------------------------------------------------------------------
-# 1. Schema — CHECK embargo on a real Postgres (migration 0008 applied by
+# 1. Schema — CHECK embargo on a real Postgres (migration 0009 applied by
 #    the pg_legacy_engine fixture)
 # ---------------------------------------------------------------------------
 
@@ -162,16 +162,16 @@ def test_check_accepts_reflection_on_closed_row(pg_legacy_session):
     assert got == "clean two-sentence post-mortem"
 
 
-def test_migration_0008_idempotent_reapply(pg_legacy_engine):
-    # The fixture already applied 0008 once; a re-apply must be a no-op.
-    sql = MIGRATION_0008_UP.read_text()
+def test_migration_0009_idempotent_reapply(pg_legacy_engine):
+    # The fixture already applied 0009 once; a re-apply must be a no-op.
+    sql = MIGRATION_0009_UP.read_text()
     with pg_legacy_engine.begin() as conn:
         conn.execute(text(sql))
 
 
-def test_migration_0008_downgrade_then_up_roundtrip(pg_legacy_engine):
-    down = MIGRATION_0008_DOWN.read_text()
-    up = MIGRATION_0008_UP.read_text()
+def test_migration_0009_downgrade_then_up_roundtrip(pg_legacy_engine):
+    down = MIGRATION_0009_DOWN.read_text()
+    up = MIGRATION_0009_UP.read_text()
     with pg_legacy_engine.begin() as conn:
         conn.execute(text(down))
     cols = {

--- a/tests/test_paper/test_reflections.py
+++ b/tests/test_paper/test_reflections.py
@@ -465,14 +465,83 @@ def test_render_reflections_section_empty_is_blank():
     assert render_reflections_section([]) == ""
 
 
-def test_reflection_prompt_section_appended_in_generate_thesis_path():
-    """The service appends the reflections block to the calibration section."""
-    import inspect as _inspect
+@pytest.mark.asyncio
+async def test_reflections_block_lands_in_thesis_user_prompt(monkeypatch):
+    """generate_thesis appends the reflections block to the LLM user prompt."""
+    import json
+    from unittest.mock import patch
 
-    from rainier.llm_thesis import service as thesis_service
+    from rainier.core.config import LLMThesisConfig, Settings
+    from rainier.llm_thesis.schemas import EvidencePack
+    from rainier.llm_thesis.service import generate_thesis
 
-    src = _inspect.getsource(thesis_service.generate_thesis)
-    assert "reflection" in src  # R-A wired into the thesis prompt build
+    monkeypatch.setattr(
+        "rainier.paper.calibration.load_latest_calibration",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "rainier.paper.reflection.load_recent_reflections",
+        lambda *a, **k: [
+            {
+                "symbol": "RFL",
+                "exit_date": "2026-06-05",
+                "exit_reason": "target",
+                "return_pct": 0.08,
+                "reflection": "Breakout ran straight to target; thesis held.",
+            }
+        ],
+    )
+
+    valid = json.dumps(
+        {
+            "verdict": "setup_long",
+            "setup_quality": 7,
+            "llm_confidence": 7,
+            "paragraph_radar": "r",
+            "paragraph_evidence": "e",
+            "paragraph_invalidation": "i",
+            "risks": [],
+            "watch_items": [],
+            "evidence_used": ["pattern"],
+            "signals_used": [],
+            "patterns_in_chart_not_in_indicators": "none",
+        }
+    )
+    pack = EvidencePack(
+        symbol="NVDA",
+        scan_date="2026-06-08",
+        session_name="close",
+        candidate={"rank": 5},
+        signals={},
+    )
+    settings = Settings(database_url="postgresql://test:test@localhost/test")
+    settings.llm_thesis = LLMThesisConfig(model="test-model", prompt_version="v3")
+
+    captured: dict = {}
+
+    def fake_call_llm(*, model, system_prompt, user_prompt, image_bytes):
+        captured["user_prompt"] = user_prompt
+        return valid, 10, 20
+
+    with patch(
+        "rainier.llm_thesis.service._tier1_lookup", return_value=None
+    ), patch(
+        "rainier.llm_thesis.service._call_llm", side_effect=fake_call_llm
+    ), patch(
+        "rainier.llm_thesis.service._persist_thesis", return_value=1
+    ):
+        thesis, _cost, _rid = await generate_thesis(
+            symbol="NVDA",
+            scan_date=date(2026, 6, 8),
+            session_name="close",
+            evidence_provider=lambda: (pack, [], None),
+            settings=settings,
+            max_usd_remaining=1.0,
+        )
+    assert thesis is not None
+    assert "Recent trade reflections" in captured["user_prompt"]
+    assert "RFL" in captured["user_prompt"]
+    assert "thesis held" in captured["user_prompt"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_paper/test_reflections.py
+++ b/tests/test_paper/test_reflections.py
@@ -1,0 +1,520 @@
+"""R-A — per-trade post-exit LLM reflections (task qu100-ra-reflections-587f).
+
+Covers (TASK-PLAN acceptance):
+  1. Schema: `paper_trade.reflection TEXT` + CHECK (reflection IS NULL OR
+     exit_reason IS NOT NULL) — the outcome embargo at the schema level.
+     Additive migration 0008 on $LEGACY_DATABASE_URL.
+  2. Generation: closed trades with reflection IS NULL and exit_date <= as_of,
+     bounded to the trailing 30 days; one LLM call per trade; idempotent;
+     LLM failure -> reflection stays NULL (retried next run, never blocks).
+     Chart attachment is FEATURE-DETECTED: `paper_trade.chart_id` column
+     present + set -> image input; column absent (pre-chart-archive main) ->
+     text-only path, no crash.
+  3. Prompt injection: rolling last K=10 reflections appended to the
+     calibration section; bounded; labeled; strictly-before discipline;
+     PROMPT_VERSION bumped (v3) in lockstep across module/config/yaml;
+     input_hash unaffected.
+  4. Reflections only ever exist for resolved trades.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import IntegrityError
+
+from rainier.core.models import PaperTrade
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_0008_UP = REPO_ROOT / "migrations" / "0008_paper_reflection.sql"
+MIGRATION_0008_DOWN = (
+    REPO_ROOT / "migrations" / "0008_paper_reflection_downgrade.sql"
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Schema — ORM metadata (no Postgres needed)
+# ---------------------------------------------------------------------------
+
+
+def test_paper_trade_has_nullable_reflection_column():
+    cols = {c.name for c in inspect(PaperTrade).columns}
+    assert "reflection" in cols
+    assert PaperTrade.__table__.c.reflection.nullable
+
+
+def test_reflection_check_constraint_declared():
+    checks = [
+        c
+        for c in PaperTrade.__table__.constraints
+        if c.__class__.__name__ == "CheckConstraint"
+    ]
+    sqltexts = {c.name: str(c.sqltext) for c in checks}
+    assert "ck_paper_trade_reflection_after_exit" in sqltexts
+    assert (
+        "reflection IS NULL OR exit_reason IS NOT NULL"
+        in sqltexts["ck_paper_trade_reflection_after_exit"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# helpers — insert a thesis + paper_trade row in the pg test schema
+# ---------------------------------------------------------------------------
+
+
+def _mk_thesis(session) -> int:
+    rid = session.execute(
+        text(
+            "INSERT INTO analysis_results (reasoning, structured_output) "
+            "VALUES ('w_bottom forming, neckline 142.50', "
+            "'{\"paragraph_evidence\": \"flow streak + neckline\"}'::jsonb) "
+            "RETURNING id"
+        )
+    ).scalar()
+    return int(rid)
+
+
+def _mk_trade(
+    session,
+    *,
+    symbol: str = "AAA",
+    status: str = "closed",
+    entry_date: date | None = date(2026, 6, 1),
+    exit_date: date | None = date(2026, 6, 5),
+    exit_reason: str | None = "target",
+    reflection: str | None = None,
+    return_pct: float | None = 0.08,
+) -> int:
+    thesis_id = _mk_thesis(session)
+    tid = session.execute(
+        text(
+            "INSERT INTO paper_trade "
+            "(thesis_id, symbol, scan_date, session_name, status, "
+            " planned_entry_price, stop_loss, target_price, pattern_type, "
+            " llm_confidence, verdict, entry_date, entry_price, shares, "
+            " exit_date, exit_price, exit_reason, return_pct, pnl, reflection) "
+            "VALUES "
+            "(:thesis_id, :symbol, '2026-05-29', 'close', :status, "
+            " 100.0, 95.0, 110.0, 'w_bottom', "
+            " 7, 'setup_long', :entry_date, 100.0, 100, "
+            " :exit_date, :exit_price, :exit_reason, :return_pct, :pnl, "
+            " :reflection) "
+            "RETURNING id"
+        ),
+        {
+            "thesis_id": thesis_id,
+            "symbol": symbol,
+            "status": status,
+            "entry_date": entry_date,
+            "exit_date": exit_date,
+            "exit_price": 108.0 if exit_date else None,
+            "exit_reason": exit_reason,
+            "return_pct": return_pct,
+            "pnl": 800.0 if exit_date else None,
+            "reflection": reflection,
+        },
+    ).scalar()
+    session.commit()
+    return int(tid)
+
+
+# ---------------------------------------------------------------------------
+# 1. Schema — CHECK embargo on a real Postgres (migration 0008 applied by
+#    the pg_legacy_engine fixture)
+# ---------------------------------------------------------------------------
+
+
+def test_check_rejects_reflection_on_open_row(pg_legacy_session):
+    with pytest.raises(IntegrityError):
+        _mk_trade(
+            pg_legacy_session,
+            status="open",
+            exit_date=None,
+            exit_reason=None,
+            return_pct=None,
+            reflection="premature reflection on an open trade",
+        )
+    pg_legacy_session.rollback()
+
+
+def test_check_rejects_reflection_on_pending_row(pg_legacy_session):
+    with pytest.raises(IntegrityError):
+        _mk_trade(
+            pg_legacy_session,
+            status="pending",
+            entry_date=None,
+            exit_date=None,
+            exit_reason=None,
+            return_pct=None,
+            reflection="premature reflection on a pending trade",
+        )
+    pg_legacy_session.rollback()
+
+
+def test_check_accepts_reflection_on_closed_row(pg_legacy_session):
+    tid = _mk_trade(pg_legacy_session, reflection="clean two-sentence post-mortem")
+    got = pg_legacy_session.execute(
+        text("SELECT reflection FROM paper_trade WHERE id = :id"), {"id": tid}
+    ).scalar()
+    assert got == "clean two-sentence post-mortem"
+
+
+def test_migration_0008_idempotent_reapply(pg_legacy_engine):
+    # The fixture already applied 0008 once; a re-apply must be a no-op.
+    sql = MIGRATION_0008_UP.read_text()
+    with pg_legacy_engine.begin() as conn:
+        conn.execute(text(sql))
+
+
+def test_migration_0008_downgrade_then_up_roundtrip(pg_legacy_engine):
+    down = MIGRATION_0008_DOWN.read_text()
+    up = MIGRATION_0008_UP.read_text()
+    with pg_legacy_engine.begin() as conn:
+        conn.execute(text(down))
+    cols = {
+        r[0]
+        for r in pg_legacy_engine.connect()
+        .execute(
+            text(
+                "SELECT attname FROM pg_attribute "
+                "WHERE attrelid = 'paper_trade'::regclass AND attnum > 0 "
+                "AND NOT attisdropped"
+            )
+        )
+        .all()
+    }
+    assert "reflection" not in cols
+    with pg_legacy_engine.begin() as conn:
+        conn.execute(text(up))
+        conn.execute(text(up))  # idempotent after a fresh up as well
+    cols2 = {
+        r[0]
+        for r in pg_legacy_engine.connect()
+        .execute(
+            text(
+                "SELECT attname FROM pg_attribute "
+                "WHERE attrelid = 'paper_trade'::regclass AND attnum > 0 "
+                "AND NOT attisdropped"
+            )
+        )
+        .all()
+    }
+    assert "reflection" in cols2
+
+
+# ---------------------------------------------------------------------------
+# 2. Generation — selection, idempotency, failure isolation
+# ---------------------------------------------------------------------------
+
+
+class _StubLLM:
+    """Deterministic llm_fn stub. Records every call."""
+
+    def __init__(self, reply: str = "Price ran to target. Thesis held.",
+                 fail: bool = False):
+        self.reply = reply
+        self.fail = fail
+        self.calls: list[dict] = []
+
+    def __call__(self, *, model, system_prompt, user_prompt, image_bytes):
+        self.calls.append(
+            {
+                "model": model,
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "image_bytes": image_bytes,
+            }
+        )
+        if self.fail:
+            raise RuntimeError("llm unavailable")
+        return self.reply
+
+
+AS_OF = date(2026, 6, 8)
+
+
+def test_generation_writes_reflection_once(pg_legacy_session):
+    from rainier.paper.reflection import generate_reflections
+
+    tid = _mk_trade(pg_legacy_session, symbol="AAA")
+    stub = _StubLLM()
+    stats = generate_reflections(AS_OF, model="test-model", llm_fn=stub)
+    assert stats["written"] == 1
+    assert len(stub.calls) == 1
+    # Two-part post-mortem prompt: what price did + was the reasoning validated.
+    prompt = stub.calls[0]["user_prompt"]
+    assert "AAA" in prompt
+    assert "w_bottom" in prompt           # pattern that triggered entry
+    assert "target" in prompt             # exit_reason — what price did
+    got = pg_legacy_session.execute(
+        text("SELECT reflection FROM paper_trade WHERE id = :id"), {"id": tid}
+    ).scalar()
+    assert got == stub.reply
+
+
+def test_generation_is_idempotent_on_rerun(pg_legacy_session):
+    from rainier.paper.reflection import generate_reflections
+
+    tid = _mk_trade(pg_legacy_session, symbol="AAA")
+    first = _StubLLM(reply="first run reflection")
+    generate_reflections(AS_OF, model="test-model", llm_fn=first)
+    second = _StubLLM(reply="SECOND run must never land")
+    stats = generate_reflections(AS_OF, model="test-model", llm_fn=second)
+    assert stats["written"] == 0
+    assert second.calls == []  # no duplicate LLM spend
+    got = pg_legacy_session.execute(
+        text("SELECT reflection FROM paper_trade WHERE id = :id"), {"id": tid}
+    ).scalar()
+    assert got == "first run reflection"  # no rewrite
+
+
+def test_generation_llm_failure_leaves_null_and_is_retried(pg_legacy_session):
+    from rainier.paper.reflection import generate_reflections
+
+    tid = _mk_trade(pg_legacy_session, symbol="AAA")
+    broken = _StubLLM(fail=True)
+    stats = generate_reflections(AS_OF, model="test-model", llm_fn=broken)
+    assert stats["written"] == 0
+    assert stats["failed"] == 1
+    got = pg_legacy_session.execute(
+        text("SELECT reflection FROM paper_trade WHERE id = :id"), {"id": tid}
+    ).scalar()
+    assert got is None  # stays NULL — never a partial/placeholder write
+    # Day D+1: the NULL row is naturally re-selected and succeeds.
+    working = _StubLLM(reply="retried fine")
+    stats2 = generate_reflections(
+        AS_OF + timedelta(days=1), model="test-model", llm_fn=working
+    )
+    assert stats2["written"] == 1
+
+
+def test_generation_selection_bounds(pg_legacy_session):
+    from rainier.paper.reflection import generate_reflections
+
+    # Not selected: open trade (no exit), future exit, stale exit (>30d back).
+    _mk_trade(
+        pg_legacy_session, symbol="OPN", status="open",
+        exit_date=None, exit_reason=None, return_pct=None,
+    )
+    _mk_trade(pg_legacy_session, symbol="FUT", exit_date=AS_OF + timedelta(days=2))
+    _mk_trade(pg_legacy_session, symbol="OLD", exit_date=AS_OF - timedelta(days=31))
+    # Selected: exit on as_of itself (<= bound).
+    _mk_trade(pg_legacy_session, symbol="NOW", exit_date=AS_OF)
+    stub = _StubLLM()
+    stats = generate_reflections(AS_OF, model="test-model", llm_fn=stub)
+    assert stats["written"] == 1
+    assert len(stub.calls) == 1
+    assert "NOW" in stub.calls[0]["user_prompt"]
+
+
+def test_generation_truncates_overlong_reply(pg_legacy_session):
+    from rainier.paper.reflection import (
+        REFLECTION_MAX_CHARS,
+        generate_reflections,
+    )
+
+    tid = _mk_trade(pg_legacy_session, symbol="AAA")
+    stub = _StubLLM(reply="x" * (REFLECTION_MAX_CHARS + 500))
+    generate_reflections(AS_OF, model="test-model", llm_fn=stub)
+    got = pg_legacy_session.execute(
+        text("SELECT reflection FROM paper_trade WHERE id = :id"), {"id": tid}
+    ).scalar()
+    assert got is not None
+    assert len(got) <= REFLECTION_MAX_CHARS
+
+
+# ---------------------------------------------------------------------------
+# 2. Generation — feature-detected chart attachment
+# ---------------------------------------------------------------------------
+
+
+def test_chart_column_absent_text_only_no_crash(pg_legacy_session):
+    """Pre-chart-archive main: no `paper_trade.chart_id` -> text-only path."""
+    from rainier.paper.reflection import generate_reflections
+
+    _mk_trade(pg_legacy_session, symbol="AAA")
+    stub = _StubLLM()
+    stats = generate_reflections(AS_OF, model="test-model", llm_fn=stub)
+    assert stats["written"] == 1
+    assert stub.calls[0]["image_bytes"] is None
+
+
+def test_chart_column_present_attaches_image(pg_legacy_engine, pg_legacy_session):
+    """Post-chart-archive schema: chart_id column + value -> image attached."""
+    from rainier.paper.reflection import generate_reflections
+
+    with pg_legacy_engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS chart_images ("
+                " id SERIAL PRIMARY KEY, image_bytes BYTEA)"
+            )
+        )
+        conn.execute(
+            text("ALTER TABLE paper_trade ADD COLUMN IF NOT EXISTS chart_id BIGINT")
+        )
+    tid = _mk_trade(pg_legacy_session, symbol="AAA")
+    chart_id = pg_legacy_session.execute(
+        text(
+            "INSERT INTO chart_images (image_bytes) VALUES (:b) RETURNING id"
+        ),
+        {"b": b"\x89PNG-fake-bytes"},
+    ).scalar()
+    pg_legacy_session.execute(
+        text("UPDATE paper_trade SET chart_id = :c WHERE id = :id"),
+        {"c": chart_id, "id": tid},
+    )
+    pg_legacy_session.commit()
+    stub = _StubLLM()
+    stats = generate_reflections(AS_OF, model="test-model", llm_fn=stub)
+    assert stats["written"] == 1
+    assert stub.calls[0]["image_bytes"] == b"\x89PNG-fake-bytes"
+
+
+def test_chart_column_present_but_null_falls_back_to_text(
+    pg_legacy_engine, pg_legacy_session
+):
+    from rainier.paper.reflection import generate_reflections
+
+    with pg_legacy_engine.begin() as conn:
+        conn.execute(
+            text("ALTER TABLE paper_trade ADD COLUMN IF NOT EXISTS chart_id BIGINT")
+        )
+    _mk_trade(pg_legacy_session, symbol="AAA")
+    stub = _StubLLM()
+    stats = generate_reflections(AS_OF, model="test-model", llm_fn=stub)
+    assert stats["written"] == 1
+    assert stub.calls[0]["image_bytes"] is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Prompt injection — last K, strictly-before, bounded, labeled
+# ---------------------------------------------------------------------------
+
+
+def test_load_recent_reflections_last_k_strictly_before(pg_legacy_session):
+    from rainier.paper.reflection import load_recent_reflections
+
+    # 12 reflected closed trades on consecutive days + 1 exiting ON as_of.
+    base = AS_OF - timedelta(days=20)
+    for i in range(12):
+        _mk_trade(
+            pg_legacy_session,
+            symbol=f"S{i:02d}",
+            exit_date=base + timedelta(days=i),
+            reflection=f"reflection {i}",
+        )
+    _mk_trade(
+        pg_legacy_session,
+        symbol="TODAY",
+        exit_date=AS_OF,
+        reflection="same-day reflection must NOT leak into a day-D scan",
+    )
+    rows = load_recent_reflections(AS_OF, k=10)
+    assert len(rows) == 10
+    symbols = [r["symbol"] for r in rows]
+    assert "TODAY" not in symbols          # strictly-before discipline
+    assert symbols[0] == "S11"             # most recent first
+    assert "S00" not in symbols            # only the last K survive
+    assert "S01" not in symbols
+
+
+def test_load_recent_reflections_skips_null_reflections(pg_legacy_session):
+    from rainier.paper.reflection import load_recent_reflections
+
+    _mk_trade(pg_legacy_session, symbol="NULLR", reflection=None)
+    assert load_recent_reflections(AS_OF, k=10) == []
+
+
+def test_render_reflections_section_labeled_and_bounded():
+    from rainier.paper.reflection import (
+        REFLECTION_RENDER_CHARS,
+        render_reflections_section,
+    )
+
+    rows = [
+        {
+            "symbol": "AAA",
+            "exit_date": "2026-06-05",
+            "exit_reason": "target",
+            "return_pct": 0.08,
+            "reflection": "y" * (REFLECTION_RENDER_CHARS + 200),
+        },
+        {
+            "symbol": "BBB",
+            "exit_date": "2026-06-04",
+            "exit_reason": "stop_loss",
+            "return_pct": -0.05,
+            "reflection": "Stop hit fast; breakout was a fakeout.",
+        },
+    ]
+    section = render_reflections_section(rows)
+    assert "Recent trade reflections" in section  # labeled
+    assert "AAA" in section and "BBB" in section
+    # Each reflection line is truncated to the render bound.
+    for line in section.splitlines():
+        assert len(line) <= REFLECTION_RENDER_CHARS + 80  # facts prefix slack
+
+
+def test_render_reflections_section_empty_is_blank():
+    from rainier.paper.reflection import render_reflections_section
+
+    assert render_reflections_section([]) == ""
+
+
+def test_reflection_prompt_section_appended_in_generate_thesis_path():
+    """The service appends the reflections block to the calibration section."""
+    import inspect as _inspect
+
+    from rainier.llm_thesis import service as thesis_service
+
+    src = _inspect.getsource(thesis_service.generate_thesis)
+    assert "reflection" in src  # R-A wired into the thesis prompt build
+
+
+# ---------------------------------------------------------------------------
+# 3. Cache correctness — prompt_version bumped in lockstep; input_hash inert
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_version_bumped_for_reflections():
+    from rainier.llm_thesis.prompt import PROMPT_VERSION
+
+    # v2 was the calibration block; R-A's reflections block changes the prompt
+    # again, so the Tier-1 key must move past v2.
+    assert PROMPT_VERSION not in ("v1", "v2")
+
+
+def test_prompt_version_yaml_tracks_module():
+    import yaml
+
+    from rainier.llm_thesis.prompt import PROMPT_VERSION
+
+    cfg = yaml.safe_load((REPO_ROOT / "config" / "settings.yaml").read_text())
+    assert cfg["llm_thesis"]["prompt_version"] == PROMPT_VERSION
+
+
+def test_prompt_version_config_default_tracks_module():
+    from rainier.core.config import LLMThesisConfig
+    from rainier.llm_thesis.prompt import PROMPT_VERSION
+
+    assert LLMThesisConfig().prompt_version == PROMPT_VERSION
+
+
+def test_input_hash_unaffected_by_reflections_text():
+    from rainier.llm_thesis.schemas import EvidencePack, compute_input_hash
+
+    pack = EvidencePack(
+        symbol="AAA",
+        scan_date="2026-06-08",
+        session_name="close",
+        candidate={"rank": 5},
+        signals={},
+    )
+    # The reflections block lives in prompt text, never in the pack — identical
+    # packs hash identically regardless of any reflections rendered.
+    assert compute_input_hash(pack, b"img") == compute_input_hash(pack, b"img")
+    assert "reflection" not in pack.model_dump()

--- a/tests/test_paper/test_reflections.py
+++ b/tests/test_paper/test_reflections.py
@@ -357,9 +357,112 @@ def test_generation_truncates_overlong_reply(pg_legacy_session):
     assert len(got) <= REFLECTION_MAX_CHARS
 
 
+def test_generation_continues_batch_after_one_failure(pg_legacy_session):
+    """Per-trade isolation: one failing LLM call never blocks the batch."""
+    from rainier.paper.reflection import generate_reflections
+
+    _mk_trade(pg_legacy_session, symbol="BAD", exit_date=AS_OF - timedelta(days=2))
+    ok_tid = _mk_trade(pg_legacy_session, symbol="GOOD", exit_date=AS_OF)
+
+    class _FailFirst(_StubLLM):
+        def __call__(self, **kw):
+            super().__call__(**kw)
+            if len(self.calls) == 1:
+                raise RuntimeError("llm unavailable")
+            return self.reply
+
+    stub = _FailFirst(reply="second trade reflected fine")
+    stats = generate_reflections(AS_OF, model="test-model", llm_fn=stub)
+    assert stats == {"candidates": 2, "written": 1, "failed": 1, "deferred": 0}
+    got = pg_legacy_session.execute(
+        text("SELECT reflection FROM paper_trade WHERE id = :id"), {"id": ok_tid}
+    ).scalar()
+    assert got == "second trade reflected fine"
+
+
+def test_generation_empty_reply_counts_failed(pg_legacy_session):
+    """Whitespace-only LLM reply -> failed, reflection stays NULL (no
+    placeholder write that would block the natural retry)."""
+    from rainier.paper.reflection import generate_reflections
+
+    tid = _mk_trade(pg_legacy_session, symbol="AAA")
+    stub = _StubLLM(reply="   ")
+    stats = generate_reflections(AS_OF, model="test-model", llm_fn=stub)
+    assert stats["written"] == 0
+    assert stats["failed"] == 1
+    got = pg_legacy_session.execute(
+        text("SELECT reflection FROM paper_trade WHERE id = :id"), {"id": tid}
+    ).scalar()
+    assert got is None
+
+
+def test_generation_selects_at_lookback_boundary(pg_legacy_session):
+    """exit_date == as_of - LOOKBACK days is inside the window (inclusive)."""
+    from rainier.paper.reflection import (
+        REFLECTION_LOOKBACK_DAYS,
+        generate_reflections,
+    )
+
+    _mk_trade(
+        pg_legacy_session,
+        symbol="EDG",
+        exit_date=AS_OF - timedelta(days=REFLECTION_LOOKBACK_DAYS),
+    )
+    stub = _StubLLM()
+    stats = generate_reflections(AS_OF, model="test-model", llm_fn=stub)
+    assert stats["written"] == 1
+    assert "EDG" in stub.calls[0]["user_prompt"]
+
+
+def test_generation_bumps_updated_at(pg_legacy_session):
+    """Raw-SQL reflection write must advance updated_at (the ORM onupdate
+    does not fire for raw UPDATEs; change-detection consumers read it)."""
+    from rainier.paper.reflection import generate_reflections
+
+    tid = _mk_trade(pg_legacy_session, symbol="AAA")
+    pg_legacy_session.execute(
+        text(
+            "UPDATE paper_trade SET updated_at = NOW() - interval '1 day' "
+            "WHERE id = :id"
+        ),
+        {"id": tid},
+    )
+    pg_legacy_session.commit()
+    before = pg_legacy_session.execute(
+        text("SELECT updated_at FROM paper_trade WHERE id = :id"), {"id": tid}
+    ).scalar()
+    generate_reflections(AS_OF, model="test-model", llm_fn=_StubLLM())
+    after = pg_legacy_session.execute(
+        text("SELECT updated_at FROM paper_trade WHERE id = :id"), {"id": tid}
+    ).scalar()
+    assert after > before
+
+
 # ---------------------------------------------------------------------------
 # 2. Generation — feature-detected chart attachment
 # ---------------------------------------------------------------------------
+
+
+def test_chart_probe_degrades_to_false_on_error():
+    """The pg_attribute probe swallows any failure -> False (text-only path)."""
+    from unittest.mock import Mock
+
+    from rainier.paper.reflection import _chart_id_column_exists
+
+    broken = Mock()
+    broken.execute.side_effect = RuntimeError("no pg_attribute here")
+    assert _chart_id_column_exists(broken) is False
+
+
+def test_chart_fetch_degrades_to_none_on_error():
+    """A failing chart fetch returns None (text-only), never raises."""
+    from unittest.mock import Mock
+
+    from rainier.paper.reflection import _load_chart_bytes
+
+    broken = Mock()
+    broken.execute.side_effect = RuntimeError("chart_images missing")
+    assert _load_chart_bytes(broken, 1, has_chart_col=True) is None
 
 
 def test_chart_column_absent_text_only_no_crash(pg_legacy_session):
@@ -496,32 +599,16 @@ def test_render_reflections_section_empty_is_blank():
     assert render_reflections_section([]) == ""
 
 
-@pytest.mark.asyncio
-async def test_reflections_block_lands_in_thesis_user_prompt(monkeypatch):
-    """generate_thesis appends the reflections block to the LLM user prompt."""
+async def _run_thesis_capture(monkeypatch) -> tuple:
+    """Drive generate_thesis with stubbed LLM/cache/persist; return
+    (thesis, captured_user_prompt). Calibration/reflection loaders are
+    monkeypatched by the caller BEFORE calling this."""
     import json
     from unittest.mock import patch
 
     from rainier.core.config import LLMThesisConfig, Settings
     from rainier.llm_thesis.schemas import EvidencePack
     from rainier.llm_thesis.service import generate_thesis
-
-    monkeypatch.setattr(
-        "rainier.paper.calibration.load_latest_calibration",
-        lambda *a, **k: None,
-    )
-    monkeypatch.setattr(
-        "rainier.paper.reflection.load_recent_reflections",
-        lambda *a, **k: [
-            {
-                "symbol": "RFL",
-                "exit_date": "2026-06-05",
-                "exit_reason": "target",
-                "return_pct": 0.08,
-                "reflection": "Breakout ran straight to target; thesis held.",
-            }
-        ],
-    )
 
     valid = json.dumps(
         {
@@ -569,10 +656,79 @@ async def test_reflections_block_lands_in_thesis_user_prompt(monkeypatch):
             settings=settings,
             max_usd_remaining=1.0,
         )
+    return thesis, captured["user_prompt"]
+
+
+_RFL_ROW = {
+    "symbol": "RFL",
+    "exit_date": "2026-06-05",
+    "exit_reason": "target",
+    "return_pct": 0.08,
+    "reflection": "Breakout ran straight to target; thesis held.",
+}
+
+
+@pytest.mark.asyncio
+async def test_reflections_block_lands_in_thesis_user_prompt(monkeypatch):
+    """generate_thesis appends the reflections block to the LLM user prompt."""
+    monkeypatch.setattr(
+        "rainier.paper.calibration.load_latest_calibration",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "rainier.paper.reflection.load_recent_reflections",
+        lambda *a, **k: [_RFL_ROW],
+    )
+    thesis, user_prompt = await _run_thesis_capture(monkeypatch)
     assert thesis is not None
-    assert "Recent trade reflections" in captured["user_prompt"]
-    assert "RFL" in captured["user_prompt"]
-    assert "thesis held" in captured["user_prompt"]
+    assert "Recent trade reflections" in user_prompt
+    assert "RFL" in user_prompt
+    assert "thesis held" in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_thesis_survives_reflections_load_failure(monkeypatch):
+    """Best-effort isolation: a raising reflections loader costs the block,
+    never the thesis (the daily scan must not crash on a reflections bug)."""
+
+    def _boom(*a, **k):
+        raise RuntimeError("reflections DB unavailable")
+
+    monkeypatch.setattr(
+        "rainier.paper.calibration.load_latest_calibration",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "rainier.paper.reflection.load_recent_reflections", _boom
+    )
+    thesis, user_prompt = await _run_thesis_capture(monkeypatch)
+    assert thesis is not None
+    assert "Recent trade reflections" not in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_reflections_appended_after_calibration_block(monkeypatch):
+    """With both blocks present, calibration text survives and the
+    reflections block is appended after it (the join branch)."""
+    monkeypatch.setattr(
+        "rainier.paper.calibration.load_latest_calibration",
+        lambda *a, **k: object(),
+    )
+    monkeypatch.setattr(
+        "rainier.paper.calibration.render_calibration_section",
+        lambda *a, **k: "CALIB-BLOCK-SENTINEL",
+    )
+    monkeypatch.setattr(
+        "rainier.paper.reflection.load_recent_reflections",
+        lambda *a, **k: [_RFL_ROW],
+    )
+    thesis, user_prompt = await _run_thesis_capture(monkeypatch)
+    assert thesis is not None
+    assert "CALIB-BLOCK-SENTINEL" in user_prompt
+    assert "Recent trade reflections" in user_prompt
+    assert user_prompt.index("CALIB-BLOCK-SENTINEL") < user_prompt.index(
+        "Recent trade reflections"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -605,6 +761,8 @@ def test_prompt_version_config_default_tracks_module():
 
 
 def test_input_hash_unaffected_by_reflections_text():
+    import inspect
+
     from rainier.llm_thesis.schemas import EvidencePack, compute_input_hash
 
     pack = EvidencePack(
@@ -614,7 +772,11 @@ def test_input_hash_unaffected_by_reflections_text():
         candidate={"rank": 5},
         signals={},
     )
-    # The reflections block lives in prompt text, never in the pack — identical
-    # packs hash identically regardless of any reflections rendered.
-    assert compute_input_hash(pack, b"img") == compute_input_hash(pack, b"img")
+    # Structural guarantee: the Tier-2 hash is computed from the EvidencePack +
+    # image bytes ONLY — prompt text (calibration/reflections blocks) cannot
+    # enter it because the function takes no prompt-text parameter and the pack
+    # carries no reflection field. (PROMPT_VERSION busts Tier-1 instead.)
+    params = list(inspect.signature(compute_input_hash).parameters)
+    assert params == ["pack", "image_bytes"]
     assert "reflection" not in pack.model_dump()
+    assert compute_input_hash(pack, b"img") == compute_input_hash(pack, b"img")

--- a/tests/test_paper/test_reflections.py
+++ b/tests/test_paper/test_reflections.py
@@ -310,6 +310,37 @@ def test_generation_selection_bounds(pg_legacy_session):
     assert "NOW" in stub.calls[0]["user_prompt"]
 
 
+def test_generation_caps_llm_calls_per_run(pg_legacy_session):
+    """Spend bound: a cold-start backlog drains max_per_run per night,
+    oldest exit first; the deferred remainder is re-selected next run."""
+    from rainier.paper.reflection import generate_reflections
+
+    for i in range(3):
+        _mk_trade(
+            pg_legacy_session,
+            symbol=f"C{i:02d}",
+            exit_date=AS_OF - timedelta(days=5 - i),  # C00 oldest
+        )
+    stub = _StubLLM()
+    stats = generate_reflections(
+        AS_OF, model="test-model", llm_fn=stub, max_per_run=2
+    )
+    assert stats["written"] == 2
+    assert stats["deferred"] == 1
+    assert len(stub.calls) == 2  # the cap bounds LLM spend
+    prompts = "\n".join(c["user_prompt"] for c in stub.calls)
+    assert "C00" in prompts and "C01" in prompts  # oldest-first drain
+    assert "C02" not in prompts
+    # Next run picks up the deferred trade — nothing is lost.
+    stub2 = _StubLLM()
+    stats2 = generate_reflections(
+        AS_OF, model="test-model", llm_fn=stub2, max_per_run=2
+    )
+    assert stats2["written"] == 1
+    assert stats2["deferred"] == 0
+    assert "C02" in stub2.calls[0]["user_prompt"]
+
+
 def test_generation_truncates_overlong_reply(pg_legacy_session):
     from rainier.paper.reflection import (
         REFLECTION_MAX_CHARS,


### PR DESCRIPTION
## Summary
- R-A per-trade post-exit reflections per `docs/TASK-PLAN-qu100-ra-reflections-587f.md`: schema CHECK embargo on `PaperTrade.reflection` (migrations/0008 + downgrade), daily reflection generation in `paper/reflection.py`, last-K (K=10, strictly-before) reflection injection into the thesis prompt (v3 lockstep).
- Text-only path; chart attachment is feature-detected (`pg_attribute` probe) since the chart-archive branch is unmerged.
- Hardening from review: reflections respect the `llm_thesis.enabled` kill switch; per-run LLM call cap (`REFLECTION_MAX_PER_RUN=25`) + `max_tokens=300`/`timeout=120` bound nightly spend.

## MIGRATION NOTE (read before merge/deploy)
**This PR adds `migrations/0008_paper_reflection.sql`. Open PR #138 adds `migrations/0008_paper_skip_zero_share.sql`. Whichever merges SECOND must renumber its migration to 0009 at rebase — including the path constants in `tests/test_paper/conftest.py` and `tests/test_paper/test_reflections.py`. Do not renumber preemptively.**

**Deploy:** apply migration 0008 to `$LEGACY_DATABASE_URL` before/with deploy (new ORM column on `PaperTrade`).

## Review
- /review: passed (claude rounds: 3 — r1 found P1 kill-switch bypass + uncapped spend, fixed in cefba1e; r2 + r3 clean)
- codex review: passed (codex rounds: 2 — zero P0/P1 both runs)

## Deferred findings
- [P2] codex r1: data-only boundary framing for re-injected reflection text in `render_reflections_section`
- [P2] codex r2: defensive `session.rollback()` in `_load_chart_bytes` except — claim empirically disproven on SQLAlchemy 2.0.48/psycopg (commit after swallowed execute error exits cleanly); bounded impact (trade retried next run)
- [P3] rowcount captured after session close (works on psycopg)
- [P3] `reflections_generated` log `candidates=` is post-cap count
- [P3] K=10 block has no age bound (matches design)
- [P3] repo-wide: CI pg-lane all-skips (`RAINIER_TEST_DATABASE_URL` unset in ci.yml + migration glob applies `*_downgrade.sql`) — pre-existing on main; recommend filing an issue

## Test plan
- [x] 25 worker tests + 13 review tests green (reflections 33 + wiring 5 + llm_thesis suites = 251 passed)
- [x] Full suite failure set identical to origin/main baseline (pre-existing environmental failures only)
- [x] ruff clean
- [ ] CI green