### PR TITLE
fix(test-infra): WS C — per-run test schema names + rainier db gc-test-schemas

### DIFF
--- a/migrations/0012_reclaim_queue.sql
+++ b/migrations/0012_reclaim_queue.sql
@@ -1,0 +1,60 @@
+-- Migration 0012 — WS B: reconsider invalidated bull-traps (false_breakout)
+--
+-- A `false_breakout` is a CORRECT bearish setup (price pokes above resistance,
+-- then rejects). It declines as designed. But when a LATER close reclaims the
+-- trap high (`false_high`), the bear thesis is dead — the symbol may now be a
+-- fresh LONG. The scheduled LLM run only sees today's top-5, so a reclaimed
+-- name outside it would be lost. This migration adds:
+--
+--   1. screened_stocks.bearish_invalidation_level — the trap high (`false_high`,
+--      from the pattern's key_points), persisted ONLY for exact `false_breakout`
+--      (NOT `false_breakout_hs`, which has no false_high). NULL otherwise. This
+--      is the level a later close must reclaim to invalidate the bear setup.
+--      NOTE: this is `false_high`, NOT `stop_loss` (= false_high*(1+buffer),
+--      higher) — the detector's stop sits above the trap high.
+--
+--   2. paper_reclaim_queue — a durable queue so a reclaim detected on a symbol
+--      not in today's top-5 isn't dropped. One row per (symbol,
+--      invalidated_thesis_id). Status: queued -> reenqueued -> done | expired.
+--      K-day dedup + idempotency live in the daily check (paper/reclaim.py).
+--
+-- Applies to the LEGACY local-TimescaleDB engine (NOT Neon — see memory
+-- project_two_database_url_engines). Idempotent (IF NOT EXISTS throughout).
+--
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0012_reclaim_queue.sql
+--
+-- Downgrade: migrations/0012_reclaim_queue_downgrade.sql.
+
+BEGIN;
+
+ALTER TABLE screened_stocks
+    ADD COLUMN IF NOT EXISTS bearish_invalidation_level DOUBLE PRECISION;
+
+CREATE TABLE IF NOT EXISTS paper_reclaim_queue (
+    id                     SERIAL PRIMARY KEY,
+    symbol                 VARCHAR(10) NOT NULL,
+    -- The declined bearish thesis whose trap was reclaimed. FK kept loose
+    -- (no ON DELETE) — the stale declined row is never mutated by this path.
+    invalidated_thesis_id  INTEGER NOT NULL REFERENCES analysis_results (id),
+    invalidation_level     DOUBLE PRECISION NOT NULL,
+    -- The close that reclaimed the level (drives K-day dedup).
+    reclaim_date           DATE NOT NULL,
+    reclaim_close          DOUBLE PRECISION NOT NULL,
+    status                 VARCHAR(20) NOT NULL DEFAULT 'queued',
+    invalidated_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    reenqueued_at          TIMESTAMP WITH TIME ZONE,
+    -- The fresh long thesis spawned from this reclaim (NULL until the audit
+    -- gate passes and a new thesis is created).
+    fresh_thesis_id        INTEGER REFERENCES analysis_results (id),
+    CONSTRAINT uq_paper_reclaim_symbol_thesis
+        UNIQUE (symbol, invalidated_thesis_id),
+    CONSTRAINT ck_paper_reclaim_status
+        CHECK (status IN ('queued', 'reenqueued', 'done', 'expired'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_paper_reclaim_status
+    ON paper_reclaim_queue (status);
+CREATE INDEX IF NOT EXISTS ix_paper_reclaim_symbol
+    ON paper_reclaim_queue (symbol);
+
+COMMIT;

--- a/migrations/0012_reclaim_queue_downgrade.sql
+++ b/migrations/0012_reclaim_queue_downgrade.sql
@@ -1,0 +1,11 @@
+-- Downgrade for migration 0012 (WS B reclaim queue). Idempotent.
+--
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0012_reclaim_queue_downgrade.sql
+
+BEGIN;
+
+DROP TABLE IF EXISTS paper_reclaim_queue;
+ALTER TABLE screened_stocks
+    DROP COLUMN IF EXISTS bearish_invalidation_level;
+
+COMMIT;

--- a/migrations/0013_paper_trade_shadow.sql
+++ b/migrations/0013_paper_trade_shadow.sql
@@ -1,0 +1,43 @@
+-- Migration 0013 — WS A: shadow WATCH-buy measurement
+--
+-- The loop has never bought a stock (0 setup_long). The review found WATCH
+-- verdicts outperform NO_SETUP, but acting naively is risky — the headline
+-- return is a stops-free point-to-point estimate, not real P&L. So we MEASURE
+-- first: a WATCH verdict (conf >= T, valid long-shape levels) opens a SHADOW
+-- paper_trade that runs through the REAL fill/exit engine but is excluded from
+-- every live read. The live book is unchanged. The live buy-flip (A2) is a
+-- separate, gated change — NOT this migration.
+--
+-- Adds:
+--   * paper_trade.shadow BOOLEAN NOT NULL DEFAULT FALSE — flags a shadow row.
+--   * The existing one-active-position-per-symbol partial unique index is
+--     re-scoped to `... AND shadow = false`, so a shadow position can NEVER
+--     consume a LIVE symbol's active slot (isolation invariant). A new partial
+--     unique index does the same for shadow rows so the shadow book itself
+--     still honors one-active-per-symbol.
+--
+-- Applies to the LEGACY local-TimescaleDB engine (NOT Neon — see memory
+-- project_two_database_url_engines). Idempotent.
+--
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0013_paper_trade_shadow.sql
+--
+-- Downgrade: migrations/0013_paper_trade_shadow_downgrade.sql.
+
+BEGIN;
+
+ALTER TABLE paper_trade
+    ADD COLUMN IF NOT EXISTS shadow BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Re-scope the live active-symbol uniqueness to NON-shadow rows only. Drop the
+-- old index (it covered all rows regardless of shadow) and recreate scoped.
+DROP INDEX IF EXISTS idx_paper_trade_active_symbol;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_paper_trade_active_symbol
+    ON paper_trade (symbol)
+    WHERE status IN ('pending', 'open') AND shadow = false;
+
+-- The shadow book honors one-active-per-symbol independently.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_paper_trade_active_symbol_shadow
+    ON paper_trade (symbol)
+    WHERE status IN ('pending', 'open') AND shadow = true;
+
+COMMIT;

--- a/migrations/0013_paper_trade_shadow_downgrade.sql
+++ b/migrations/0013_paper_trade_shadow_downgrade.sql
@@ -1,0 +1,19 @@
+-- Downgrade for migration 0013 (WS A shadow column). Idempotent.
+--
+-- Restores the original all-rows active-symbol unique index and drops the
+-- shadow column + its scoped index.
+--
+--   psql "$LEGACY_DATABASE_URL" -f migrations/0013_paper_trade_shadow_downgrade.sql
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_paper_trade_active_symbol_shadow;
+DROP INDEX IF EXISTS idx_paper_trade_active_symbol;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_paper_trade_active_symbol
+    ON paper_trade (symbol)
+    WHERE status IN ('pending', 'open');
+
+ALTER TABLE paper_trade
+    DROP COLUMN IF EXISTS shadow;
+
+COMMIT;

--- a/src/rainier/analysis/stock_screener.py
+++ b/src/rainier/analysis/stock_screener.py
@@ -585,6 +585,20 @@ def _to_candidate(
     if bp and bp.breakout_idx is not None and total_bars:
         bars_since = int(total_bars) - 1 - bp.breakout_idx
 
+    # WS B: capture the trap-high invalidation level ONLY for an exact
+    # `false_breakout` (NOT `false_breakout_hs`, whose key_points carry no
+    # `false_high`). This is `false_high`, not `stop_loss` (which sits a buffer
+    # above it). A later close above this level invalidates the bear setup.
+    bearish_invalidation_level = None
+    if (
+        bp is not None
+        and bp.pattern_type == "false_breakout"
+        and bp.key_points is not None
+    ):
+        false_high = bp.key_points.get("false_high")
+        if false_high is not None:
+            bearish_invalidation_level = float(false_high)
+
     return StockCandidate(
         symbol=result.symbol,
         rank=result.qu100_rank,
@@ -602,6 +616,7 @@ def _to_candidate(
         stop_loss=result.stop_loss,
         target_price=result.target,
         rr_ratio=bp.rr_ratio if bp else None,
+        bearish_invalidation_level=bearish_invalidation_level,
         volume_confirmed=bp.volume_confirmed if bp else False,
         current_price=round(current_price, 2) if current_price else None,
         distance_to_entry_pct=dist_to_entry,

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1931,6 +1931,56 @@ def paper_group() -> None:
     """QU100 paper-trade tracker — open positions, update exits, report."""
 
 
+@paper_group.command(name="shadow-replay")
+@click.option(
+    "--start", "start_iso", required=True, help="Window start (YYYY-MM-DD)"
+)
+@click.option("--end", "end_iso", required=True, help="Window end (YYYY-MM-DD)")
+@click.option(
+    "--thresholds",
+    default="4,5,6",
+    show_default=True,
+    help="Comma-separated WATCH confidence thresholds to sweep.",
+)
+@click.option(
+    "--benchmark", default="SPY", show_default=True, help="Benchmark symbol."
+)
+def paper_shadow_replay(start_iso, end_iso, thresholds, benchmark):
+    """WS A — replay the shadow WATCH-buy book over a window per threshold T.
+
+    Drives the REAL fill/exit engine day by day over historical theses, opening
+    SHADOW positions (excluded from the live book) at each T, and prints the
+    shadow book's return vs cash and vs the benchmark. Use the two review
+    windows (2026-05-29→06-12 and 2026-05-22→06-12) to compare arms.
+
+    NOTE: shadow rows persist in the DB. Run against a throwaway/replay schema
+    or `rainier db gc-test-schemas` afterward — this command does not isolate
+    arms from each other; it is a measurement tool, not a live mutation.
+    """
+    from datetime import date as _date
+
+    from rainier.paper.calendar import DEFAULT_CALENDAR
+    from rainier.paper.replay import replay_threshold
+
+    start = _date.fromisoformat(start_iso)
+    end = _date.fromisoformat(end_iso)
+    ts = [int(t) for t in thresholds.split(",") if t.strip()]
+    days = DEFAULT_CALENDAR.sessions_between(start, end)
+
+    click.echo(f"Shadow replay {start}..{end} ({len(days)} sessions), bench={benchmark}")
+    click.echo(f"{'T':>3} {'fired':>6} {'book%':>8} {'cash%':>7} {'bench%':>8}")
+    for t in ts:
+        arm = replay_threshold(
+            threshold=t, trading_days=days, benchmark_symbol=benchmark
+        )
+        click.echo(
+            f"{arm.threshold:>3} {arm.fired:>6} "
+            f"{arm.book_return_pct * 100:>7.2f}% "
+            f"{arm.cash_return_pct * 100:>6.2f}% "
+            f"{arm.benchmark_return_pct * 100:>7.2f}%"
+        )
+
+
 @paper_group.command(name="open")
 @click.option("--date", "as_of_iso", default=None, help="Fill as-of date (YYYY-MM-DD)")
 @click.pass_context

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1726,6 +1726,52 @@ def db_init(ctx):
     click.echo("Database initialized successfully.")
 
 
+@db.command(name="gc-test-schemas")
+@click.option(
+    "--apply",
+    is_flag=True,
+    default=False,
+    help="Drop the leaked test schemas. Without this, dry-run lists them only.",
+)
+def db_gc_test_schemas(apply: bool) -> None:
+    """Reap leaked throwaway test schemas from the LEGACY database.
+
+    The paper-tracker test fixtures build disposable Postgres schemas
+    (``rainier_paper_test*`` etc). A SIGKILL'd run can leave one behind in the
+    live local TimescaleDB. This lists them (dry-run) and, with ``--apply``,
+    drops only those matching the anchored allowlist regex — NEVER
+    ``public`` / ``market`` / the active schema. Targets the legacy
+    ``core.database`` engine (``LEGACY_DATABASE_URL``), never canonical Neon
+    (the 2026-06-01 two-engine trap).
+    """
+    from rainier.core.database import get_engine
+    from rainier.core.test_schema_gc import gc_test_schemas
+
+    engine = get_engine()
+    result = gc_test_schemas(engine, apply=apply)
+    candidates = result["candidates"]
+    if apply:
+        dropped = result["dropped"]
+        failed = result["failed"]
+        click.echo(f"gc-test-schemas: dropped {len(dropped)} leaked schema(s).")
+        for name in dropped:
+            click.echo(f"  dropped {name}")
+        if failed:
+            for name, err in failed:
+                click.echo(f"  FAILED to drop {name}: {err}", err=True)
+            raise click.ClickException(
+                f"gc-test-schemas: {len(failed)} schema(s) could not be "
+                f"dropped (see above). Resolve the error and re-run --apply."
+            )
+    else:
+        click.echo(
+            f"DRY-RUN gc-test-schemas: would drop {len(candidates)} leaked "
+            f"schema(s). Re-run with --apply to drop."
+        )
+        for name in candidates:
+            click.echo(f"  {name}")
+
+
 @db.command(name="backfill-prices")
 @click.option("--years", default=5, type=int, help="Years of history to fetch")
 @click.option("--batch-size", default=20, type=int, help="Symbols per yfinance batch")

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -513,6 +513,8 @@ def load_settings(config_path: Path | None = None) -> Settings:
         if signals is not None:
             thesis_kwargs["signals"] = signals
         kwargs["llm_thesis"] = LLMThesisConfig(**thesis_kwargs)
+    if "paper" in yaml_config:
+        kwargs["paper"] = PaperConfig(**yaml_config["paper"])
     if "notify" in yaml_config:
         kwargs["notify"] = NotifyConfig(**yaml_config["notify"])
     if "stock_screener" in yaml_config:

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -329,6 +329,38 @@ class LLMThesisConfig(BaseModel):
     chart_lookback_days: int = 120
 
 
+class PaperConfig(BaseModel):
+    """Paper-tracker tuning for the P0 batch loop fixes (WS A + WS B).
+
+    All reversible / config-gated. WS A ships shadow-only this PR (no live
+    buy-flip); WS B's auto-thesis stays gated on the post-reclaim audit.
+    """
+
+    # --- WS A: shadow WATCH-buy measurement ---------------------------------
+    # When True, a WATCH verdict with confidence >= watch_buy_min_confidence AND
+    # valid long-shape levels opens a SHADOW paper_trade (flagged, excluded from
+    # every live read) that runs through the real fill/exit engine. The live
+    # book is unchanged. Default ON (measurement); the LIVE flip (A2) is a
+    # separate, gated change and is NOT controlled here.
+    watch_buy_shadow: bool = True
+    # T threshold for shadow WATCH-buys. WATCH confidence maxes at 6.
+    watch_buy_min_confidence: int = 5
+
+    # --- WS B: reconsider invalidated bull-traps ----------------------------
+    # Re-enqueue a reclaimed symbol at most once per this many days (whipsaw
+    # dedup).
+    reclaim_dedup_days: int = 5
+    # Track invalidation over this many days after the bearish thesis.
+    reclaim_window_days: int = 20
+    # Auto-thesis (creating a FRESH long thesis from the queue) is enabled only
+    # when the post-reclaim audit clears: mean forward return > 0 across at least
+    # `reclaim_audit_min_events` historical reclaim events. Below the floor or
+    # <= 0 mean → detection + queue only (the designed fallback).
+    reclaim_auto_thesis: bool = False
+    reclaim_audit_min_events: int = 10
+    reclaim_audit_horizon_days: int = 10
+
+
 class NotifyConfig(BaseModel):
     enabled: bool = True
     subject_prefix: str = "[Rainier]"
@@ -400,6 +432,9 @@ class Settings(BaseSettings):
 
     # LLM thesis (PR1)
     llm_thesis: LLMThesisConfig = LLMThesisConfig()
+
+    # Paper-tracker P0 batch (WS A shadow WATCH-buy + WS B reclaim queue)
+    paper: PaperConfig = PaperConfig()
 
     # Notifications
     notify: NotifyConfig = NotifyConfig()

--- a/src/rainier/core/models.py
+++ b/src/rainier/core/models.py
@@ -700,6 +700,16 @@ class PaperTrade(Base):
         BigInteger, ForeignKey("chart_images.id")
     )
 
+    # WS A (shadow WATCH-buy, migration 0013): a shadow row is a measurement-only
+    # position opened by a WATCH verdict. It runs through the REAL fill/exit
+    # engine but is EXCLUDED from every live read (book, paper_skip, calibration,
+    # reports, charts, research) and never consumes a LIVE symbol's active slot
+    # (the partial-unique index below is scoped to shadow=false). The live book
+    # is byte-identical whether or not shadow rows exist.
+    shadow: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+
     __table_args__ = (
         UniqueConstraint("thesis_id", name="uq_paper_trade_thesis_id"),
         CheckConstraint(
@@ -716,13 +726,22 @@ class PaperTrade(Base):
             "reflection IS NULL OR exit_reason IS NOT NULL",
             name="ck_paper_trade_reflection_after_exit",
         ),
-        # Partial unique index — one pending/open position per symbol (design
-        # D1). Closed/expired rows fall out, so a symbol can be re-traded later.
+        # Partial unique index — one pending/open LIVE position per symbol
+        # (design D1). Scoped to shadow=false (WS A) so a shadow position never
+        # consumes a live symbol's active slot. Closed/expired rows fall out, so
+        # a symbol can be re-traded later.
         Index(
             "idx_paper_trade_active_symbol",
             "symbol",
             unique=True,
-            postgresql_where="status IN ('pending', 'open')",
+            postgresql_where="status IN ('pending', 'open') AND shadow = false",
+        ),
+        # The shadow book honors one-active-per-symbol independently (WS A).
+        Index(
+            "idx_paper_trade_active_symbol_shadow",
+            "symbol",
+            unique=True,
+            postgresql_where="status IN ('pending', 'open') AND shadow = true",
         ),
     )
 

--- a/src/rainier/core/models.py
+++ b/src/rainier/core/models.py
@@ -460,6 +460,15 @@ class ScreenedStockRecord(Base):
     target_price: Mapped[float | None] = mapped_column(Float)
     rr_ratio: Mapped[float | None] = mapped_column(Float)
 
+    # WS B (reclaim queue, migration 0012): the trap-high invalidation level for
+    # an exact `false_breakout` (the pattern's `false_high` key-point — NOT
+    # `stop_loss`, which sits a buffer above it). Persisted ONLY for
+    # `pattern_type == 'false_breakout'`; NULL for every other pattern (incl.
+    # `false_breakout_hs`, which has no `false_high`). A later close above this
+    # level invalidates the bear setup and queues the symbol for a fresh long
+    # thesis. Additive (`ADD COLUMN IF NOT EXISTS`).
+    bearish_invalidation_level: Mapped[float | None] = mapped_column(Float)
+
     # From LLM (nullable — only afternoon/close top-5 get this)
     llm_confidence: Mapped[int | None] = mapped_column(Integer)
     shadow_combined_score: Mapped[float | None] = mapped_column(Float)
@@ -844,6 +853,56 @@ class QU100DailyFeatures(Base):
             "data_date",
             "ranking_type",
             name="uq_qu100_daily_features_symbol_date_ranking",
+        ),
+    )
+
+
+class PaperReclaimQueue(Base):
+    """WS B — durable queue of invalidated bull-traps awaiting re-evaluation.
+
+    A `false_breakout` is a correct bearish setup; it declines as designed. When
+    a later close reclaims the trap high (`bearish_invalidation_level`), the bear
+    thesis is dead and the symbol may be a fresh LONG. The scheduled LLM run only
+    sees today's top-5, so a reclaimed name outside it would be lost — this queue
+    persists it. The daily check (`paper/reclaim.py`) enforces idempotency
+    (UNIQUE(symbol, invalidated_thesis_id)) and once-per-K-days dedup; the
+    audit gate decides whether a fresh thesis is actually spawned.
+
+    Status lifecycle:  queued -> reenqueued -> done | expired
+    Created in migrations/0012_reclaim_queue.sql.
+    """
+
+    __tablename__ = "paper_reclaim_queue"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    symbol: Mapped[str] = mapped_column(String(10), nullable=False, index=True)
+    invalidated_thesis_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("analysis_results.id"), nullable=False
+    )
+    invalidation_level: Mapped[float] = mapped_column(Float, nullable=False)
+    reclaim_date: Mapped[date] = mapped_column(Date, nullable=False)
+    reclaim_close: Mapped[float] = mapped_column(Float, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="queued", server_default="queued",
+        index=True,
+    )
+    invalidated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    reenqueued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    fresh_thesis_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("analysis_results.id")
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "symbol",
+            "invalidated_thesis_id",
+            name="uq_paper_reclaim_symbol_thesis",
+        ),
+        CheckConstraint(
+            "status IN ('queued', 'reenqueued', 'done', 'expired')",
+            name="ck_paper_reclaim_status",
         ),
     )
 

--- a/src/rainier/core/test_schema_gc.py
+++ b/src/rainier/core/test_schema_gc.py
@@ -1,0 +1,105 @@
+"""Reap leaked throwaway test schemas from the LEGACY engine's database.
+
+The paper-tracker test suite builds disposable Postgres schemas
+(``rainier_paper_test``, ``rainier_chartmig_test``, ``rainier_mig0006_test``,
+and — after this change — per-run suffixed variants like
+``rainier_paper_test_ab12``). Teardown normally drops them, but a SIGKILL'd
+test run, a crashed worker, or a pre-fix fixture can leave a schema behind in
+the live local TimescaleDB. Those orphans accumulate silently.
+
+This module lists and (on apply) drops ONLY schemas matching the anchored
+allowlist regex, and NEVER ``public`` / ``market`` / the connection's current
+schema — even if such a name somehow matched the regex. It targets the
+**legacy** engine (``core.database`` / ``legacy_database_url``), never the
+canonical Neon ``db.engine`` (the 2026-06-01 two-engine trap).
+
+ASCII flow:
+
+    list_test_schemas(engine)  -> [names matching regex, minus protected]
+    gc_test_schemas(engine,
+                    apply=False) -> {"candidates": [...], "dropped": []}
+                    apply=True   -> drops each, {"candidates": [...],
+                                                 "dropped": [...],
+                                                 "failed": [(name, err)]}
+"""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+# Anchored allowlist. The trailing ``(_[a-z0-9]+)*`` permits per-run AND
+# per-worker suffix tokens appended after the base name, e.g.
+# ``rainier_paper_test_ab12`` or ``rainier_paper_test_ab12_w3``. A raw prefix
+# match (``startswith("rainier_")``) is deliberately NOT used — it would sweep
+# in unrelated namespaces.
+TEST_SCHEMA_RE = re.compile(r"^rainier_(paper|chartmig|mig0006)_test(_[a-z0-9]+)*$")
+
+# Never droppable, regardless of regex match. ``current_schema()`` is added
+# dynamically at call time (the active schema must never be dropped out from
+# under the live connection).
+HARD_PROTECTED = frozenset({"public", "market"})
+
+
+def is_droppable_test_schema(name: str, *, protected: frozenset[str]) -> bool:
+    """True iff ``name`` matches the allowlist regex and is not protected.
+
+    Protected names (``public``, ``market``, the current schema) are refused
+    even when they match the regex — the regex can never authorise dropping
+    them.
+    """
+    if name in protected:
+        return False
+    return TEST_SCHEMA_RE.match(name) is not None
+
+
+def _protected_set(engine: Engine) -> frozenset[str]:
+    with engine.connect() as conn:
+        current = conn.execute(text("SELECT current_schema()")).scalar()
+    extra = {current} if current else set()
+    return HARD_PROTECTED | extra
+
+
+def list_test_schemas(engine: Engine) -> list[str]:
+    """Return sorted names of droppable leaked test schemas on ``engine``'s DB."""
+    protected = _protected_set(engine)
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text("SELECT schema_name FROM information_schema.schemata")
+        ).scalars().all()
+    return sorted(
+        n for n in rows if is_droppable_test_schema(n, protected=protected)
+    )
+
+
+def gc_test_schemas(engine: Engine, *, apply: bool = False) -> dict:
+    """List (and on ``apply`` drop) leaked test schemas.
+
+    Dry-run by default: returns the candidate list without touching the DB.
+    With ``apply=True`` each candidate is ``DROP SCHEMA ... CASCADE``'d in its
+    own transaction; a failure on one does not abort the rest. The candidate
+    list is re-computed under the protected guard, so a protected schema can
+    never be dropped even if a caller passes a hand-built list.
+    """
+    candidates = list_test_schemas(engine)
+    result: dict = {"candidates": candidates, "dropped": [], "failed": []}
+    if not apply:
+        return result
+
+    protected = _protected_set(engine)
+    for name in candidates:
+        # Defense in depth: re-check the guard right before the destructive op.
+        if not is_droppable_test_schema(name, protected=protected):
+            continue
+        try:
+            with engine.begin() as conn:
+                # Identifier is regex-validated against the anchored allowlist
+                # above, so interpolation here cannot inject (no quotes/spaces
+                # possible in a matching name).
+                conn.execute(text(f'DROP SCHEMA IF EXISTS "{name}" CASCADE'))
+            result["dropped"].append(name)
+        except Exception as exc:  # pragma: no cover - exercised via failed-drop test
+            result["failed"].append((name, str(exc)))
+    return result

