### PR TITLE
feat(paper): R-D chart archive — renderer, supersession, capture, CLI

### DIFF
--- a/migrations/0010_chart_archive.sql
+++ b/migrations/0010_chart_archive.sql
@@ -1,0 +1,61 @@
+-- Migration 0010 — R-D chart archive (DESIGN-qu100-llm-feedback-loop, PR 2)
+--
+-- NUMBERING NOTE: 0008 is claimed by BOTH open PRs #138 (miss-sweep) and #139
+-- at the time this ships; this file takes 0010 and the final number is
+-- reconciled at merge time.
+--
+-- Adds (on the LEGACY local-TimescaleDB engine — NOT Neon, see memory
+-- project_two_database_url_engines):
+--   * chart_images.source        — 'thesis' (backfilled onto ALL existing rows,
+--                                  which are thesis-path renders) / 'trade_close'
+--                                  / 'miss_sweep'.
+--   * chart_images.as_of_date    — the archive chart's logical as-of date.
+--                                  STAYS NULL for source='thesis' forever
+--                                  (existing AND future thesis persists): thesis
+--                                  rows live OUTSIDE the logical-identity
+--                                  contract, and NULLs never collide in the
+--                                  partial unique below, so the up-to-4-renders/
+--                                  day thesis pattern is unaffected.
+--   * chart_images.superseded_by — self-FK; append-only supersession. The
+--                                  current row for a logical identity is the one
+--                                  with superseded_by IS NULL; superseded rows
+--                                  keep their bytes forever (LLM/snapshot
+--                                  references stay valid).
+--   * idx_chart_images_logical   — partial unique on (symbol, as_of_date,
+--                                  source) WHERE superseded_by IS NULL: one
+--                                  CURRENT row per logical identity. Governs
+--                                  only trade_close/miss_sweep rows (thesis rows
+--                                  carry NULL as_of_date).
+--   * paper_trade.chart_id       — FK to the trade's CURRENT close chart.
+--
+-- Apply with:
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0010_chart_archive.sql
+--
+-- Idempotent: re-applying is safe (IF NOT EXISTS throughout; the backfill
+-- only touches rows whose source is still NULL, so trade_close/miss_sweep
+-- rows written after the first apply are never clobbered).
+
+BEGIN;
+
+ALTER TABLE chart_images
+    ADD COLUMN IF NOT EXISTS source VARCHAR(20);
+
+ALTER TABLE chart_images
+    ADD COLUMN IF NOT EXISTS as_of_date DATE;
+
+ALTER TABLE chart_images
+    ADD COLUMN IF NOT EXISTS superseded_by BIGINT REFERENCES chart_images (id);
+
+-- Backfill: every pre-0010 row is a thesis-path render. as_of_date stays NULL.
+UPDATE chart_images SET source = 'thesis' WHERE source IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_chart_images_logical
+    ON chart_images (symbol, as_of_date, source)
+    WHERE superseded_by IS NULL;
+
+ALTER TABLE paper_trade
+    ADD COLUMN IF NOT EXISTS chart_id BIGINT REFERENCES chart_images (id);
+
+COMMIT;
+
+-- Downgrade lives in migrations/0010_chart_archive_downgrade.sql.

--- a/migrations/0010_chart_archive_downgrade.sql
+++ b/migrations/0010_chart_archive_downgrade.sql
@@ -1,0 +1,23 @@
+-- Migration 0010 DOWNGRADE — reverses 0010_chart_archive.sql.
+--
+-- Drops EXACTLY: chart_images.{source, as_of_date, superseded_by},
+-- idx_chart_images_logical, and paper_trade.chart_id. Chart BYTES are never
+-- touched — superseded rows simply lose the supersession pointer (they were
+-- append-only duplicates, so the pre-0010 reader semantics are restored).
+--
+-- Apply with:
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0010_chart_archive_downgrade.sql
+--
+-- Idempotent: re-applying is safe (IF EXISTS).
+
+BEGIN;
+
+ALTER TABLE paper_trade DROP COLUMN IF EXISTS chart_id;
+
+DROP INDEX IF EXISTS idx_chart_images_logical;
+
+ALTER TABLE chart_images DROP COLUMN IF EXISTS superseded_by;
+ALTER TABLE chart_images DROP COLUMN IF EXISTS as_of_date;
+ALTER TABLE chart_images DROP COLUMN IF EXISTS source;
+
+COMMIT;

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1988,6 +1988,95 @@ def paper_report(as_of_iso, week, regenerate):
     click.echo(render_payload(payload))
 
 
+@paper_group.command(name="appearances")
+@click.argument("symbol")
+@click.option(
+    "--as-of", "as_of_iso", default=None, help="As-of date (YYYY-MM-DD, default today)"
+)
+@click.option(
+    "--window",
+    default=None,
+    type=int,
+    help="Trailing trading-session window (default: chart_lookback_days config)",
+)
+@click.option(
+    "--all-sessions",
+    is_flag=True,
+    help="Every intraday top100 capture (default: one row/day, latest capture)",
+)
+@click.pass_context
+def paper_appearances(ctx, symbol, as_of_iso, window, all_sessions):
+    """Days SYMBOL was in the QU100 top-100 (and its rank each day)."""
+    from datetime import date as _date
+
+    from rainier.paper.ingest import get_qu100_appearances
+
+    symbol = symbol.strip().upper()
+    as_of = _date.fromisoformat(as_of_iso) if as_of_iso else _date.today()
+    if window is None:
+        window = ctx.obj["settings"].llm_thesis.chart_lookback_days
+
+    apps = get_qu100_appearances(
+        symbol, as_of=as_of, window=window, all_sessions=all_sessions
+    )
+    if not apps:
+        click.echo(
+            f"No QU100 top-100 appearances for {symbol} in the last "
+            f"{window} sessions ending {as_of}."
+        )
+        return
+    for a in apps:
+        line = f"{a.data_date}  #{a.rank}"
+        if all_sessions:
+            line += f"  {a.capture_session}  {a.captured_at.isoformat()}"
+        click.echo(line)
+
+
+@paper_group.command(name="chart")
+@click.argument("symbol")
+@click.option(
+    "--as-of", "as_of_iso", default=None, help="As-of date (YYYY-MM-DD, default today)"
+)
+@click.option(
+    "--window",
+    default=None,
+    type=int,
+    help="Daily-bar window (default: chart_lookback_days config)",
+)
+@click.option(
+    "--out",
+    "out_path",
+    default=None,
+    help="Output PNG path (default ./<SYMBOL>_<as-of>.png)",
+)
+@click.pass_context
+def paper_chart(ctx, symbol, as_of_iso, window, out_path):
+    """Render-on-demand archive chart (zero stored pixels, design App. C).
+
+    Rebuilds the annotated chart for SYMBOL at --as-of from stored inputs
+    (stock_prices + money_flow_snapshots + paper_trade). On unchanged data
+    this reproduces a stored trade-close chart byte-identically.
+    """
+    from datetime import date as _date
+    from pathlib import Path as _Path
+
+    from rainier.paper.chart_archive import regenerate_chart
+
+    symbol = symbol.strip().upper()
+    as_of = _date.fromisoformat(as_of_iso) if as_of_iso else _date.today()
+    if window is None:
+        window = ctx.obj["settings"].llm_thesis.chart_lookback_days
+
+    try:
+        png, sha = regenerate_chart(symbol, as_of=as_of, window=window)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    out = _Path(out_path) if out_path else _Path(f"{symbol}_{as_of}.png")
+    out.write_bytes(png)
+    click.echo(f"Wrote {out} ({len(png):,} bytes, sha256 {sha[:12]})")
+
+
 # ---------------------------------------------------------------------------
 # Feature store commands
 # ---------------------------------------------------------------------------

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -323,6 +323,10 @@ class LLMThesisConfig(BaseModel):
     # baseline until Phase 2's discover_time_stop sets a value). The mechanism
     # ships in Phase 0+1; the value stays None here.
     learned_time_stop_days: int | None = None
+    # R-D chart archive: trailing daily-bar window for archive chart renders
+    # (design Appendix C: default 120; 90 acceptable). The thesis-path 60-bar
+    # render is NOT governed by this — only the new paper/chart_archive path.
+    chart_lookback_days: int = 120
 
 
 class NotifyConfig(BaseModel):

--- a/src/rainier/core/models.py
+++ b/src/rainier/core/models.py
@@ -237,6 +237,17 @@ class ChartImage(Base):
     The partial unique index on ``(symbol, scan_date, sha256)`` (declared in
     migrations/0004_llm_thesis_pr5.sql) makes the persist path idempotent —
     two re-runs that produce identical PNG bytes collapse to one row.
+
+    R-D chart archive (migration 0010): ``source`` ('thesis' / 'trade_close' /
+    'miss_sweep'), ``as_of_date``, and ``superseded_by`` give archive rows an
+    append-only logical identity ``(symbol, as_of_date, source)``; the CURRENT
+    row is the one with ``superseded_by IS NULL`` (partial unique
+    ``idx_chart_images_logical``). Thesis rows stay OUTSIDE that contract:
+    ``as_of_date`` is NULL for ``source='thesis'`` forever (existing backfilled
+    + future persists) — NULLs never collide in the partial unique, so the
+    up-to-4-renders/day thesis pattern is unaffected. Archive rows keep
+    ``scan_date`` NULL (they live on ``as_of_date``) so a flip-flop re-render
+    can never collide with a superseded row in the 0004 partial unique.
     """
 
     __tablename__ = "chart_images"
@@ -259,6 +270,14 @@ class ChartImage(Base):
     scan_date: Mapped[date | None] = mapped_column(Date, index=True)
     width: Mapped[int | None] = mapped_column(Integer)
     height: Mapped[int | None] = mapped_column(Integer)
+    # R-D archive columns (0010). source/as_of_date are nullable because the
+    # 3-step supersession staging inserts them NULL and promotes in-transaction;
+    # thesis rows keep as_of_date NULL permanently.
+    source: Mapped[str | None] = mapped_column(String(20))
+    as_of_date: Mapped[date | None] = mapped_column(Date)
+    superseded_by: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("chart_images.id")
+    )
 
     stock: Mapped[Stock] = relationship(
         back_populates="chart_images",
@@ -277,6 +296,17 @@ class ChartImage(Base):
             "sha256",
             unique=True,
             postgresql_where="sha256 IS NOT NULL",
+        ),
+        # R-D logical identity (0010): one CURRENT archive row per
+        # (symbol, as_of_date, source). Thesis rows (as_of_date NULL) and
+        # staged rows (source NULL) never collide — NULLS DISTINCT default.
+        Index(
+            "idx_chart_images_logical",
+            "symbol",
+            "as_of_date",
+            "source",
+            unique=True,
+            postgresql_where="superseded_by IS NULL",
         ),
     )
 
@@ -655,6 +685,11 @@ class PaperTrade(Base):
     # Written once by paper/reflection.py (NULL-only update, idempotent); the
     # last K feed the thesis prompt's calibration section.
     reflection: Mapped[str | None] = mapped_column(Text)
+    # R-D chart archive (0010): the trade's CURRENT close chart. Moves to the
+    # new row on supersession; superseded charts stay readable by id forever.
+    chart_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("chart_images.id")
+    )
 
     __table_args__ = (
         UniqueConstraint("thesis_id", name="uq_paper_trade_thesis_id"),

--- a/src/rainier/llm_thesis/chart_persistence.py
+++ b/src/rainier/llm_thesis/chart_persistence.py
@@ -40,8 +40,16 @@ def persist_chart_image(
     sha256: str,
     width: int = 1280,
     height: int = 800,
+    timeframe_days: int = 120,
 ) -> int | None:
     """Insert (or reuse) a ChartImage row for this (symbol, scan_date, sha256).
