### PR TITLE
feat: R-C market-regime tag on weekly paper lessons

### DIFF
--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -1205,6 +1205,51 @@ def discover_time_stop(
 
 PAPER_LESSONS_SUBJECT = "paper_pnl"
 
+# R-C — coarse market-regime tag stamped on each weekly lesson, so a lesson
+# learned in one regime isn't blindly applied in another. SPY close vs its
+# 200-day SMA on the lesson's as-of date: strictly above → bull, else bear;
+# fewer than 200 usable bars → unknown (NEVER a partial-window SMA).
+REGIME_SYMBOL = "SPY"
+REGIME_SMA_WINDOW = 200
+REGIMES: tuple[str, ...] = ("bull", "bear", "unknown")
+
+
+def compute_market_regime(*, as_of: date) -> str:
+    """Classify the market regime on ``as_of``: SPY close vs its 200-day SMA.
+
+    Reads the last ``REGIME_SMA_WINDOW`` usable SPY closes at-or-before
+    ``as_of`` from `stock_prices` (legacy engine — same store the paper
+    ingest writes). Returns:
+
+    * ``"bull"``    — latest close strictly above the 200-bar SMA
+    * ``"bear"``    — latest close at-or-below the 200-bar SMA
+    * ``"unknown"`` — fewer than 200 usable bars (no partial-window SMA;
+      `ensure_spy_history` backfills coverage so this is transient)
+    """
+    from rainier.core.models import StockPrice
+
+    # Bars are stored at the canonical 00:00 UTC instant of their trading
+    # date (paper.ingest.canonical_instant), so <= this instant includes the
+    # as-of bar and excludes anything after it.
+    instant = datetime(as_of.year, as_of.month, as_of.day, tzinfo=timezone.utc)
+    with get_session() as session:
+        closes = session.execute(
+            select(StockPrice.close)
+            .where(
+                StockPrice.symbol == REGIME_SYMBOL,
+                StockPrice.date <= instant,
+                StockPrice.close.isnot(None),
+            )
+            .order_by(StockPrice.date.desc())
+            .limit(REGIME_SMA_WINDOW)
+        ).scalars().all()
+
+    if len(closes) < REGIME_SMA_WINDOW:
+        return "unknown"
+    latest = float(closes[0])  # newest first (date desc)
+    sma = sum(float(c) for c in closes) / len(closes)
+    return "bull" if latest > sma else "bear"
+
 
 def check_paper_lessons(
     *,
@@ -1217,7 +1262,9 @@ def check_paper_lessons(
 
     Summarizes realized win-rate, exit-reason mix, and the best/worst closed
     trade so the operator (and later the prompt) can see what the paper book
-    actually did. No weight-tuning here (that is D7b, deferred)."""
+    actually did. Stamped with the coarse market-regime tag (R-C: SPY vs
+    200-day SMA → bull/bear/unknown) in both the evidence payload and the
+    rendered rationale. No weight-tuning here (that is D7b, deferred)."""
     from rainier.core.models import PaperTrade
 
     anchor = eval_date if eval_date is not None else date.today()
@@ -1256,7 +1303,13 @@ def check_paper_lessons(
     best = max(rows, key=lambda r: r["return_pct"])
     worst = min(rows, key=lambda r: r["return_pct"])
 
+    # R-C: stamp the lesson with the market regime on its as-of date so the
+    # operator can weigh cross-regime advice. Degrades to "unknown" when SPY
+    # coverage is short — never blocks the lesson itself.
+    regime = compute_market_regime(as_of=anchor)
+
     evidence = {
+        "regime": regime,
         "days": days,
         "n_closed": n,
         "win_rate": wins / n,
@@ -1267,6 +1320,7 @@ def check_paper_lessons(
     }
     mix_str = ", ".join(f"{kk}:{vv}" for kk, vv in sorted(reason_mix.items()))
     rationale = (
+        f"[regime: {regime}] "
         f"Paper book closed {n} trades over {days}d: win-rate {wins / n:.0%}, "
         f"realized ${total_pnl:,.2f}. Exit mix [{mix_str}]. "
         f"Best {best['symbol']} {best['return_pct']:+.2%}; "

--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -1211,7 +1211,6 @@ PAPER_LESSONS_SUBJECT = "paper_pnl"
 # fewer than 200 usable bars → unknown (NEVER a partial-window SMA).
 REGIME_SYMBOL = "SPY"
 REGIME_SMA_WINDOW = 200
-REGIMES: tuple[str, ...] = ("bull", "bear", "unknown")
 
 
 def compute_market_regime(*, as_of: date) -> str:

--- a/src/rainier/paper/ingest.py
+++ b/src/rainier/paper/ingest.py
@@ -215,6 +215,66 @@ def ingest_prices(
 
 
 # ---------------------------------------------------------------------------
+# R-C — SPY ensure-history (regime 200-SMA coverage)
+# ---------------------------------------------------------------------------
+
+# The regime tag (llm_thesis.research.compute_market_regime) needs 200 usable
+# SPY closes; the default 10-day ingest window can never build that, so a
+# one-time deeper backfill is required. 250 sessions ≈ one trading year —
+# comfortably past the 200-bar SMA window.
+REGIME_MIN_BARS = 200
+REGIME_BACKFILL_WINDOW_DAYS = 250
+
+
+def ensure_spy_history(
+    *,
+    as_of: date,
+    fetch_fn: FetchFn,
+    min_bars: int = REGIME_MIN_BARS,
+    window_days: int = REGIME_BACKFILL_WINDOW_DAYS,
+    calendar: TradingCalendar | None = None,
+) -> dict[str, Any]:
+    """One-time SPY history backfill so the regime 200-SMA can be computed.
+
+    Counts usable SPY closes at-or-before ``as_of``; with ``min_bars`` or more
+    this is a pure no-op (no fetch). Below that, runs the standard gap-aware
+    ``ingest_prices`` over a ``window_days``-session window (≥ 250 — the
+    default 10-day daily window can never feed a 200-SMA). After the one-time
+    backfill, the daily paper ingest (which includes SPY) keeps it fresh.
+
+    Returns ``{"upserted": n, "backfilled": bool}``.
+    """
+    instant = canonical_instant(as_of)
+    with get_session() as session:
+        n_bars = session.execute(
+            select(func.count())
+            .select_from(StockPrice)
+            .where(
+                StockPrice.symbol == "SPY",
+                StockPrice.date <= instant,
+                StockPrice.close.isnot(None),
+            )
+        ).scalar_one()
+
+    if n_bars >= min_bars:
+        log.info("spy_history_ok bars=%d", n_bars)
+        return {"upserted": 0, "backfilled": False}
+
+    log.info(
+        "spy_history_backfill bars=%d min_bars=%d window_days=%d",
+        n_bars, min_bars, window_days,
+    )
+    res = ingest_prices(
+        ["SPY"],
+        as_of=as_of,
+        fetch_fn=fetch_fn,
+        window_days=window_days,
+        calendar=calendar,
+    )
+    return {"upserted": res["upserted"], "backfilled": True}
+
+
+# ---------------------------------------------------------------------------
 # Universe selectors
 # ---------------------------------------------------------------------------
 

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -238,27 +238,32 @@ async def run_daily_eval(eval_date_iso: str | None = None) -> None:
 
 
 def run_paper_daily_steps(eval_date) -> None:
-    """Paper steps (i)-(iii): ingest (active ∪ screened) → fill → update.
+    """Paper steps (i)-(iii): ingest (SPY ∪ active ∪ screened) → fill → update.
 
     Ingest MUST precede fill/update or a pending's T+1 open would be absent
     (G2). Each step is its own DB-driven, idempotent operation.
     """
-    from rainier.paper.ingest import (
-        _yfinance_fetch_fn,
-        active_symbols,
-        ingest_prices,
-        screened_symbols,
-    )
-    from rainier.paper.positions import fill_pending_positions, update_open_positions
+    from rainier.paper import ingest as paper_ingest
+    from rainier.paper import positions as paper_positions
 
     settings = load_settings_fresh()
     learned_ts = settings.llm_thesis.learned_time_stop_days
 
-    symbols = sorted(set(active_symbols()) | set(screened_symbols(eval_date)))
-    if symbols:
-        ingest_prices(symbols, as_of=eval_date, fetch_fn=_yfinance_fetch_fn)
-    fill_pending_positions(as_of=eval_date, learned_time_stop_days=learned_ts)
-    update_open_positions(as_of=eval_date)
+    # SPY is always in the daily window: it feeds the market-regime tag on
+    # weekly lessons (R-C). `ensure_spy_history` (research job) does the
+    # one-time deep backfill; this daily 10-day window keeps it fresh.
+    symbols = sorted(
+        {"SPY"}
+        | set(paper_ingest.active_symbols())
+        | set(paper_ingest.screened_symbols(eval_date))
+    )
+    paper_ingest.ingest_prices(
+        symbols, as_of=eval_date, fetch_fn=paper_ingest._yfinance_fetch_fn
+    )
+    paper_positions.fill_pending_positions(
+        as_of=eval_date, learned_time_stop_days=learned_ts
+    )
+    paper_positions.update_open_positions(as_of=eval_date)
 
 
 def run_paper_daily_report(eval_date, discord_config) -> None:
@@ -323,6 +328,21 @@ async def run_research_job(eval_date_iso: str | None = None) -> None:
     )
 
     log.info("research_job_starting", eval_date=eval_date.isoformat())
+
+    # R-C: the lessons regime tag needs ≥200 usable SPY closes. Ensure the
+    # one-time deep backfill ran BEFORE the checks compute the regime — a pure
+    # no-op once coverage exists (the daily ingest keeps SPY fresh). Non-fatal:
+    # on failure the lesson degrades to regime=unknown, never crashes the job.
+    try:
+        from rainier.paper import ingest as paper_ingest
+
+        await asyncio.to_thread(
+            lambda: paper_ingest.ensure_spy_history(
+                as_of=eval_date, fetch_fn=paper_ingest._yfinance_fetch_fn
+            )
+        )
+    except Exception as exc:
+        log.error("research_spy_ensure_failed", error=str(exc))
 
     try:
         stale_count = await asyncio.to_thread(mark_stale, 30)

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -311,9 +311,11 @@ async def run_research_job(eval_date_iso: str | None = None) -> None:
     Discord research-report.
 
     Triggered Friday 09:00 PT. The job:
-      1. mark_stale() — flips pending insights >30 days old to status=stale.
-      2. run_research(eval_date=today, days=30) — runs all 6 check classes.
-      3. send_research_report() — posts a Discord summary of pending
+      1. ensure_spy_history() — one-time SPY backfill so the lessons regime
+         tag (R-C) has 200-SMA coverage; no-op once covered, non-fatal.
+      2. mark_stale() — flips pending insights >30 days old to status=stale.
+      3. run_research(eval_date=today, days=30) — runs all 6 check classes.
+      4. send_research_report() — posts a Discord summary of pending
          warn/critical insights.
 
     eval_date_iso lets CLI / replay callers override "today".

--- a/tests/test_paper/conftest.py
+++ b/tests/test_paper/conftest.py
@@ -35,6 +35,11 @@ MIGRATION_0008_DOWN = (
 # full-entity PaperTrade ORM reads (positions.py et al) see the column.
 MIGRATION_0009_UP = REPO_ROOT / "migrations" / "0009_paper_reflection.sql"
 MIGRATION_0009_DOWN = REPO_ROOT / "migrations" / "0009_paper_reflection_downgrade.sql"
+# research_insights (0003, self-contained + idempotent) — the lessons tests
+# (check_paper_lessons → emit_insight) round-trip ResearchInsight rows. Without
+# this the tests only pass when a prior suite left the table in `public`
+# (search_path fallback) — an order-dependent pass on a fresh test DB.
+MIGRATION_0003_UP = REPO_ROOT / "migrations" / "0003_llm_thesis_pr3.sql"
 
 # Minimal DDL for the FK-target tables the paper migration references. The real
 # schema lives in migrations/0001-0004; for an isolated paper-tracker test DB we
@@ -261,6 +266,7 @@ def pg_legacy_engine(request):
     _apply_sql(engine, MIGRATION_0007_UP)  # D7a paper_calibration
     _apply_sql(engine, MIGRATION_0008_UP)  # Phase 3 zero_share_price skip reason
     _apply_sql(engine, MIGRATION_0009_UP)  # R-A paper_trade.reflection
+    _apply_sql(engine, MIGRATION_0003_UP)  # research_insights (lessons tests)
 
     from rainier.core import config, database
 

--- a/tests/test_paper/test_regime_tag.py
+++ b/tests/test_paper/test_regime_tag.py
@@ -1,0 +1,291 @@
+"""R-C — coarse market-regime tag on weekly paper lessons.
+
+Regime = SPY close vs its 200-day SMA on the lesson's as-of date:
+above → `bull`, below → `bear`, <200 usable bars → `unknown` (never a
+partial-window SMA). The tag lands in the lesson insight's evidence payload
+AND its rendered rationale text. SPY history is guaranteed by a one-time
+gap-aware ensure-history backfill (window_days ≥ 250); the daily paper
+ingest keeps it fresh afterwards.
+
+Postgres lane (stock_prices + research_insights ORM round-trips).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date, timedelta
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import text
+
+from rainier.core.models import PaperTrade, StockPrice
+from rainier.paper.ingest import canonical_instant
+
+pytestmark = pytest.mark.requires_postgres
+
+AS_OF = date(2026, 3, 20)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_spy(session, closes, *, end=AS_OF):
+    """Seed one SPY bar per consecutive calendar day ending at ``end``,
+    oldest-first, with the given closes."""
+    session.execute(
+        text("INSERT INTO stocks (symbol) VALUES ('SPY') ON CONFLICT DO NOTHING")
+    )
+    n = len(closes)
+    session.add_all(
+        StockPrice(
+            symbol="SPY",
+            date=canonical_instant(end - timedelta(days=n - 1 - i)),
+            open=float(c),
+            high=float(c),
+            low=float(c),
+            close=float(c),
+            volume=1,
+        )
+        for i, c in enumerate(closes)
+    )
+    session.commit()
+
+
+def _seed_thesis(session, tid):
+    session.execute(
+        text(
+            "INSERT INTO analysis_results (id, llm_model, prompt_template) "
+            "VALUES (:i,'m','t') ON CONFLICT DO NOTHING"
+        ),
+        {"i": tid},
+    )
+
+
+def _add_closed(session, tid, symbol, *, exit_date, return_pct, pnl, reason):
+    _seed_thesis(session, tid)
+    session.add(PaperTrade(
+        thesis_id=tid, symbol=symbol, scan_date=date(2026, 3, 1),
+        session_name="close", status="closed", planned_entry_price=100.0,
+        stop_loss=90.0, target_price=120.0, entry_date=date(2026, 3, 2),
+        entry_price=100.0, shares=100, residual_cash=0.0, exit_date=exit_date,
+        exit_price=100 * (1 + return_pct), exit_reason=reason,
+        return_pct=return_pct, pnl=pnl,
+    ))
+    session.commit()
+
+
+def _mk_fetch_fn(calls):
+    """Deterministic fetch_fn: one synthetic SPY bar per calendar day in the
+    requested [start, end] range (ingest keeps only trading sessions)."""
+
+    def fetch(symbols, start, end):
+        calls.append((tuple(symbols), start, end))
+        bars = []
+        d, i = start, 0
+        while d <= end:
+            px = 100.0 + i * 0.1
+            bars.append({
+                "date": d, "open": px, "high": px, "low": px,
+                "close": px, "volume": 1000,
+            })
+            d += timedelta(days=1)
+            i += 1
+        return {"SPY": bars}
+
+    return fetch
+
+
+# ---------------------------------------------------------------------------
+# compute_market_regime — SPY close vs 200-day SMA
+# ---------------------------------------------------------------------------
+
+
+def test_regime_bull_close_above_sma(pg_legacy_session):
+    from rainier.llm_thesis.research import compute_market_regime
+
+    # Rising closes 100..299: latest 299 > SMA(200) = 199.5 → bull.
+    _seed_spy(pg_legacy_session, range(100, 300))
+    assert compute_market_regime(as_of=AS_OF) == "bull"
+
+
+def test_regime_bear_close_below_sma(pg_legacy_session):
+    from rainier.llm_thesis.research import compute_market_regime
+
+    # Falling closes 300..101: latest 101 < SMA(200) = 200.5 → bear.
+    _seed_spy(pg_legacy_session, range(300, 100, -1))
+    assert compute_market_regime(as_of=AS_OF) == "bear"
+
+
+def test_regime_unknown_under_200_bars(pg_legacy_session):
+    from rainier.llm_thesis.research import compute_market_regime
+
+    # 199 bars: NEVER a partial-window SMA — unknown.
+    _seed_spy(pg_legacy_session, range(100, 299))
+    assert compute_market_regime(as_of=AS_OF) == "unknown"
+
+
+def test_regime_unknown_no_spy_rows(pg_legacy_session):
+    from rainier.llm_thesis.research import compute_market_regime
+
+    assert compute_market_regime(as_of=AS_OF) == "unknown"
+
+
+def test_regime_ignores_bars_after_as_of(pg_legacy_session):
+    from rainier.llm_thesis.research import compute_market_regime
+
+    # Bull series ending AS_OF, plus a post-as-of crash bar that must NOT
+    # contaminate the as-of regime.
+    _seed_spy(pg_legacy_session, range(100, 300))
+    _seed_spy(pg_legacy_session, [1.0], end=AS_OF + timedelta(days=5))
+    assert compute_market_regime(as_of=AS_OF) == "bull"
+
+
+# ---------------------------------------------------------------------------
+# lesson insight carries the tag (payload + rendered text)
+# ---------------------------------------------------------------------------
+
+
+def test_lesson_carries_regime_tag(pg_legacy_session):
+    from rainier.llm_thesis.research import check_paper_lessons
+
+    _seed_spy(pg_legacy_session, range(100, 300))
+    _add_closed(pg_legacy_session, 1, "WIN", exit_date=date(2026, 3, 10),
+                return_pct=0.10, pnl=1000.0, reason="target")
+
+    out = check_paper_lessons(eval_date=AS_OF, days=30)
+    assert len(out) == 1
+    ins = out[0]
+    assert ins.evidence["regime"] == "bull"
+    assert "[regime: bull]" in ins.rationale
+
+
+def test_lesson_regime_unknown_without_spy_history(pg_legacy_session):
+    """Missing SPY rows → tag degrades to `unknown`, never a crash."""
+    from rainier.llm_thesis.research import check_paper_lessons
+
+    _add_closed(pg_legacy_session, 1, "LOS", exit_date=date(2026, 3, 12),
+                return_pct=-0.05, pnl=-500.0, reason="stop_loss")
+
+    out = check_paper_lessons(eval_date=AS_OF, days=30)
+    assert len(out) == 1
+    ins = out[0]
+    assert ins.evidence["regime"] == "unknown"
+    assert "[regime: unknown]" in ins.rationale
+
+
+# ---------------------------------------------------------------------------
+# ensure_spy_history — one-time ≥250-session backfill, then no-op
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_spy_history_backfills_then_noop(pg_legacy_session):
+    from sqlalchemy import func, select
+
+    from rainier.paper.ingest import ensure_spy_history
+
+    calls: list = []
+    fetch_fn = _mk_fetch_fn(calls)
+
+    res = ensure_spy_history(as_of=AS_OF, fetch_fn=fetch_fn)
+    assert res["backfilled"] is True
+    assert len(calls) == 1
+    # The backfill window must feed a 200-SMA: ≥ 250 trading sessions.
+    symbols, start, end = calls[0]
+    assert symbols == ("SPY",)
+    n_rows = pg_legacy_session.execute(
+        select(func.count()).select_from(StockPrice).where(
+            StockPrice.symbol == "SPY",
+            StockPrice.date <= canonical_instant(AS_OF),
+        )
+    ).scalar_one()
+    assert n_rows >= 250
+
+    # Coverage now satisfied → second call is a pure no-op (no fetch).
+    res2 = ensure_spy_history(as_of=AS_OF, fetch_fn=fetch_fn)
+    assert res2["backfilled"] is False
+    assert res2["upserted"] == 0
+    assert len(calls) == 1
+
+
+def test_ensure_spy_history_noop_with_existing_coverage(pg_legacy_session):
+    from rainier.paper.ingest import ensure_spy_history
+
+    _seed_spy(pg_legacy_session, range(100, 300))  # 200 usable bars
+    calls: list = []
+    res = ensure_spy_history(as_of=AS_OF, fetch_fn=_mk_fetch_fn(calls))
+    assert res["backfilled"] is False
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# scheduler wiring — daily ingest keeps SPY fresh; research job ensures history
+# ---------------------------------------------------------------------------
+
+
+def test_daily_ingest_includes_spy(monkeypatch):
+    from rainier.paper import ingest as ingest_mod
+    from rainier.paper import positions as positions_mod
+    from rainier.scheduler import service
+
+    captured: dict = {}
+
+    monkeypatch.setattr(ingest_mod, "active_symbols", lambda: ["AAA"])
+    monkeypatch.setattr(ingest_mod, "screened_symbols", lambda as_of: ["BBB"])
+
+    def fake_ingest(symbols, *, as_of, fetch_fn, **kw):
+        captured["symbols"] = list(symbols)
+        return {"upserted": 0}
+
+    monkeypatch.setattr(ingest_mod, "ingest_prices", fake_ingest)
+    monkeypatch.setattr(
+        positions_mod, "fill_pending_positions", lambda **kw: {"filled": 0}
+    )
+    monkeypatch.setattr(
+        positions_mod, "update_open_positions", lambda **kw: {"updated": 0}
+    )
+    monkeypatch.setattr(
+        service,
+        "load_settings_fresh",
+        lambda: SimpleNamespace(
+            llm_thesis=SimpleNamespace(learned_time_stop_days=None)
+        ),
+    )
+
+    service.run_paper_daily_steps(AS_OF)
+    assert "SPY" in captured["symbols"]
+
+
+def test_research_job_ensures_spy_history_before_research(monkeypatch):
+    from rainier.alerts import discord as discord_mod
+    from rainier.llm_thesis import research as research_mod
+    from rainier.paper import ingest as ingest_mod
+    from rainier.scheduler import service
+
+    events: list[str] = []
+
+    monkeypatch.setattr(
+        ingest_mod,
+        "ensure_spy_history",
+        lambda **kw: events.append("ensure") or {"upserted": 0, "backfilled": False},
+    )
+    monkeypatch.setattr(research_mod, "mark_stale", lambda days: 0)
+    monkeypatch.setattr(
+        research_mod,
+        "run_research",
+        lambda **kw: events.append("research") or [],
+    )
+    monkeypatch.setattr(
+        discord_mod, "send_research_report", lambda **kw: events.append("report")
+    )
+    monkeypatch.setattr(
+        service,
+        "load_settings_fresh",
+        lambda: SimpleNamespace(alerts=SimpleNamespace(discord=None)),
+    )
+
+    asyncio.run(service.run_research_job(eval_date_iso=AS_OF.isoformat()))
+    # SPY coverage must be ensured BEFORE the checks compute the regime.
+    assert events == ["ensure", "research", "report"]

--- a/tests/test_paper/test_regime_tag.py
+++ b/tests/test_paper/test_regime_tag.py
@@ -119,6 +119,15 @@ def test_regime_bear_close_below_sma(pg_legacy_session):
     assert compute_market_regime(as_of=AS_OF) == "bear"
 
 
+def test_regime_boundary_close_equal_sma_is_bear(pg_legacy_session):
+    from rainier.llm_thesis.research import compute_market_regime
+
+    # Boundary: 200 identical closes → latest == SMA exactly. Bull requires
+    # close STRICTLY above the SMA, so equality classifies as bear.
+    _seed_spy(pg_legacy_session, [100.0] * 200)
+    assert compute_market_regime(as_of=AS_OF) == "bear"
+
+
 def test_regime_unknown_under_200_bars(pg_legacy_session):
     from rainier.llm_thesis.research import compute_market_regime
 
@@ -289,3 +298,36 @@ def test_research_job_ensures_spy_history_before_research(monkeypatch):
     asyncio.run(service.run_research_job(eval_date_iso=AS_OF.isoformat()))
     # SPY coverage must be ensured BEFORE the checks compute the regime.
     assert events == ["ensure", "research", "report"]
+
+
+def test_research_job_survives_spy_ensure_failure(monkeypatch):
+    """yfinance down on Friday → ensure_spy_history raises → the research job
+    logs and continues (lessons degrade to regime=unknown, never a crash)."""
+    from rainier.alerts import discord as discord_mod
+    from rainier.llm_thesis import research as research_mod
+    from rainier.paper import ingest as ingest_mod
+    from rainier.scheduler import service
+
+    events: list[str] = []
+
+    def boom(**kw):
+        raise RuntimeError("yfinance unreachable")
+
+    monkeypatch.setattr(ingest_mod, "ensure_spy_history", boom)
+    monkeypatch.setattr(research_mod, "mark_stale", lambda days: 0)
+    monkeypatch.setattr(
+        research_mod,
+        "run_research",
+        lambda **kw: events.append("research") or [],
+    )
+    monkeypatch.setattr(
+        discord_mod, "send_research_report", lambda **kw: events.append("report")
+    )
+    monkeypatch.setattr(
+        service,
+        "load_settings_fresh",
+        lambda: SimpleNamespace(alerts=SimpleNamespace(discord=None)),
+    )
+
+    asyncio.run(service.run_research_job(eval_date_iso=AS_OF.isoformat()))
+    assert events == ["research", "report"]


### PR DESCRIPTION
## Summary
- R-C market-regime tag on weekly lessons per docs/TASK-PLAN-qu100-rc-regime-tags-c6f8.md: classify SPY close vs 200-SMA as bull/bear/unknown and tag each weekly paper lesson with the regime.
- SPY ensure-history backfill (>=250 sessions) via `ensure_spy_history` in paper/ingest.py; daily SPY ingest added to the scheduler union (service.py).
- Scope guard: lessons only — no prompt changes, NO migration in this PR.

## Review
- /review: passed (claude rounds: 3) — iter-1 finding fixed in ed3296c (test-fixture run-order leak: lessons tests were order-dependent on a fresh DB; fixture now applies 0003); rounds 2+3 clean consecutively.
- codex review: passed (codex rounds: 2, 0 P0/P1, 0 fix iterations).

## Tests
- 13 worker+reviewer tests (11 worker TDD tests + boundary test close==SMA → bear + research-job ensure-failure survival test).
- Fresh-DB suites green: test_paper 139 passed; llm_thesis/scheduler/pipeline 256 passed; ruff clean.
- Full suite: zero new failures vs the documented pre-existing environmental cluster (tests/test_db_migrations.py, tests/test_db_*.py, test_neon_source.py — identical on a main-identical tree).

## Deferred [P2] (codex)
1. Intraday Friday-morning SPY bar can feed regime classification (research.py:1229) — a Friday-morning run may classify off an in-progress intraday SPY bar.
2. `ensure_spy_history` no-ops on >=200 stale bars without checking recency (ingest.py:249) — self-heals after first deploy via daily SPY ingest.

## Test plan
- [ ] CI green
- [ ] verify locally