--- a/src/rainier/core/types.py
+++ b/src/rainier/core/types.py
@@ -187,6 +187,12 @@ class StockCandidate:
     rr_ratio: float | None = None
     volume_confirmed: bool = False
 
+    # WS B: trap-high invalidation level for an exact `false_breakout` only
+    # (the pattern's `false_high` key-point). NULL for every other pattern.
+    # Persisted onto screened_stocks so a later close above it can re-enqueue
+    # the symbol for a fresh long thesis.
+    bearish_invalidation_level: float | None = None
+
     # Actionability context (today's price vs pattern levels)
     current_price: float | None = None
     distance_to_entry_pct: float | None = None  # % from current price to entry

--- a/src/rainier/llm_thesis/eval.py
+++ b/src/rainier/llm_thesis/eval.py
@@ -32,12 +32,27 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from rainier.core.database import get_session
 from rainier.core.models import (
     LLMAnalysisRecord,
+    PaperTrade,
     ScreenedStockRecord,
     StockPrice,
     ThesisEvaluation,
 )
 
 log = logging.getLogger(__name__)
+
+
+def _thesis_opened_long(thesis_id: int) -> bool:
+    """WS A — True iff a (shadow) paper_trade was OPENED for this thesis, i.e.
+    the loop actually took a long action on a WATCH verdict. A pending/expired
+    row that never filled is not an action; only entry_price set counts."""
+    with get_session() as session:
+        row = session.execute(
+            select(PaperTrade.id).where(
+                PaperTrade.thesis_id == thesis_id,
+                PaperTrade.entry_price.isnot(None),
+            )
+        ).first()
+    return row is not None
 
 
 # Horizons we evaluate. Centralized here so callers don't typo strings.
@@ -132,14 +147,20 @@ def _trading_days_back(end: date, n: int) -> date:
     return target.date()
 
 
-def _hit(verdict: str, return_pct: float) -> bool:
+def _hit(verdict: str, return_pct: float, *, acted_long: bool = False) -> bool:
     """Did the thesis direction match the realized return sign?
 
-    setup_long: hit iff return_pct > 0
-    watch / no_setup: hit iff return_pct <= 0 (LLM was right NOT to buy)
+    WS A — split "verdict label" from "action taken". When a WATCH verdict
+    actually OPENED a (shadow) long position (``acted_long=True``), grade it on
+    the TRADE outcome (hit iff return_pct > 0), NOT the abstention rule — the
+    loop bought, so a profitable move IS a win. Without an action, the original
+    abstention grading stands.
+
+    setup_long (or any acted long): hit iff return_pct > 0
+    watch / no_setup (no action): hit iff return_pct <= 0 (right NOT to buy)
     Unknown verdicts default to False so we never silently mark them hits.
     """
-    if verdict == "setup_long":
+    if acted_long or verdict == "setup_long":
         return return_pct > 0
     if verdict in ("watch", "no_setup"):
         return return_pct <= 0
@@ -251,7 +272,10 @@ def evaluate_horizon(
             continue
 
         return_pct = (exit_close - entry_close) / entry_close
-        hit = _hit(verdict, return_pct)
+        # WS A: if this WATCH thesis actually opened a (shadow) long, grade it on
+        # the trade outcome, not the abstention rule (split label from action).
+        acted_long = verdict == "watch" and _thesis_opened_long(row.id)
+        hit = _hit(verdict, return_pct, acted_long=acted_long)
 
         with get_session() as session:
             stmt = (

--- a/src/rainier/llm_thesis/persistence.py
+++ b/src/rainier/llm_thesis/persistence.py
@@ -63,6 +63,13 @@ def _candidate_row(
         "rr_ratio": (
             float(candidate.rr_ratio) if candidate.rr_ratio is not None else None
         ),
+        # WS B: trap-high invalidation level (exact false_breakout only; NULL
+        # otherwise). A later close above this re-enqueues the symbol.
+        "bearish_invalidation_level": (
+            float(candidate.bearish_invalidation_level)
+            if candidate.bearish_invalidation_level is not None
+            else None
+        ),
     }
 
 
@@ -114,6 +121,11 @@ def persist_screened_stocks(
                     tbl.c.target_price, stmt.excluded.target_price
                 ),
                 "rr_ratio": func.coalesce(tbl.c.rr_ratio, stmt.excluded.rr_ratio),
+                # WS B: backfill the trap-high level on re-persist if NULL.
+                "bearish_invalidation_level": func.coalesce(
+                    tbl.c.bearish_invalidation_level,
+                    stmt.excluded.bearish_invalidation_level,
+                ),
             },
         )
         session.execute(stmt)