+
+    R-D (migration 0010): thesis rows carry ``source='thesis'`` and KEEP
+    ``as_of_date`` NULL forever — they live outside the archive's logical
+    identity ``(symbol, as_of_date, source)`` partial unique, so the
+    up-to-4-renders/day thesis pattern never collides (NULLs are distinct).
+    ``timeframe_days`` follows the caller's actual render window (the 120
+    default is the thesis-path constant; the archive path passes its own).
 
     Returns the row id, or ``None`` on persistence failure. The SELECT before
     INSERT is a deliberate two-step on the partial unique index: Postgres'
@@ -81,7 +89,10 @@ def persist_chart_image(
                     file_size_bytes=len(image_bytes),
                     width=int(width),
                     height=int(height),
-                    timeframe_days=120,
+                    timeframe_days=int(timeframe_days),
+                    # R-D: thesis source, as_of_date stays NULL (outside the
+                    # archive logical-identity contract — see docstring).
+                    source="thesis",
                 )
                 .returning(ChartImage.id)
             )

--- a/src/rainier/paper/chart_archive.py
+++ b/src/rainier/paper/chart_archive.py
@@ -1,0 +1,460 @@
+"""R-D annotated chart archive (DESIGN-qu100-llm-feedback-loop §5/§6, App. B/C).
+
+A 120-day (config ``llm_thesis.chart_lookback_days``) daily-candle PNG for
+every closed paper trade — QU100 appearance dates marked (vertical line,
+"#rank · M/D" label) and entry/stop/target/exit overlaid — persisted
+append-only and regenerable on demand.
+
+    stock_prices ──► load_daily_bars ──┐
+                                       ├─► build_archive_figure ─► kaleido PNG
+    money_flow_snapshots ─► appearances┘        │                  + metadata
+    paper_trade (closed) ─► TradeOverlay ───────┘                  scrub
+                                                                     │
+                       persist_archive_chart (append-only supersession)
+                                                                     │
+                                   chart_images + paper_trade.chart_id
+
+DETERMINISM / CACHE CONTRACT: this module lives OUTSIDE the thesis-chart
+render path on purpose. ``CHART_RENDER_VERSION`` hashes the raw bytes of
+``llm_thesis/chart_render_version.py``, ``llm_thesis/chart_export.py``, and
+``viz/charts.py`` — this module IMPORTS from two of them (figure assembly,
+PNG metadata scrub) but never edits them, so the thesis Tier-1 cache SHA is
+untouched. The kaleido pinning + scrub it imports keep archive renders
+byte-deterministic for the same inputs, which is what makes the
+zero-stored-pixels render-on-demand policy (`regenerate_chart`) faithful.
+
+STORAGE POLICY (design Appendix C): bytes are stored ONLY for the flagged set
+(closed trades now; weekly-sweep names via the follow-up below) — everything
+else re-renders from `stock_prices` + `money_flow_snapshots`.
+
+FOLLOW-UP (one commit, after PR #138 qu100-miss-sweep merges): sweep-side
+capture — the weekly sweep calls `persist_archive_chart(...,
+source=SOURCE_MISS_SWEEP, as_of=<sweep as-of>)` for each flagged name
+(missed winners + R-B dodged losers). The renderer + persistence here already
+support ``miss_sweep`` end-to-end (tested); only the hook inside
+``paper/sweep.py`` is missing because PR #138 is unmerged at the time this
+ships — do not block on it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from datetime import date as date_cls
+
+import pandas as pd
+from sqlalchemy import select
+
+from rainier.core.database import get_session
+from rainier.core.models import ChartImage, PaperTrade, Stock, StockPrice
+from rainier.llm_thesis.chart_export import (
+    RENDER_HEIGHT,
+    RENDER_SCALE,
+    RENDER_WIDTH,
+    _strip_png_metadata,
+)
+from rainier.paper.ingest import canonical_instant, get_qu100_appearances
+from rainier.viz.charts import create_static_stock_chart
+
+log = logging.getLogger(__name__)
+
+# chart_images.source values. 'thesis' rows are written by
+# llm_thesis/chart_persistence.py and stay OUTSIDE the logical-identity
+# contract (as_of_date NULL forever).
+SOURCE_THESIS = "thesis"
+SOURCE_TRADE_CLOSE = "trade_close"
+SOURCE_MISS_SWEEP = "miss_sweep"
+
+# Mirrors LLMThesisConfig.chart_lookback_days — the figure-level default when
+# no config is threaded (pure callers/tests).
+DEFAULT_CHART_LOOKBACK_DAYS = 120
+
+# Marker/overlay palette. Levels reuse the thesis-path colors (green entry /
+# red SL / blue target) so charts read identically across both paths.
+_APPEARANCE_COLOR = "#FFD54F"
+_LEVEL_STYLE = (
+    ("entry_price", "#26a69a", "Entry"),
+    ("stop_loss", "#ef5350", "SL"),
+    ("target_price", "#42A5F5", "Target"),
+)
+_CHART_FONT = "DejaVu Sans, sans-serif"  # same bundled-kaleido family
+
+
+@dataclass(frozen=True)
+class TradeOverlay:
+    """The booked trade levels/points drawn onto an archive chart."""
+
+    entry_date: date_cls | None
+    entry_price: float | None
+    stop_loss: float | None
+    target_price: float | None
+    exit_date: date_cls | None
+    exit_price: float | None
+    exit_reason: str | None
+
+    @classmethod
+    def from_trade(cls, trade: PaperTrade) -> TradeOverlay:
+        return cls(
+            entry_date=trade.entry_date,
+            # Closed trades always carry the booked fill; planned level is the
+            # defensive fallback so a malformed row still renders.
+            entry_price=trade.entry_price or trade.planned_entry_price,
+            stop_loss=trade.stop_loss,
+            target_price=trade.target_price,
+            exit_date=trade.exit_date,
+            exit_price=trade.exit_price,
+            exit_reason=trade.exit_reason,
+        )
+
+
+def build_archive_figure(
+    symbol: str,
+    df: pd.DataFrame,
+    *,
+    window: int = DEFAULT_CHART_LOOKBACK_DAYS,
+    appearances=(),
+    trade: TradeOverlay | None = None,
+):
+    """Assemble the annotated archive figure (no kaleido — pure Plotly).
+
+    Reuses ``create_static_stock_chart`` (UNMODIFIED — it already takes a
+    ``bars`` window parameter) for the candles/layout, then decorates:
+
+    * one vertical line + "#rank · M/D" label per QU100 appearance whose
+      data_date has a visible bar (dates without a bar, or outside the
+      window, are skipped — positional x-axis has nowhere to put them);
+    * trade overlay — entry/SL/target horizontal dotted lines across the full
+      width, plus arrowed point annotations at (entry_date, entry_price) and
+      (exit_date, exit_price) when those dates are visible.
+
+    Deterministic: appearances are drawn sorted by (data_date, rank); no wall
+    clock, no random state — same inputs, same figure JSON.
+    """
+    tail = df.tail(window) if df is not None and not df.empty else df
+    fig = create_static_stock_chart(symbol, tail, pattern=None, bars=window)
+    if tail is None or tail.empty:
+        return fig
+
+    # date -> positional x (the candlestick x-axis is range(len(tail))).
+    pos_by_date = {}
+    for i, ts in enumerate(tail.index):
+        d = ts.date() if hasattr(ts, "date") else ts
+        pos_by_date[d] = i
+
+    # --- QU100 appearance markers -----------------------------------------
+    drawn = 0
+    for app in sorted(appearances, key=lambda a: (a[0], a[1])):
+        data_date, rank = app[0], app[1]
+        pos = pos_by_date.get(data_date)
+        if pos is None:
+            continue
+        fig.add_shape(
+            type="line",
+            x0=pos, x1=pos, y0=0, y1=1,
+            xref="x", yref="paper",
+            line=dict(color=_APPEARANCE_COLOR, width=1, dash="dot"),
+        )
+        fig.add_annotation(
+            x=pos,
+            # Alternate two label rows so adjacent markers don't overlap.
+            y=1.02 if drawn % 2 == 0 else 0.985,
+            xref="x", yref="paper",
+            text=f"#{rank} · {data_date.month}/{data_date.day}",
+            showarrow=False,
+            font=dict(family=_CHART_FONT, size=10, color=_APPEARANCE_COLOR),
+        )
+        drawn += 1
+
+    # --- Trade overlay ------------------------------------------------------
+    if trade is not None:
+        x1 = len(tail) - 1
+        for field, color, label in _LEVEL_STYLE:
+            price = getattr(trade, field)
+            if price is None or price <= 0:
+                continue
+            fig.add_shape(
+                type="line",
+                x0=0, x1=x1, y0=price, y1=price,
+                line=dict(color=color, width=1.5, dash="dot"),
+            )
+            fig.add_annotation(
+                x=x1, y=price, text=f"{label} {price:.2f}",
+                showarrow=False, xanchor="right", xshift=-4,
+                font=dict(family=_CHART_FONT, size=10, color=color),
+            )
+
+        def _point(d: date_cls | None, price: float | None, text: str, color: str):
+            if d is None or price is None:
+                return
+            pos = pos_by_date.get(d)
+            if pos is None:
+                return
+            fig.add_annotation(
+                x=pos, y=price, xref="x", yref="y",
+                text=text, showarrow=True, arrowhead=2, arrowcolor=color,
+                ax=0, ay=-30,
+                font=dict(family=_CHART_FONT, size=10, color=color),
+            )
+
+        _point(
+            trade.entry_date, trade.entry_price,
+            f"Entry {trade.entry_price:.2f}" if trade.entry_price else "",
+            "#26a69a",
+        )
+        if trade.exit_price is not None:
+            reason = f" ({trade.exit_reason})" if trade.exit_reason else ""
+            _point(
+                trade.exit_date, trade.exit_price,
+                f"Exit {trade.exit_price:.2f}{reason}",
+                "#FF8A65",
+            )
+    return fig
+
+
+def render_archive_chart_png(
+    symbol: str,
+    df: pd.DataFrame,
+    *,
+    window: int = DEFAULT_CHART_LOOKBACK_DAYS,
+    appearances=(),
+    trade: TradeOverlay | None = None,
+    width: int = RENDER_WIDTH,
+    height: int = RENDER_HEIGHT,
+) -> tuple[bytes, str]:
+    """Figure → deterministic PNG bytes + sha256 (same pinning as thesis path).
+
+    kaleido engine, pinned scale, post-render metadata scrub (imported from
+    ``chart_export`` — the scrub keeps the sha a pure function of the inputs).
+    """
+    fig = build_archive_figure(
+        symbol, df, window=window, appearances=appearances, trade=trade
+    )
+    raw = fig.to_image(
+        format="png", width=width, height=height,
+        scale=RENDER_SCALE, engine="kaleido",
+    )
+    png = _strip_png_metadata(raw)
+    return png, hashlib.sha256(png).hexdigest()
+
+
+def load_daily_bars(
+    symbol: str, *, as_of: date_cls, window: int
+) -> pd.DataFrame:
+    """Last ``window`` usable daily bars for ``symbol`` at-or-before ``as_of``.
+
+    Reads `stock_prices` (canonical 00:00-UTC instants, D9). Only bars with
+    full OHLC count (a NULL/partial re-fetch row is not a renderable candle).
+    Deterministic: ordered by date; the same DB state always yields the same
+    frame — the foundation of the render-on-demand byte-identity contract.
+    """
+    with get_session() as session:
+        rows = session.execute(
+            select(
+                StockPrice.date,
+                StockPrice.open,
+                StockPrice.high,
+                StockPrice.low,
+                StockPrice.close,
+                StockPrice.volume,
+            )
+            .where(
+                StockPrice.symbol == symbol,
+                StockPrice.date <= canonical_instant(as_of),
+                StockPrice.open.isnot(None),
+                StockPrice.high.isnot(None),
+                StockPrice.low.isnot(None),
+                StockPrice.close.isnot(None),
+            )
+            .order_by(StockPrice.date)
+        ).all()
+    if not rows:
+        return pd.DataFrame()
+    df = pd.DataFrame(
+        rows, columns=["date", "open", "high", "low", "close", "volume"]
+    ).set_index("date")
+    return df.tail(window)
+
+
+def persist_archive_chart(
+    *,
+    symbol: str,
+    as_of: date_cls,
+    source: str,
+    png_bytes: bytes,
+    sha256: str,
+    timeframe_days: int,
+    width: int = RENDER_WIDTH,
+    height: int = RENDER_HEIGHT,
+) -> int:
+    """Persist an archive chart under logical identity (symbol, as_of, source).
+
+    Append-only supersession (TASK-PLAN acceptance 4), ONE transaction:
+
+      identical bytes (current row's sha matches) ─► dedup no-op, same id
+      changed bytes ─► 3-step staging:
+        1. INSERT the new row with the nullable logical-key columns
+           (`as_of_date`/`source`) staged NULL — `symbol` is NOT NULL and set;
+        2. point the old current row's `superseded_by` at the new id;
+        3. promote: fill the new row's `as_of_date`/`source`.
+
+    The partial unique (symbol, as_of_date, source) WHERE superseded_by IS
+    NULL is never violated mid-transaction (the staged row has NULL key
+    columns while the old row is still current). Bytes are never overwritten
+    or deleted — snapshot payloads keep their original chart id and
+    LLM-referenced rows stay valid forever. Archive rows keep `scan_date`
+    NULL so a flip-flop re-render can't collide with a superseded row in the
+    0004 (symbol, scan_date, sha256) partial unique.
+
+    Returns the CURRENT chart id for the identity.
+    """
+    if source not in (SOURCE_TRADE_CLOSE, SOURCE_MISS_SWEEP):
+        raise ValueError(
+            f"archive source must be trade_close/miss_sweep, got {source!r} "
+            "(thesis rows go through llm_thesis.chart_persistence)"
+        )
+    with get_session() as session:
+        # Parent stocks row (FK target) — same ensure-pattern as the ingest.
+        if (
+            session.execute(
+                select(Stock.symbol).where(Stock.symbol == symbol)
+            ).first()
+            is None
+        ):
+            session.add(Stock(symbol=symbol))
+            session.flush()
+
+        current = session.execute(
+            select(ChartImage).where(
+                ChartImage.symbol == symbol,
+                ChartImage.as_of_date == as_of,
+                ChartImage.source == source,
+                ChartImage.superseded_by.is_(None),
+            )
+        ).scalar_one_or_none()
+        if current is not None and current.sha256 == sha256:
+            return int(current.id)
+
+        staged = ChartImage(
+            symbol=symbol,
+            source=None,  # staged — promoted below, same transaction
+            as_of_date=None,
+            scan_date=None,  # archive rows live on as_of_date (see docstring)
+            image_bytes=png_bytes,
+            sha256=sha256,
+            file_size_bytes=len(png_bytes),
+            width=int(width),
+            height=int(height),
+            timeframe_days=int(timeframe_days),
+        )
+        session.add(staged)
+        session.flush()  # assigns staged.id
+        if current is not None:
+            current.superseded_by = staged.id
+            session.flush()
+        staged.as_of_date = as_of
+        staged.source = source
+        session.flush()
+        return int(staged.id)
+
+
+def _archive_window(window: int | None) -> int:
+    if window is not None:
+        return int(window)
+    from rainier.core.config import get_settings
+
+    return int(get_settings().llm_thesis.chart_lookback_days)
+
+
+def capture_trade_close_charts(
+    *, as_of: date_cls, window: int | None = None
+) -> int:
+    """Close-side capture (daily job step (v), unconditional): archive a chart
+    for every paper trade CLOSED on ``as_of`` and point its ``chart_id`` at
+    the current row.
+
+    Idempotent: a same-tick re-run sha-dedups to the existing row; changed
+    inputs supersede append-only and MOVE ``chart_id`` to the new current row
+    (snapshot payloads keep the old id). Per-trade failure isolation — one
+    bad symbol never starves the rest. Returns the number of trades whose
+    chart_id is set/confirmed.
+    """
+    window = _archive_window(window)
+    with get_session() as session:
+        trades = session.execute(
+            select(PaperTrade.id, PaperTrade.symbol).where(
+                PaperTrade.status == "closed",
+                PaperTrade.exit_date == as_of,
+            )
+        ).all()
+
+    captured = 0
+    for trade_id, symbol in trades:
+        try:
+            df = load_daily_bars(symbol, as_of=as_of, window=window)
+            if df is None or df.empty:
+                log.warning(
+                    "close_chart_no_bars symbol=%s as_of=%s", symbol, as_of
+                )
+                continue
+            appearances = get_qu100_appearances(
+                symbol, as_of=as_of, window=window
+            )
+            with get_session() as session:
+                trade = session.get(PaperTrade, trade_id)
+                overlay = TradeOverlay.from_trade(trade)
+            png, sha = render_archive_chart_png(
+                symbol, df, window=window, appearances=appearances, trade=overlay
+            )
+            chart_id = persist_archive_chart(
+                symbol=symbol,
+                as_of=as_of,
+                source=SOURCE_TRADE_CLOSE,
+                png_bytes=png,
+                sha256=sha,
+                timeframe_days=window,
+            )
+            with get_session() as session:
+                trade = session.get(PaperTrade, trade_id)
+                trade.chart_id = chart_id
+            captured += 1
+        except Exception:
+            log.exception(
+                "close_chart_capture_failed symbol=%s as_of=%s", symbol, as_of
+            )
+    log.info("close_charts_done as_of=%s captured=%d", as_of, captured)
+    return captured
+
+
+def regenerate_chart(
+    symbol: str, *, as_of: date_cls, window: int | None = None
+) -> tuple[bytes, str]:
+    """Render-on-demand (zero stored pixels): rebuild the archive chart for
+    (symbol, as_of) from stored inputs only.
+
+    Reconstructs exactly what the capture path saw — bars ``<= as_of``,
+    appearances ``<= as_of``, and the closed trade exited ON ``as_of`` (if
+    any) for the overlay — so on unchanged data the PNG is byte-identical to
+    a stored trade_close chart for the same identity.
+    """
+    window = _archive_window(window)
+    df = load_daily_bars(symbol, as_of=as_of, window=window)
+    if df is None or df.empty:
+        raise ValueError(f"no stored daily bars for {symbol} at {as_of}")
+    appearances = get_qu100_appearances(symbol, as_of=as_of, window=window)
+
+    overlay: TradeOverlay | None = None
+    with get_session() as session:
+        trade = session.execute(
+            select(PaperTrade).where(
+                PaperTrade.symbol == symbol,
+                PaperTrade.status == "closed",
+                PaperTrade.exit_date == as_of,
+            )
+        ).scalar_one_or_none()
+        if trade is not None:
+            overlay = TradeOverlay.from_trade(trade)
+
+    return render_archive_chart_png(
+        symbol, df, window=window, appearances=appearances, trade=overlay
+    )

--- a/src/rainier/paper/chart_archive.py
+++ b/src/rainier/paper/chart_archive.py
@@ -197,17 +197,16 @@ def build_archive_figure(
                 font=dict(family=_CHART_FONT, size=10, color=color),
             )
 
-        _point(
-            trade.entry_date, trade.entry_price,
-            f"Entry {trade.entry_price:.2f}" if trade.entry_price else "",
-            "#26a69a",
-        )
+        if trade.entry_price is not None:
+            _point(
+                trade.entry_date, trade.entry_price,
+                f"Entry {trade.entry_price:.2f}", "#26a69a",
+            )
         if trade.exit_price is not None:
             reason = f" ({trade.exit_reason})" if trade.exit_reason else ""
             _point(
                 trade.exit_date, trade.exit_price,
-                f"Exit {trade.exit_price:.2f}{reason}",
-                "#FF8A65",
+                f"Exit {trade.exit_price:.2f}{reason}", "#FF8A65",
             )
     return fig
 
@@ -381,11 +380,17 @@ def capture_trade_close_charts(
     """
     window = _archive_window(window)
     with get_session() as session:
+        # Ascending id order: if two closed trades of one symbol ever share an
+        # exit_date (re-trade edge), the LAST one captured is the highest id —
+        # the same trade `regenerate_chart` picks — so the stored current
+        # chart and a re-render agree.
         trades = session.execute(
-            select(PaperTrade.id, PaperTrade.symbol).where(
+            select(PaperTrade.id, PaperTrade.symbol)
+            .where(
                 PaperTrade.status == "closed",
                 PaperTrade.exit_date == as_of,
             )
+            .order_by(PaperTrade.id)
         ).all()
 
     captured = 0
@@ -445,13 +450,22 @@ def regenerate_chart(
 
     overlay: TradeOverlay | None = None
     with get_session() as session:
-        trade = session.execute(
-            select(PaperTrade).where(
-                PaperTrade.symbol == symbol,
-                PaperTrade.status == "closed",
-                PaperTrade.exit_date == as_of,
+        # Highest id wins on the multiple-closed-trades edge — mirrors the
+        # capture loop's ascending order (its last persist is the current row).
+        trade = (
+            session.execute(
+                select(PaperTrade)
+                .where(
+                    PaperTrade.symbol == symbol,
+                    PaperTrade.status == "closed",
+                    PaperTrade.exit_date == as_of,
+                )
+                .order_by(PaperTrade.id.desc())
+                .limit(1)
             )
-        ).scalar_one_or_none()
+            .scalars()
+            .first()
+        )
         if trade is not None:
             overlay = TradeOverlay.from_trade(trade)
 

--- a/src/rainier/paper/ingest.py
+++ b/src/rainier/paper/ingest.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 import math
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, Callable
+from typing import Any, Callable, NamedTuple
 
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -305,6 +305,44 @@ def screened_symbols(as_of: date) -> list[str]:
     return sorted({r[0] for r in rows})
 
 
+# ---------------------------------------------------------------------------
+# QU100 per-day dedup + cohort/appearance queries
+# ---------------------------------------------------------------------------
+
+
+def top100_latest_capture_subquery(
+    start: date | None = None, end: date | None = None
+):
+    """THE per-day dedup rule for QU100 snapshots, as a reusable subquery:
+    for each ``data_date`` carrying ``ranking_type='top100'`` rows, the latest
+    ``captured_at`` — i.e. the freshest capture batch of the day (4 intraday
+    captures collapse to one). ``data_date`` groups first, so a backfill that
+    stamped older data_dates with one shared ``captured_at`` can't win.
+
+    SINGLE SOURCE OF TRUTH (TASK-PLAN acceptance 2): both
+    ``get_qu100_appearances`` and ``get_current_qu100_cohort`` below derive
+    their day-level dedup from this helper — the rule is never implemented
+    twice.
+
+    Columns: ``data_date``, ``max_captured_at``.
+    """
+    from rainier.core.models import MoneyFlowSnapshot
+
+    q = (
+        select(
+            MoneyFlowSnapshot.data_date.label("data_date"),
+            func.max(MoneyFlowSnapshot.captured_at).label("max_captured_at"),
+        )
+        .where(MoneyFlowSnapshot.ranking_type == "top100")
+        .group_by(MoneyFlowSnapshot.data_date)
+    )
+    if start is not None:
+        q = q.where(MoneyFlowSnapshot.data_date >= start)
+    if end is not None:
+        q = q.where(MoneyFlowSnapshot.data_date <= end)
+    return q.subquery()
+
+
 def get_current_qu100_cohort(as_of: date) -> list[dict[str, Any]]:
     """The current QU100 cohort at-or-before ``as_of`` (shared API — the weekly
     miss-sweep uses it now; PR 5 reuses it for the daily ingest universe).
@@ -354,6 +392,90 @@ def get_current_qu100_cohort(as_of: date) -> list[dict[str, Any]]:
         ).all()
     return [
         {"symbol": r[0], "rank": int(r[1]), "data_date": r[2], "captured_at": r[3]}
+        for r in rows
+    ]
+
+
+class QU100Appearance(NamedTuple):
+    """One QU100 top-100 appearance of a symbol on a trading day."""
+
+    data_date: date
+    rank: int
+    capture_session: str
+    captured_at: datetime
+
+
+def get_qu100_appearances(
+    symbol: str,
+    *,
+    as_of: date,
+    window: int = 120,
+    all_sessions: bool = False,
+    calendar: TradingCalendar | None = None,
+) -> list[QU100Appearance]:
+    """Days ``symbol`` was in the QU100 top-100 (with rank), trailing window.
+
+    Appearances with ``data_date <= as_of`` inside the trailing ``window``
+    TRADING sessions ending at ``as_of`` — the ``as_of`` contract makes
+    historical chart re-renders faithful (a re-render never sees a later
+    appearance). Default: per-day dedup via the day's latest top100 capture
+    batch (`top100_latest_capture_subquery`) → one ``(data_date, rank)`` per
+    day, consistent with the day's cohort. ``all_sessions=True`` returns every
+    intraday top100 capture row instead (rank moves within the day).
+
+    Ascending by ``data_date`` (then ``captured_at`` for all_sessions).
+    """
+    from rainier.core.models import MoneyFlowSnapshot
+
+    cal = calendar or DEFAULT_CALENDAR
+    sessions = _recent_window(as_of, window, cal)
+    if not sessions:
+        return []
+    start = sessions[0]
+
+    with get_session() as session:
+        if all_sessions:
+            rows = session.execute(
+                select(
+                    MoneyFlowSnapshot.data_date,
+                    MoneyFlowSnapshot.rank,
+                    MoneyFlowSnapshot.capture_session,
+                    MoneyFlowSnapshot.captured_at,
+                )
+                .where(
+                    MoneyFlowSnapshot.ranking_type == "top100",
+                    MoneyFlowSnapshot.symbol == symbol,
+                    MoneyFlowSnapshot.data_date >= start,
+                    MoneyFlowSnapshot.data_date <= as_of,
+                )
+                .order_by(
+                    MoneyFlowSnapshot.data_date, MoneyFlowSnapshot.captured_at
+                )
+            ).all()
+        else:
+            latest = top100_latest_capture_subquery(start=start, end=as_of)
+            rows = session.execute(
+                select(
+                    MoneyFlowSnapshot.data_date,
+                    MoneyFlowSnapshot.rank,
+                    MoneyFlowSnapshot.capture_session,
+                    MoneyFlowSnapshot.captured_at,
+                )
+                .join(
+                    latest,
+                    (MoneyFlowSnapshot.data_date == latest.c.data_date)
+                    & (MoneyFlowSnapshot.captured_at == latest.c.max_captured_at),
+                )
+                .where(
+                    MoneyFlowSnapshot.ranking_type == "top100",
+                    MoneyFlowSnapshot.symbol == symbol,
+                )
+                .order_by(MoneyFlowSnapshot.data_date)
+            ).all()
+    return [
+        QU100Appearance(
+            data_date=r[0], rank=int(r[1]), capture_session=r[2], captured_at=r[3]
+        )
         for r in rows
     ]
 

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -204,9 +204,16 @@ async def run_daily_eval(eval_date_iso: str | None = None) -> None:
     # every trade closed today + set paper_trade.chart_id. Runs after the
     # exits are booked (step iii) and before the daily report goes out.
     # Unconditional (every day; idempotent sha-dedup) but non-fatal — a
-    # render failure must never block the daily report.
+    # render failure must never block the daily report. The window comes from
+    # THIS run's `load_settings_fresh()` (not the process-cached singleton) so
+    # a chart_lookback_days YAML edit takes effect without a daemon restart —
+    # the same fresh-settings discipline as the other scheduled paper steps.
     try:
-        await asyncio.to_thread(run_paper_close_charts, eval_date)
+        await asyncio.to_thread(
+            run_paper_close_charts,
+            eval_date,
+            settings.llm_thesis.chart_lookback_days,
+        )
     except Exception as exc:
         log.error("daily_close_charts_failed", error=str(exc))
 
@@ -276,16 +283,19 @@ def run_paper_daily_steps(eval_date) -> None:
     paper_positions.update_open_positions(as_of=eval_date)
 
 
-def run_paper_close_charts(eval_date) -> None:
+def run_paper_close_charts(eval_date, window: int | None = None) -> None:
     """Paper step (v) addendum (R-D): close-side chart capture.
 
     Renders + persists an annotated archive chart for every paper trade
     closed on ``eval_date`` and points ``paper_trade.chart_id`` at it.
     Idempotent (sha dedup / append-only supersession in the persist path).
+    ``window`` is the freshly-loaded ``chart_lookback_days`` from the caller's
+    `load_settings_fresh()`; ``None`` falls back to the process-cached config
+    (codex: the scheduled path must pass it so YAML edits apply live).
     """
     from rainier.paper.chart_archive import capture_trade_close_charts
 
-    n = capture_trade_close_charts(as_of=eval_date)
+    n = capture_trade_close_charts(as_of=eval_date, window=window)
     log.info("daily_close_charts_done", charts=n)
 
 

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -200,6 +200,16 @@ async def run_daily_eval(eval_date_iso: str | None = None) -> None:
     except Exception as exc:
         log.error("daily_eval_discord_failed", error=str(exc))
 
+    # Step (v) addendum (R-D chart archive): archive an annotated chart for
+    # every trade closed today + set paper_trade.chart_id. Runs after the
+    # exits are booked (step iii) and before the daily report goes out.
+    # Unconditional (every day; idempotent sha-dedup) but non-fatal — a
+    # render failure must never block the daily report.
+    try:
+        await asyncio.to_thread(run_paper_close_charts, eval_date)
+    except Exception as exc:
+        log.error("daily_close_charts_failed", error=str(exc))
+
     # Step (v): paper-book daily report — compute, persist the snapshot, push to
     # Discord. Runs after the horizon eval per the authoritative order. Non-fatal.
     try:
@@ -264,6 +274,19 @@ def run_paper_daily_steps(eval_date) -> None:
         as_of=eval_date, learned_time_stop_days=learned_ts
     )
     paper_positions.update_open_positions(as_of=eval_date)
+
+
+def run_paper_close_charts(eval_date) -> None:
+    """Paper step (v) addendum (R-D): close-side chart capture.
+
+    Renders + persists an annotated archive chart for every paper trade
+    closed on ``eval_date`` and points ``paper_trade.chart_id`` at it.
+    Idempotent (sha dedup / append-only supersession in the persist path).
+    """
+    from rainier.paper.chart_archive import capture_trade_close_charts
+
+    n = capture_trade_close_charts(as_of=eval_date)
+    log.info("daily_close_charts_done", charts=n)
 
 
 def run_paper_daily_report(eval_date, discord_config) -> None:

--- a/tests/test_paper/conftest.py
+++ b/tests/test_paper/conftest.py
@@ -40,6 +40,11 @@ MIGRATION_0009_DOWN = REPO_ROOT / "migrations" / "0009_paper_reflection_downgrad
 # this the tests only pass when a prior suite left the table in `public`
 # (search_path fallback) — an order-dependent pass on a fresh test DB.
 MIGRATION_0003_UP = REPO_ROOT / "migrations" / "0003_llm_thesis_pr3.sql"
+# R-D chart archive (task qu100-chart-archive-77f3): chart_images
+# source/as_of_date/superseded_by + paper_trade.chart_id. Applied on top of 0005
+# so full-entity PaperTrade ORM reads see paper_trade.chart_id.
+MIGRATION_0010_UP = REPO_ROOT / "migrations" / "0010_chart_archive.sql"
+MIGRATION_0010_DOWN = REPO_ROOT / "migrations" / "0010_chart_archive_downgrade.sql"
 
 # Minimal DDL for the FK-target tables the paper migration references. The real
 # schema lives in migrations/0001-0004; for an isolated paper-tracker test DB we
@@ -119,9 +124,34 @@ CREATE TABLE IF NOT EXISTS stock_prices (
     CONSTRAINT uq_stock_price_symbol_date UNIQUE (symbol, date)
 );
 
+-- Mirror the ChartImage ORM (models.py) at its PRE-0010 shape (0001 create +
+-- 0004 additive columns/indexes) so migration 0010's additive step stays under
+-- test. chart_images has no CREATE TABLE migration (it predates the numbered
+-- migrations; prod got it via `db init` create_all).
+CREATE TABLE IF NOT EXISTS chart_images (
+    id              SERIAL PRIMARY KEY,
+    symbol          VARCHAR(10) NOT NULL REFERENCES stocks (symbol),
+    captured_at     TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    timeframe_days  INTEGER DEFAULT 120,
+    file_path       VARCHAR(500),
+    file_size_bytes INTEGER,
+    image_bytes     BYTEA,
+    sha256          VARCHAR(64),
+    scan_date       DATE,
+    width           INTEGER,
+    height          INTEGER
+);
+CREATE INDEX IF NOT EXISTS ix_chart_images_sha256 ON chart_images (sha256);
+CREATE INDEX IF NOT EXISTS ix_chart_images_scan_date ON chart_images (scan_date);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_chart_image_symbol_scan_sha
+    ON chart_images (symbol, scan_date, sha256)
+    WHERE sha256 IS NOT NULL;
+
 -- Mirror the MoneyFlowSnapshot ORM (models.py) for the Phase-3 miss-sweep
 -- cohort selector (`get_current_qu100_cohort` reads data_date / ranking_type /
--- captured_at / rank). ORM inserts emit ALL columns, so all must exist.
+-- captured_at / rank) AND the R-D appearance-query tests. ORM inserts emit ALL
+-- columns, so all must exist. Plain table here (prod is a TimescaleDB
+-- hypertable; the composite PK is the only hypertable-specific shape, preserved).
 CREATE TABLE IF NOT EXISTS money_flow_snapshots (
     id              BIGSERIAL,
     captured_at     TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -267,6 +297,12 @@ def pg_legacy_engine(request):
     _apply_sql(engine, MIGRATION_0008_UP)  # Phase 3 zero_share_price skip reason
     _apply_sql(engine, MIGRATION_0009_UP)  # R-A paper_trade.reflection
     _apply_sql(engine, MIGRATION_0003_UP)  # research_insights (lessons tests)
+    # R-D chart archive. `exists()` guard keeps the rest of the paper suite
+    # runnable during the tdd-red phase before the migration file lands;
+    # test_chart_archive.py::test_migration_0010_files_exist pins the file's
+    # existence so a green run can never silently skip it.
+    if MIGRATION_0010_UP.exists():
+        _apply_sql(engine, MIGRATION_0010_UP)
 
     from rainier.core import config, database
 
@@ -297,6 +333,50 @@ def pg_legacy_session(pg_legacy_engine):
     finally:
         sess.rollback()
         sess.close()
+
+
+# --------------------------------------------------------------------------
+# Migration 0010 (R-D chart archive) fixtures — PRE-0010 state so the
+# migration's backfill / index creation / idempotency / downgrade run under
+# test. Own disposable schema; teardown can never reach shared `public`.
+# --------------------------------------------------------------------------
+
+_CHART_MIG_SCHEMA = "rainier_chartmig_test"
+
+
+@pytest.fixture
+def pg_chart_mig_engine(request):
+    """Ephemeral Postgres at the PRE-0010 schema state (prereqs + 0005 only).
+
+    Tests seed pre-existing `chart_images` rows (incl. same-day duplicate
+    thesis charts), then apply 0010 themselves and assert backfill/index/
+    downgrade behavior. The legacy `core.database` singleton is NOT bound —
+    these tests drive raw SQL/ORM sessions against the returned engine.
+    """
+    url = _resolve_pg_url(request)
+    admin = create_engine(url, future=True)
+    with admin.begin() as conn:
+        conn.execute(text(f"DROP SCHEMA IF EXISTS {_CHART_MIG_SCHEMA} CASCADE"))
+        conn.execute(text(f"CREATE SCHEMA {_CHART_MIG_SCHEMA}"))
+    admin.dispose()
+
+    engine = create_engine(
+        url,
+        future=True,
+        connect_args={"options": f"-csearch_path={_CHART_MIG_SCHEMA},public"},
+    )
+    engine.rainier_schema = _CHART_MIG_SCHEMA  # type: ignore[attr-defined]
+    with engine.begin() as conn:
+        conn.execute(text(_PREREQ_DDL))
+    _apply_sql(engine, MIGRATION_UP)  # 0005: paper_trade (0010 alters it)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+        admin = create_engine(url, future=True)
+        with admin.begin() as conn:
+            conn.execute(text(f"DROP SCHEMA IF EXISTS {_CHART_MIG_SCHEMA} CASCADE"))
+        admin.dispose()
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_paper/test_chart_archive.py
+++ b/tests/test_paper/test_chart_archive.py
@@ -788,8 +788,9 @@ def test_run_paper_close_charts_calls_capture(monkeypatch):
 
     called: dict = {}
 
-    def fake_capture(*, as_of):
+    def fake_capture(*, as_of, window=None):
         called["as_of"] = as_of
+        called["window"] = window
         return 2
 
     monkeypatch.setattr(
@@ -797,6 +798,12 @@ def test_run_paper_close_charts_calls_capture(monkeypatch):
     )
     service.run_paper_close_charts(AS_OF)
     assert called["as_of"] == AS_OF
+    assert called["window"] is None  # no explicit window → capture's config fallback
+
+    # The scheduled path passes the freshly-loaded chart_lookback_days through
+    # (codex P2: must NOT re-read the process-cached singleton mid-daemon).
+    service.run_paper_close_charts(AS_OF, 90)
+    assert called["window"] == 90
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_paper/test_chart_archive.py
+++ b/tests/test_paper/test_chart_archive.py
@@ -1,0 +1,770 @@
+"""R-D chart archive tests (task qu100-chart-archive-77f3).
+
+Covers (TASK-PLAN §Validation):
+
+* figure assembly — 120-bar window (not the 60-bar thesis tail), 90-bar config
+  respected, appearance markers ("#rank · M/D" labels), trade overlay
+  (entry/SL/target lines + entry/exit point annotations);
+* byte-determinism of the new renderer (same kaleido pinning + metadata scrub
+  as the thesis path — IMPORTED from chart_export, never edited);
+* `get_qu100_appearances` per-day dedup (latest captured_at within
+  ranking_type='top100') + `--all-sessions` + as-of/window cuts;
+* append-only supersession (sha dedup no-op; 3-step single-transaction
+  staging; bytes never overwritten; flip-flop renders never violate the 0004
+  partial-unique because archive rows keep `scan_date` NULL);
+* thesis rows stay OUTSIDE the logical-identity contract (`as_of_date` NULL
+  for source='thesis', existing + future);
+* migration 0010 up/backfill/idempotency/downgrade;
+* close-side capture (`capture_trade_close_charts`) incl. chart_id move on
+  supersession;
+* render-on-demand byte-identical reproduction;
+* CLI registration + threading.
+
+Figure tests are pure (no DB, no kaleido). Render tests skip without kaleido.
+DB tests ride the `pg_legacy_engine` (0010 applied) / `pg_chart_mig_engine`
+(pre-0010) postgres lane.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import date, datetime, timedelta, timezone
+
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+from sqlalchemy import select, text
+
+from rainier.paper import chart_archive
+from rainier.paper.chart_archive import (
+    SOURCE_MISS_SWEEP,
+    SOURCE_TRADE_CLOSE,
+    TradeOverlay,
+    build_archive_figure,
+    capture_trade_close_charts,
+    load_daily_bars,
+    persist_archive_chart,
+    regenerate_chart,
+    render_archive_chart_png,
+)
+from rainier.paper.ingest import canonical_instant, get_qu100_appearances
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+AS_OF = date(2026, 6, 5)  # a Friday
+
+
+def _mk_df(n: int = 200, end: date = AS_OF) -> pd.DataFrame:
+    """Synthetic ascending daily OHLCV over the last `n` business days."""
+    idx = pd.bdate_range(end=end, periods=n)
+    base = [100.0 + i * 0.1 for i in range(n)]
+    return pd.DataFrame(
+        {
+            "open": base,
+            "high": [b + 1.0 for b in base],
+            "low": [b - 1.0 for b in base],
+            "close": [b + 0.5 for b in base],
+            "volume": [1_000_000] * n,
+        },
+        index=idx,
+    )
+
+
+def _tail_dates(df: pd.DataFrame, window: int) -> list[date]:
+    return [ts.date() for ts in df.tail(window).index]
+
+
+def _vertical_shapes(fig) -> list:
+    return [s for s in fig.layout.shapes if s.x0 == s.x1]
+
+
+def _horizontal_shapes(fig) -> list:
+    return [s for s in fig.layout.shapes if s.y0 == s.y1]
+
+
+def _annotation_texts(fig) -> list[str]:
+    return [a.text for a in fig.layout.annotations]
+
+
+def _appearance(d: date, rank: int):
+    """Minimal (data_date, rank) appearance record the figure builder accepts."""
+    return (d, rank)
+
+
+# ---------------------------------------------------------------------------
+# Figure assembly (pure — no DB, no kaleido)
+# ---------------------------------------------------------------------------
+
+
+def test_figure_window_default_120():
+    """120-bar window honored — NOT the thesis path's 60-bar tail."""
+    fig = build_archive_figure("AAPL", _mk_df(200))
+    assert len(fig.data[0].open) == 120
+
+
+def test_figure_window_90():
+    """A 90-day configured window is honored end-to-end in the figure."""
+    fig = build_archive_figure("AAPL", _mk_df(200), window=90)
+    assert len(fig.data[0].open) == 90
+
+
+def test_appearance_markers_drawn_with_rank_date_labels():
+    df = _mk_df(200)
+    dates = _tail_dates(df, 120)
+    d1, d2 = dates[10], dates[50]
+    fig = build_archive_figure(
+        "AAPL", df, appearances=[_appearance(d1, 23), _appearance(d2, 5)]
+    )
+    verts = _vertical_shapes(fig)
+    assert len(verts) == 2
+    assert sorted(v.x0 for v in verts) == [10, 50]
+    texts = _annotation_texts(fig)
+    assert f"#23 · {d1.month}/{d1.day}" in texts
+    assert f"#5 · {d2.month}/{d2.day}" in texts
+
+
+def test_appearance_multiple_markers_same_symbol():
+    """Multi-appearance symbol → one marker per appearance date."""
+    df = _mk_df(200)
+    dates = _tail_dates(df, 120)
+    apps = [_appearance(dates[i], i + 1) for i in (5, 30, 60, 100)]
+    fig = build_archive_figure("NVDA", df, appearances=apps)
+    assert len(_vertical_shapes(fig)) == 4
+
+
+def test_appearance_outside_window_or_missing_bar_skipped():
+    df = _mk_df(200)
+    visible = _tail_dates(df, 120)
+    older = _tail_dates(df, 200)[0]  # oldest bar — outside the 120 window
+    assert older not in visible
+    saturday = AS_OF + timedelta(days=1)  # no bar on a weekend
+    fig = build_archive_figure(
+        "AAPL",
+        df,
+        appearances=[_appearance(older, 7), _appearance(saturday, 9)],
+    )
+    assert len(_vertical_shapes(fig)) == 0
+
+
+def test_trade_overlay_levels_and_markers():
+    df = _mk_df(200)
+    dates = _tail_dates(df, 120)
+    entry_d, exit_d = dates[80], dates[110]
+    trade = TradeOverlay(
+        entry_date=entry_d,
+        entry_price=105.0,
+        stop_loss=101.5,
+        target_price=112.25,
+        exit_date=exit_d,
+        exit_price=112.3,
+        exit_reason="target",
+    )
+    fig = build_archive_figure("AAPL", df, trade=trade)
+    level_prices = {s.y0 for s in _horizontal_shapes(fig)}
+    assert {105.0, 101.5, 112.25} <= level_prices
+    # Entry/exit point annotations at the correct (date-pos, price).
+    points = {
+        (a.x, a.y): a.text
+        for a in fig.layout.annotations
+        if a.xref == "x" and a.yref == "y" and a.showarrow
+    }
+    assert (80, 105.0) in points and "105.00" in points[(80, 105.0)]
+    assert (110, 112.3) in points and "target" in points[(110, 112.3)]
+
+
+def test_trade_overlay_without_exit_still_renders():
+    """Defensive: overlay with no exit booked draws levels, no exit marker."""
+    df = _mk_df(200)
+    trade = TradeOverlay(
+        entry_date=None,
+        entry_price=105.0,
+        stop_loss=101.5,
+        target_price=112.25,
+        exit_date=None,
+        exit_price=None,
+        exit_reason=None,
+    )
+    fig = build_archive_figure("AAPL", df, trade=trade)
+    assert {105.0, 101.5, 112.25} <= {s.y0 for s in _horizontal_shapes(fig)}
+    assert not [a for a in fig.layout.annotations if a.showarrow]
+
+
+def test_config_chart_lookback_days_default():
+    from rainier.core.config import LLMThesisConfig
+
+    assert LLMThesisConfig().chart_lookback_days == 120
+
+
+# ---------------------------------------------------------------------------
+# Renderer determinism (kaleido)
+# ---------------------------------------------------------------------------
+
+
+def test_render_archive_chart_png_deterministic():
+    pytest.importorskip("kaleido")
+    df = _mk_df(200)
+    dates = _tail_dates(df, 120)
+    apps = [_appearance(dates[10], 23)]
+    trade = TradeOverlay(
+        entry_date=dates[80],
+        entry_price=105.0,
+        stop_loss=101.5,
+        target_price=112.25,
+        exit_date=dates[110],
+        exit_price=112.3,
+        exit_reason="target",
+    )
+    png1, sha1 = render_archive_chart_png("AAPL", df, appearances=apps, trade=trade)
+    png2, sha2 = render_archive_chart_png("AAPL", df, appearances=apps, trade=trade)
+    assert png1 == png2
+    assert sha1 == sha2 == hashlib.sha256(png1).hexdigest()
+    assert png1.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+# ---------------------------------------------------------------------------
+# Appearance query (postgres lane)
+# ---------------------------------------------------------------------------
+
+
+def _seed_stock(session, symbol: str) -> None:
+    session.execute(
+        text(
+            "INSERT INTO stocks (symbol) VALUES (:s) ON CONFLICT (symbol) DO NOTHING"
+        ),
+        {"s": symbol},
+    )
+
+
+def _seed_snapshot(
+    session,
+    symbol: str,
+    data_date: date,
+    rank: int,
+    captured_at: datetime,
+    session_name: str = "close",
+    ranking_type: str = "top100",
+) -> None:
+    session.execute(
+        text(
+            "INSERT INTO money_flow_snapshots "
+            "(captured_at, capture_session, data_date, ranking_type, symbol, rank) "
+            "VALUES (:cap, :ses, :dd, :rt, :sym, :rk)"
+        ),
+        {
+            "cap": captured_at,
+            "ses": session_name,
+            "dd": data_date,
+            "rt": ranking_type,
+            "sym": symbol,
+            "rk": rank,
+        },
+    )
+
+
+def _cap(d: date, hour: int) -> datetime:
+    return datetime(d.year, d.month, d.day, hour, 0, tzinfo=timezone.utc)
+
+
+def test_appearances_per_day_dedup_latest_capture(pg_legacy_session):
+    """4 sessions/day → ONE (date, rank): the day's latest captured_at batch."""
+    s = pg_legacy_session
+    _seed_stock(s, "AAPL")
+    d = date(2026, 6, 3)
+    for hour, rank, ses in [
+        (14, 40, "morning"), (16, 30, "midday"), (19, 20, "afternoon"), (21, 10, "close"),
+    ]:
+        _seed_snapshot(s, "AAPL", d, rank, _cap(d, hour), session_name=ses)
+    s.commit()
+
+    apps = get_qu100_appearances("AAPL", as_of=AS_OF, window=10)
+    assert [(a.data_date, a.rank) for a in apps] == [(d, 10)]
+
+
+def test_appearances_all_sessions_exposes_intraday(pg_legacy_session):
+    s = pg_legacy_session
+    _seed_stock(s, "AAPL")
+    d = date(2026, 6, 3)
+    for hour, rank in [(14, 40), (21, 10)]:
+        _seed_snapshot(s, "AAPL", d, rank, _cap(d, hour))
+    s.commit()
+
+    apps = get_qu100_appearances("AAPL", as_of=AS_OF, window=10, all_sessions=True)
+    assert [(a.data_date, a.rank) for a in apps] == [(d, 40), (d, 10)]
+
+
+def test_appearances_as_of_and_window_cuts(pg_legacy_session):
+    s = pg_legacy_session
+    _seed_stock(s, "AAPL")
+    inside = date(2026, 6, 1)
+    after = date(2026, 6, 8)  # data_date > as_of — excluded
+    way_back = date(2025, 6, 5)  # far outside any reasonable trailing window
+    for d, rank in [(inside, 5), (after, 6), (way_back, 7)]:
+        _seed_snapshot(s, "AAPL", d, rank, _cap(d, 21))
+    s.commit()
+
+    apps = get_qu100_appearances("AAPL", as_of=AS_OF, window=10)
+    assert [(a.data_date, a.rank) for a in apps] == [(inside, 5)]
+
+
+def test_appearances_dedup_is_cohort_consistent(pg_legacy_session):
+    """A symbol present in an early batch but absent from the day's LATEST
+    top100 batch is NOT an appearance (same rule as the day's cohort);
+    --all-sessions still shows the intraday row. Non-top100 rows never count."""
+    s = pg_legacy_session
+    for sym in ("AAPL", "MSFT"):
+        _seed_stock(s, sym)
+    d = date(2026, 6, 3)
+    _seed_snapshot(s, "AAPL", d, 90, _cap(d, 14))  # morning batch only
+    _seed_snapshot(s, "MSFT", d, 90, _cap(d, 21))  # the day's latest batch
+    _seed_snapshot(s, "AAPL", d, 1, _cap(d, 22), ranking_type="bottom100")
+    s.commit()
+
+    assert get_qu100_appearances("AAPL", as_of=AS_OF, window=10) == []
+    apps_all = get_qu100_appearances("AAPL", as_of=AS_OF, window=10, all_sessions=True)
+    assert [(a.data_date, a.rank) for a in apps_all] == [(d, 90)]
+
+
+# ---------------------------------------------------------------------------
+# Append-only supersession (postgres lane, 0010 applied)
+# ---------------------------------------------------------------------------
+
+
+def _chart_rows(session, symbol: str):
+    from rainier.core.models import ChartImage
+
+    return (
+        session.execute(
+            select(ChartImage).where(ChartImage.symbol == symbol).order_by(ChartImage.id)
+        )
+        .scalars()
+        .all()
+    )
+
+
+def test_persist_same_bytes_is_dedup_noop(pg_legacy_session):
+    _seed_stock(pg_legacy_session, "AAPL")
+    pg_legacy_session.commit()
+    png = b"\x89PNG\r\n\x1a\nfakebytes-a"
+    sha = hashlib.sha256(png).hexdigest()
+    id1 = persist_archive_chart(
+        symbol="AAPL", as_of=AS_OF, source=SOURCE_TRADE_CLOSE,
+        png_bytes=png, sha256=sha, timeframe_days=120,
+    )
+    id2 = persist_archive_chart(
+        symbol="AAPL", as_of=AS_OF, source=SOURCE_TRADE_CLOSE,
+        png_bytes=png, sha256=sha, timeframe_days=120,
+    )
+    assert id1 == id2
+    rows = _chart_rows(pg_legacy_session, "AAPL")
+    assert len(rows) == 1
+    assert rows[0].source == SOURCE_TRADE_CLOSE
+    assert rows[0].as_of_date == AS_OF
+    assert rows[0].superseded_by is None
+    assert rows[0].scan_date is None  # archive rows live on as_of_date, not scan_date
+
+
+def test_persist_changed_bytes_supersedes_append_only(pg_legacy_session):
+    _seed_stock(pg_legacy_session, "AAPL")
+    pg_legacy_session.commit()
+    png_a, png_b = b"\x89PNG\r\n\x1a\nbytes-a", b"\x89PNG\r\n\x1a\nbytes-b"
+    sha_a = hashlib.sha256(png_a).hexdigest()
+    sha_b = hashlib.sha256(png_b).hexdigest()
+    id_a = persist_archive_chart(
+        symbol="AAPL", as_of=AS_OF, source=SOURCE_MISS_SWEEP,
+        png_bytes=png_a, sha256=sha_a, timeframe_days=120,
+    )
+    id_b = persist_archive_chart(
+        symbol="AAPL", as_of=AS_OF, source=SOURCE_MISS_SWEEP,
+        png_bytes=png_b, sha256=sha_b, timeframe_days=120,
+    )
+    assert id_b != id_a
+    rows = {r.id: r for r in _chart_rows(pg_legacy_session, "AAPL")}
+    old, new = rows[id_a], rows[id_b]
+    # Old row: superseded, bytes UNCHANGED (append-only; snapshot payloads
+    # holding id_a stay valid forever).
+    assert old.superseded_by == id_b
+    assert bytes(old.image_bytes) == png_a
+    # New row: promoted current.
+    assert new.superseded_by is None
+    assert new.source == SOURCE_MISS_SWEEP
+    assert new.as_of_date == AS_OF
+
+
+def test_persist_flip_flop_render_no_unique_violation(pg_legacy_session):
+    """A→B→A sha sequence: the third render re-produces sha_a while a
+    superseded row with sha_a already exists. Must not trip either unique
+    index (0004's (symbol, scan_date, sha) — archive rows keep scan_date
+    NULL — or 0010's logical partial-unique)."""
+    _seed_stock(pg_legacy_session, "AAPL")
+    pg_legacy_session.commit()
+    png_a, png_b = b"\x89PNG\r\n\x1a\nflip-a", b"\x89PNG\r\n\x1a\nflip-b"
+    sha_a = hashlib.sha256(png_a).hexdigest()
+    sha_b = hashlib.sha256(png_b).hexdigest()
+    kw = dict(symbol="AAPL", as_of=AS_OF, source=SOURCE_TRADE_CLOSE, timeframe_days=120)
+    id1 = persist_archive_chart(png_bytes=png_a, sha256=sha_a, **kw)
+    id2 = persist_archive_chart(png_bytes=png_b, sha256=sha_b, **kw)
+    id3 = persist_archive_chart(png_bytes=png_a, sha256=sha_a, **kw)
+    assert len({id1, id2, id3}) == 3
+    rows = {r.id: r for r in _chart_rows(pg_legacy_session, "AAPL")}
+    assert rows[id1].superseded_by == id2
+    assert rows[id2].superseded_by == id3
+    assert rows[id3].superseded_by is None
+
+
+def test_persist_timeframe_days_follows_window(pg_legacy_session):
+    _seed_stock(pg_legacy_session, "AAPL")
+    pg_legacy_session.commit()
+    png = b"\x89PNG\r\n\x1a\nninety"
+    cid = persist_archive_chart(
+        symbol="AAPL", as_of=AS_OF, source=SOURCE_TRADE_CLOSE,
+        png_bytes=png, sha256=hashlib.sha256(png).hexdigest(), timeframe_days=90,
+    )
+    row = {r.id: r for r in _chart_rows(pg_legacy_session, "AAPL")}[cid]
+    assert row.timeframe_days == 90
+
+
+def test_thesis_rows_stay_outside_logical_contract(pg_legacy_session):
+    """Future thesis persists: source='thesis', as_of_date NULL — two same-day
+    same-symbol thesis charts coexist (NULLs never collide in the partial
+    unique), and the up-to-4-renders/day thesis pattern is unaffected."""
+    from rainier.llm_thesis.chart_persistence import persist_chart_image
+
+    _seed_stock(pg_legacy_session, "AAPL")
+    pg_legacy_session.commit()
+    d = date(2026, 6, 3)
+    png_a, png_b = b"\x89PNG\r\n\x1a\nthesis-a", b"\x89PNG\r\n\x1a\nthesis-b"
+    id_a = persist_chart_image(
+        symbol="AAPL", scan_date=d, image_bytes=png_a,
+        sha256=hashlib.sha256(png_a).hexdigest(),
+    )
+    id_b = persist_chart_image(
+        symbol="AAPL", scan_date=d, image_bytes=png_b,
+        sha256=hashlib.sha256(png_b).hexdigest(), timeframe_days=90,
+    )
+    assert id_a is not None and id_b is not None and id_a != id_b
+    rows = {r.id: r for r in _chart_rows(pg_legacy_session, "AAPL")}
+    for cid in (id_a, id_b):
+        assert rows[cid].source == "thesis"
+        assert rows[cid].as_of_date is None
+        assert rows[cid].superseded_by is None
+    # timeframe_days follows the caller's window (90 here), default stays 120.
+    assert rows[id_a].timeframe_days == 120
+    assert rows[id_b].timeframe_days == 90
+
+
+# ---------------------------------------------------------------------------
+# Close-side capture (postgres lane; renderer faked — figure correctness is
+# covered by the pure tests above)
+# ---------------------------------------------------------------------------
+
+
+def _seed_closed_trade(session, symbol: str, exit_d: date) -> int:
+    thesis_id = session.execute(
+        text("INSERT INTO analysis_results (llm_model, prompt_template) "
+             "VALUES ('test', 'test') RETURNING id")
+    ).scalar_one()
+    trade_id = session.execute(
+        text(
+            "INSERT INTO paper_trade (thesis_id, symbol, scan_date, session_name, "
+            "status, planned_entry_price, stop_loss, target_price, entry_date, "
+            "entry_price, shares, exit_date, exit_price, exit_reason, return_pct) "
+            "VALUES (:tid, :sym, :sd, 'close', 'closed', 100.0, 95.0, 110.0, :ed, "
+            "101.0, 10, :xd, 110.5, 'target', 9.4) RETURNING id"
+        ),
+        {"tid": thesis_id, "sym": symbol, "sd": exit_d - timedelta(days=7),
+         "ed": exit_d - timedelta(days=5), "xd": exit_d},
+    ).scalar_one()
+    session.commit()
+    return trade_id
+
+
+def _fake_renderer(png: bytes):
+    def _render(symbol, df, *, window=120, appearances=(), trade=None, **kw):
+        return png, hashlib.sha256(png).hexdigest()
+
+    return _render
+
+
+def test_capture_trade_close_charts_sets_chart_id(pg_legacy_session, monkeypatch):
+    _seed_stock(pg_legacy_session, "AAPL")
+    pg_legacy_session.commit()
+    trade_id = _seed_closed_trade(pg_legacy_session, "AAPL", AS_OF)
+    monkeypatch.setattr(
+        chart_archive, "load_daily_bars", lambda symbol, *, as_of, window: _mk_df(130)
+    )
+    monkeypatch.setattr(
+        chart_archive, "render_archive_chart_png",
+        _fake_renderer(b"\x89PNG\r\n\x1a\ncapture-1"),
+    )
+
+    n = capture_trade_close_charts(as_of=AS_OF)
+    assert n == 1
+    from rainier.core.models import PaperTrade
+
+    trade = pg_legacy_session.get(PaperTrade, trade_id)
+    pg_legacy_session.refresh(trade)
+    assert trade.chart_id is not None
+    rows = _chart_rows(pg_legacy_session, "AAPL")
+    assert len(rows) == 1
+    assert rows[0].source == SOURCE_TRADE_CLOSE
+    assert rows[0].as_of_date == AS_OF
+
+    # Same-tick re-run → sha dedup, no new row, chart_id unchanged.
+    first_chart_id = trade.chart_id
+    assert capture_trade_close_charts(as_of=AS_OF) == 1
+    pg_legacy_session.refresh(trade)
+    assert trade.chart_id == first_chart_id
+    assert len(_chart_rows(pg_legacy_session, "AAPL")) == 1
+
+    # Changed inputs (new bytes) → supersession; chart_id MOVES to the new
+    # current row; the snapshot-referenced old id still resolves.
+    monkeypatch.setattr(
+        chart_archive, "render_archive_chart_png",
+        _fake_renderer(b"\x89PNG\r\n\x1a\ncapture-2"),
+    )
+    assert capture_trade_close_charts(as_of=AS_OF) == 1
+    pg_legacy_session.refresh(trade)
+    rows = {r.id: r for r in _chart_rows(pg_legacy_session, "AAPL")}
+    assert len(rows) == 2
+    assert trade.chart_id != first_chart_id
+    assert rows[first_chart_id].superseded_by == trade.chart_id
+    assert bytes(rows[first_chart_id].image_bytes) == b"\x89PNG\r\n\x1a\ncapture-1"
+
+
+def test_capture_skips_symbol_with_no_bars(pg_legacy_session, monkeypatch):
+    _seed_stock(pg_legacy_session, "NOPX")
+    pg_legacy_session.commit()
+    _seed_closed_trade(pg_legacy_session, "NOPX", AS_OF)
+    monkeypatch.setattr(
+        chart_archive, "load_daily_bars",
+        lambda symbol, *, as_of, window: pd.DataFrame(),
+    )
+    assert capture_trade_close_charts(as_of=AS_OF) == 0
+    assert _chart_rows(pg_legacy_session, "NOPX") == []
+
+
+# ---------------------------------------------------------------------------
+# load_daily_bars + render-on-demand byte-identical reproduction
+# ---------------------------------------------------------------------------
+
+
+def _seed_prices(session, symbol: str, n: int = 130, end: date = AS_OF) -> list[date]:
+    days = [ts.date() for ts in pd.bdate_range(end=end, periods=n)]
+    for i, d in enumerate(days):
+        session.execute(
+            text(
+                "INSERT INTO stock_prices (symbol, date, open, high, low, close, volume) "
+                "VALUES (:sym, :dt, :o, :h, :l, :c, 1000000)"
+            ),
+            {"sym": symbol, "dt": canonical_instant(d), "o": 100.0 + i * 0.1,
+             "h": 101.0 + i * 0.1, "l": 99.0 + i * 0.1, "c": 100.5 + i * 0.1},
+        )
+    session.commit()
+    return days
+
+
+def test_load_daily_bars_window_and_as_of(pg_legacy_session):
+    _seed_stock(pg_legacy_session, "AAPL")
+    pg_legacy_session.commit()
+    days = _seed_prices(pg_legacy_session, "AAPL", n=130)
+    df = load_daily_bars("AAPL", as_of=AS_OF, window=120)
+    assert len(df) == 120
+    assert [ts.date() for ts in df.index] == days[-120:]
+    # as_of strictly bounds the data — a re-render never sees future bars.
+    earlier = days[-10]
+    df2 = load_daily_bars("AAPL", as_of=earlier, window=120)
+    assert [ts.date() for ts in df2.index][-1] == earlier
+
+
+def test_render_on_demand_reproduces_stored_chart_byte_identically(
+    pg_legacy_session, monkeypatch
+):
+    pytest.importorskip("kaleido")
+    _seed_stock(pg_legacy_session, "AAPL")
+    pg_legacy_session.commit()
+    days = _seed_prices(pg_legacy_session, "AAPL", n=130)
+    _seed_snapshot(
+        pg_legacy_session, "AAPL", days[-20], 23, _cap(days[-20], 21)
+    )
+    pg_legacy_session.commit()
+    trade_id = _seed_closed_trade(pg_legacy_session, "AAPL", AS_OF)
+
+    n = capture_trade_close_charts(as_of=AS_OF)
+    assert n == 1
+    from rainier.core.models import PaperTrade
+
+    trade = pg_legacy_session.get(PaperTrade, trade_id)
+    pg_legacy_session.refresh(trade)
+    stored = {r.id: r for r in _chart_rows(pg_legacy_session, "AAPL")}[trade.chart_id]
+
+    png, sha = regenerate_chart("AAPL", as_of=AS_OF)
+    assert sha == stored.sha256
+    assert png == bytes(stored.image_bytes)
+
+
+# ---------------------------------------------------------------------------
+# Migration 0010 (pre-0010 fixture; the test applies/downgrades itself)
+# ---------------------------------------------------------------------------
+
+from .conftest import MIGRATION_0010_DOWN, MIGRATION_0010_UP, _apply_sql  # noqa: E402
+
+
+def test_migration_0010_files_exist():
+    """Pins the files so conftest's exists() guard can never silently skip."""
+    assert MIGRATION_0010_UP.exists()
+    assert MIGRATION_0010_DOWN.exists()
+
+
+def _col_names(engine, table: str) -> set[str]:
+    from sqlalchemy import inspect
+
+    return {c["name"] for c in inspect(engine).get_columns(table, schema=engine.rainier_schema)}
+
+
+def test_migration_0010_backfill_index_idempotency(pg_chart_mig_engine):
+    eng = pg_chart_mig_engine
+    with eng.begin() as conn:
+        conn.execute(text("INSERT INTO stocks (symbol) VALUES ('AAPL')"))
+        # Two same-day duplicate thesis charts (the live-DB shape that must
+        # survive the migration + backfill without tripping the new index).
+        for sfx in ("a", "b"):
+            conn.execute(
+                text(
+                    "INSERT INTO chart_images (symbol, scan_date, image_bytes, sha256) "
+                    "VALUES ('AAPL', '2026-06-03', :png, :sha)"
+                ),
+                {"png": f"png-{sfx}".encode(), "sha": hashlib.sha256(sfx.encode()).hexdigest()},
+            )
+
+    _apply_sql(eng, MIGRATION_0010_UP)
+
+    cols = _col_names(eng, "chart_images")
+    assert {"source", "as_of_date", "superseded_by"} <= cols
+    assert "chart_id" in _col_names(eng, "paper_trade")
+    with eng.connect() as conn:
+        rows = conn.execute(
+            text("SELECT source, as_of_date FROM chart_images ORDER BY id")
+        ).all()
+        assert rows == [("thesis", None), ("thesis", None)]
+        idx = conn.execute(
+            text(
+                "SELECT indexname FROM pg_indexes WHERE tablename='chart_images' "
+                "AND schemaname=:sch"
+            ),
+            {"sch": eng.rainier_schema},
+        ).scalars().all()
+        assert "idx_chart_images_logical" in idx
+
+    # Idempotent re-apply (and the backfill never clobbers non-NULL sources).
+    with eng.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO chart_images (symbol, scan_date, image_bytes, sha256, "
+                "source, as_of_date) VALUES ('AAPL', NULL, 'arc', :sha, "
+                "'trade_close', '2026-06-05')"
+            ),
+            {"sha": hashlib.sha256(b"arc").hexdigest()},
+        )
+    _apply_sql(eng, MIGRATION_0010_UP)
+    with eng.connect() as conn:
+        src = conn.execute(
+            text("SELECT source FROM chart_images ORDER BY id")
+        ).scalars().all()
+        assert src == ["thesis", "thesis", "trade_close"]
+
+
+def test_migration_0010_downgrade_then_up(pg_chart_mig_engine):
+    eng = pg_chart_mig_engine
+    _apply_sql(eng, MIGRATION_0010_UP)
+    _apply_sql(eng, MIGRATION_0010_DOWN)
+    cols = _col_names(eng, "chart_images")
+    assert not ({"source", "as_of_date", "superseded_by"} & cols)
+    assert "chart_id" not in _col_names(eng, "paper_trade")
+    # Up again from the downgraded state — round-trip safe.
+    _apply_sql(eng, MIGRATION_0010_UP)
+    assert {"source", "as_of_date", "superseded_by"} <= _col_names(eng, "chart_images")
+
+
+# ---------------------------------------------------------------------------
+# Daily-job wiring (close-side capture is unconditional, step (v))
+# ---------------------------------------------------------------------------
+
+
+def test_run_paper_close_charts_calls_capture(monkeypatch):
+    from rainier.scheduler import service
+
+    called: dict = {}
+
+    def fake_capture(*, as_of):
+        called["as_of"] = as_of
+        return 2
+
+    monkeypatch.setattr(
+        "rainier.paper.chart_archive.capture_trade_close_charts", fake_capture
+    )
+    service.run_paper_close_charts(AS_OF)
+    assert called["as_of"] == AS_OF
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_paper_lists_new_commands():
+    from rainier.cli import cli
+
+    result = CliRunner().invoke(cli, ["paper", "--help"])
+    assert result.exit_code == 0
+    assert "appearances" in result.output
+    assert "chart" in result.output
+
+
+def test_cli_paper_appearances_renders_rows(monkeypatch):
+    from rainier.cli import cli
+    from rainier.paper.ingest import QU100Appearance
+
+    def fake_appearances(symbol, *, as_of, window, all_sessions=False, calendar=None):
+        assert symbol == "AAPL"
+        assert as_of == date(2026, 6, 5)
+        assert window == 30
+        return [
+            QU100Appearance(
+                data_date=date(2026, 5, 28), rank=23,
+                capture_session="close", captured_at=_cap(date(2026, 5, 28), 21),
+            )
+        ]
+
+    monkeypatch.setattr(
+        "rainier.paper.ingest.get_qu100_appearances", fake_appearances
+    )
+    result = CliRunner().invoke(
+        cli,
+        ["paper", "appearances", "AAPL", "--as-of", "2026-06-05", "--window", "30"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "2026-05-28" in result.output
+    assert "#23" in result.output
+
+
+def test_cli_paper_chart_writes_png(monkeypatch, tmp_path):
+    from rainier.cli import cli
+
+    png = b"\x89PNG\r\n\x1a\ncli-bytes"
+
+    def fake_regen(symbol, *, as_of, window=None):
+        assert symbol == "AAPL"
+        assert as_of == date(2026, 6, 5)
+        return png, hashlib.sha256(png).hexdigest()
+
+    monkeypatch.setattr("rainier.paper.chart_archive.regenerate_chart", fake_regen)
+    out = tmp_path / "aapl.png"
+    result = CliRunner().invoke(
+        cli,
+        ["paper", "chart", "AAPL", "--as-of", "2026-06-05", "--out", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.read_bytes() == png
+    assert hashlib.sha256(png).hexdigest()[:12] in result.output

--- a/tests/test_paper/test_chart_archive.py
+++ b/tests/test_paper/test_chart_archive.py
@@ -334,6 +334,10 @@ def test_appearances_dedup_is_cohort_consistent(pg_legacy_session):
 def _chart_rows(session, symbol: str):
     from rainier.core.models import ChartImage
 
+    # The production code writes through its own sessions; expire this
+    # session's identity map so the re-read sees committed DB state, not
+    # cached instances.
+    session.expire_all()
     return (
         session.execute(
             select(ChartImage).where(ChartImage.symbol == symbol).order_by(ChartImage.id)

--- a/tests/test_paper/test_chart_archive.py
+++ b/tests/test_paper/test_chart_archive.py
@@ -502,6 +502,20 @@ def test_persist_timeframe_days_follows_window(pg_legacy_session):
     assert row.timeframe_days == 90
 
 
+def test_persist_rejects_thesis_source():
+    """Guard: thesis rows go through llm_thesis.chart_persistence, never the
+    archive persist path — a 'thesis' (or unknown) source raises before any DB
+    work, so the logical-identity contract can't be polluted."""
+    png = b"\x89PNG\r\n\x1a\nguard"
+    for bad in ("thesis", "bogus"):
+        with pytest.raises(ValueError, match="trade_close/miss_sweep"):
+            persist_archive_chart(
+                symbol="AAPL", as_of=AS_OF, source=bad,
+                png_bytes=png, sha256=hashlib.sha256(png).hexdigest(),
+                timeframe_days=120,
+            )
+
+
 def test_thesis_rows_stay_outside_logical_contract(pg_legacy_session):
     """Future thesis persists: source='thesis', as_of_date NULL — two same-day
     same-symbol thesis charts coexist (NULLs never collide in the partial

--- a/tests/test_paper/test_chart_archive.py
+++ b/tests/test_paper/test_chart_archive.py
@@ -27,6 +27,7 @@ DB tests ride the `pg_legacy_engine` (0010 applied) / `pg_chart_mig_engine`
 
 from __future__ import annotations
 
+import functools
 import hashlib
 from datetime import date, datetime, timedelta, timezone
 
@@ -202,8 +203,28 @@ def test_config_chart_lookback_days_default():
 # ---------------------------------------------------------------------------
 
 
+@functools.lru_cache(maxsize=1)
+def _kaleido_usable() -> bool:
+    """True if kaleido can actually RENDER (installed AND its Chromium starts).
+
+    ``pytest.importorskip("kaleido")`` only proves the package imports; on
+    hosts where the bundled Chromium can't start (sandboxed CI, some Apple
+    Silicon builds) the render itself raises and would redline the suite on an
+    environmental precondition. Probe once, skip with a clear reason — same
+    treatment as tests/test_llm_thesis/test_chart_determinism.py (codex).
+    """
+    try:
+        import plotly.graph_objects as go
+
+        go.Figure().to_image(format="png", engine="kaleido", width=64, height=64)
+    except Exception:
+        return False
+    return True
+
+
 def test_render_archive_chart_png_deterministic():
-    pytest.importorskip("kaleido")
+    if not _kaleido_usable():
+        pytest.skip("kaleido cannot render on this host — skipping byte check")
     df = _mk_df(200)
     dates = _tail_dates(df, 120)
     apps = [_appearance(dates[10], 23)]
@@ -672,7 +693,8 @@ def test_load_daily_bars_window_and_as_of(pg_legacy_session):
 def test_render_on_demand_reproduces_stored_chart_byte_identically(
     pg_legacy_session, monkeypatch
 ):
-    pytest.importorskip("kaleido")
+    if not _kaleido_usable():
+        pytest.skip("kaleido cannot render on this host — skipping byte check")
     _seed_stock(pg_legacy_session, "AAPL")
     pg_legacy_session.commit()
     days = _seed_prices(pg_legacy_session, "AAPL", n=130)

--- a/tests/test_paper/test_chart_archive.py
+++ b/tests/test_paper/test_chart_archive.py
@@ -417,6 +417,79 @@ def test_persist_flip_flop_render_no_unique_violation(pg_legacy_session):
     assert rows[id3].superseded_by is None
 
 
+def test_persist_race_partial_unique_blocks_second_promote(
+    pg_legacy_engine, pg_legacy_session
+):
+    """Two concurrent-ish persists for ONE logical identity, interleaved on two
+    raw connections (the worst-case race the single-threaded daily job never
+    produces): staging (NULL key columns) never trips the partial unique while
+    both transactions are open, and the loser's PROMOTE is rejected by
+    ``idx_chart_images_logical`` — the whole losing transaction rolls back, so
+    'one CURRENT row per (symbol, as_of_date, source)' holds at the DB level
+    and the old row's ``superseded_by`` ends up pointing at the winner only."""
+    from sqlalchemy.exc import IntegrityError
+
+    _seed_stock(pg_legacy_session, "AAPL")
+    pg_legacy_session.commit()
+    png0 = b"\x89PNG\r\n\x1a\nrace-0"
+    cur_id = persist_archive_chart(
+        symbol="AAPL", as_of=AS_OF, source=SOURCE_TRADE_CLOSE,
+        png_bytes=png0, sha256=hashlib.sha256(png0).hexdigest(), timeframe_days=120,
+    )
+
+    ins = text(
+        "INSERT INTO chart_images (symbol, scan_date, source, as_of_date, "
+        "image_bytes, sha256) VALUES ('AAPL', NULL, NULL, NULL, :png, :sha) "
+        "RETURNING id"
+    )
+    supersede = text("UPDATE chart_images SET superseded_by = :n WHERE id = :o")
+    promote = text(
+        "UPDATE chart_images SET as_of_date = :d, source = :s WHERE id = :n"
+    )
+    conn1 = pg_legacy_engine.connect()
+    conn2 = pg_legacy_engine.connect()
+    try:
+        tx1 = conn1.begin()
+        new1 = conn1.execute(
+            ins, {"png": b"race-1", "sha": hashlib.sha256(b"race-1").hexdigest()}
+        ).scalar_one()
+        # Interleave: conn2 stages while conn1's transaction is still OPEN —
+        # two staged rows + the current row coexist without touching the
+        # partial unique (mid-transaction safety of step 1).
+        tx2 = conn2.begin()
+        new2 = conn2.execute(
+            ins, {"png": b"race-2", "sha": hashlib.sha256(b"race-2").hexdigest()}
+        ).scalar_one()
+
+        # conn1 wins: supersede + promote + commit (steps 2-3).
+        conn1.execute(supersede, {"n": new1, "o": cur_id})
+        conn1.execute(promote, {"d": AS_OF, "s": SOURCE_TRADE_CLOSE, "n": new1})
+        tx1.commit()
+
+        # conn2 loses: its promote would create a SECOND current row for the
+        # identity — idx_chart_images_logical rejects it.
+        conn2.execute(supersede, {"n": new2, "o": cur_id})
+        with pytest.raises(IntegrityError, match="idx_chart_images_logical"):
+            conn2.execute(
+                promote, {"d": AS_OF, "s": SOURCE_TRADE_CLOSE, "n": new2}
+            )
+        tx2.rollback()
+    finally:
+        conn1.close()
+        conn2.close()
+
+    rows = {r.id: r for r in _chart_rows(pg_legacy_session, "AAPL")}
+    # Loser's transaction rolled back WHOLE: its staged row and its
+    # superseded_by overwrite are both gone; the winner is the only current.
+    assert new2 not in rows
+    assert rows[cur_id].superseded_by == new1
+    current = [
+        r for r in rows.values()
+        if r.superseded_by is None and r.source == SOURCE_TRADE_CLOSE
+    ]
+    assert [r.id for r in current] == [new1]
+
+
 def test_persist_timeframe_days_follows_window(pg_legacy_session):
     _seed_stock(pg_legacy_session, "AAPL")
     pg_legacy_session.commit()

--- a/tests/test_paper/test_daily_wiring.py
+++ b/tests/test_paper/test_daily_wiring.py
@@ -53,6 +53,15 @@ def test_g1_daily_eval_runs_steps_in_order(monkeypatch):
     )
     monkeypatch.setattr("rainier.alerts.discord.send_eval_report", lambda **k: None)
 
+    # R-D close-side chart capture (step v addendum, unconditional).
+    def fake_close_charts(*, as_of):
+        calls.append("close_charts")
+        return 0
+
+    monkeypatch.setattr(
+        "rainier.paper.chart_archive.capture_trade_close_charts", fake_close_charts
+    )
+
     # Paper report (step v).
     def fake_compute(as_of):
         calls.append("report")
@@ -103,6 +112,10 @@ def test_g1_daily_eval_runs_steps_in_order(monkeypatch):
     assert calls.index("horizon") < calls.index("report")
     assert calls.index("report") < calls.index("reflections")
     assert calls.index("reflections") < calls.index("calibration")
+    # R-D: close-side chart capture runs in the step (v) block — after the
+    # exits are booked (update) and before the daily report goes out.
+    assert calls.index("update") < calls.index("close_charts")
+    assert calls.index("close_charts") < calls.index("report")
 
 
 class _FakeDiscord:

--- a/tests/test_paper/test_daily_wiring.py
+++ b/tests/test_paper/test_daily_wiring.py
@@ -53,9 +53,14 @@ def test_g1_daily_eval_runs_steps_in_order(monkeypatch):
     )
     monkeypatch.setattr("rainier.alerts.discord.send_eval_report", lambda **k: None)
 
-    # R-D close-side chart capture (step v addendum, unconditional).
-    def fake_close_charts(*, as_of):
+    # R-D close-side chart capture (step v addendum, unconditional). The
+    # scheduler must thread the FRESH settings' chart_lookback_days through
+    # (codex P2: never the process-cached singleton mid-daemon).
+    seen_windows: list = []
+
+    def fake_close_charts(*, as_of, window=None):
         calls.append("close_charts")
+        seen_windows.append(window)
         return 0
 
     monkeypatch.setattr(
@@ -116,6 +121,9 @@ def test_g1_daily_eval_runs_steps_in_order(monkeypatch):
     # exits are booked (update) and before the daily report goes out.
     assert calls.index("update") < calls.index("close_charts")
     assert calls.index("close_charts") < calls.index("report")
+    # ... and the window is the fresh-settings value (117 is deliberately NOT
+    # the 120 config default — proves it came from load_settings_fresh()).
+    assert seen_windows == [117]
 
 
 class _FakeDiscord:
@@ -132,6 +140,9 @@ class _FakeLLMThesis:
     model = "test-model"
     # The operator's LLM kill switch — reflections (R-A) gate on it too.
     enabled = True
+    # Deliberately NOT the 120 default: G1 asserts this exact value reaches
+    # capture_trade_close_charts, proving the fresh-settings threading.
+    chart_lookback_days = 117
 
 
 class _FakeSettings:

--- a/tests/test_paper/test_reflections.py
+++ b/tests/test_paper/test_reflections.py
@@ -481,21 +481,27 @@ def test_chart_column_present_attaches_image(pg_legacy_engine, pg_legacy_session
     from rainier.paper.reflection import generate_reflections
 
     with pg_legacy_engine.begin() as conn:
-        conn.execute(
-            text(
-                "CREATE TABLE IF NOT EXISTS chart_images ("
-                " id SERIAL PRIMARY KEY, image_bytes BYTEA)"
-            )
-        )
+        # chart_images + paper_trade.chart_id are created by the R-D archive
+        # migration (0010), applied by the pg_legacy_engine fixture. Guard the
+        # column add so this test still runs against a pre-0010 schema.
         conn.execute(
             text("ALTER TABLE paper_trade ADD COLUMN IF NOT EXISTS chart_id BIGINT")
         )
+        conn.execute(
+            text(
+                "INSERT INTO stocks (symbol) VALUES ('AAA') "
+                "ON CONFLICT (symbol) DO NOTHING"
+            )
+        )
     tid = _mk_trade(pg_legacy_session, symbol="AAA")
+    # chart_images carries a NOT NULL symbol FK under the real (R-D) schema, so
+    # supply it; the test only cares that image_bytes flows to the LLM.
     chart_id = pg_legacy_session.execute(
         text(
-            "INSERT INTO chart_images (image_bytes) VALUES (:b) RETURNING id"
+            "INSERT INTO chart_images (symbol, image_bytes) "
+            "VALUES (:s, :b) RETURNING id"
         ),
-        {"b": b"\x89PNG-fake-bytes"},
+        {"s": "AAA", "b": b"\x89PNG-fake-bytes"},
     ).scalar()
     pg_legacy_session.execute(
         text("UPDATE paper_trade SET chart_id = :c WHERE id = :id"),


### PR DESCRIPTION
## Summary
- R-D annotated chart archive per docs/TASK-PLAN-qu100-chart-archive-77f3.md: new `paper/chart_archive.py` renderer with appearance markers carrying rank labels
- Append-only supersession schema; `rainier paper appearances` / `rainier paper chart` CLIs; close-side capture wired
- Sweep-side capture is a documented follow-up pending PR #138's merge

## Migration note
**Numbered 0010 because 0008 is claimed by BOTH open PRs #138 and #139** — final numbering reconciles at merge time; second/third-to-merge renumber accordingly.

## Review
- /review: passed (claude rounds: 5)
- codex review: passed (codex rounds: 4)
- Supersession invariant is race-test-proven (partial-unique rejects second concurrent promote)

## Deferred [P2]/[P3]
- [P2] same-day QU batch skip — pre-existing behavior, out of scope here
- [P2] `regenerate_chart` window=None default — taste call, left as-is

## Tests
- 31 worker + reviewer test additions; 454 suite green; zero new failures vs the documented pre-existing cluster

## Test plan
- [ ] CI green
- [ ] verify locally