### PR TITLE
fix(paper): daily report Discord errors log status+error_type, never the webhook token

### DIFF
--- a/src/rainier/paper/report.py
+++ b/src/rainier/paper/report.py
@@ -292,12 +292,16 @@ def send_daily_paper_report(payload: dict[str, Any], discord_config: Any) -> boo
     webhook configured (H6): logs + returns False, never raises."""
     text = render_payload(payload)
     try:
-        # _http_status extracts the HTTP code (404/401/429) WITHOUT the URL;
-        # the webhook URL carries a secret token, so the except below logs
-        # status + exception class only — never str(exc) / log.exception,
-        # which would persist the token into data/qu-scrape.log (P1 leak,
-        # same class fixed in 96fbd13 + the weekly sweep).
-        from rainier.alerts.discord import _http_status, send_daily_report
+        # The except below logs status + exception class only — never
+        # str(exc) / log.exception, which would persist the webhook's secret
+        # token (last URL path segment, echoed by HTTPStatusError.__str__)
+        # into data/qu-scrape.log (P1 leak, same class fixed in 96fbd13 +
+        # the weekly sweep). _http_status pulls the HTTP code WITHOUT the URL.
+        # The status extractor is computed inline so a failed import of
+        # rainier.alerts.discord (which would land in the except before any
+        # bound helper) still honors the "returns False, never raises"
+        # contract instead of raising UnboundLocalError.
+        from rainier.alerts.discord import send_daily_report
 
         webhook = getattr(discord_config, "webhook_url", None) if discord_config else None
         if not discord_config or not getattr(discord_config, "enabled", False) or not webhook:
@@ -306,9 +310,11 @@ def send_daily_paper_report(payload: dict[str, Any], discord_config: Any) -> boo
         send_daily_report(text, discord_config)
         return True
     except Exception as exc:
+        resp = getattr(exc, "response", None)
+        status = getattr(resp, "status_code", None) if resp is not None else None
         log.error(
             "paper_report_discord_failed status=%s error_type=%s",
-            _http_status(exc),
+            status,
             type(exc).__name__,
         )
         return False

--- a/src/rainier/paper/report.py
+++ b/src/rainier/paper/report.py
@@ -292,7 +292,12 @@ def send_daily_paper_report(payload: dict[str, Any], discord_config: Any) -> boo
     webhook configured (H6): logs + returns False, never raises."""
     text = render_payload(payload)
     try:
-        from rainier.alerts.discord import send_daily_report
+        # _http_status extracts the HTTP code (404/401/429) WITHOUT the URL;
+        # the webhook URL carries a secret token, so the except below logs
+        # status + exception class only — never str(exc) / log.exception,
+        # which would persist the token into data/qu-scrape.log (P1 leak,
+        # same class fixed in 96fbd13 + the weekly sweep).
+        from rainier.alerts.discord import _http_status, send_daily_report
 
         webhook = getattr(discord_config, "webhook_url", None) if discord_config else None
         if not discord_config or not getattr(discord_config, "enabled", False) or not webhook:
@@ -300,6 +305,10 @@ def send_daily_paper_report(payload: dict[str, Any], discord_config: Any) -> boo
             return False
         send_daily_report(text, discord_config)
         return True
-    except Exception:
-        log.exception("paper_report_discord_failed")
+    except Exception as exc:
+        log.error(
+            "paper_report_discord_failed status=%s error_type=%s",
+            _http_status(exc),
+            type(exc).__name__,
+        )
         return False

--- a/tests/test_paper/test_report_discord_leak.py
+++ b/tests/test_paper/test_report_discord_leak.py
@@ -15,6 +15,7 @@ regression is silently skipped in non-Postgres lanes.
 
 from __future__ import annotations
 
+import builtins
 import json
 import logging
 from types import SimpleNamespace
@@ -86,3 +87,33 @@ def test_daily_report_failure_never_leaks_webhook_token(caplog):
     )
     assert secret not in blob, "webhook token leaked into report logs"
     assert "webhooks/123456" not in blob
+
+
+def test_daily_report_import_failure_returns_false_without_raising(caplog):
+    """The lazy ``from rainier.alerts.discord import send_daily_report`` lands
+    in the except block if the module fails to import. The status extractor
+    must NOT depend on a helper imported on that same line, or the except
+    raises ``UnboundLocalError`` and breaks the "returns False, never raises"
+    contract in exactly the failure mode this wrapper exists to absorb."""
+    config = SimpleNamespace(enabled=True, webhook_url="https://discord.com/api/webhooks/1/tok")
+
+    real_import = builtins.__import__
+
+    def _boom(name, *args, **kwargs):
+        if name == "rainier.alerts.discord":
+            raise ImportError("simulated discord import failure")
+        return real_import(name, *args, **kwargs)
+
+    with caplog.at_level(logging.INFO, logger="rainier.paper.report"):
+        with patch.object(builtins, "__import__", _boom):
+            result = send_daily_paper_report(PAYLOAD, config)
+
+    # Contract held: no UnboundLocalError, returns False.
+    assert result is False
+    failed = [
+        r for r in caplog.records if "paper_report_discord_failed" in r.getMessage()
+    ]
+    assert failed, "expected a paper_report_discord_failed log record"
+    # status=None (no HTTP response on an ImportError), error_type=ImportError.
+    assert "ImportError" in failed[0].getMessage()
+    assert "status=None" in failed[0].getMessage()