--- a/src/rainier/llm_thesis/research.py
+++ b/src/rainier/llm_thesis/research.py
@@ -999,7 +999,10 @@ def _load_time_stop_trades(
     trades: list[dict[str, Any]] = []
     with get_session() as session:
         positions = session.execute(
-            select(PaperTrade).where(PaperTrade.entry_date.isnot(None))
+            select(PaperTrade).where(
+                PaperTrade.entry_date.isnot(None),
+                PaperTrade.shadow.is_(False),  # WS A isolation: live read only.
+            )
         ).scalars().all()
         meta = [
             {
@@ -1276,6 +1279,7 @@ def check_paper_lessons(
                 PaperTrade.exit_date.isnot(None),
                 PaperTrade.exit_date >= cutoff,
                 PaperTrade.exit_date <= anchor,
+                PaperTrade.shadow.is_(False),  # WS A isolation: live read only.
             )
         ).scalars().all()
         rows = [

--- a/src/rainier/llm_thesis/service.py
+++ b/src/rainier/llm_thesis/service.py
@@ -796,6 +796,7 @@ async def _compute_theses_async(
     # this runs AFTER update_with_thesis + persist_screened_stocks have landed
     # the row. Each insert is in its own get_session() scope; failures here are
     # non-fatal to thesis rendering.
+    paper_theses: list[dict[str, Any]] = []
     try:
         paper_theses = [
             {
@@ -818,5 +819,23 @@ async def _compute_theses_async(
             )
     except Exception:
         log.exception("paper_position_creation_failed scan_date=%s", scan_date)
+
+    # WS A — shadow WATCH-buy (measurement only). A `watch` verdict (conf >= T,
+    # long-shape levels) opens a SHADOW paper_trade through the real engine,
+    # excluded from every live read. Default ON; the live buy-flip (A2) is a
+    # separate, gated change. Failure-isolated and never touches the live book.
+    try:
+        if settings.paper.watch_buy_shadow and paper_theses:
+            from rainier.paper.positions import (
+                create_shadow_positions_for_theses,
+            )
+
+            create_shadow_positions_for_theses(
+                paper_theses,
+                scan_date=scan_date,
+                min_confidence=settings.paper.watch_buy_min_confidence,
+            )
+    except Exception:
+        log.exception("shadow_position_creation_failed scan_date=%s", scan_date)
 
     return out

--- a/src/rainier/paper/calibration.py
+++ b/src/rainier/paper/calibration.py
@@ -185,6 +185,7 @@ def compute_calibration_payload(
                 PaperTrade.status == "closed",
                 PaperTrade.exit_date.isnot(None),
                 PaperTrade.exit_date <= as_of,
+                PaperTrade.shadow.is_(False),  # WS A isolation: live read only.
             )
             .order_by(PaperTrade.exit_date.desc(), PaperTrade.id.desc())
             .limit(k)

--- a/src/rainier/paper/chart_archive.py
+++ b/src/rainier/paper/chart_archive.py
@@ -389,6 +389,7 @@ def capture_trade_close_charts(
             .where(
                 PaperTrade.status == "closed",
                 PaperTrade.exit_date == as_of,
+                PaperTrade.shadow.is_(False),  # WS A isolation: live read only.
             )
             .order_by(PaperTrade.id)
         ).all()
@@ -459,6 +460,7 @@ def regenerate_chart(
                     PaperTrade.symbol == symbol,
                     PaperTrade.status == "closed",
                     PaperTrade.exit_date == as_of,
+                    PaperTrade.shadow.is_(False),  # WS A isolation: live only.
                 )
                 .order_by(PaperTrade.id.desc())
                 .limit(1)

--- a/src/rainier/paper/positions.py
+++ b/src/rainier/paper/positions.py
@@ -48,6 +48,18 @@ _SESSION_ORDER = {"afternoon": 0, "close": 1}
 
 _REQUIRED_LEVELS = ("entry_price", "stop_loss", "target_price")
 
+# WS A: bullish pattern allowlist for the shadow WATCH-buy long-shape guard. An
+# exact `false_breakout` is bearish — it must never open a long shadow position.
+_BULLISH_PATTERNS = frozenset(
+    {
+        "w_bottom",
+        "false_breakdown",
+        "false_breakdown_w_bottom",
+        "bull_flag",
+        "hs_bottom",
+    }
+)
+
 # Fixed $10k notional per position (design D2).
 NOTIONAL_USD = 10_000.0
 # A pending position with no fill after this many trading sessions → expired (D3).
@@ -113,15 +125,48 @@ def _persisted_levels(
     ).scalars().first()
 
 
-def _active_position(session, symbol: str) -> PaperTrade | None:
-    """The current pending/open position holding ``symbol``'s active slot, if
-    any (the partial-unique index guarantees at most one)."""
+def _active_position(session, symbol: str, *, shadow: bool = False) -> PaperTrade | None:
+    """The current pending/open position holding ``symbol``'s active slot in the
+    requested book (live vs shadow), if any. Scoped to ``shadow`` so a shadow
+    pick checks shadow slots and a live pick checks live slots — the two books
+    have independent one-active-per-symbol uniqueness (WS A)."""
     return session.execute(
         select(PaperTrade).where(
             PaperTrade.symbol == symbol,
             PaperTrade.status.in_(("pending", "open")),
+            PaperTrade.shadow.is_(shadow),
         )
     ).scalars().first()
+
+
+def _is_watch_buy_signal(
+    verdict: str | None,
+    llm_confidence: int | None,
+    session: str,
+    min_confidence: int,
+) -> bool:
+    """WS A: a `watch` verdict passing the shadow confidence + session gate. The
+    long-shape level guard is applied separately (it needs the persisted row)."""
+    return (
+        verdict == "watch"
+        and session in ACTIONABLE_SESSIONS
+        and llm_confidence is not None
+        and int(llm_confidence) >= min_confidence
+    )
+
+
+def _is_long_shape(levels: dict[str, Any], pattern_type: str | None) -> bool:
+    """WS A long-shape guard: a valid LONG setup has entry below target and stop
+    below entry, and a bullish pattern. An exact `false_breakout` (bearish) is
+    excluded — it would open a level-less / wrong-direction long otherwise."""
+    entry = levels.get("entry_price")
+    stop = levels.get("stop_loss")
+    target = levels.get("target_price")
+    if entry is None or stop is None or target is None:
+        return False
+    if not (stop < entry < target):
+        return False
+    return pattern_type in _BULLISH_PATTERNS
 
 
 def create_positions_for_theses(
@@ -186,7 +231,64 @@ def create_positions_for_theses(
     return {"created": created, "skipped": skipped}
 
 
-def _create_one(thesis: dict[str, Any], scan_date: date) -> bool:
+def create_shadow_positions_for_theses(
+    theses: list[dict[str, Any]],
+    *,
+    scan_date: date,
+    min_confidence: int,
+) -> dict[str, int]:
+    """WS A — open SHADOW positions for WATCH verdicts (measurement only).
+
+    A `watch` verdict with ``llm_confidence >= min_confidence`` AND valid
+    long-shape levels (entry<target, stop<entry, bullish pattern) opens a
+    `paper_trade` flagged ``shadow=True``. Shadow rows run through the SAME
+    fill/exit engine but are excluded from every live read and never consume a
+    live symbol's active slot (the partial-unique index is scoped to
+    shadow=false). The live book is untouched by this call.
+
+    Same dedupe rules as the live path (highest conf wins; tie → earliest
+    session), applied within the shadow book. Returns ``{"created", "skipped"}``.
+    """
+    eligible = [
+        t
+        for t in theses
+        if _is_watch_buy_signal(
+            t.get("verdict"),
+            t.get("llm_confidence"),
+            t.get("session_name", ""),
+            min_confidence,
+        )
+    ]
+    if not eligible:
+        return {"created": 0, "skipped": 0}
+
+    by_symbol: dict[str, list[dict[str, Any]]] = {}
+    for t in eligible:
+        by_symbol.setdefault(t["symbol"], []).append(t)
+
+    winners: list[dict[str, Any]] = []
+    for _symbol, group in by_symbol.items():
+        group_sorted = sorted(
+            group,
+            key=lambda t: (
+                -int(t["llm_confidence"]),
+                _SESSION_ORDER.get(t.get("session_name", ""), 99),
+                int(t["thesis_id"]),
+            ),
+        )
+        winners.append(group_sorted[0])
+
+    created = 0
+    skipped = len(eligible) - len(winners)
+    for t in winners:
+        if _create_one(t, scan_date, shadow=True):
+            created += 1
+        else:
+            skipped += 1
+    return {"created": created, "skipped": skipped}
+
+
+def _create_one(thesis: dict[str, Any], scan_date: date, *, shadow: bool = False) -> bool:
     """Create one position. Returns True iff a row was inserted; otherwise a
     skip-ledger row is written (or the thesis was already opened — idempotent
     no-op). Runs entirely in its own session scope."""
@@ -211,13 +313,23 @@ def _create_one(thesis: dict[str, Any], scan_date: date) -> bool:
             }
 
     if levels is None:
-        _record_skip(thesis_id, symbol, scan_date, "missing_screened_record")
+        # Shadow never touches the live skip ledger (a live-read surface, WS A).
+        if not shadow:
+            _record_skip(thesis_id, symbol, scan_date, "missing_screened_record")
         return False
 
     # Any required level NULL → skip missing_levels (guard BEFORE insert so a
     # later C2 backfill + re-run can still create the position, D8).
     if any(levels.get(k) is None for k in _REQUIRED_LEVELS):
-        _record_skip(thesis_id, symbol, scan_date, "missing_levels")
+        if not shadow:
+            _record_skip(thesis_id, symbol, scan_date, "missing_levels")
+        return False
+
+    # WS A long-shape guard: a shadow WATCH-buy must be a valid LONG setup with a
+    # bullish pattern. A level-less or bearish (false_breakout) candidate never
+    # opens. This is the regression that a `watch` on `false_breakout` does NOT
+    # open a shadow position.
+    if shadow and not _is_long_shape(levels, getattr(screened, "pattern_type", None)):
         return False
 
     # Active-symbol resolution (D7 + D10 cross-session). `create_positions_for_
@@ -232,7 +344,7 @@ def _create_one(thesis: dict[str, Any], scan_date: date) -> bool:
     #     close pick DISPLACES it (expire the old pending, record the old thesis
     #     `same_symbol_lower_conviction`), then fall through to insert the new.
     with get_session() as session:
-        active = _active_position(session, symbol)
+        active = _active_position(session, symbol, shadow=shadow)
         if active is not None:
             # Idempotent re-run: the active row IS this thesis's own position
             # (D5). No skip, no displacement — just a no-op.
@@ -249,14 +361,18 @@ def _create_one(thesis: dict[str, Any], scan_date: date) -> bool:
             )
             existing_conf = active.llm_confidence
             if not cross_session_pending:
-                _record_skip(thesis_id, symbol, scan_date, "symbol_already_active")
+                if not shadow:
+                    _record_skip(
+                        thesis_id, symbol, scan_date, "symbol_already_active"
+                    )
                 return False
             if existing_conf is not None and existing_conf >= new_conf:
                 # Incumbent out-convicts (or ties → earliest session, i.e. the
                 # already-pending one) → the new pick loses (D10).
-                _record_skip(
-                    thesis_id, symbol, scan_date, "same_symbol_lower_conviction"
-                )
+                if not shadow:
+                    _record_skip(
+                        thesis_id, symbol, scan_date, "same_symbol_lower_conviction"
+                    )
                 return False
             # New pick out-convicts the same-day pending → displace it (only if
             # still pending — a concurrent fill may have opened it meanwhile).
@@ -269,7 +385,7 @@ def _create_one(thesis: dict[str, Any], scan_date: date) -> bool:
         else:
             displaced_thesis = None
 
-    if displaced_thesis is not None:
+    if displaced_thesis is not None and not shadow:
         _record_skip(
             displaced_thesis, symbol, scan_date, "same_symbol_lower_conviction"
         )
@@ -290,6 +406,7 @@ def _create_one(thesis: dict[str, Any], scan_date: date) -> bool:
         "pattern_type": getattr(screened, "pattern_type", None),
         "llm_confidence": int(thesis["llm_confidence"]),
         "verdict": thesis.get("verdict"),
+        "shadow": shadow,
         # fill fields stay NULL while pending (D1).
     }
 
@@ -305,7 +422,7 @@ def _create_one(thesis: dict[str, Any], scan_date: date) -> bool:
             # DO NOTHING conflict it's empty. rowcount is unreliable here (-1 for
             # ON CONFLICT inserts under psycopg), so use the returned row instead.
             inserted = session.execute(stmt).first() is not None
-        if inserted:
+        if inserted and not shadow:
             # D8 retry: a thesis previously skipped (missing_levels/missing_
             # screened_record) that now opens must not linger in the skip ledger.
             _clear_skip(thesis_id)
@@ -313,8 +430,10 @@ def _create_one(thesis: dict[str, Any], scan_date: date) -> bool:
     except IntegrityError:
         # Partial-unique conflict (symbol already active) raced past the
         # pre-check. The txn rolled back cleanly (its own scope); record the
-        # skip and let the batch continue (D7c).
-        _record_skip(thesis_id, symbol, scan_date, "symbol_already_active")
+        # skip and let the batch continue (D7c). Shadow never writes the live
+        # skip ledger.
+        if not shadow:
+            _record_skip(thesis_id, symbol, scan_date, "symbol_already_active")
         return False
 
 

--- a/src/rainier/paper/positions.py
+++ b/src/rainier/paper/positions.py
@@ -490,6 +490,9 @@ def fill_pending_positions(
                 "id": p.id, "thesis_id": p.thesis_id, "symbol": p.symbol,
                 "scan_date": _as_date(p.scan_date), "stop_loss": p.stop_loss,
                 "target_price": p.target_price,
+                # WS A: carry shadow so the fill path never writes the live skip
+                # ledger for a shadow row (isolation invariant — same as create).
+                "shadow": bool(p.shadow),
             }
             for p in pending
         ]
@@ -532,10 +535,12 @@ def fill_pending_positions(
             # Fill-validity guard (E1c): open gapped past a level → expired.
             if open_px >= it["target_price"] or open_px <= it["stop_loss"]:
                 if _expire_locked(session, it["id"]):
-                    _record_skip(
-                        it["thesis_id"], it["symbol"], it["scan_date"],
-                        "gap_invalidated",
-                    )
+                    # WS A isolation: shadow never writes the live skip ledger.
+                    if not it["shadow"]:
+                        _record_skip(
+                            it["thesis_id"], it["symbol"], it["scan_date"],
+                            "gap_invalidated",
+                        )
                     expired += 1
                 continue
 
@@ -547,10 +552,12 @@ def fill_pending_positions(
             # while tracking nothing). Expire + skip `zero_share_price`.
             if shares == 0:
                 if _expire_locked(session, it["id"]):
-                    _record_skip(
-                        it["thesis_id"], it["symbol"], it["scan_date"],
-                        "zero_share_price",
-                    )
+                    # WS A isolation: shadow never writes the live skip ledger.
+                    if not it["shadow"]:
+                        _record_skip(
+                            it["thesis_id"], it["symbol"], it["scan_date"],
+                            "zero_share_price",
+                        )
                     expired += 1
                 continue
 

--- a/src/rainier/paper/reclaim.py
+++ b/src/rainier/paper/reclaim.py
@@ -1,0 +1,364 @@
+"""WS B — reconsider invalidated bull-traps (`false_breakout` only).
+
+A `false_breakout` is a CORRECT bearish setup: price pokes above a resistance
+high (the "trap high" / `false_high`), then rejects and declines. The detector
+is correct and untouched. But when a LATER daily close reclaims the trap high,
+the bear thesis is dead — the symbol may now be a fresh LONG. The scheduled LLM
+run only ever sees today's top-5, so a reclaimed name outside it would be lost.
+
+This module:
+
+  1. detect_and_enqueue_reclaims — daily post-ingest check. For each recently
+     declined `false_breakout` thesis with a persisted trap high, if a close in
+     the lookback window reclaimed the level, durably enqueue the symbol
+     (idempotent + once-per-K-days dedup).
+  2. audit_reclaims — historical hit-rate of reclaim events (mean forward
+     return over N days). The auto-thesis gate reads this.
+  3. process_reclaim_queue — when auto-thesis is enabled AND the audit gate
+     passes, inject queued symbols into the thesis path as FRESH long theses;
+     otherwise leave them queued for human review (detection-only fallback).
+
+ASCII flow:
+
+    daily ingest done
+        │
+        ▼
+    detect_and_enqueue_reclaims(eval_date)
+        │  (declined false_breakout, trap reclaimed, K-day dedup)
+        ▼
+    paper_reclaim_queue rows  ── status: queued
+        │
+        ▼
+    process_reclaim_queue(eval_date)
+        │  gate = reclaim_auto_thesis AND audit passes
+        ├─ gate FAILS → leave queued (detection-only)
+        └─ gate PASSES → spawn fresh long thesis, status: reenqueued→done
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+from sqlalchemy import func, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from rainier.core.database import get_session
+from rainier.core.models import (
+    LLMAnalysisRecord,
+    PaperReclaimQueue,
+    ScreenedStockRecord,
+    StockPrice,
+)
+
+log = logging.getLogger(__name__)
+
+# Only the exact bearish trap pattern is in scope. `false_breakout_hs` has no
+# `false_high` key-point, so it never persists a `bearish_invalidation_level`
+# and never enters this path (scope regression in the tests).
+RECLAIM_PATTERN = "false_breakout"
+
+
+@dataclass(frozen=True)
+class ReclaimCandidate:
+    """A declined false_breakout whose trap high might be reclaimed."""
+
+    symbol: str
+    invalidated_thesis_id: int
+    invalidation_level: float
+    scan_date: date
+
+
+def is_reclaimed(closes: list[float], invalidation_level: float) -> bool:
+    """Pure: True iff any close strictly exceeds the trap high.
+
+    A close back ABOVE the trap high invalidates the bear setup (the breakout
+    is no longer false). Equality does not reclaim — the bear setup needs price
+    to clear, not merely touch, the level.
+    """
+    return any(c > invalidation_level for c in closes)
+
+
+def _closes_in_window(
+    session, symbol: str, start: date, end: date
+) -> list[tuple[date, float]]:
+    from rainier.paper.ingest import canonical_instant
+
+    rows = session.execute(
+        select(StockPrice.date, StockPrice.close)
+        .where(
+            StockPrice.symbol == symbol,
+            StockPrice.date >= canonical_instant(start),
+            StockPrice.date <= canonical_instant(end),
+            StockPrice.close.is_not(None),
+        )
+        .order_by(StockPrice.date)
+    ).all()
+    out: list[tuple[date, float]] = []
+    for d, c in rows:
+        dd = d.date() if hasattr(d, "date") else d
+        out.append((dd, float(c)))
+    return out
+
+
+def _find_reclaim_candidates(
+    session, *, eval_date: date, window_days: int
+) -> list[ReclaimCandidate]:
+    """Declined false_breakout theses in the window with a persisted trap high.
+
+    A row qualifies when its pattern is exactly `false_breakout`, it carries a
+    `bearish_invalidation_level`, it has an LLM thesis, and that thesis did NOT
+    recommend a long (a `setup_long` was already acted on the bullish side, so
+    there is no bear trap to reconsider).
+    """
+    earliest = eval_date - timedelta(days=window_days)
+    rows = session.execute(
+        select(
+            ScreenedStockRecord.symbol,
+            ScreenedStockRecord.thesis_id,
+            ScreenedStockRecord.bearish_invalidation_level,
+            ScreenedStockRecord.scan_date,
+            LLMAnalysisRecord.recommendation,
+        )
+        .join(
+            LLMAnalysisRecord,
+            LLMAnalysisRecord.id == ScreenedStockRecord.thesis_id,
+        )
+        .where(
+            ScreenedStockRecord.pattern_type == RECLAIM_PATTERN,
+            ScreenedStockRecord.bearish_invalidation_level.is_not(None),
+            ScreenedStockRecord.thesis_id.is_not(None),
+            ScreenedStockRecord.scan_date >= earliest,
+            ScreenedStockRecord.scan_date <= eval_date,
+        )
+    ).all()
+
+    candidates: list[ReclaimCandidate] = []
+    for symbol, thesis_id, level, scan_date, recommendation in rows:
+        if recommendation == "setup_long":
+            continue
+        sd = scan_date.date() if hasattr(scan_date, "date") else scan_date
+        candidates.append(
+            ReclaimCandidate(
+                symbol=symbol,
+                invalidated_thesis_id=int(thesis_id),
+                invalidation_level=float(level),
+                scan_date=sd,
+            )
+        )
+    return candidates
+
+
+def _recent_queue_row(
+    session, symbol: str, *, since: date
+) -> PaperReclaimQueue | None:
+    """Most-recent queue row for `symbol` with reclaim_date >= `since` (K-day
+    dedup). Any such row means we already enqueued this symbol within K days."""
+    return session.execute(
+        select(PaperReclaimQueue)
+        .where(
+            PaperReclaimQueue.symbol == symbol,
+            PaperReclaimQueue.reclaim_date >= since,
+        )
+        .order_by(PaperReclaimQueue.reclaim_date.desc())
+    ).scalars().first()
+
+
+def detect_and_enqueue_reclaims(
+    *,
+    eval_date: date,
+    window_days: int,
+    dedup_days: int,
+) -> dict[str, int]:
+    """Detect reclaimed bull-traps and durably enqueue them (idempotent).
+
+    For each declined `false_breakout` in the last `window_days`, look for a
+    close in (scan_date .. eval_date] that exceeds the trap high. On a reclaim,
+    insert a `paper_reclaim_queue` row UNLESS:
+      * the same (symbol, invalidated_thesis_id) is already queued
+        (UNIQUE constraint → ON CONFLICT DO NOTHING), or
+      * the symbol was already enqueued within the last `dedup_days`
+        (whipsaw dedup: below→above→below→above within K days → one row).
+
+    Returns {"detected": n, "enqueued": m}.
+    """
+    detected = enqueued = 0
+    dedup_since = eval_date - timedelta(days=dedup_days)
+
+    with get_session() as session:
+        candidates = _find_reclaim_candidates(
+            session, eval_date=eval_date, window_days=window_days
+        )
+
+    for cand in candidates:
+        with get_session() as session:
+            # Only consider closes AFTER the bearish scan (the trap formed then).
+            closes = _closes_in_window(
+                session, cand.symbol, cand.scan_date, eval_date
+            )
+            reclaim_close = None
+            reclaim_date = None
+            for d, c in closes:
+                if c > cand.invalidation_level:
+                    reclaim_close = c
+                    reclaim_date = d
+                    break
+            if reclaim_close is None:
+                continue
+            detected += 1
+
+            # Whipsaw / K-day dedup: skip if this symbol was enqueued recently.
+            if _recent_queue_row(session, cand.symbol, since=dedup_since) is not None:
+                continue
+
+            stmt = (
+                pg_insert(PaperReclaimQueue)
+                .values(
+                    symbol=cand.symbol,
+                    invalidated_thesis_id=cand.invalidated_thesis_id,
+                    invalidation_level=cand.invalidation_level,
+                    reclaim_date=reclaim_date,
+                    reclaim_close=reclaim_close,
+                    status="queued",
+                )
+                .on_conflict_do_nothing(
+                    constraint="uq_paper_reclaim_symbol_thesis"
+                )
+                .returning(PaperReclaimQueue.id)
+            )
+            inserted = session.execute(stmt).first() is not None
+            if inserted:
+                enqueued += 1
+
+    return {"detected": detected, "enqueued": enqueued}
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    """Post-reclaim audit summary feeding the auto-thesis gate."""
+
+    events: int
+    mean_forward_return: float | None
+    passes: bool
+
+
+def compute_audit_pass(
+    forward_returns: list[float], *, min_events: int
+) -> AuditResult:
+    """Pure: the auto-thesis gate decision.
+
+    Gate passes iff there are at least `min_events` historical reclaim events
+    AND their mean forward return is strictly positive. Below the floor or a
+    non-positive mean → fail (detection + queue only).
+    """
+    events = len(forward_returns)
+    if events == 0:
+        return AuditResult(events=0, mean_forward_return=None, passes=False)
+    mean = sum(forward_returns) / events
+    passes = events >= min_events and mean > 0.0
+    return AuditResult(events=events, mean_forward_return=mean, passes=passes)
+
+
+def audit_reclaims(*, eval_date: date, horizon_days: int, min_events: int) -> AuditResult:
+    """Audit historical reclaim events: forward return `horizon_days` after each.
+
+    For every queue row whose reclaim is old enough to have a full forward
+    window, compute the close-to-close return from the reclaim close to the
+    close `horizon_days` later. Feeds `compute_audit_pass`.
+    """
+    cutoff = eval_date - timedelta(days=horizon_days)
+    with get_session() as session:
+        rows = session.execute(
+            select(
+                PaperReclaimQueue.symbol,
+                PaperReclaimQueue.reclaim_date,
+                PaperReclaimQueue.reclaim_close,
+            ).where(PaperReclaimQueue.reclaim_date <= cutoff)
+        ).all()
+
+        forward_returns: list[float] = []
+        for symbol, reclaim_date, reclaim_close in rows:
+            rd = reclaim_date.date() if hasattr(reclaim_date, "date") else reclaim_date
+            target_day = rd + timedelta(days=horizon_days)
+            closes = _closes_in_window(session, symbol, rd, target_day)
+            if not closes or reclaim_close in (None, 0):
+                continue
+            # Last available close at/after the horizon.
+            _, fwd_close = closes[-1]
+            forward_returns.append((fwd_close - reclaim_close) / reclaim_close)
+
+    return compute_audit_pass(forward_returns, min_events=min_events)
+
+
+def process_reclaim_queue(
+    *,
+    eval_date: date,
+    auto_thesis: bool,
+    audit_horizon_days: int,
+    audit_min_events: int,
+    spawn_fn=None,
+) -> dict[str, int]:
+    """Act on queued reclaims, gated on config + the post-reclaim audit.
+
+    Default behavior (auto_thesis False OR audit gate fails): leave every queued
+    row as-is (detection + queue only) — the designed fallback. The queue is
+    surfaced for review but no fresh thesis is spawned.
+
+    When `auto_thesis` is True AND the audit gate passes, each `queued` row is
+    transitioned `queued -> reenqueued` and `spawn_fn(symbol, queue_id)` is
+    invoked to create a fresh long thesis via the normal screen→LLM path. On a
+    truthy return (the new thesis_id), the row is finalized
+    `reenqueued -> done` with `fresh_thesis_id` set. `spawn_fn` is injected so
+    the scheduled top-5 run is never disturbed by this single-symbol path and so
+    tests can drive it deterministically.
+
+    Returns {"gate_passed": 0|1, "processed": n, "spawned": m}.
+    """
+    audit = audit_reclaims(
+        eval_date=eval_date,
+        horizon_days=audit_horizon_days,
+        min_events=audit_min_events,
+    )
+    gate_passed = bool(auto_thesis and audit.passes)
+    result = {"gate_passed": int(gate_passed), "processed": 0, "spawned": 0}
+    if not gate_passed or spawn_fn is None:
+        return result
+
+    with get_session() as session:
+        queued = session.execute(
+            select(PaperReclaimQueue).where(PaperReclaimQueue.status == "queued")
+        ).scalars().all()
+        items = [(q.id, q.symbol) for q in queued]
+
+    for queue_id, symbol in items:
+        # Claim the row (queued -> reenqueued) race-safely; only proceed if we
+        # won the transition.
+        with get_session() as session:
+            res = session.execute(
+                update(PaperReclaimQueue)
+                .where(
+                    PaperReclaimQueue.id == queue_id,
+                    PaperReclaimQueue.status == "queued",
+                )
+                .values(status="reenqueued", reenqueued_at=func.now())
+            )
+            if int(res.rowcount or 0) == 0:
+                continue
+        result["processed"] += 1
+
+        try:
+            fresh_thesis_id = spawn_fn(symbol, queue_id)
+        except Exception as exc:  # spawn must never poison the rest of the queue
+            log.error("reclaim_spawn_failed symbol=%s error=%s", symbol, exc)
+            continue
+        if fresh_thesis_id:
+            with get_session() as session:
+                session.execute(
+                    update(PaperReclaimQueue)
+                    .where(PaperReclaimQueue.id == queue_id)
+                    .values(status="done", fresh_thesis_id=int(fresh_thesis_id))
+                )
+            result["spawned"] += 1
+
+    return result

--- a/src/rainier/paper/reflection.py
+++ b/src/rainier/paper/reflection.py
@@ -259,6 +259,9 @@ def select_reflection_candidates(as_of: date) -> list[dict[str, Any]]:
                 "  AND pt.exit_date IS NOT NULL "
                 "  AND pt.exit_date <= :as_of "
                 "  AND pt.exit_date >= :cutoff "
+                # WS A isolation: never reflect on shadow trades (no LLM spend on
+                # measurement rows; their outcomes must not reach live prompts).
+                "  AND pt.shadow = false "
                 "ORDER BY pt.exit_date ASC, pt.id ASC"
             ),
             {"as_of": as_of, "cutoff": cutoff},
@@ -382,6 +385,8 @@ def load_recent_reflections(
                 "FROM paper_trade "
                 "WHERE reflection IS NOT NULL "
                 "  AND exit_date IS NOT NULL AND exit_date < :as_of "
+                # WS A isolation: shadow outcomes must never enter live prompts.
+                "  AND shadow = false "
                 "ORDER BY exit_date DESC, id DESC "
                 "LIMIT :k"
             ),

--- a/src/rainier/paper/replay.py
+++ b/src/rainier/paper/replay.py
@@ -1,0 +1,183 @@
+"""WS A — real-engine replay harness for the shadow WATCH-buy measurement.
+
+`paper/sweep.py` is missed-winner attribution, NOT position replay. This is a
+new day-by-day driver: it walks historical theses over a window, opens SHADOW
+positions for WATCH verdicts at each candidate threshold T, runs them through
+the REAL fill/exit engine (`positions.create_shadow_positions_for_theses` ->
+`fill_pending_positions` -> `update_open_positions`), and reports the shadow
+book's return per T vs cash and vs a benchmark.
+
+The harness is config-/DB-driven; the per-T return MATH is factored into pure
+functions (`shadow_book_return`, `benchmark_return`) so it is unit-testable
+without a database. The orchestration loop is exercised by the postgres-lane
+integration test.
+
+ASCII flow (per threshold T, per trading day d in window):
+    theses(d) ──► create_shadow_positions_for_theses(conf>=T, long-shape)
+                       │
+                       ▼
+              fill_pending_positions(as_of=d)
+                       │
+                       ▼
+              update_open_positions(as_of=d)
+    end of window ──► shadow_book_return() vs cash(0) vs benchmark_return()
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ReplayArm:
+    """One threshold arm's measured outcome over a window."""
+
+    threshold: int
+    fired: int            # shadow positions opened
+    book_return_pct: float  # shadow book return over the window
+    benchmark_return_pct: float
+    cash_return_pct: float  # always 0.0 (the do-nothing baseline)
+
+
+def shadow_book_return(trade_returns: list[float]) -> float:
+    """Pure: equal-weight mean return across the shadow book's resolved trades.
+
+    Each entry is a single trade's fractional return (e.g. 0.05 = +5%). With no
+    trades the book sat in cash → 0.0. Equal-weight matches the fixed-$10k-per-
+    position sizing the live engine uses.
+    """
+    if not trade_returns:
+        return 0.0
+    return sum(trade_returns) / len(trade_returns)
+
+
+def benchmark_return(start_close: float | None, end_close: float | None) -> float:
+    """Pure: benchmark (e.g. SPY) point-to-point return over the window.
+
+    Returns 0.0 when either endpoint is missing or the start is non-positive
+    (no data → no measurable benchmark move).
+    """
+    if start_close is None or end_close is None or start_close <= 0:
+        return 0.0
+    return (end_close - start_close) / start_close
+
+
+def _theses_on(session, scan_date: date) -> list[dict]:
+    """Historical theses scanned on `scan_date`, shaped for the position fns."""
+    from sqlalchemy import select
+
+    from rainier.core.models import LLMAnalysisRecord, ScreenedStockRecord
+
+    rows = session.execute(
+        select(
+            ScreenedStockRecord.thesis_id,
+            ScreenedStockRecord.symbol,
+            ScreenedStockRecord.session_name,
+            LLMAnalysisRecord.recommendation,
+            ScreenedStockRecord.llm_confidence,
+        )
+        .join(
+            LLMAnalysisRecord,
+            LLMAnalysisRecord.id == ScreenedStockRecord.thesis_id,
+        )
+        .where(
+            ScreenedStockRecord.scan_date == scan_date,
+            ScreenedStockRecord.thesis_id.is_not(None),
+        )
+    ).all()
+    return [
+        {
+            "thesis_id": int(tid),
+            "symbol": symbol,
+            "verdict": rec,
+            "llm_confidence": conf,
+            "session_name": session_name,
+        }
+        for tid, symbol, session_name, rec, conf in rows
+    ]
+
+
+def _benchmark_endpoints(
+    session, benchmark_symbol: str, start: date, end: date
+) -> tuple[float | None, float | None]:
+    from sqlalchemy import select
+
+    from rainier.core.models import StockPrice
+    from rainier.paper.ingest import canonical_instant
+
+    def _close_on(d: date) -> float | None:
+        row = session.execute(
+            select(StockPrice.close)
+            .where(
+                StockPrice.symbol == benchmark_symbol,
+                StockPrice.date <= canonical_instant(d),
+                StockPrice.close.is_not(None),
+            )
+            .order_by(StockPrice.date.desc())
+            .limit(1)
+        ).first()
+        return float(row[0]) if row else None
+
+    return _close_on(start), _close_on(end)
+
+
+def replay_threshold(
+    *,
+    threshold: int,
+    trading_days: list[date],
+    benchmark_symbol: str = "SPY",
+) -> ReplayArm:
+    """Replay one threshold T over `trading_days`, returning the arm outcome.
+
+    Drives the REAL engine day by day. Shadow rows opened here are flagged and
+    excluded from every live read, so this never touches the live book. Caller
+    is responsible for isolating runs (e.g. one throwaway schema per T) so arms
+    don't contaminate each other's shadow book.
+    """
+    from rainier.core.database import get_session
+    from rainier.paper import positions
+
+    if not trading_days:
+        return ReplayArm(threshold, 0, 0.0, 0.0, 0.0)
+
+    fired = 0
+    for d in trading_days:
+        with get_session() as session:
+            theses = _theses_on(session, d)
+        if theses:
+            res = positions.create_shadow_positions_for_theses(
+                theses, scan_date=d, min_confidence=threshold
+            )
+            fired += res["created"]
+        positions.fill_pending_positions(as_of=d)
+        positions.update_open_positions(as_of=d)
+
+    # Collect the shadow book's resolved trade returns.
+    from sqlalchemy import select
+
+    from rainier.core.models import PaperTrade
+
+    with get_session() as session:
+        rows = session.execute(
+            select(PaperTrade.return_pct).where(
+                PaperTrade.shadow.is_(True),
+                PaperTrade.return_pct.is_not(None),
+            )
+        ).all()
+        trade_returns = [float(r[0]) for r in rows]
+
+        start_close, end_close = _benchmark_endpoints(
+            session, benchmark_symbol, trading_days[0], trading_days[-1]
+        )
+
+    return ReplayArm(
+        threshold=threshold,
+        fired=fired,
+        book_return_pct=shadow_book_return(trade_returns),
+        benchmark_return_pct=benchmark_return(start_close, end_close),
+        cash_return_pct=0.0,
+    )

--- a/src/rainier/paper/report.py
+++ b/src/rainier/paper/report.py
@@ -112,7 +112,11 @@ def compute_daily_payload(as_of: date) -> dict[str, Any]:
     trades opened or closed after ``as_of`` (codex).
     """
     with get_session() as session:
-        positions = session.execute(select(PaperTrade)).scalars().all()
+        # WS A isolation: the daily report is a LIVE read — shadow rows must
+        # never surface here.
+        positions = session.execute(
+            select(PaperTrade).where(PaperTrade.shadow.is_(False))
+        ).scalars().all()
 
         counts = {"pending": 0, "open": 0, "closed": 0, "expired": 0}
         realized_pnl = 0.0
@@ -198,7 +202,10 @@ def _count_same_bar_exits(session, as_of: date) -> int:
     from rainier.paper.ingest import canonical_instant
 
     positions = session.execute(
-        select(PaperTrade).where(PaperTrade.exit_date.isnot(None))
+        select(PaperTrade).where(
+            PaperTrade.exit_date.isnot(None),
+            PaperTrade.shadow.is_(False),  # WS A isolation: live read only.
+        )
     ).scalars().all()
     n = 0
     for p in positions:

--- a/src/rainier/paper/sweep.py
+++ b/src/rainier/paper/sweep.py
@@ -188,6 +188,7 @@ def _held_symbols(session, window_start: date, window_end: date) -> set[str]:
             PaperTrade.status.in_(("open", "closed")),
             PaperTrade.entry_date <= window_end,
             func.coalesce(PaperTrade.exit_date, window_end) >= window_start,
+            PaperTrade.shadow.is_(False),  # WS A isolation: live read only.
         )
         .distinct()
     ).all()

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -348,6 +348,13 @@ def run_paper_daily_steps(eval_date) -> None:
             window_days=pcfg.reclaim_window_days,
             dedup_days=pcfg.reclaim_dedup_days,
         )
+        # DETECTION-ONLY this PR: `spawn_fn=None` makes process_reclaim_queue a
+        # no-op even if `reclaim_auto_thesis` is flipped on, because the
+        # single-symbol fresh-thesis spawn path is not wired yet (a separate,
+        # gated change). The flag + audit args are passed through so the audit
+        # still runs (and logs gate_passed), but no fresh thesis is created
+        # until a real spawn_fn lands here. Until then, auto-thesis is inert by
+        # design — the queue is surfaced for human review.
         paper_reclaim.process_reclaim_queue(
             eval_date=eval_date,
             auto_thesis=pcfg.reclaim_auto_thesis,

--- a/src/rainier/scheduler/service.py
+++ b/src/rainier/scheduler/service.py
@@ -335,6 +335,29 @@ def run_paper_daily_steps(eval_date) -> None:
     )
     paper_positions.update_open_positions(as_of=eval_date)
 
+    # WS B — reconsider invalidated bull-traps. Failure-isolated: a reclaim
+    # error must never block the trading steps above (they already ran). Detect
+    # + enqueue is mandatory; spawning a fresh thesis is gated on config AND the
+    # post-reclaim audit (default detection-only).
+    try:
+        from rainier.paper import reclaim as paper_reclaim
+
+        pcfg = settings.paper
+        paper_reclaim.detect_and_enqueue_reclaims(
+            eval_date=eval_date,
+            window_days=pcfg.reclaim_window_days,
+            dedup_days=pcfg.reclaim_dedup_days,
+        )
+        paper_reclaim.process_reclaim_queue(
+            eval_date=eval_date,
+            auto_thesis=pcfg.reclaim_auto_thesis,
+            audit_horizon_days=pcfg.reclaim_audit_horizon_days,
+            audit_min_events=pcfg.reclaim_audit_min_events,
+            spawn_fn=None,
+        )
+    except Exception as exc:
+        log.error("daily_reclaim_step_failed", error=str(exc))
+
 
 def run_paper_close_charts(eval_date, window: int | None = None) -> None:
     """Paper step (v) addendum (R-D): close-side chart capture.

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -40,7 +40,7 @@ def test_db_group_does_not_shadow_legacy_subcommands():
     result = runner.invoke(cli, ["db", "--help"])
     assert result.exit_code == 0, result.output
 
-    for subcmd in ("init", "backfill-prices", "ping", "migrate"):
+    for subcmd in ("init", "backfill-prices", "ping", "migrate", "gc-test-schemas"):
         assert subcmd in result.output, (
             f"`rainier db --help` is missing `{subcmd}` — likely caused by a "
             f"duplicate `@cli.group() def db()` shadowing the original. "
@@ -53,6 +53,95 @@ def test_db_group_does_not_shadow_legacy_subcommands():
     assert legacy_init.exit_code == 0, legacy_init.output
     legacy_backfill = runner.invoke(cli, ["db", "backfill-prices", "--help"])
     assert legacy_backfill.exit_code == 0, legacy_backfill.output
+
+
+def test_db_gc_test_schemas_dry_run_lists_without_dropping(monkeypatch):
+    """`db gc-test-schemas` (no --apply) lists candidates and never drops.
+
+    Stubs the legacy engine + the gc helper so the test needs no live DB. The
+    command must call the helper with ``apply=False`` and echo each candidate.
+    """
+    from rainier import cli as cli_mod
+
+    calls = {}
+
+    def _fake_get_engine():
+        return object()
+
+    def _fake_gc(engine, *, apply):
+        calls["apply"] = apply
+        return {
+            "candidates": ["rainier_paper_test_ab12"],
+            "dropped": [],
+            "failed": [],
+        }
+
+    import rainier.core.database as db_mod
+    import rainier.core.test_schema_gc as gc_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", _fake_get_engine)
+    monkeypatch.setattr(gc_mod, "gc_test_schemas", _fake_gc)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "gc-test-schemas"])
+    assert result.exit_code == 0, result.output
+    assert calls["apply"] is False
+    assert "DRY-RUN" in result.output
+    assert "rainier_paper_test_ab12" in result.output
+
+
+def test_db_gc_test_schemas_apply_drops(monkeypatch):
+    """`db gc-test-schemas --apply` drops candidates and reports them."""
+    from rainier import cli as cli_mod
+
+    def _fake_get_engine():
+        return object()
+
+    def _fake_gc(engine, *, apply):
+        assert apply is True
+        return {
+            "candidates": ["rainier_paper_test_ab12"],
+            "dropped": ["rainier_paper_test_ab12"],
+            "failed": [],
+        }
+
+    import rainier.core.database as db_mod
+    import rainier.core.test_schema_gc as gc_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", _fake_get_engine)
+    monkeypatch.setattr(gc_mod, "gc_test_schemas", _fake_gc)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "gc-test-schemas", "--apply"])
+    assert result.exit_code == 0, result.output
+    assert "dropped 1" in result.output
+    assert "rainier_paper_test_ab12" in result.output
+
+
+def test_db_gc_test_schemas_apply_surfaces_failures(monkeypatch):
+    """A failed drop makes the command exit non-zero (automation safety)."""
+    from rainier import cli as cli_mod
+
+    def _fake_get_engine():
+        return object()
+
+    def _fake_gc(engine, *, apply):
+        return {
+            "candidates": ["rainier_paper_test_ab12"],
+            "dropped": [],
+            "failed": [("rainier_paper_test_ab12", "boom")],
+        }
+
+    import rainier.core.database as db_mod
+    import rainier.core.test_schema_gc as gc_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", _fake_get_engine)
+    monkeypatch.setattr(gc_mod, "gc_test_schemas", _fake_gc)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "gc-test-schemas", "--apply"])
+    assert result.exit_code != 0
+    assert "FAILED" in result.output
 
 
 def test_db_migrate_help_exposes_downgrade_flag():

--- a/tests/test_paper/conftest.py
+++ b/tests/test_paper/conftest.py
@@ -69,6 +69,11 @@ MIGRATION_0011_UP = REPO_ROOT / "migrations" / "0011_qu100_daily_features.sql"
 MIGRATION_0011_DOWN = (
     REPO_ROOT / "migrations" / "0011_qu100_daily_features_downgrade.sql"
 )
+# WS B (P0 batch): screened_stocks.bearish_invalidation_level +
+# paper_reclaim_queue. Applied on top of 0005 so reclaim-path tests have the
+# column + table.
+MIGRATION_0012_UP = REPO_ROOT / "migrations" / "0012_reclaim_queue.sql"
+MIGRATION_0012_DOWN = REPO_ROOT / "migrations" / "0012_reclaim_queue_downgrade.sql"
 
 # Minimal DDL for the FK-target tables the paper migration references. The real
 # schema lives in migrations/0001-0004; for an isolated paper-tracker test DB we
@@ -339,6 +344,7 @@ def pg_legacy_engine(request):
         if MIGRATION_0010_UP.exists():
             _apply_sql(engine, MIGRATION_0010_UP)
         _apply_sql(engine, MIGRATION_0011_UP)  # R-E qu100_daily_features
+        _apply_sql(engine, MIGRATION_0012_UP)  # WS B reclaim queue + column
 
         from rainier.core import config, database
 

--- a/tests/test_paper/conftest.py
+++ b/tests/test_paper/conftest.py
@@ -74,6 +74,11 @@ MIGRATION_0011_DOWN = (
 # column + table.
 MIGRATION_0012_UP = REPO_ROOT / "migrations" / "0012_reclaim_queue.sql"
 MIGRATION_0012_DOWN = REPO_ROOT / "migrations" / "0012_reclaim_queue_downgrade.sql"
+# WS A (P0 batch): paper_trade.shadow + shadow-scoped active-symbol indexes.
+MIGRATION_0013_UP = REPO_ROOT / "migrations" / "0013_paper_trade_shadow.sql"
+MIGRATION_0013_DOWN = (
+    REPO_ROOT / "migrations" / "0013_paper_trade_shadow_downgrade.sql"
+)
 
 # Minimal DDL for the FK-target tables the paper migration references. The real
 # schema lives in migrations/0001-0004; for an isolated paper-tracker test DB we
@@ -345,6 +350,7 @@ def pg_legacy_engine(request):
             _apply_sql(engine, MIGRATION_0010_UP)
         _apply_sql(engine, MIGRATION_0011_UP)  # R-E qu100_daily_features
         _apply_sql(engine, MIGRATION_0012_UP)  # WS B reclaim queue + column
+        _apply_sql(engine, MIGRATION_0013_UP)  # WS A paper_trade.shadow
 
         from rainier.core import config, database
 

--- a/tests/test_paper/conftest.py
+++ b/tests/test_paper/conftest.py
@@ -13,6 +13,7 @@ Two execution lanes (TEST-SPEC §Engine):
 from __future__ import annotations
 
 import os
+import secrets
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,23 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_suffix() -> str:
+    """A short per-run/per-worker token for throwaway schema names.
+
+    Including the xdist worker id (``PYTEST_XDIST_WORKER``, e.g. ``gw3``) and a
+    random token guarantees two concurrent runs against the SAME shared test DB
+    never collide on a fixed schema name — the old fixed names
+    (``rainier_paper_test``) could clobber each other and, if a run was SIGKILL'd,
+    leak. The token stays within the gc allowlist regex
+    (``^rainier_(paper|chartmig|mig0006)_test(_[a-z0-9]+)*$``): lowercase
+    alphanumerics joined by underscores. ``rainier db gc-test-schemas`` reaps any
+    that still leak.
+    """
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "").lower()
+    worker = "".join(c for c in worker if c.isalnum()) or "main"
+    return f"{worker}_{secrets.token_hex(3)}"
 MIGRATION_UP = REPO_ROOT / "migrations" / "0005_paper_tracker.sql"
 MIGRATION_DOWN = REPO_ROOT / "migrations" / "0005_paper_tracker_downgrade.sql"
 # Phase 2 (D7a): paper_calibration. Applied on top of 0005 in the same throwaway
@@ -268,66 +286,81 @@ def _apply_sql(engine, path: Path) -> None:
 # in `public`) stay resolvable. Mirrors the 0006 fixtures. The fixture exposes
 # `engine.rainier_schema` so schema-scoped inspector calls in the 0005 tests can
 # target the right namespace.
-_PAPER_SCHEMA = "rainier_paper_test"
+# Base name; the live schema gets a per-run suffix (see `_run_suffix`) so two
+# concurrent runs against a shared test DB never collide. Both stay within the
+# `rainier db gc-test-schemas` allowlist.
+_PAPER_SCHEMA_BASE = "rainier_paper_test"
 
 
 @pytest.fixture
 def pg_legacy_engine(request):
     """Ephemeral Postgres with prereq tables + the 0005 migration applied.
 
-    Builds everything in a disposable schema (`_PAPER_SCHEMA`) so teardown drops
-    only that schema (never shared `public`) and each run starts clean. Also
-    binds the legacy `core.database` singleton to it so production code under
-    test (ingest / fill / positions) hits this DB. Resets the singleton before
-    and after (PR #115 discipline).
+    Builds everything in a per-run disposable schema so teardown drops only that
+    schema (never shared `public`) and each run starts clean. Also binds the
+    legacy `core.database` singleton to it so production code under test (ingest
+    / fill / positions) hits this DB. Resets the singleton before and after (PR
+    #115 discipline).
+
+    Leak-hardening (WS C): the schema name carries a per-run/per-worker suffix
+    (no fixed-name collisions) and ALL setup (CREATE SCHEMA + DDL + migrations +
+    singleton bind) runs INSIDE the try whose `finally` drops the schema — so a
+    failure partway through setup still reaps the schema instead of leaking it.
     """
     url = _resolve_pg_url(request)
-    # search_path-free admin connection so DROP/CREATE SCHEMA targets the right
-    # namespace regardless of any pinned path.
-    admin = create_engine(url, future=True)
-    with admin.begin() as conn:
-        conn.execute(text(f"DROP SCHEMA IF EXISTS {_PAPER_SCHEMA} CASCADE"))
-        conn.execute(text(f"CREATE SCHEMA {_PAPER_SCHEMA}"))
-    admin.dispose()
-
-    engine = create_engine(
-        url,
-        future=True,
-        connect_args={"options": f"-csearch_path={_PAPER_SCHEMA},public"},
-    )
-    engine.rainier_schema = _PAPER_SCHEMA  # type: ignore[attr-defined]
-    with engine.begin() as conn:
-        conn.execute(text(_PREREQ_DDL))
-    _apply_sql(engine, MIGRATION_UP)
-    _apply_sql(engine, MIGRATION_0007_UP)  # D7a paper_calibration
-    _apply_sql(engine, MIGRATION_0008_UP)  # Phase 3 zero_share_price skip reason
-    _apply_sql(engine, MIGRATION_0009_UP)  # R-A paper_trade.reflection
-    _apply_sql(engine, MIGRATION_0003_UP)  # research_insights (lessons tests)
-    # R-D chart archive. `exists()` guard keeps the rest of the paper suite
-    # runnable during the tdd-red phase before the migration file lands;
-    # test_chart_archive.py::test_migration_0010_files_exist pins the file's
-    # existence so a green run can never silently skip it.
-    if MIGRATION_0010_UP.exists():
-        _apply_sql(engine, MIGRATION_0010_UP)
-    _apply_sql(engine, MIGRATION_0011_UP)  # R-E qu100_daily_features
-
-    from rainier.core import config, database
-
-    config._settings = None
-    database._engine = engine
-    database._session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+    schema = f"{_PAPER_SCHEMA_BASE}_{_run_suffix()}"
+    engine = None
     try:
+        # search_path-free admin connection so DROP/CREATE SCHEMA targets the
+        # right namespace regardless of any pinned path.
+        admin = create_engine(url, future=True)
+        with admin.begin() as conn:
+            conn.execute(text(f"DROP SCHEMA IF EXISTS {schema} CASCADE"))
+            conn.execute(text(f"CREATE SCHEMA {schema}"))
+        admin.dispose()
+
+        engine = create_engine(
+            url,
+            future=True,
+            connect_args={"options": f"-csearch_path={schema},public"},
+        )
+        engine.rainier_schema = schema  # type: ignore[attr-defined]
+        with engine.begin() as conn:
+            conn.execute(text(_PREREQ_DDL))
+        _apply_sql(engine, MIGRATION_UP)
+        _apply_sql(engine, MIGRATION_0007_UP)  # D7a paper_calibration
+        _apply_sql(engine, MIGRATION_0008_UP)  # Phase 3 zero_share_price skip
+        _apply_sql(engine, MIGRATION_0009_UP)  # R-A paper_trade.reflection
+        _apply_sql(engine, MIGRATION_0003_UP)  # research_insights (lessons tests)
+        # R-D chart archive. `exists()` guard keeps the rest of the paper suite
+        # runnable during the tdd-red phase before the migration file lands;
+        # test_chart_archive.py::test_migration_0010_files_exist pins the file's
+        # existence so a green run can never silently skip it.
+        if MIGRATION_0010_UP.exists():
+            _apply_sql(engine, MIGRATION_0010_UP)
+        _apply_sql(engine, MIGRATION_0011_UP)  # R-E qu100_daily_features
+
+        from rainier.core import config, database
+
+        config._settings = None
+        database._engine = engine
+        database._session_factory = sessionmaker(
+            bind=engine, expire_on_commit=False
+        )
         yield engine
     finally:
+        from rainier.core import config, database
+
         database._engine = None
         database._session_factory = None
         config._settings = None
-        engine.dispose()
+        if engine is not None:
+            engine.dispose()
         # Drop ONLY the throwaway schema — never shared `public`. A reused
         # `RAINIER_TEST_DATABASE_URL` keeps its real ORM tables intact.
         admin = create_engine(url, future=True)
         with admin.begin() as conn:
-            conn.execute(text(f"DROP SCHEMA IF EXISTS {_PAPER_SCHEMA} CASCADE"))
+            conn.execute(text(f"DROP SCHEMA IF EXISTS {schema} CASCADE"))
         admin.dispose()
 
 
@@ -348,7 +381,7 @@ def pg_legacy_session(pg_legacy_engine):
 # test. Own disposable schema; teardown can never reach shared `public`.
 # --------------------------------------------------------------------------
 
-_CHART_MIG_SCHEMA = "rainier_chartmig_test"
+_CHART_MIG_SCHEMA_BASE = "rainier_chartmig_test"
 
 
 @pytest.fixture
@@ -359,30 +392,36 @@ def pg_chart_mig_engine(request):
     thesis charts), then apply 0010 themselves and assert backfill/index/
     downgrade behavior. The legacy `core.database` singleton is NOT bound —
     these tests drive raw SQL/ORM sessions against the returned engine.
+
+    Leak-hardening (WS C): per-run schema name; all setup inside the try whose
+    finally drops the schema.
     """
     url = _resolve_pg_url(request)
-    admin = create_engine(url, future=True)
-    with admin.begin() as conn:
-        conn.execute(text(f"DROP SCHEMA IF EXISTS {_CHART_MIG_SCHEMA} CASCADE"))
-        conn.execute(text(f"CREATE SCHEMA {_CHART_MIG_SCHEMA}"))
-    admin.dispose()
-
-    engine = create_engine(
-        url,
-        future=True,
-        connect_args={"options": f"-csearch_path={_CHART_MIG_SCHEMA},public"},
-    )
-    engine.rainier_schema = _CHART_MIG_SCHEMA  # type: ignore[attr-defined]
-    with engine.begin() as conn:
-        conn.execute(text(_PREREQ_DDL))
-    _apply_sql(engine, MIGRATION_UP)  # 0005: paper_trade (0010 alters it)
+    schema = f"{_CHART_MIG_SCHEMA_BASE}_{_run_suffix()}"
+    engine = None
     try:
-        yield engine
-    finally:
-        engine.dispose()
         admin = create_engine(url, future=True)
         with admin.begin() as conn:
-            conn.execute(text(f"DROP SCHEMA IF EXISTS {_CHART_MIG_SCHEMA} CASCADE"))
+            conn.execute(text(f"DROP SCHEMA IF EXISTS {schema} CASCADE"))
+            conn.execute(text(f"CREATE SCHEMA {schema}"))
+        admin.dispose()
+
+        engine = create_engine(
+            url,
+            future=True,
+            connect_args={"options": f"-csearch_path={schema},public"},
+        )
+        engine.rainier_schema = schema  # type: ignore[attr-defined]
+        with engine.begin() as conn:
+            conn.execute(text(_PREREQ_DDL))
+        _apply_sql(engine, MIGRATION_UP)  # 0005: paper_trade (0010 alters it)
+        yield engine
+    finally:
+        if engine is not None:
+            engine.dispose()
+        admin = create_engine(url, future=True)
+        with admin.begin() as conn:
+            conn.execute(text(f"DROP SCHEMA IF EXISTS {schema} CASCADE"))
         admin.dispose()
 
 
@@ -434,39 +473,42 @@ CREATE TABLE IF NOT EXISTS stocks (
 # `RAINIER_TEST_DATABASE_URL` at a reusable Postgres with the full schema is safe
 # (a CASCADE drop of `public.stocks` would otherwise strip FK constraints from
 # every sibling table that references it). Codex review P2.
-_MIG0006_SCHEMA = "rainier_mig0006_test"
+_MIG0006_SCHEMA_BASE = "rainier_mig0006_test"
 
 
-def _isolated_engine(url: str):
+def _isolated_engine(url: str, schema: str):
     """Engine whose connections resolve names in the disposable 0006 test schema.
 