--- a/tests/test_paper/test_report_discord_leak.py
+++ b/tests/test_paper/test_report_discord_leak.py
@@ -1,0 +1,88 @@
+"""Regression: the daily paper-report Discord error path must never leak the
+webhook token into logs.
+
+``httpx.HTTPStatusError.__str__`` embeds the request URL, and a Discord webhook
+URL carries its secret token as the last path segment. ``send_daily_paper_report``
+catches send failures and used to ``log.exception`` the full traceback — which
+serializes ``str(exc)`` and thus the token — into ``data/qu-scrape.log``. This is
+the same P1 leak class fixed in 96fbd13 (Discord client) and the weekly sweep.
+
+This file is UNMARKED on purpose: it mocks ``send_daily_report`` (httpx) and
+captures the stdlib ``rainier.paper.report`` logger via ``caplog``. No DB is
+touched, so it must NOT sit behind ``requires_postgres`` — otherwise the
+regression is silently skipped in non-Postgres lanes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+
+from rainier.paper.report import send_daily_paper_report
+
+PAYLOAD = {
+    "report_type": "daily",
+    "as_of_date": "2026-06-17",
+    "counts_by_status": {"pending": 0, "open": 0, "closed": 0, "expired": 0},
+    "realized_pnl": 0.0,
+    "mtm_including_open_pnl": 0.0,
+    "open_mtm_pnl": 0.0,
+    "todays_exits": [],
+    "win_rate_closed": None,
+    "closed_trades": 0,
+    "same_bar_ambiguous_exits": 0,
+    "total_residual_cash": 0.0,
+    "stale_mtm_symbols": [],
+    "disclosure": "",
+}
+
+
+def _status_error(url: str) -> httpx.HTTPStatusError:
+    """Build the real leak vector: raise_for_status auto-generates a message
+    that embeds the request URL (which carries the token)."""
+    req = httpx.Request("POST", url)
+    resp = httpx.Response(401, request=req)
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        return exc
+    raise AssertionError("raise_for_status did not raise")  # pragma: no cover
+
+
+def test_daily_report_failure_never_leaks_webhook_token(caplog):
+    secret = "SUPERSECRETtoken9999"
+    url = f"https://discord.com/api/webhooks/123456/{secret}"
+    config = SimpleNamespace(enabled=True, webhook_url=url)
+
+    err = _status_error(url)
+    # Guard: prove the test exercises the REAL leak vector, not a no-op.
+    assert secret in str(err)
+
+    with caplog.at_level(logging.INFO, logger="rainier.paper.report"):
+        with patch(
+            "rainier.alerts.discord.send_daily_report", side_effect=err
+        ):
+            result = send_daily_paper_report(PAYLOAD, config)
+
+    # Non-fatal contract: returns False, never raises.
+    assert result is False
+
+    # A failure record was emitted with the exception class diagnostic.
+    failed = [
+        r for r in caplog.records if "paper_report_discord_failed" in r.getMessage()
+    ]
+    assert failed, "expected a paper_report_discord_failed log record"
+    assert "HTTPStatusError" in failed[0].getMessage()
+
+    # The token (and the webhook path) must not appear anywhere in the logs —
+    # serialize every record the way the discord.py regression test does.
+    blob = json.dumps(
+        [r.getMessage() for r in caplog.records]
+        + [(r.exc_text or "") for r in caplog.records]
+    )
+    assert secret not in blob, "webhook token leaked into report logs"
+    assert "webhooks/123456" not in blob


### PR DESCRIPTION
## Summary

daily paper-report Discord send-failure handler leaked the webhook URL+token into `data/qu-scrape.log` via `log.exception` (`httpx.HTTPStatusError.__str__` embeds the request URL). Now logs status code + exception class only (same `_http_status` pattern as 96fbd13). Mirrors the prior leak fixes; weekly-sweep path was already safe. Inlined the status extraction so an import failure can't break the "returns False, never raises" contract (codex iter-1).

Task plan: docs/TASK-PLAN-daily-discord-log-leak-cd57.md.

## Review

/review: passed (claude rounds: 4); codex review: passed (codex rounds: 3).

## Test plan

- New unmarked regression test `tests/test_paper/test_report_discord_leak.py` (token absent from caplog; runs in default lane, not Postgres-gated) + `test_daily_report_import_failure_returns_false_without_raising`.
- Full `tests/test_paper`: 142 passed / 192 skipped; ruff clean.
- [ ] CI green.