-    `search_path` puts `_MIG0006_SCHEMA` FIRST, so `create_all` / `init_db()` /
-    the migration's unqualified `stock_prices`/`stocks` all create and resolve
-    there (shadowing any `public` namesakes in a reused DB). `public` stays on
-    the path only as a fallback so the timescaledb extension functions
+    `search_path` puts `schema` FIRST, so `create_all` / `init_db()` / the
+    migration's unqualified `stock_prices`/`stocks` all create and resolve there
+    (shadowing any `public` namesakes in a reused DB). `public` stays on the path
+    only as a fallback so the timescaledb extension functions
     (`create_hypertable`, installed in `public`) remain resolvable. The schema is
     (re)created fresh and dropped CASCADE around the fixture body — CASCADE is
     scoped to throwaway objects only, never the shared `public` ORM tables.
+
+    `schema` carries a per-run/per-worker suffix (WS C) so concurrent runs never
+    collide on a fixed name.
     """
     engine = create_engine(
         url,
         future=True,
-        connect_args={"options": f"-csearch_path={_MIG0006_SCHEMA},public"},
+        connect_args={"options": f"-csearch_path={schema},public"},
     )
     # Recreate the schema fresh using a search_path-free connection so the DROP
     # CASCADE targets the right schema regardless of the pinned path.
     admin = create_engine(url, future=True)
     with admin.begin() as conn:
-        conn.execute(text(f"DROP SCHEMA IF EXISTS {_MIG0006_SCHEMA} CASCADE"))
-        conn.execute(text(f"CREATE SCHEMA {_MIG0006_SCHEMA}"))
+        conn.execute(text(f"DROP SCHEMA IF EXISTS {schema} CASCADE"))
+        conn.execute(text(f"CREATE SCHEMA {schema}"))
     admin.dispose()
     return engine
 
 
-def _drop_isolated_schema(url: str) -> None:
+def _drop_isolated_schema(url: str, schema: str) -> None:
     admin = create_engine(url, future=True)
     with admin.begin() as conn:
-        conn.execute(text(f"DROP SCHEMA IF EXISTS {_MIG0006_SCHEMA} CASCADE"))
+        conn.execute(text(f"DROP SCHEMA IF EXISTS {schema} CASCADE"))
     admin.dispose()
 
 
@@ -502,26 +544,29 @@ def pg_oldshape_engine(request):
     Exposes `engine.rainier_has_timescaledb` (bool) for tests to gate on.
     """
     url = _resolve_pg_url(request)
-    # Isolated schema: setup/teardown CASCADE can't touch shared `public` tables.
-    engine = _isolated_engine(url)
-    has_ts = _try_create_extension(engine)
-    with engine.begin() as conn:
-        conn.execute(text(_STOCKS_ONLY_DDL))
-        conn.execute(text(_OLD_STOCK_PRICES_DDL))
-    if has_ts:
-        with engine.begin() as conn:
-            conn.execute(
-                text(
-                    "SELECT create_hypertable('stock_prices', 'date', "
-                    "migrate_data => true, if_not_exists => true)"
-                )
-            )
-    engine.rainier_has_timescaledb = has_ts  # type: ignore[attr-defined]
+    schema = f"{_MIG0006_SCHEMA_BASE}_{_run_suffix()}"
+    engine = None
     try:
+        # Isolated schema: setup/teardown CASCADE can't touch shared `public`.
+        engine = _isolated_engine(url, schema)
+        has_ts = _try_create_extension(engine)
+        with engine.begin() as conn:
+            conn.execute(text(_STOCKS_ONLY_DDL))
+            conn.execute(text(_OLD_STOCK_PRICES_DDL))
+        if has_ts:
+            with engine.begin() as conn:
+                conn.execute(
+                    text(
+                        "SELECT create_hypertable('stock_prices', 'date', "
+                        "migrate_data => true, if_not_exists => true)"
+                    )
+                )
+        engine.rainier_has_timescaledb = has_ts  # type: ignore[attr-defined]
         yield engine
     finally:
-        engine.dispose()
-        _drop_isolated_schema(url)
+        if engine is not None:
+            engine.dispose()
+        _drop_isolated_schema(url, schema)
 
 
 @pytest.fixture
@@ -532,21 +577,30 @@ def pg_empty_engine(request):
     and resets it before/after (PR #115 discipline).
     """
     url = _resolve_pg_url(request)
-    # Isolated, freshly-(re)created empty schema so init_db() exercises the create
-    # path; teardown CASCADE is scoped to this schema, never shared `public`.
-    engine = _isolated_engine(url)
-    engine.rainier_has_timescaledb = _try_create_extension(engine)  # type: ignore[attr-defined]
-
-    from rainier.core import config, database
-
-    config._settings = None
-    database._engine = engine
-    database._session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+    schema = f"{_MIG0006_SCHEMA_BASE}_{_run_suffix()}"
+    engine = None
     try:
+        # Isolated, freshly-(re)created empty schema so init_db() exercises the
+        # create path; teardown CASCADE is scoped to this schema, never `public`.
+        engine = _isolated_engine(url, schema)
+        engine.rainier_has_timescaledb = _try_create_extension(  # type: ignore[attr-defined]
+            engine
+        )
+
+        from rainier.core import config, database
+
+        config._settings = None
+        database._engine = engine
+        database._session_factory = sessionmaker(
+            bind=engine, expire_on_commit=False
+        )
         yield engine
     finally:
+        from rainier.core import config, database
+
         database._engine = None
         database._session_factory = None
         config._settings = None
-        engine.dispose()
-        _drop_isolated_schema(url)
+        if engine is not None:
+            engine.dispose()
+        _drop_isolated_schema(url, schema)

--- a/tests/test_paper/test_cli.py
+++ b/tests/test_paper/test_cli.py
@@ -22,8 +22,38 @@ def test_paper_group_registered():
     runner = CliRunner()
     result = runner.invoke(cli, ["paper", "--help"])
     assert result.exit_code == 0
-    for sub in ("open", "update", "report"):
+    for sub in ("open", "update", "report", "shadow-replay"):
         assert sub in result.output
+
+
+def test_paper_shadow_replay_invokes_harness_per_threshold(monkeypatch):
+    """WS A — `paper shadow-replay` sweeps the given thresholds through the
+    replay harness and prints one row per arm. Stub the harness so no DB is
+    needed."""
+    from rainier.paper.replay import ReplayArm
+
+    seen = []
+
+    def _fake_replay(*, threshold, trading_days, benchmark_symbol):
+        seen.append(threshold)
+        return ReplayArm(
+            threshold=threshold, fired=1, book_return_pct=0.04,
+            benchmark_return_pct=0.02, cash_return_pct=0.0,
+        )
+
+    monkeypatch.setattr("rainier.paper.replay.replay_threshold", _fake_replay)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "paper", "shadow-replay",
+            "--start", "2026-05-29", "--end", "2026-06-12",
+            "--thresholds", "4,5,6",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert seen == [4, 5, 6]
+    assert "book%" in result.output
 
 
 def test_db_ingest_prices_registered():

--- a/tests/test_paper/test_daily_wiring.py
+++ b/tests/test_paper/test_daily_wiring.py
@@ -25,9 +25,21 @@ class _FakeLLMThesis:
     chart_lookback_days = 120  # R-D close-chart window
 
 
+class _FakePaper:
+    # WS B reclaim config (auto-thesis OFF by default — detection only).
+    watch_buy_shadow = True
+    watch_buy_min_confidence = 5
+    reclaim_dedup_days = 5
+    reclaim_window_days = 20
+    reclaim_auto_thesis = False
+    reclaim_audit_min_events = 10
+    reclaim_audit_horizon_days = 10
+
+
 class _FakeSettings:
     alerts = _FakeAlerts()
     llm_thesis = _FakeLLMThesis()
+    paper = _FakePaper()
 
 
 def _patch_pipeline(
@@ -111,6 +123,22 @@ def _patch_pipeline(
         "rainier.paper.positions.update_open_positions", fake_update
     )
 
+    # WS B — reclaim detect+enqueue then queue-process, after update (post-ingest).
+    def fake_detect(**kw):
+        calls.append("reclaim_detect")
+        return {"detected": 0, "enqueued": 0}
+
+    def fake_process(**kw):
+        calls.append("reclaim_process")
+        return {"gate_passed": 0, "processed": 0, "spawned": 0}
+
+    monkeypatch.setattr(
+        "rainier.paper.reclaim.detect_and_enqueue_reclaims", fake_detect
+    )
+    monkeypatch.setattr(
+        "rainier.paper.reclaim.process_reclaim_queue", fake_process
+    )
+
     # Existing horizon eval (step iv).
     def fake_evaluate_horizon(eval_date, horizon):
         calls.append("horizon")
@@ -187,11 +215,34 @@ def test_g1_daily_eval_runs_steps_in_order(monkeypatch):
     assert calls.index("update") < calls.index("horizon")
     assert calls.index("horizon") < calls.index("report")
     assert calls.index("report") < calls.index("calibration")
+    # WS B reclaim runs after the trading steps (post-ingest) — detect then
+    # process — and never blocks the horizon/report/calibration tail.
+    assert calls.index("update") < calls.index("reclaim_detect")
+    assert calls.index("reclaim_detect") < calls.index("reclaim_process")
 
 
 def test_g3_horizon_eval_still_runs(monkeypatch):
     calls, _ = _run(monkeypatch)
     assert "horizon" in calls
+
+
+def test_reclaim_step_failure_never_blocks_trading_tail(monkeypatch):
+    """WS B isolation — a reclaim error must not block horizon/report/calibration."""
+    from rainier.scheduler import service
+
+    calls: list[str] = []
+    captured: dict = {}
+    _patch_pipeline(monkeypatch, calls, captured)
+
+    def boom(**kw):
+        raise RuntimeError("reclaim boom")
+
+    monkeypatch.setattr(
+        "rainier.paper.reclaim.detect_and_enqueue_reclaims", boom
+    )
+    asyncio.run(service.run_daily_eval("2026-01-09"))
+    for step in ("ingest", "fill", "update", "horizon", "report", "calibration"):
+        assert step in calls, f"{step} was blocked by a reclaim failure"
 
 
 def test_g4_feature_step_failure_never_blocks_trading_steps(monkeypatch):

--- a/tests/test_paper/test_fill_and_update.py
+++ b/tests/test_paper/test_fill_and_update.py
@@ -26,12 +26,12 @@ def _seed_thesis(session, tid):
 
 
 def _mk_pending(session, tid, symbol, scan_date, *, stop=90.0, target=120.0,
-                time_stop_days=None):
+                time_stop_days=None, shadow=False):
     _seed_thesis(session, tid)
     p = PaperTrade(
         thesis_id=tid, symbol=symbol, scan_date=scan_date, session_name="close",
         status="pending", planned_entry_price=100.0, stop_loss=stop,
-        target_price=target, time_stop_days=time_stop_days,
+        target_price=target, time_stop_days=time_stop_days, shadow=shadow,
     )
     session.add(p)
     session.commit()
@@ -115,6 +115,48 @@ def test_e1c_fill_validity_guard_gap_past_stop(pg_legacy_session):
     _price(s, "AAA", date(2026, 1, 6), 88, 92, 85, 89)  # open <= stop
     fill_pending_positions(as_of=date(2026, 1, 6))
     assert _get(s, pid).status == "expired"
+
+
+def test_e1c_shadow_gap_does_not_write_live_skip(pg_legacy_session):
+    """WS A isolation regression — a SHADOW pending that gaps past a level must
+    expire WITHOUT writing the live skip ledger (the fill path was leaking
+    `gap_invalidated` skips for shadow rows)."""
+    s = pg_legacy_session
+    pid = _mk_pending(s, 1, "AAA", date(2026, 1, 5), stop=90, target=120,
+                      shadow=True)
+    _price(s, "AAA", date(2026, 1, 6), 125, 130, 124, 128)  # gap past target
+    fill_pending_positions(as_of=date(2026, 1, 6))
+    assert _get(s, pid).status == "expired"
+    skips = s.execute(select(PaperSkip)).scalars().all()
+    assert skips == []
+
+
+def test_zero_share_shadow_does_not_write_live_skip(pg_legacy_session):
+    """WS A isolation regression — a SHADOW pending that floors to 0 shares (open
+    above the $10k notional) must expire WITHOUT a live `zero_share_price`
+    skip."""
+    s = pg_legacy_session
+    # open=10001 < target so it's a valid fill price, but floor(10000/10001)=0.
+    pid = _mk_pending(s, 1, "AAA", date(2026, 1, 5), stop=90, target=20000,
+                      shadow=True)
+    _price(s, "AAA", date(2026, 1, 6), 10001, 10005, 10000, 10002)
+    fill_pending_positions(as_of=date(2026, 1, 6))
+    assert _get(s, pid).status == "expired"
+    skips = s.execute(select(PaperSkip)).scalars().all()
+    assert skips == []
+
+
+def test_e1c_live_gap_still_writes_skip(pg_legacy_session):
+    """Companion: the LIVE path still writes `gap_invalidated` (the shadow guard
+    must not suppress live skips)."""
+    s = pg_legacy_session
+    pid = _mk_pending(s, 1, "AAA", date(2026, 1, 5), stop=90, target=120,
+                      shadow=False)
+    _price(s, "AAA", date(2026, 1, 6), 125, 130, 124, 128)
+    fill_pending_positions(as_of=date(2026, 1, 6))
+    assert _get(s, pid).status == "expired"
+    skips = s.execute(select(PaperSkip)).scalars().all()
+    assert len(skips) == 1 and skips[0].reason == "gap_invalidated"
 
 
 def test_e2_sizing_residual(pg_legacy_session):

--- a/tests/test_paper/test_reclaim.py
+++ b/tests/test_paper/test_reclaim.py
@@ -1,0 +1,248 @@
+"""WS B — reconsider invalidated bull-traps (`false_breakout` only).
+
+Lanes:
+  * pure-logic (no DB): the reclaim predicate + audit gate math;
+  * postgres-lane (`pg_legacy_engine`, skips without PG): detect+enqueue
+    idempotency / K-day whipsaw dedup / scope exclusion / queue processing.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+from sqlalchemy import text
+
+from rainier.core.database import get_session
+from rainier.paper.reclaim import (
+    compute_audit_pass,
+    detect_and_enqueue_reclaims,
+    is_reclaimed,
+    process_reclaim_queue,
+)
+
+# --------------------------------------------------------------------------
+# Pure-logic lane
+# --------------------------------------------------------------------------
+
+
+def test_is_reclaimed_true_when_close_exceeds_level():
+    assert is_reclaimed([90.0, 95.0, 101.0], 100.0) is True
+
+
+def test_is_reclaimed_false_when_no_close_exceeds():
+    assert is_reclaimed([90.0, 99.99, 100.0], 100.0) is False
+
+
+def test_is_reclaimed_equality_does_not_reclaim():
+    # A close exactly AT the trap high does not clear it.
+    assert is_reclaimed([100.0], 100.0) is False
+
+
+def test_audit_gate_fails_below_min_events():
+    res = compute_audit_pass([0.1, 0.2], min_events=5)
+    assert res.events == 2
+    assert res.passes is False
+
+
+def test_audit_gate_fails_on_nonpositive_mean():
+    res = compute_audit_pass([0.1, -0.3, 0.1], min_events=2)
+    assert res.mean_forward_return is not None
+    assert res.mean_forward_return < 0
+    assert res.passes is False
+
+
+def test_audit_gate_passes_with_enough_positive_events():
+    res = compute_audit_pass([0.05, 0.1, 0.2], min_events=3)
+    assert res.events == 3
+    assert res.passes is True
+
+
+def test_audit_gate_fails_with_no_events():
+    res = compute_audit_pass([], min_events=1)
+    assert res.events == 0
+    assert res.mean_forward_return is None
+    assert res.passes is False
+
+
+def test_migration_0012_files_exist():
+    from tests.test_paper.conftest import MIGRATION_0012_DOWN, MIGRATION_0012_UP
+
+    assert MIGRATION_0012_UP.exists()
+    assert MIGRATION_0012_DOWN.exists()
+
+
+# --------------------------------------------------------------------------
+# Postgres-lane — detect+enqueue, idempotency, dedup, scope. Skips without PG.
+# --------------------------------------------------------------------------
+
+
+def _seed_thesis(session, *, symbol: str, recommendation: str) -> int:
+    res = session.execute(
+        text(
+            "INSERT INTO analysis_results (llm_model, prompt_template, "
+            "recommendation) VALUES ('test', 'test', :rec) RETURNING id"
+        ),
+        {"rec": recommendation},
+    )
+    return int(res.scalar())
+
+
+def _seed_screened(
+    session,
+    *,
+    symbol: str,
+    scan_date: date,
+    thesis_id: int,
+    pattern_type: str,
+    invalidation_level: float | None,
+) -> None:
+    session.execute(
+        text(
+            "INSERT INTO screened_stocks "
+            "(scan_date, session_name, symbol, rule_rank, composite_score, "
+            " pattern_type, thesis_id, bearish_invalidation_level) "
+            "VALUES (:sd, 'close', :sym, 1, 0.5, :pt, :tid, :lvl)"
+        ),
+        {
+            "sd": scan_date,
+            "sym": symbol,
+            "pt": pattern_type,
+            "tid": thesis_id,
+            "lvl": invalidation_level,
+        },
+    )
+
+
+def _seed_price(session, *, symbol: str, d: date, close: float) -> None:
+    session.execute(
+        text(
+            "INSERT INTO stock_prices (symbol, date, open, high, low, close, "
+            "volume) VALUES (:sym, :d, :c, :c, :c, :c, 1000)"
+        ),
+        {"sym": symbol, "d": datetime(d.year, d.month, d.day, tzinfo=timezone.utc),
+         "c": close},
+    )
+
+
+@pytest.fixture
+def reclaim_db(pg_legacy_engine):
+    """A seeded DB: one declined false_breakout (trap=100) whose later close
+    reclaimed it (105), plus a control no-reclaim symbol."""
+    eval_date = date(2026, 6, 12)
+    scan_date = date(2026, 6, 2)
+    with get_session() as session:
+        # Reclaimed: trap 100, later close 105.
+        tid = _seed_thesis(session, symbol="CRDO", recommendation="watch")
+        _seed_screened(
+            session, symbol="CRDO", scan_date=scan_date, thesis_id=tid,
+            pattern_type="false_breakout", invalidation_level=100.0,
+        )
+        _seed_price(session, symbol="CRDO", d=scan_date, close=95.0)
+        _seed_price(session, symbol="CRDO", d=date(2026, 6, 10), close=105.0)
+
+        # Not reclaimed: trap 200, later close 150.
+        tid2 = _seed_thesis(session, symbol="TTMI", recommendation="watch")
+        _seed_screened(
+            session, symbol="TTMI", scan_date=scan_date, thesis_id=tid2,
+            pattern_type="false_breakout", invalidation_level=200.0,
+        )
+        _seed_price(session, symbol="TTMI", d=scan_date, close=180.0)
+        _seed_price(session, symbol="TTMI", d=date(2026, 6, 10), close=150.0)
+    return {"eval_date": eval_date, "scan_date": scan_date}
+
+
+def _queue_rows(symbol: str | None = None) -> list[dict]:
+    with get_session() as session:
+        sql = "SELECT symbol, status, invalidation_level FROM paper_reclaim_queue"
+        if symbol:
+            sql += " WHERE symbol = :sym"
+            rows = session.execute(text(sql), {"sym": symbol}).mappings().all()
+        else:
+            rows = session.execute(text(sql)).mappings().all()
+    return [dict(r) for r in rows]
+
+
+def test_detect_enqueues_reclaimed_not_unreclaimed(reclaim_db):
+    res = detect_and_enqueue_reclaims(
+        eval_date=reclaim_db["eval_date"], window_days=30, dedup_days=5
+    )
+    assert res["enqueued"] == 1
+    rows = _queue_rows()
+    symbols = {r["symbol"] for r in rows}
+    assert symbols == {"CRDO"}
+    assert rows[0]["status"] == "queued"
+
+
+def test_detect_is_idempotent(reclaim_db):
+    detect_and_enqueue_reclaims(
+        eval_date=reclaim_db["eval_date"], window_days=30, dedup_days=5
+    )
+    # Second run on the same state must NOT create a second row.
+    res2 = detect_and_enqueue_reclaims(
+        eval_date=reclaim_db["eval_date"], window_days=30, dedup_days=5
+    )
+    assert res2["enqueued"] == 0
+    assert len(_queue_rows("CRDO")) == 1
+
+
+def test_false_breakout_hs_never_enters_queue(pg_legacy_engine):
+    """Scope regression: false_breakout_hs has no false_high → never persists a
+    bearish_invalidation_level → never enters the reclaim queue."""
+    scan_date = date(2026, 6, 2)
+    with get_session() as session:
+        tid = _seed_thesis(session, symbol="SGHC", recommendation="watch")
+        # NULL invalidation level (mirrors what the screener persists for _hs).
+        _seed_screened(
+            session, symbol="SGHC", scan_date=scan_date, thesis_id=tid,
+            pattern_type="false_breakout_hs", invalidation_level=None,
+        )
+        _seed_price(session, symbol="SGHC", d=scan_date, close=95.0)
+        _seed_price(session, symbol="SGHC", d=date(2026, 6, 10), close=999.0)
+    res = detect_and_enqueue_reclaims(
+        eval_date=date(2026, 6, 12), window_days=30, dedup_days=5
+    )
+    assert res["enqueued"] == 0
+    assert _queue_rows("SGHC") == []
+
+
+def test_setup_long_thesis_not_reconsidered(pg_legacy_engine):
+    """A false_breakout whose thesis was setup_long is already acted on the
+    bullish side — no bear trap to reconsider."""
+    scan_date = date(2026, 6, 2)
+    with get_session() as session:
+        tid = _seed_thesis(session, symbol="XYZ", recommendation="setup_long")
+        _seed_screened(
+            session, symbol="XYZ", scan_date=scan_date, thesis_id=tid,
+            pattern_type="false_breakout", invalidation_level=100.0,
+        )
+        _seed_price(session, symbol="XYZ", d=scan_date, close=95.0)
+        _seed_price(session, symbol="XYZ", d=date(2026, 6, 10), close=120.0)
+    res = detect_and_enqueue_reclaims(
+        eval_date=date(2026, 6, 12), window_days=30, dedup_days=5
+    )
+    assert res["enqueued"] == 0
+
+
+def test_process_queue_detection_only_when_gate_disabled(reclaim_db):
+    """auto_thesis False → rows stay queued, nothing spawned (the default)."""
+    detect_and_enqueue_reclaims(
+        eval_date=reclaim_db["eval_date"], window_days=30, dedup_days=5
+    )
+    spawned = []
+
+    def _spawn(symbol, queue_id):  # must NOT be called when gate is off
+        spawned.append(symbol)
+        return 999
+
+    res = process_reclaim_queue(
+        eval_date=reclaim_db["eval_date"],
+        auto_thesis=False,
+        audit_horizon_days=10,
+        audit_min_events=1,
+        spawn_fn=_spawn,
+    )
+    assert res["gate_passed"] == 0
+    assert res["spawned"] == 0
+    assert spawned == []
+    assert _queue_rows("CRDO")[0]["status"] == "queued"

--- a/tests/test_paper/test_reflections.py
+++ b/tests/test_paper/test_reflections.py
@@ -87,6 +87,7 @@ def _mk_trade(
     exit_reason: str | None = "target",
     reflection: str | None = None,
     return_pct: float | None = 0.08,
+    shadow: bool = False,
 ) -> int:
     thesis_id = _mk_thesis(session)
     tid = session.execute(
@@ -95,13 +96,14 @@ def _mk_trade(
             "(thesis_id, symbol, scan_date, session_name, status, "
             " planned_entry_price, stop_loss, target_price, pattern_type, "
             " llm_confidence, verdict, entry_date, entry_price, shares, "
-            " exit_date, exit_price, exit_reason, return_pct, pnl, reflection) "
+            " exit_date, exit_price, exit_reason, return_pct, pnl, reflection, "
+            " shadow) "
             "VALUES "
             "(:thesis_id, :symbol, '2026-05-29', 'close', :status, "
             " 100.0, 95.0, 110.0, 'w_bottom', "
             " 7, 'setup_long', :entry_date, 100.0, 100, "
             " :exit_date, :exit_price, :exit_reason, :return_pct, :pnl, "
-            " :reflection) "
+            " :reflection, :shadow) "
             "RETURNING id"
         ),
         {
@@ -115,6 +117,7 @@ def _mk_trade(
             "return_pct": return_pct,
             "pnl": 800.0 if exit_date else None,
             "reflection": reflection,
+            "shadow": shadow,
         },
     ).scalar()
     session.commit()
@@ -308,6 +311,45 @@ def test_generation_selection_bounds(pg_legacy_session):
     assert stats["written"] == 1
     assert len(stub.calls) == 1
     assert "NOW" in stub.calls[0]["user_prompt"]
+
+
+def test_generation_excludes_shadow_trades(pg_legacy_session):
+    """WS A isolation — a closed SHADOW trade must never be a reflection
+    candidate (no LLM spend on measurement rows; outcomes stay out of prompts)."""
+    from rainier.paper.reflection import (
+        generate_reflections,
+        select_reflection_candidates,
+    )
+
+    _mk_trade(pg_legacy_session, symbol="SHD", exit_date=AS_OF, shadow=True)
+    _mk_trade(pg_legacy_session, symbol="LIV", exit_date=AS_OF, shadow=False)
+
+    cands = select_reflection_candidates(AS_OF)
+    symbols = {c["symbol"] for c in cands}
+    assert "SHD" not in symbols and "LIV" in symbols
+
+    stub = _StubLLM()
+    stats = generate_reflections(AS_OF, model="test-model", llm_fn=stub)
+    assert stats["written"] == 1  # only the live trade
+    assert all("SHD" not in c["user_prompt"] for c in stub.calls)
+
+
+def test_load_recent_reflections_excludes_shadow(pg_legacy_session):
+    """WS A isolation — even a shadow row that somehow carries reflection text
+    must not be injected into the live thesis prompt."""
+    from rainier.paper.reflection import load_recent_reflections
+
+    _mk_trade(
+        pg_legacy_session, symbol="SHD", exit_date=AS_OF - timedelta(days=1),
+        reflection="shadow post-mortem", shadow=True,
+    )
+    _mk_trade(
+        pg_legacy_session, symbol="LIV", exit_date=AS_OF - timedelta(days=1),
+        reflection="live post-mortem", shadow=False,
+    )
+    rows = load_recent_reflections(AS_OF, k=10)
+    symbols = {r["symbol"] for r in rows}
+    assert "SHD" not in symbols and "LIV" in symbols
 
 
 def test_generation_caps_llm_calls_per_run(pg_legacy_session):

--- a/tests/test_paper/test_schema_gc.py
+++ b/tests/test_paper/test_schema_gc.py
@@ -1,0 +1,137 @@
+"""WS C — leaked test-schema gc + fixture-leak regression.
+
+Two lanes:
+  * pure guard tests (no DB) — the allowlist regex + protected-name refusal;
+  * postgres-lane tests (``requires_postgres`` via the shared pg url) — seed a
+    leaked schema, prove dry-run lists it, ``--apply`` drops it, and protected
+    schemas are refused.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from rainier.core.test_schema_gc import (
+    gc_test_schemas,
+    is_droppable_test_schema,
+    list_test_schemas,
+)
+
+# --------------------------------------------------------------------------
+# Pure guard lane (no DB)
+# --------------------------------------------------------------------------
+
+_NO_PROTECTED: frozenset[str] = frozenset()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "rainier_paper_test",
+        "rainier_chartmig_test",
+        "rainier_mig0006_test",
+        "rainier_paper_test_ab12",          # per-run suffix
+        "rainier_paper_test_ab12_w3",       # per-run + per-worker suffix
+    ],
+)
+def test_allowlist_matches_test_schemas(name):
+    assert is_droppable_test_schema(name, protected=_NO_PROTECTED)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "public",
+        "market",
+        "rainier",                  # not a test schema
+        "rainier_paper",            # missing _test
+        "rainier_other_test",       # not in {paper,chartmig,mig0006}
+        "xrainier_paper_test",      # not anchored at start
+        "rainier_paper_test_AB12",  # uppercase suffix not allowed
+        "rainier_paper_testx",      # suffix not separated by underscore
+    ],
+)
+def test_allowlist_refuses_non_test_schemas(name):
+    assert not is_droppable_test_schema(name, protected=_NO_PROTECTED)
+
+
+def test_protected_names_refused_even_if_regex_would_match():
+    # A protected name that *also* matches the regex must still be refused.
+    protected = frozenset({"rainier_paper_test"})
+    assert not is_droppable_test_schema("rainier_paper_test", protected=protected)
+
+
+# --------------------------------------------------------------------------
+# Postgres lane — seed a leak, gc it. Skips cleanly without a pg url.
+# --------------------------------------------------------------------------
+
+
+def _pg_url() -> str | None:
+    return os.environ.get("RAINIER_TEST_DATABASE_URL")
+
+
+requires_pg_url = pytest.mark.skipif(
+    _pg_url() is None,
+    reason="RAINIER_TEST_DATABASE_URL not set",
+)
+
+_LEAK = "rainier_paper_test_gcseed"
+
+
+@pytest.fixture
+def seeded_leak_engine():
+    """Engine on the shared pg url with one seeded leaked test schema.
+
+    Always drops the seed in teardown (success AND failure) so this test never
+    becomes the leak it is testing for.
+    """
+    url = _pg_url()
+    engine = create_engine(url, future=True)
+    with engine.begin() as conn:
+        conn.execute(text(f'DROP SCHEMA IF EXISTS "{_LEAK}" CASCADE'))
+        conn.execute(text(f'CREATE SCHEMA "{_LEAK}"'))
+    try:
+        yield engine
+    finally:
+        with engine.begin() as conn:
+            conn.execute(text(f'DROP SCHEMA IF EXISTS "{_LEAK}" CASCADE'))
+        engine.dispose()
+
+
+@requires_pg_url
+def test_dry_run_lists_seeded_leak(seeded_leak_engine):
+    listed = list_test_schemas(seeded_leak_engine)
+    assert _LEAK in listed
+    result = gc_test_schemas(seeded_leak_engine, apply=False)
+    assert _LEAK in result["candidates"]
+    assert result["dropped"] == []
+    # Dry-run must not have dropped it.
+    assert _LEAK in list_test_schemas(seeded_leak_engine)
+
+
+@requires_pg_url
+def test_apply_drops_seeded_leak(seeded_leak_engine):
+    result = gc_test_schemas(seeded_leak_engine, apply=True)
+    assert _LEAK in result["dropped"]
+    assert _LEAK not in list_test_schemas(seeded_leak_engine)
+
+
+@requires_pg_url
+def test_gc_never_drops_public_or_market(seeded_leak_engine):
+    # public always exists; market may or may not — neither may ever appear.
+    result = gc_test_schemas(seeded_leak_engine, apply=True)
+    assert "public" not in result["candidates"]
+    assert "public" not in result["dropped"]
+    assert "market" not in result["dropped"]
+    # public still present after apply.
+    with seeded_leak_engine.connect() as conn:
+        present = conn.execute(
+            text(
+                "SELECT 1 FROM information_schema.schemata "
+                "WHERE schema_name = 'public'"
+            )
+        ).scalar()
+    assert present == 1

--- a/tests/test_paper/test_shadow_watch_buy.py
+++ b/tests/test_paper/test_shadow_watch_buy.py
@@ -1,0 +1,296 @@
+"""WS A — shadow WATCH-buy: gates, long-shape guard, isolation, eval split.
+
+Lanes:
+  * pure-logic (no DB): watch-buy gate, long-shape guard, replay math, eval
+    action-split;
+  * postgres-lane (`pg_legacy_engine`, skips without PG): shadow creation,
+    long-shape regression, live-read isolation (byte-identical), replay.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import select, text
+
+from rainier.core.database import get_session
+from rainier.core.models import PaperSkip, PaperTrade
+from rainier.llm_thesis.eval import _hit
+from rainier.paper.positions import (
+    _is_long_shape,
+    _is_watch_buy_signal,
+    create_positions_for_theses,
+    create_shadow_positions_for_theses,
+)
+from rainier.paper.replay import benchmark_return, shadow_book_return
+
+# --------------------------------------------------------------------------
+# Pure-logic lane
+# --------------------------------------------------------------------------
+
+
+def test_watch_buy_gate_accepts_watch_at_threshold():
+    assert _is_watch_buy_signal("watch", 5, "close", 5) is True
+
+
+def test_watch_buy_gate_rejects_below_threshold():
+    assert _is_watch_buy_signal("watch", 4, "close", 5) is False
+
+
+def test_watch_buy_gate_rejects_non_watch_verdict():
+    assert _is_watch_buy_signal("no_setup", 6, "close", 5) is False
+    assert _is_watch_buy_signal("setup_long", 6, "close", 5) is False
+
+
+def test_watch_buy_gate_rejects_non_actionable_session():
+    assert _is_watch_buy_signal("watch", 6, "morning", 5) is False
+
+
+def test_long_shape_accepts_valid_bullish_setup():
+    levels = {"entry_price": 100.0, "stop_loss": 95.0, "target_price": 110.0}
+    assert _is_long_shape(levels, "w_bottom") is True
+
+
+def test_long_shape_rejects_false_breakout_bearish_pattern():
+    # Even with numerically long-looking levels, false_breakout is bearish.
+    levels = {"entry_price": 100.0, "stop_loss": 95.0, "target_price": 110.0}
+    assert _is_long_shape(levels, "false_breakout") is False
+
+
+def test_long_shape_rejects_inverted_levels():
+    levels = {"entry_price": 100.0, "stop_loss": 105.0, "target_price": 110.0}
+    assert _is_long_shape(levels, "w_bottom") is False
+
+
+def test_long_shape_rejects_missing_level():
+    levels = {"entry_price": 100.0, "stop_loss": None, "target_price": 110.0}
+    assert _is_long_shape(levels, "w_bottom") is False
+
+
+def test_replay_book_return_equal_weight_mean():
+    assert shadow_book_return([0.10, -0.04, 0.06]) == pytest.approx(0.04)
+
+
+def test_replay_book_return_empty_is_cash():
+    assert shadow_book_return([]) == 0.0
+
+
+def test_benchmark_return_point_to_point():
+    assert benchmark_return(100.0, 105.0) == pytest.approx(0.05)
+
+
+def test_benchmark_return_missing_endpoint_is_zero():
+    assert benchmark_return(None, 105.0) == 0.0
+    assert benchmark_return(100.0, None) == 0.0
+
+
+def test_eval_split_grades_acted_watch_by_trade_outcome():
+    # A WATCH that opened a long: a positive move is a WIN (not the abstention
+    # rule which would call return>0 a miss for watch).
+    assert _hit("watch", 0.05, acted_long=True) is True
+    assert _hit("watch", -0.03, acted_long=True) is False
+
+
+def test_eval_abstention_grading_when_no_action():
+    # A WATCH that did NOT act keeps the abstention grading.
+    assert _hit("watch", -0.03, acted_long=False) is True
+    assert _hit("watch", 0.05, acted_long=False) is False
+
+
+def test_migration_0013_files_exist():
+    from tests.test_paper.conftest import MIGRATION_0013_DOWN, MIGRATION_0013_UP
+
+    assert MIGRATION_0013_UP.exists()
+    assert MIGRATION_0013_DOWN.exists()
+
+
+# --------------------------------------------------------------------------
+# Postgres-lane — shadow creation + isolation. Skips without PG.
+# --------------------------------------------------------------------------
+
+
+def _seed_thesis(session, recommendation: str) -> int:
+    res = session.execute(
+        text(
+            "INSERT INTO analysis_results (llm_model, prompt_template, "
+            "recommendation) VALUES ('test', 'test', :rec) RETURNING id"
+        ),
+        {"rec": recommendation},
+    )
+    return int(res.scalar())
+
+
+def _seed_screened(
+    session,
+    *,
+    symbol: str,
+    scan_date: date,
+    thesis_id: int,
+    pattern_type: str,
+    entry: float,
+    stop: float,
+    target: float,
+) -> None:
+    session.execute(
+        text(
+            "INSERT INTO screened_stocks "
+            "(scan_date, session_name, symbol, rule_rank, composite_score, "
+            " pattern_type, thesis_id, entry_price, stop_loss, target_price) "
+            "VALUES (:sd, 'close', :sym, 1, 0.5, :pt, :tid, :e, :s, :t)"
+        ),
+        {"sd": scan_date, "sym": symbol, "pt": pattern_type, "tid": thesis_id,
+         "e": entry, "s": stop, "t": target},
+    )
+
+
+def _thesis_dict(thesis_id: int, symbol: str, verdict: str, conf: int) -> dict:
+    return {
+        "thesis_id": thesis_id,
+        "symbol": symbol,
+        "verdict": verdict,
+        "llm_confidence": conf,
+        "session_name": "close",
+    }
+
+
+def test_shadow_watch_buy_opens_isolated_position(pg_legacy_engine):
+    scan_date = date(2026, 6, 2)
+    with get_session() as session:
+        tid = _seed_thesis(session, "watch")
+        _seed_screened(
+            session, symbol="AAA", scan_date=scan_date, thesis_id=tid,
+            pattern_type="w_bottom", entry=100.0, stop=95.0, target=110.0,
+        )
+    res = create_shadow_positions_for_theses(
+        [_thesis_dict(tid, "AAA", "watch", 5)],
+        scan_date=scan_date, min_confidence=5,
+    )
+    assert res["created"] == 1
+    with get_session() as session:
+        rows = session.execute(select(PaperTrade)).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].shadow is True
+    assert rows[0].verdict == "watch"
+
+
+def test_watch_on_false_breakout_does_not_open(pg_legacy_engine):
+    """WS A acceptance 3: a watch on false_breakout (bearish) never opens."""
+    scan_date = date(2026, 6, 2)
+    with get_session() as session:
+        tid = _seed_thesis(session, "watch")
+        _seed_screened(
+            session, symbol="BBB", scan_date=scan_date, thesis_id=tid,
+            pattern_type="false_breakout", entry=100.0, stop=95.0, target=110.0,
+        )
+    res = create_shadow_positions_for_theses(
+        [_thesis_dict(tid, "BBB", "watch", 6)],
+        scan_date=scan_date, min_confidence=5,
+    )
+    assert res["created"] == 0
+    with get_session() as session:
+        rows = session.execute(select(PaperTrade)).scalars().all()
+    assert rows == []
+
+
+def test_watch_below_threshold_does_not_open(pg_legacy_engine):
+    scan_date = date(2026, 6, 2)
+    with get_session() as session:
+        tid = _seed_thesis(session, "watch")
+        _seed_screened(
+            session, symbol="CCC", scan_date=scan_date, thesis_id=tid,
+            pattern_type="w_bottom", entry=100.0, stop=95.0, target=110.0,
+        )
+    res = create_shadow_positions_for_theses(
+        [_thesis_dict(tid, "CCC", "watch", 4)],
+        scan_date=scan_date, min_confidence=5,
+    )
+    assert res["created"] == 0
+
+
+def test_shadow_never_writes_live_skip_ledger(pg_legacy_engine):
+    """A watch with no screened row would `missing_screened_record`-skip in the
+    live path; shadow must NOT write the live skip ledger."""
+    scan_date = date(2026, 6, 2)
+    with get_session() as session:
+        tid = _seed_thesis(session, "watch")  # no screened row seeded
+    create_shadow_positions_for_theses(
+        [_thesis_dict(tid, "DDD", "watch", 6)],
+        scan_date=scan_date, min_confidence=5,
+    )
+    with get_session() as session:
+        skips = session.execute(select(PaperSkip)).scalars().all()
+    assert skips == []
+
+
+def test_shadow_does_not_consume_live_active_slot(pg_legacy_engine):
+    """Isolation invariant: a shadow position on a symbol must not block a LIVE
+    setup_long on the SAME symbol from opening."""
+    scan_date = date(2026, 6, 2)
+    with get_session() as session:
+        shadow_tid = _seed_thesis(session, "watch")
+        live_tid = _seed_thesis(session, "setup_long")
+        _seed_screened(
+            session, symbol="EEE", scan_date=scan_date, thesis_id=shadow_tid,
+            pattern_type="w_bottom", entry=100.0, stop=95.0, target=110.0,
+        )
+        _seed_screened(
+            session, symbol="EEE", scan_date=date(2026, 6, 3),
+            thesis_id=live_tid, pattern_type="w_bottom",
+            entry=100.0, stop=95.0, target=110.0,
+        )
+    # Shadow opens first on EEE.
+    s = create_shadow_positions_for_theses(
+        [_thesis_dict(shadow_tid, "EEE", "watch", 6)],
+        scan_date=scan_date, min_confidence=5,
+    )
+    assert s["created"] == 1
+    # Live setup_long on EEE must STILL open (shadow didn't consume the slot).
+    live = create_positions_for_theses(
+        [_thesis_dict(live_tid, "EEE", "setup_long", 6)],
+        scan_date=date(2026, 6, 3),
+    )
+    assert live["created"] == 1
+    with get_session() as session:
+        live_rows = session.execute(
+            select(PaperTrade).where(PaperTrade.shadow.is_(False))
+        ).scalars().all()
+        shadow_rows = session.execute(
+            select(PaperTrade).where(PaperTrade.shadow.is_(True))
+        ).scalars().all()
+    assert len(live_rows) == 1
+    assert len(shadow_rows) == 1
+
+
+def test_live_book_byte_identical_with_shadow_present(pg_legacy_engine):
+    """Isolation regression: the live daily-report read returns the same rows
+    whether or not a shadow position exists for a DIFFERENT symbol."""
+    from rainier.paper.report import compute_daily_payload
+
+    scan_date = date(2026, 6, 2)
+    with get_session() as session:
+        live_tid = _seed_thesis(session, "setup_long")
+        _seed_screened(
+            session, symbol="FFF", scan_date=scan_date, thesis_id=live_tid,
+            pattern_type="w_bottom", entry=100.0, stop=95.0, target=110.0,
+        )
+    create_positions_for_theses(
+        [_thesis_dict(live_tid, "FFF", "setup_long", 6)], scan_date=scan_date
+    )
+    payload_before = compute_daily_payload(date(2026, 6, 2))
+
+    # Now add a shadow position on a different symbol.
+    with get_session() as session:
+        shadow_tid = _seed_thesis(session, "watch")
+        _seed_screened(
+            session, symbol="GGG", scan_date=scan_date, thesis_id=shadow_tid,
+            pattern_type="w_bottom", entry=50.0, stop=45.0, target=60.0,
+        )
+    create_shadow_positions_for_theses(
+        [_thesis_dict(shadow_tid, "GGG", "watch", 6)],
+        scan_date=scan_date, min_confidence=5,
+    )
+    payload_after = compute_daily_payload(date(2026, 6, 2))
+
+    # The live report must be byte-identical despite the shadow row's existence.
+    assert payload_before == payload_after

--- a/tests/test_paper_config.py
+++ b/tests/test_paper_config.py
@@ -34,3 +34,27 @@ def test_paper_config_env_override_reloads(monkeypatch):
     s = Settings()
     assert s.paper.watch_buy_min_confidence == 6
     assert s.paper.reclaim_auto_thesis is True
+
+
+def test_paper_config_yaml_block_is_parsed(monkeypatch, tmp_path):
+    """The `paper:` YAML block must reach PaperConfig — otherwise the documented
+    kill-switch (`watch_buy_shadow: false`) for the default-ON shadow feature is
+    inert in the scheduler's YAML-reload path."""
+    from rainier.core.config import load_settings
+
+    yaml_path = tmp_path / "settings.yaml"
+    yaml_path.write_text(
+        "paper:\n"
+        "  watch_buy_shadow: false\n"
+        "  watch_buy_min_confidence: 6\n"
+        "  reclaim_window_days: 30\n",
+        encoding="utf-8",
+    )
+    # chdir to a clean tmp dir so the project's real .env doesn't leak in.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PAPER__WATCH_BUY_SHADOW", raising=False)
+    monkeypatch.delenv("PAPER__WATCH_BUY_MIN_CONFIDENCE", raising=False)
+    s = load_settings(config_path=yaml_path)
+    assert s.paper.watch_buy_shadow is False  # kill-switch honored
+    assert s.paper.watch_buy_min_confidence == 6
+    assert s.paper.reclaim_window_days == 30

--- a/tests/test_paper_config.py
+++ b/tests/test_paper_config.py
@@ -1,0 +1,36 @@
+"""WS A/B — typed `paper` config block: defaults + env-override reload.
+
+Acceptance A5: config typed + reload-tested; shadow default ON, live OFF.
+"""
+
+from __future__ import annotations
+
+from rainier.core.config import PaperConfig, Settings
+
+
+def test_paper_config_defaults():
+    cfg = PaperConfig()
+    # WS A: shadow measurement ON; the live buy-flip (A2) is NOT this config.
+    assert cfg.watch_buy_shadow is True
+    assert cfg.watch_buy_min_confidence == 5
+    # WS B: auto-thesis OFF by default (detection + queue only).
+    assert cfg.reclaim_auto_thesis is False
+    assert cfg.reclaim_dedup_days == 5
+    assert cfg.reclaim_window_days == 20
+    assert cfg.reclaim_audit_min_events == 10
+    assert cfg.reclaim_audit_horizon_days == 10
+
+
+def test_settings_exposes_paper_block():
+    s = Settings()
+    assert isinstance(s.paper, PaperConfig)
+    assert s.paper.watch_buy_shadow is True
+
+
+def test_paper_config_env_override_reloads(monkeypatch):
+    """A fresh Settings() picks up nested env overrides (reload contract)."""
+    monkeypatch.setenv("PAPER__WATCH_BUY_MIN_CONFIDENCE", "6")
+    monkeypatch.setenv("PAPER__RECLAIM_AUTO_THESIS", "true")
+    s = Settings()
+    assert s.paper.watch_buy_min_confidence == 6
+    assert s.paper.reclaim_auto_thesis is True

--- a/tests/test_screener_invalidation_level.py
+++ b/tests/test_screener_invalidation_level.py
@@ -1,0 +1,92 @@
+"""WS B — `_to_candidate` captures the trap-high invalidation level.
+
+Only an EXACT `false_breakout` (with a `false_high` key-point) yields a
+`bearish_invalidation_level`. `false_breakout_hs` (no `false_high`) and every
+bullish pattern yield None — the scope guard the reclaim path relies on.
+"""
+
+from __future__ import annotations
+
+from rainier.analysis.stock_screener import _to_candidate
+from rainier.core.types import MoneyFlowSignal, PatternSignal, StockScreenResult
+
+
+def _result(pattern: PatternSignal | None) -> StockScreenResult:
+    return StockScreenResult(
+        symbol="CRDO",
+        name="CRDO",
+        sector="Tech",
+        money_flow_score=0.5,
+        long_short="Long in",
+        qu100_rank=1,
+        sector_trend="bullish",
+        sector_boost=0.0,
+        patterns=[pattern] if pattern else [],
+        best_pattern=pattern,
+        composite_score=0.5,
+        recommendation="watch",
+        entry_price=pattern.entry_price if pattern else None,
+        stop_loss=pattern.stop_loss if pattern else None,
+        target=pattern.target_wave1 if pattern else None,
+    )
+
+
+def _signal_map() -> dict[str, MoneyFlowSignal]:
+    return {
+        "CRDO": MoneyFlowSignal(
+            symbol="CRDO", rank=1, rank_change=0, long_short="Long in",
+            capital_flow_direction="+", days_in_top100=5, sector="Tech",
+            industry="Semis", signal_strength=0.5,
+        )
+    }
+
+
+def _false_breakout(pattern_type: str, *, with_false_high: bool) -> PatternSignal:
+    key_points = {"prior_high": 95.0, "rejection_bar": 3}
+    if with_false_high:
+        key_points["false_high"] = 100.0
+    return PatternSignal(
+        symbol="CRDO",
+        pattern_type=pattern_type,
+        direction="bearish",
+        status="confirmed",
+        confidence=0.9,
+        entry_price=95.0,
+        stop_loss=102.0,
+        target_wave1=85.0,
+        key_points=key_points,
+    )
+
+
+def test_exact_false_breakout_captures_invalidation_level():
+    pattern = _false_breakout("false_breakout", with_false_high=True)
+    cand = _to_candidate(_result(pattern), _signal_map(), {"CRDO": 96.0})
+    # The trap high is false_high (100.0), NOT stop_loss (102.0).
+    assert cand.bearish_invalidation_level == 100.0
+
+
+def test_false_breakout_hs_yields_no_invalidation_level():
+    pattern = _false_breakout("false_breakout_hs", with_false_high=False)
+    cand = _to_candidate(_result(pattern), _signal_map(), {"CRDO": 96.0})
+    assert cand.bearish_invalidation_level is None
+
+
+def test_bullish_pattern_yields_no_invalidation_level():
+    pattern = PatternSignal(
+        symbol="CRDO",
+        pattern_type="w_bottom",
+        direction="bullish",
+        status="confirmed",
+        confidence=0.8,
+        entry_price=95.0,
+        stop_loss=90.0,
+        target_wave1=110.0,
+        key_points={"first_low": 88.0},
+    )
+    cand = _to_candidate(_result(pattern), _signal_map(), {"CRDO": 96.0})
+    assert cand.bearish_invalidation_level is None
+
+
+def test_no_pattern_yields_no_invalidation_level():
+    cand = _to_candidate(_result(None), _signal_map(), {"CRDO": 96.0})
+    assert cand.bearish_invalidation_level is None


### PR DESCRIPTION
## Summary
P0 batch — 3 workstreams in one PR:
- **WS C (test-infra):** per-run test schema names (no cross-run clobber) + `rainier db gc-test-schemas` to reap orphaned schemas.
- **WS B (paper):** reconsider invalidated bull-traps via `false_breakout` — trap-high persistence + reclaim queue (detection-only; reclaim daily path is `spawn_fn=None` until spawn is wired).
- **WS A (paper):** shadow-mode WATCH-buy measurement with real-engine replay harness.

Review-iteration fixes (2× P1 shadow-isolation leaks):
- Shadow rows must not write the live PaperSkip ledger on fill (`gap_invalidated` / `zero_share_price`).
- Shadow trades excluded from LLM reflection generation + prompt injection; parse `paper:` YAML block.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 3)

## Test plan
- [ ] CI green
- [ ] verify locally