### PR TITLE
fix(backfill): coverage-based backfill-prices — re-fetch present-but-incomplete symbols

### DIFF
--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -400,10 +400,14 @@ def select_symbols_needing_backfill(
         re-pulled.
 
       - GATE (``True`` — "what must be COVERED to exit 0"): clamp to the symbol's
-        ranked life ``[max(start, first_ranking), min(end, last_ranking + tail)]``
-        so the success gate does NOT fail forever on an IPO (no pre-listing
-        history exists) or a delisted former member (no post-delisting history
-        exists). The forward tail covers the entry+hold past the last ranking.
+        ranked life ``[max(start, first_ranking),
+        min(end, last_traded, last_ranking + tail)]`` so the success gate does NOT
+        fail forever on an IPO (no pre-listing history exists) or a delisted former
+        member (no post-delisting history exists). The forward tail covers the
+        entry+hold past the last ranking; the ``last_traded`` cap (operator
+        decision 2026-06-17 #3) bounds a delisted name at its real last bar so a
+        post-delist tail it can never have is not demanded — while never shrinking
+        below ``last_ranking`` (a live stale-tail symbol stays flagged).
     """
     usable = _symbol_usable_dates(list(symbols), window_start, window_end)
     span = _symbol_ranking_span(list(symbols)) if clamp_to_ranking_life else {}
@@ -413,11 +417,33 @@ def select_symbols_needing_backfill(
         if clamp_to_ranking_life:
             fr, lr = span.get(s, (None, None))
             eff_start = window_start if fr is None else max(window_start, fr)
-            eff_end = (
-                window_end
-                if lr is None
-                else min(window_end, cal.add_sessions(lr, COVERAGE_FORWARD_TAIL_SESSIONS))
-            )
+            if lr is None:
+                eff_end = window_end
+            else:
+                # GATE right edge = min(end_date, last_traded_session,
+                # last_ranking + N) — operator decision 2026-06-17 (task plan
+                # "Resolved coverage-semantics decisions" #3). N is a HARD CAP
+                # (not a floor): positions held past N sessions are intentionally
+                # not coverage-required, bounding fetch cost.
+                #
+                # The last_traded cap stops a DELISTED former member (price series
+                # ends at/just after its last ranking) from being asked for
+                # post-delist bars it can never have → no perpetual gate failure.
+                # last_traded = the symbol's most recent usable bar in-window
+                # (max(present)); None if it has none.
+                #
+                # `max(lr, last_traded)` keeps the cap from EVER shrinking the
+                # requirement below last_ranking: a still-ranked (live) symbol with
+                # a stale tail (last_ranking ≈ end_date, bars stop months earlier)
+                # is still flagged — the cap only bounds the forward TAIL
+                # (last_ranking, last_ranking + N], never the ranked life itself.
+                present = usable.get(s, set())
+                last_traded = max(present) if present else None
+                tail_cap = cal.add_sessions(lr, COVERAGE_FORWARD_TAIL_SESSIONS)
+                if last_traded is None:
+                    eff_end = min(window_end, tail_cap)
+                else:
+                    eff_end = min(window_end, tail_cap, max(lr, last_traded))
         else:
             # Selection: the full window — fetch all history the backtest may read.
             eff_start, eff_end = window_start, window_end

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -523,7 +523,13 @@ def _save_prices_to_db(
         if new_symbols:
             db.flush()
 
-        # Batch insert prices using INSERT ... ON CONFLICT DO NOTHING
+        # Batch upsert prices. ON CONFLICT DO UPDATE with COALESCE(EXCLUDED,
+        # existing) — a coverage re-fetch must REPAIR a NULL/placeholder bar
+        # (the row the coverage check flagged as a gap), so DO NOTHING would
+        # leave the placeholder forever and the gap would never heal. A null
+        # re-fetch field keeps the old good value (B5 discipline, mirrors
+        # paper.ingest._upsert_bar); re-fetching identical data is a no-op write
+        # (idempotent — no duplicate (symbol, date) rows).
         from sqlalchemy.dialects.postgresql import insert as pg_insert
         rows_to_insert = []
         for _, row in long_df.iterrows():
@@ -546,8 +552,19 @@ def _save_prices_to_db(
             for ci in range(0, len(rows_to_insert), chunk_size):
                 chunk = rows_to_insert[ci : ci + chunk_size]
                 stmt = pg_insert(StockPrice).values(chunk)
-                stmt = stmt.on_conflict_do_nothing(
-                    constraint="uq_stock_price_symbol_date"
+                stmt = stmt.on_conflict_do_update(
+                    constraint="uq_stock_price_symbol_date",
+                    set_={
+                        "open": func.coalesce(stmt.excluded.open, StockPrice.open),
+                        "high": func.coalesce(stmt.excluded.high, StockPrice.high),
+                        "low": func.coalesce(stmt.excluded.low, StockPrice.low),
+                        "close": func.coalesce(
+                            stmt.excluded.close, StockPrice.close
+                        ),
+                        "volume": func.coalesce(
+                            stmt.excluded.volume, StockPrice.volume
+                        ),
+                    },
                 )
                 db.execute(stmt)
                 count += len(chunk)

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -257,15 +257,22 @@ def _symbol_usable_dates(
     return result
 
 
-def _symbol_first_ranking_dates(symbols: list[str]) -> dict[str, date | None]:
-    """Each symbol's earliest top100 ranking date (None if never ranked).
+def _symbol_ranking_span(
+    symbols: list[str],
+) -> dict[str, tuple[date | None, date | None]]:
+    """Each symbol's (first, last) top100 ranking date; (None, None) if never.
 
-    The miss-sweep evaluates a symbol only from when it first APPEARS in the
-    top100 rankings, so a name that entered after the global sweep start (e.g. a
-    recent IPO) has no pre-listing history to repair — its coverage left boundary
-    is its own first-ranking date, not the global sweep start. Without this a
-    legitimate late entrant would be flagged uncovered (pre-listing sessions
-    counted as gaps) and the command would fail on every run (codex).
+    These bound the window the sweep ACTUALLY consumes for a symbol:
+      - first (left): the sweep evaluates a symbol only from when it first
+        APPEARS in top100, so a late entrant (recent IPO) has no pre-listing
+        history to repair — left boundary is its own first ranking, not the
+        global sweep start.
+      - last (right): a former constituent that stopped trading after its last
+        ranking (delist/rename/acquisition) is only consumed THROUGH that last
+        ranking date; requiring bars through today would flag it uncovered
+        forever — right boundary is its own last ranking, not the global today.
+    Both prevent the gate from failing every run on legitimate non-current names
+    (codex).
     """
     if not symbols:
         return {}
@@ -274,6 +281,7 @@ def _symbol_first_ranking_dates(symbols: list[str]) -> dict[str, date | None]:
             select(
                 MoneyFlowSnapshot.symbol,
                 func.min(MoneyFlowSnapshot.data_date),
+                func.max(MoneyFlowSnapshot.data_date),
             )
             .where(
                 MoneyFlowSnapshot.symbol.in_(list(symbols)),
@@ -281,10 +289,15 @@ def _symbol_first_ranking_dates(symbols: list[str]) -> dict[str, date | None]:
             )
             .group_by(MoneyFlowSnapshot.symbol)
         ).all()
-    first: dict[str, date | None] = {s: None for s in symbols}
-    for sym, d in rows:
-        first[sym] = d.date() if hasattr(d, "date") else d
-    return first
+    span: dict[str, tuple[date | None, date | None]] = {
+        s: (None, None) for s in symbols
+    }
+    for sym, lo, hi in rows:
+        span[sym] = (
+            lo.date() if hasattr(lo, "date") else lo,
+            hi.date() if hasattr(hi, "date") else hi,
+        )
+    return span
 
 
 def _is_covered(
@@ -355,26 +368,28 @@ def select_symbols_needing_backfill(
     of missing usable sessions, catching the recent-sliver (long left run),
     stale-tail (long right run), and split-history (long interior run) cases.
 
-    Per-symbol left boundary: a symbol's effective coverage window starts at
-    ``max(window_start, first_top100_ranking_date)``. A late entrant (e.g. a
-    recent IPO) has no pre-listing history to repair and the sweep evaluates it
-    only from when it appears in rankings, so pre-listing sessions are NOT
-    counted as gaps. The right boundary stays at ``window_end`` (every ranked
-    symbol needs recent prices for forward returns).
+    Per-symbol boundaries: a symbol's effective coverage window is
+    ``[max(window_start, first_ranking), min(window_end, last_ranking)]``. A late
+    entrant (IPO) has no pre-listing history to repair (left); a former member
+    that stopped trading after its last ranking (delist/rename) is only consumed
+    THROUGH that last ranking (right). The miss-sweep evaluates a symbol only
+    over the sessions it actually appears in rankings, so neither pre-listing nor
+    post-delisting sessions are counted as gaps — without this the gate would
+    fail every run on legitimate non-current names.
     """
     usable = _symbol_usable_dates(list(symbols), window_start, window_end)
-    first_ranked = _symbol_first_ranking_dates(list(symbols))
+    span = _symbol_ranking_span(list(symbols))
     cal = calendar or _default_calendar()
     need = []
     for s in symbols:
-        fr = first_ranked.get(s)
-        # Effective left edge: never earlier than the global window, never
-        # earlier than the symbol's first appearance in the rankings.
+        fr, lr = span.get(s, (None, None))
+        # Effective edges: clamp the global window to the symbol's ranked life.
         eff_start = window_start if fr is None else max(window_start, fr)
+        eff_end = window_end if lr is None else min(window_end, lr)
         if not _is_covered(
             usable.get(s, set()),
             eff_start,
-            window_end,
+            eff_end,
             max_gap_sessions,
             cal,
         ):

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -338,16 +338,20 @@ def _is_covered(
     row-count threshold: a dense set with one big hole still fails; a
     sparse-but-contiguous set still passes.
 
-    A symbol with NO usable bars over a non-degenerate window is never covered —
-    even a very short window (a name ranked only in the last few sessions): zero
-    prices means the sweep has nothing to read, so it must always re-fetch.
+    A symbol with NO usable bars is never covered — even when the window is
+    degenerate (no sessions, or reversed eff_start > eff_end). That reversed case
+    is reachable: a symbol first ranked on a weekend/holiday data_date that lands
+    AFTER the (last-completed-session) window_end gives eff_start > eff_end. With
+    zero bars it still needs its entry bar fetched, so it must NOT be a vacuous
+    pass (codex). Only a symbol that ALREADY has usable bars is vacuously covered
+    over an empty/reversed window (nothing more is required).
     """
     cal = calendar or _default_calendar()
+    if not present:
+        return False  # zero usable bars → never covered (incl. degenerate window)
     sessions = cal.sessions_between(window_start, window_end)
     if not sessions:
-        return True  # degenerate window (no trading days) — nothing to cover
-    if not present:
-        return False  # window has sessions but zero usable bars → not covered
+        return True  # empty/reversed window but the symbol HAS bars → nothing to add
     run = 0
     for s in sessions:
         if s in present:

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -437,6 +437,19 @@ def select_symbols_needing_backfill(
                 # a stale tail (last_ranking ≈ end_date, bars stop months earlier)
                 # is still flagged — the cap only bounds the forward TAIL
                 # (last_ranking, last_ranking + N], never the ranked life itself.
+                # A hole WITHIN the ranked life (last_traded < lr) is also still
+                # caught: max(lr, last_traded)=lr scans through lr, so _is_covered
+                # sees the interior run.
+                #
+                # Trade-off (decision 3, accepted): offline we cannot tell a
+                # genuine delisting (no bars exist past last_traded) from a live
+                # former member with a TAIL fetch-gap in (lr, lr+N] (bars exist at
+                # yfinance, just not yet pulled). The GATE caps both at last_traded
+                # so neither perpetually fails. The SELECTION pass (clamp=False,
+                # eff_end=window_end) re-flags the tail-gapped live case on EVERY
+                # run, so the fetch loop self-heals it idempotently; only a true
+                # delisting stays capped. The GATE is the don't-fail-forever guard,
+                # SELECTION is the gap detector.
                 present = usable.get(s, set())
                 last_traded = max(present) if present else None
                 tail_cap = cal.add_sessions(lr, COVERAGE_FORWARD_TAIL_SESSIONS)

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -338,20 +338,22 @@ def _is_covered(
     row-count threshold: a dense set with one big hole still fails; a
     sparse-but-contiguous set still passes.
 
-    A symbol with NO usable bars is never covered — even when the window is
-    degenerate (no sessions, or reversed eff_start > eff_end). That reversed case
-    is reachable: a symbol first ranked on a weekend/holiday data_date that lands
-    AFTER the (last-completed-session) window_end gives eff_start > eff_end. With
-    zero bars it still needs its entry bar fetched, so it must NOT be a vacuous
-    pass (codex). Only a symbol that ALREADY has usable bars is vacuously covered
-    over an empty/reversed window (nothing more is required).
+    Degenerate / reversed window (no trading sessions in ``[window_start,
+    window_end]``, e.g. a symbol first ranked AFTER the last-completed-session
+    window_end — a same-day or weekend entrant whose entry bar is not published
+    yet): there is nothing fetchable yet, so it is vacuously covered regardless
+    of ``present`` and will be picked up on the next run once its first session
+    completes. When the window DOES contain sessions, a symbol with NO usable
+    bars there is never covered (zero prices → the sweep has nothing to read).
+    Callers must pass a window_end that is the last COMPLETED session so an
+    as-yet-unpublished bar is never demanded.
     """
     cal = calendar or _default_calendar()
-    if not present:
-        return False  # zero usable bars → never covered (incl. degenerate window)
     sessions = cal.sessions_between(window_start, window_end)
     if not sessions:
-        return True  # empty/reversed window but the symbol HAS bars → nothing to add
+        return True  # no completed sessions in range → nothing fetchable yet
+    if not present:
+        return False  # window has sessions but zero usable bars → not covered
     run = 0
     for s in sessions:
         if s in present:

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -312,11 +312,17 @@ def _is_covered(
     tolerated (a late-by-3-sessions start is a run of 3 ≤ gap). It is NOT a
     row-count threshold: a dense set with one big hole still fails; a
     sparse-but-contiguous set still passes.
+
+    A symbol with NO usable bars over a non-degenerate window is never covered —
+    even a very short window (a name ranked only in the last few sessions): zero
+    prices means the sweep has nothing to read, so it must always re-fetch.
     """
     cal = calendar or _default_calendar()
     sessions = cal.sessions_between(window_start, window_end)
     if not sessions:
         return True  # degenerate window (no trading days) — nothing to cover
+    if not present:
+        return False  # window has sessions but zero usable bars → not covered
     run = 0
     for s in sessions:
         if s in present:

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -15,7 +15,8 @@ import math
 import time
 import uuid
 from dataclasses import dataclass, field
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -25,6 +26,9 @@ from sqlalchemy import func, select
 
 from rainier.core.database import get_session
 from rainier.core.models import BacktestTradingLog, MoneyFlowSnapshot
+
+if TYPE_CHECKING:
+    from rainier.paper.calendar import TradingCalendar
 
 log = structlog.get_logger()
 
@@ -146,87 +150,154 @@ def load_rankings_from_db() -> pd.DataFrame:
 # (any StockPrice row >= start). A separate incremental ingest seeded thin
 # RECENT slivers for large-caps, so they passed presence and were skipped — their
 # 2022-2025 history (most of the sweep window) was never fetched. These helpers
-# replace presence with a COVERAGE span check at BOTH window boundaries.
+# replace presence with a COVERAGE check: a symbol is "covered" only if its
+# USABLE bars (non-NULL OHLC) reach BOTH window boundaries AND have no large
+# interior hole.
 #
 #   sweep window:  [start ............................. end]
 #   recent-sliver:                              [###]   <- no left-edge bar -> refetch
 #   stale-tail:    [###########]                        <- no right-edge bar -> refetch
-#   fully-covered: [### .............................. ###] <- skip
+#   split-history: [###]...............(hole)......[###] <- interior hole -> refetch
+#   fully-covered: [############### dense ###########]   <- skip
+#
+# Why not just min/max span: a min/max span check (lo<=start, hi>=end) is fooled
+# by a split history — early + late bars with a multi-year hole between them have
+# lo at the start and hi at the end yet are NOT covered (the sweep can't measure
+# forward returns inside the hole). The check below instead works on the SET of
+# usable bar dates and looks for the largest run of consecutive missing trading
+# sessions; this catches the recent-sliver, stale-tail, AND split-history cases
+# without a bare row-count threshold (counts can pass with a hole intact).
+#
+# NULL-OHLC rows: a yfinance partial can persist a placeholder row with NULL
+# OHLC. `paper.ingest._existing_dates()` treats those as GAPS (filters
+# `close.isnot(None)` &c.) so a real bar still re-fetches. The query below
+# applies the SAME usable-OHLC filter so a placeholder near a boundary can never
+# masquerade as coverage.
 # ---------------------------------------------------------------------------
 
 # "at/near" a boundary must tolerate weekends/holidays — markets aren't open on a
-# given calendar date every year. A symbol is left/right covered if it has a bar
-# within this many calendar days of the boundary.
+# given calendar date every year. A symbol is left/right covered if it has a
+# usable bar within this many calendar days of the boundary.
 COVERAGE_BOUNDARY_TOLERANCE_DAYS = 7
+
+# The largest interior hole (run of consecutive missing TRADING sessions) a
+# covered symbol may have. A real listing trades every session; a hole longer
+# than this means whole stretches of the sweep window have no price, so the
+# symbol must re-fetch. Measured in trading sessions (not calendar days) so
+# weekends/holidays don't count as a hole. ~2 weeks of sessions.
+COVERAGE_MAX_INTERIOR_GAP_SESSIONS = 10
 
 
 def sweep_window_start() -> date:
-    """The sweep-consumption window start = earliest QU100 ranking date.
+    """The sweep-consumption window start = earliest top100 ranking date.
 
-    Derived from the same source the miss-sweep reads (``load_rankings_from_db``)
-    so selection / download / coverage all key on the window the sweep actually
-    consumes — NOT a hard-coded date or a ``--years`` arithmetic. ~2022-05-25.
+    Derived from the same source the miss-sweep reads, scoped to
+    ``ranking_type == 'top100'`` — the EXACT slice the sweep consumes
+    (cli.py filters ``rankings[ranking_type == 'top100']`` before evaluating).
+    Older ``bottom100`` / other-type snapshots are NOT consumed by the sweep, so
+    they must not widen the repair window. NOT a hard-coded date or a ``--years``
+    arithmetic. ~2022-05-25.
     """
     with get_session() as db:
         first = db.execute(
-            select(func.min(MoneyFlowSnapshot.data_date))
+            select(func.min(MoneyFlowSnapshot.data_date)).where(
+                MoneyFlowSnapshot.ranking_type == "top100"
+            )
         ).scalar()
     if first is None:
-        raise ValueError("No QU100 rankings in database; cannot derive sweep start")
+        raise ValueError("No top100 QU100 rankings in database; cannot derive sweep start")
     return first
 
 
-def _symbol_price_spans(
+def _symbol_usable_dates(
     symbols: list[str],
-) -> dict[str, tuple[date | None, date | None]]:
-    """(min_date, max_date) of persisted bars per symbol; (None, None) if absent.
+    window_start: date,
+    window_end: date,
+) -> dict[str, set[date]]:
+    """Usable-OHLC bar dates per symbol within [window_start, window_end].
 
-    One grouped query over ``stock_prices`` for the whole batch. Dates are the
-    stored instant's UTC calendar date.
+    "Usable" = all of open/high/low/close non-NULL — the SAME probe
+    ``paper.ingest._existing_dates`` uses, so a yfinance NULL/partial placeholder
+    row is treated as a GAP (not coverage). One query for the whole batch; the
+    window bound keeps the result to the bars that matter for the sweep. Returns
+    an empty set (never absent) for every requested symbol so callers needn't
+    guard ``.get``.
     """
     from rainier.core.models import StockPrice
 
+    result: dict[str, set[date]] = {s: set() for s in symbols}
     if not symbols:
-        return {}
+        return result
+    # date is stored as 00:00 UTC; compare against tz-aware instants, not strings.
+    start_dt = datetime(window_start.year, window_start.month, window_start.day,
+                        tzinfo=timezone.utc)
+    end_dt = datetime(window_end.year, window_end.month, window_end.day,
+                      tzinfo=timezone.utc)
     with get_session() as db:
         rows = db.execute(
-            select(
-                StockPrice.symbol,
-                func.min(StockPrice.date),
-                func.max(StockPrice.date),
+            select(StockPrice.symbol, StockPrice.date).where(
+                StockPrice.symbol.in_(list(symbols)),
+                StockPrice.date >= start_dt,
+                StockPrice.date <= end_dt,
+                StockPrice.open.isnot(None),
+                StockPrice.high.isnot(None),
+                StockPrice.low.isnot(None),
+                StockPrice.close.isnot(None),
             )
-            .where(StockPrice.symbol.in_(list(symbols)))
-            .group_by(StockPrice.symbol)
         ).all()
-    spans: dict[str, tuple[date | None, date | None]] = {
-        s: (None, None) for s in symbols
-    }
-    for sym, lo, hi in rows:
-        spans[sym] = (
-            lo.date() if hasattr(lo, "date") else lo,
-            hi.date() if hasattr(hi, "date") else hi,
-        )
-    return spans
+    for sym, d in rows:
+        result[sym].add(d.date() if hasattr(d, "date") else d)
+    return result
 
 
 def _is_covered(
-    lo: date | None,
-    hi: date | None,
+    present: set[date],
     window_start: date,
     window_end: date,
-    tolerance_days: int,
+    tolerance_days: int = COVERAGE_BOUNDARY_TOLERANCE_DAYS,
+    max_interior_gap_sessions: int = COVERAGE_MAX_INTERIOR_GAP_SESSIONS,
+    calendar: "TradingCalendar | None" = None,
 ) -> bool:
-    """True iff the symbol's [lo, hi] span reaches BOTH window boundaries.
+    """True iff ``present`` usable-bar dates fully cover the sweep window.
 
-    Left-covered: earliest bar at/before (window_start + tolerance).
-    Right-covered: latest bar at/after (window_end - tolerance).
-    Either edge missing → not covered → must re-fetch.
+    Covered requires ALL of:
+      - left edge: a usable bar at/before (window_start + tolerance)
+      - right edge: a usable bar at/after (window_end - tolerance)
+      - no interior hole: the longest run of consecutive MISSING trading
+        sessions strictly inside the covered span is <= max_interior_gap_sessions
+
+    The interior-hole test is what catches a split history (early + late bars,
+    multi-year hole between) that a min/max span check would wrongly pass. The
+    gap is counted in trading sessions via the calendar so weekends/holidays are
+    not mistaken for a hole, and it is NOT a row-count threshold (a dense count
+    with one big hole still fails; a sparse-but-contiguous set still passes).
     """
-    if lo is None or hi is None:
+    if not present:
         return False
-    left_ok = lo <= window_start + timedelta(days=tolerance_days)
-    right_ok = hi >= window_end - timedelta(days=tolerance_days)
-    return left_ok and right_ok
+    cal = calendar or _default_calendar()
+    left_ok = min(present) <= window_start + timedelta(days=tolerance_days)
+    right_ok = max(present) >= window_end - timedelta(days=tolerance_days)
+    if not (left_ok and right_ok):
+        return False
+    # Interior-hole scan over the trading sessions the symbol is expected to have:
+    # from its first usable bar to its last. A run of consecutive sessions with no
+    # usable bar longer than the tolerance means a real stretch is missing.
+    sessions = cal.sessions_between(min(present), max(present))
+    run = 0
+    for s in sessions:
+        if s in present:
+            run = 0
+        else:
+            run += 1
+            if run > max_interior_gap_sessions:
+                return False
+    return True
+
+
+def _default_calendar() -> "TradingCalendar":
+    from rainier.paper.calendar import DEFAULT_CALENDAR
+
+    return DEFAULT_CALENDAR
 
 
 def select_symbols_needing_backfill(
@@ -234,20 +305,29 @@ def select_symbols_needing_backfill(
     window_start: date,
     window_end: date,
     tolerance_days: int = COVERAGE_BOUNDARY_TOLERANCE_DAYS,
+    max_interior_gap_sessions: int = COVERAGE_MAX_INTERIOR_GAP_SESSIONS,
+    calendar: "TradingCalendar | None" = None,
 ) -> list[str]:
-    """Symbols lacking a bar at EITHER window boundary (sorted, deduped).
+    """Symbols not fully covering the sweep window (sorted, deduped).
 
-    A bare row-count threshold is deliberately NOT used: it can mark either
-    failure mode "covered" and re-open the gap. The span check at both edges
-    catches the recent-sliver case (no left edge) AND the stale-tail case (no
-    right edge).
+    A bare row-count threshold is deliberately NOT used: it can mark a
+    split-history or boundary-missing symbol "covered" and re-open the gap. The
+    coverage check (``_is_covered``) keys on both edges AND the largest interior
+    hole, catching the recent-sliver (no left edge), stale-tail (no right edge),
+    and split-history (interior hole) cases.
     """
-    spans = _symbol_price_spans(list(symbols))
+    usable = _symbol_usable_dates(list(symbols), window_start, window_end)
+    cal = calendar or _default_calendar()
     need = [
         s
         for s in symbols
         if not _is_covered(
-            *spans.get(s, (None, None)), window_start, window_end, tolerance_days
+            usable.get(s, set()),
+            window_start,
+            window_end,
+            tolerance_days,
+            max_interior_gap_sessions,
+            cal,
         )
     ]
     return sorted(set(need))
@@ -258,6 +338,8 @@ def assert_cohort_coverage(
     window_end: date,
     as_of: date,
     tolerance_days: int = COVERAGE_BOUNDARY_TOLERANCE_DAYS,
+    max_interior_gap_sessions: int = COVERAGE_MAX_INTERIOR_GAP_SESSIONS,
+    calendar: "TradingCalendar | None" = None,
 ) -> list[str]:
     """Current-cohort symbols still NOT covered over the sweep window (sorted).
 
@@ -272,7 +354,8 @@ def assert_cohort_coverage(
     if not cohort:
         return []
     return select_symbols_needing_backfill(
-        cohort, window_start, window_end, tolerance_days
+        cohort, window_start, window_end, tolerance_days,
+        max_interior_gap_sessions, calendar,
     )
 
 

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -186,6 +186,18 @@ def load_rankings_from_db() -> pd.DataFrame:
 # sessions.
 COVERAGE_MAX_GAP_SESSIONS = 10
 
+# Forward tail required PAST a symbol's last top100 ranking date. The backtests
+# enter on the trading day AFTER a ranking and hold for up to ~10 sessions
+# (plus entry-delay), and run_qu100_portfolio_backtest can hold past the last
+# ranking — so a symbol's prices must extend this many sessions beyond its last
+# ranking for the post-signal entry+hold tail. Clamping coverage exactly at the
+# last ranking date would skip a former member whose price series stops there and
+# silently misprice those trades. ~3 weeks of sessions (entry-delay + max hold +
+# slack). Also makes a weekend/holiday-only ranking window non-degenerate (the
+# tail pushes eff_end onto a real session), so a brand-new Saturday-seen symbol
+# with no bars is correctly flagged uncovered rather than a vacuous pass (codex).
+COVERAGE_FORWARD_TAIL_SESSIONS = 15
+
 # Back-compat alias (kept so existing imports/tests keep resolving). Same value;
 # the edge and interior tolerances are now ONE uniform rule.
 COVERAGE_BOUNDARY_TOLERANCE_DAYS = COVERAGE_MAX_GAP_SESSIONS
@@ -383,9 +395,17 @@ def select_symbols_needing_backfill(
     need = []
     for s in symbols:
         fr, lr = span.get(s, (None, None))
-        # Effective edges: clamp the global window to the symbol's ranked life.
+        # Effective edges: clamp the global window to the symbol's ranked life,
+        # but extend the right edge by the forward tail (entry+hold past the last
+        # ranking) so the post-signal bars the backtest needs are required.
         eff_start = window_start if fr is None else max(window_start, fr)
-        eff_end = window_end if lr is None else min(window_end, lr)
+        if lr is None:
+            eff_end = window_end
+        else:
+            eff_end = min(
+                window_end,
+                cal.add_sessions(lr, COVERAGE_FORWARD_TAIL_SESSIONS),
+            )
         if not _is_covered(
             usable.get(s, set()),
             eff_start,

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -15,7 +15,7 @@ import math
 import time
 import uuid
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, timedelta
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -228,15 +228,18 @@ def _symbol_usable_dates(
     guard ``.get``.
     """
     from rainier.core.models import StockPrice
+    from rainier.paper.ingest import canonical_instant, normalize_to_trading_date
 
     result: dict[str, set[date]] = {s: set() for s in symbols}
     if not symbols:
         return result
-    # date is stored as 00:00 UTC; compare against tz-aware instants, not strings.
-    start_dt = datetime(window_start.year, window_start.month, window_start.day,
-                        tzinfo=timezone.utc)
-    end_dt = datetime(window_end.year, window_end.month, window_end.day,
-                      tzinfo=timezone.utc)
+    # date is stored as canonical 00:00 UTC; compare against the SAME canonical
+    # instants (not strings) and normalize on read with normalize_to_trading_date
+    # — a non-UTC session TZ renders TIMESTAMPTZ in that zone, and a bare
+    # `d.date()` could shift a boundary bar onto the previous day (the read-side
+    # bug paper.ingest._existing_dates already guards against).
+    start_dt = canonical_instant(window_start)
+    end_dt = canonical_instant(window_end)
     with get_session() as db:
         rows = db.execute(
             select(StockPrice.symbol, StockPrice.date).where(
@@ -250,7 +253,7 @@ def _symbol_usable_dates(
             )
         ).all()
     for sym, d in rows:
-        result[sym].add(d.date() if hasattr(d, "date") else d)
+        result[sym].add(normalize_to_trading_date(d))
     return result
 
 
@@ -570,14 +573,23 @@ def _save_prices_to_db(
         # re-fetch field keeps the old good value (B5 discipline, mirrors
         # paper.ingest._upsert_bar); re-fetching identical data is a no-op write
         # (idempotent — no duplicate (symbol, date) rows).
+        #
+        # The `date` is canonicalized to 00:00 UTC (canonical_instant ∘
+        # normalize_to_trading_date) so a re-fetch CONFLICTS with the canonical
+        # row paper.ingest already wrote for that trading day — otherwise a raw
+        # yfinance timestamp at a different tz/time-of-day would dodge
+        # uq_stock_price_symbol_date and insert a SECOND row instead of repairing
+        # (breaking idempotent repair in the mixed ingest/backfill case).
         from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+        from rainier.paper.ingest import canonical_instant, normalize_to_trading_date
         rows_to_insert = []
         for _, row in long_df.iterrows():
             if pd.isna(row["close"]):
                 continue
             rows_to_insert.append({
                 "symbol": row["symbol"],
-                "date": row["date"],
+                "date": canonical_instant(normalize_to_trading_date(row["date"])),
                 "open": row["open"] if pd.notna(row["open"]) else None,
                 "high": row["high"] if pd.notna(row["high"]) else None,
                 "low": row["low"] if pd.notna(row["low"]) else None,

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -175,17 +175,21 @@ def load_rankings_from_db() -> pd.DataFrame:
 # masquerade as coverage.
 # ---------------------------------------------------------------------------
 
-# "at/near" a boundary must tolerate weekends/holidays — markets aren't open on a
-# given calendar date every year. A symbol is left/right covered if it has a
-# usable bar within this many calendar days of the boundary.
-COVERAGE_BOUNDARY_TOLERANCE_DAYS = 7
-
-# The largest interior hole (run of consecutive missing TRADING sessions) a
-# covered symbol may have. A real listing trades every session; a hole longer
-# than this means whole stretches of the sweep window have no price, so the
+# The largest hole (run of consecutive missing TRADING sessions) a covered
+# symbol may have ANYWHERE in the coverage window — at the left edge, the right
+# edge, OR the interior. A real listing trades every session; a run longer than
+# this means a whole stretch of the sweep window has no usable price, so the
 # symbol must re-fetch. Measured in trading sessions (not calendar days) so
-# weekends/holidays don't count as a hole. ~2 weeks of sessions.
-COVERAGE_MAX_INTERIOR_GAP_SESSIONS = 10
+# weekends/holidays don't count as a hole, and applied UNIFORMLY to the edges so
+# a stale tail or a late start can't slip through as "covered" the way a
+# separate calendar-day boundary tolerance let them (codex). ~2 weeks of
+# sessions.
+COVERAGE_MAX_GAP_SESSIONS = 10
+
+# Back-compat alias (kept so existing imports/tests keep resolving). Same value;
+# the edge and interior tolerances are now ONE uniform rule.
+COVERAGE_BOUNDARY_TOLERANCE_DAYS = COVERAGE_MAX_GAP_SESSIONS
+COVERAGE_MAX_INTERIOR_GAP_SESSIONS = COVERAGE_MAX_GAP_SESSIONS
 
 
 def sweep_window_start() -> date:
@@ -254,42 +258,39 @@ def _is_covered(
     present: set[date],
     window_start: date,
     window_end: date,
-    tolerance_days: int = COVERAGE_BOUNDARY_TOLERANCE_DAYS,
-    max_interior_gap_sessions: int = COVERAGE_MAX_INTERIOR_GAP_SESSIONS,
+    max_gap_sessions: int = COVERAGE_MAX_GAP_SESSIONS,
     calendar: "TradingCalendar | None" = None,
 ) -> bool:
-    """True iff ``present`` usable-bar dates fully cover the sweep window.
+    """True iff ``present`` usable-bar dates cover ``[window_start, window_end]``.
 
-    Covered requires ALL of:
-      - left edge: a usable bar at/before (window_start + tolerance)
-      - right edge: a usable bar at/after (window_end - tolerance)
-      - no interior hole: the longest run of consecutive MISSING trading
-        sessions strictly inside the covered span is <= max_interior_gap_sessions
+    ONE uniform rule: over EVERY trading session in the full coverage window,
+    the longest run of consecutive MISSING usable bars must be
+    <= ``max_gap_sessions``. The scan runs across the whole window (not just
+    ``min(present)..max(present)``), so a missing left edge, a missing right
+    edge, AND an interior hole are all measured the same way:
 
-    The interior-hole test is what catches a split history (early + late bars,
-    multi-year hole between) that a min/max span check would wrongly pass. The
-    gap is counted in trading sessions via the calendar so weekends/holidays are
-    not mistaken for a hole, and it is NOT a row-count threshold (a dense count
-    with one big hole still fails; a sparse-but-contiguous set still passes).
+      - recent sliver (no early bars)  -> long run at the LEFT  -> not covered
+      - stale tail   (no recent bars)  -> long run at the RIGHT -> not covered
+      - split history (mid-window hole)-> long run in the MIDDLE-> not covered
+      - dense/contiguous (≤ gap holes) -> covered
+
+    Counting in trading sessions (via the calendar) means weekends/holidays
+    never look like a hole, and a few-session boundary slack is naturally
+    tolerated (a late-by-3-sessions start is a run of 3 ≤ gap). It is NOT a
+    row-count threshold: a dense set with one big hole still fails; a
+    sparse-but-contiguous set still passes.
     """
-    if not present:
-        return False
     cal = calendar or _default_calendar()
-    left_ok = min(present) <= window_start + timedelta(days=tolerance_days)
-    right_ok = max(present) >= window_end - timedelta(days=tolerance_days)
-    if not (left_ok and right_ok):
-        return False
-    # Interior-hole scan over the trading sessions the symbol is expected to have:
-    # from its first usable bar to its last. A run of consecutive sessions with no
-    # usable bar longer than the tolerance means a real stretch is missing.
-    sessions = cal.sessions_between(min(present), max(present))
+    sessions = cal.sessions_between(window_start, window_end)
+    if not sessions:
+        return True  # degenerate window (no trading days) — nothing to cover
     run = 0
     for s in sessions:
         if s in present:
             run = 0
         else:
             run += 1
-            if run > max_interior_gap_sessions:
+            if run > max_gap_sessions:
                 return False
     return True
 
@@ -304,17 +305,16 @@ def select_symbols_needing_backfill(
     symbols: list[str],
     window_start: date,
     window_end: date,
-    tolerance_days: int = COVERAGE_BOUNDARY_TOLERANCE_DAYS,
-    max_interior_gap_sessions: int = COVERAGE_MAX_INTERIOR_GAP_SESSIONS,
+    max_gap_sessions: int = COVERAGE_MAX_GAP_SESSIONS,
     calendar: "TradingCalendar | None" = None,
 ) -> list[str]:
     """Symbols not fully covering the sweep window (sorted, deduped).
 
     A bare row-count threshold is deliberately NOT used: it can mark a
     split-history or boundary-missing symbol "covered" and re-open the gap. The
-    coverage check (``_is_covered``) keys on both edges AND the largest interior
-    hole, catching the recent-sliver (no left edge), stale-tail (no right edge),
-    and split-history (interior hole) cases.
+    coverage check (``_is_covered``) scans the whole window for the longest run
+    of missing usable sessions, catching the recent-sliver (long left run),
+    stale-tail (long right run), and split-history (long interior run) cases.
     """
     usable = _symbol_usable_dates(list(symbols), window_start, window_end)
     cal = calendar or _default_calendar()
@@ -325,8 +325,7 @@ def select_symbols_needing_backfill(
             usable.get(s, set()),
             window_start,
             window_end,
-            tolerance_days,
-            max_interior_gap_sessions,
+            max_gap_sessions,
             cal,
         )
     ]
@@ -337,16 +336,17 @@ def assert_cohort_coverage(
     window_start: date,
     window_end: date,
     as_of: date,
-    tolerance_days: int = COVERAGE_BOUNDARY_TOLERANCE_DAYS,
-    max_interior_gap_sessions: int = COVERAGE_MAX_INTERIOR_GAP_SESSIONS,
+    max_gap_sessions: int = COVERAGE_MAX_GAP_SESSIONS,
     calendar: "TradingCalendar | None" = None,
 ) -> list[str]:
     """Current-cohort symbols still NOT covered over the sweep window (sorted).
 
     Scope is the CURRENT cohort (``get_current_qu100_cohort``, ranking_type
     'top100') at ``as_of`` — former constituents outside today's top-100 are out
-    of scope (the sweep evaluates the current cohort). Empty list ⇒ 100%
-    coverage. Callers surface the returned list non-silently (echo/fail).
+    of scope (the sweep evaluates the current cohort). ``window_start`` must be
+    the SWEEP start (what the sweep consumes), NOT a --years-widened fetch start,
+    or a post-start IPO could never be "covered". Empty list ⇒ 100% coverage.
+    Callers surface the returned list non-silently (echo/fail).
     """
     from rainier.paper.ingest import get_current_qu100_cohort
 
@@ -354,8 +354,7 @@ def assert_cohort_coverage(
     if not cohort:
         return []
     return select_symbols_needing_backfill(
-        cohort, window_start, window_end, tolerance_days,
-        max_interior_gap_sessions, calendar,
+        cohort, window_start, window_end, max_gap_sessions, calendar,
     )
 
 

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -254,6 +254,36 @@ def _symbol_usable_dates(
     return result
 
 
+def _symbol_first_ranking_dates(symbols: list[str]) -> dict[str, date | None]:
+    """Each symbol's earliest top100 ranking date (None if never ranked).
+
+    The miss-sweep evaluates a symbol only from when it first APPEARS in the
+    top100 rankings, so a name that entered after the global sweep start (e.g. a
+    recent IPO) has no pre-listing history to repair — its coverage left boundary
+    is its own first-ranking date, not the global sweep start. Without this a
+    legitimate late entrant would be flagged uncovered (pre-listing sessions
+    counted as gaps) and the command would fail on every run (codex).
+    """
+    if not symbols:
+        return {}
+    with get_session() as db:
+        rows = db.execute(
+            select(
+                MoneyFlowSnapshot.symbol,
+                func.min(MoneyFlowSnapshot.data_date),
+            )
+            .where(
+                MoneyFlowSnapshot.symbol.in_(list(symbols)),
+                MoneyFlowSnapshot.ranking_type == "top100",
+            )
+            .group_by(MoneyFlowSnapshot.symbol)
+        ).all()
+    first: dict[str, date | None] = {s: None for s in symbols}
+    for sym, d in rows:
+        first[sym] = d.date() if hasattr(d, "date") else d
+    return first
+
+
 def _is_covered(
     present: set[date],
     window_start: date,
@@ -315,20 +345,31 @@ def select_symbols_needing_backfill(
     coverage check (``_is_covered``) scans the whole window for the longest run
     of missing usable sessions, catching the recent-sliver (long left run),
     stale-tail (long right run), and split-history (long interior run) cases.
+
+    Per-symbol left boundary: a symbol's effective coverage window starts at
+    ``max(window_start, first_top100_ranking_date)``. A late entrant (e.g. a
+    recent IPO) has no pre-listing history to repair and the sweep evaluates it
+    only from when it appears in rankings, so pre-listing sessions are NOT
+    counted as gaps. The right boundary stays at ``window_end`` (every ranked
+    symbol needs recent prices for forward returns).
     """
     usable = _symbol_usable_dates(list(symbols), window_start, window_end)
+    first_ranked = _symbol_first_ranking_dates(list(symbols))
     cal = calendar or _default_calendar()
-    need = [
-        s
-        for s in symbols
+    need = []
+    for s in symbols:
+        fr = first_ranked.get(s)
+        # Effective left edge: never earlier than the global window, never
+        # earlier than the symbol's first appearance in the rankings.
+        eff_start = window_start if fr is None else max(window_start, fr)
         if not _is_covered(
             usable.get(s, set()),
-            window_start,
+            eff_start,
             window_end,
             max_gap_sessions,
             cal,
-        )
-    ]
+        ):
+            need.append(s)
     return sorted(set(need))
 
 

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -377,8 +377,9 @@ def select_symbols_needing_backfill(
     window_end: date,
     max_gap_sessions: int = COVERAGE_MAX_GAP_SESSIONS,
     calendar: "TradingCalendar | None" = None,
+    clamp_to_ranking_life: bool = False,
 ) -> list[str]:
-    """Symbols not fully covering the sweep window (sorted, deduped).
+    """Symbols not fully covering the window (sorted, deduped).
 
     A bare row-count threshold is deliberately NOT used: it can mark a
     split-history or boundary-missing symbol "covered" and re-open the gap. The
@@ -386,32 +387,40 @@ def select_symbols_needing_backfill(
     of missing usable sessions, catching the recent-sliver (long left run),
     stale-tail (long right run), and split-history (long interior run) cases.
 
-    Per-symbol boundaries: a symbol's effective coverage window is
-    ``[max(window_start, first_ranking), min(window_end, last_ranking)]``. A late
-    entrant (IPO) has no pre-listing history to repair (left); a former member
-    that stopped trading after its last ranking (delist/rename) is only consumed
-    THROUGH that last ranking (right). The miss-sweep evaluates a symbol only
-    over the sessions it actually appears in rankings, so neither pre-listing nor
-    post-delisting sessions are counted as gaps — without this the gate would
-    fail every run on legitimate non-current names.
+    TWO scopes via ``clamp_to_ranking_life`` (do not conflate):
+
+      - SELECTION (``False``, default — "what to FETCH"): the full
+        ``[window_start, window_end]`` per symbol, NO ranking clamp. Fetch
+        GENEROUSLY: ``run_qu100_portfolio_backtest`` pulls 180d of PRE-signal
+        lookback before a symbol's first ranking and values open positions on
+        every later session (``max_hold_days`` defaults to unlimited), so the
+        repair must pull history OUTSIDE the ranked life too (codex). Over-
+        fetching is harmless (ON CONFLICT idempotent); an IPO with no pre-listing
+        bars is simply re-selected each run (cheap) and its yfinance history
+        re-pulled.
+
+      - GATE (``True`` — "what must be COVERED to exit 0"): clamp to the symbol's
+        ranked life ``[max(start, first_ranking), min(end, last_ranking + tail)]``
+        so the success gate does NOT fail forever on an IPO (no pre-listing
+        history exists) or a delisted former member (no post-delisting history
+        exists). The forward tail covers the entry+hold past the last ranking.
     """
     usable = _symbol_usable_dates(list(symbols), window_start, window_end)
-    span = _symbol_ranking_span(list(symbols))
+    span = _symbol_ranking_span(list(symbols)) if clamp_to_ranking_life else {}
     cal = calendar or _default_calendar()
     need = []
     for s in symbols:
-        fr, lr = span.get(s, (None, None))
-        # Effective edges: clamp the global window to the symbol's ranked life,
-        # but extend the right edge by the forward tail (entry+hold past the last
-        # ranking) so the post-signal bars the backtest needs are required.
-        eff_start = window_start if fr is None else max(window_start, fr)
-        if lr is None:
-            eff_end = window_end
-        else:
-            eff_end = min(
-                window_end,
-                cal.add_sessions(lr, COVERAGE_FORWARD_TAIL_SESSIONS),
+        if clamp_to_ranking_life:
+            fr, lr = span.get(s, (None, None))
+            eff_start = window_start if fr is None else max(window_start, fr)
+            eff_end = (
+                window_end
+                if lr is None
+                else min(window_end, cal.add_sessions(lr, COVERAGE_FORWARD_TAIL_SESSIONS))
             )
+        else:
+            # Selection: the full window — fetch all history the backtest may read.
+            eff_start, eff_end = window_start, window_end
         if not _is_covered(
             usable.get(s, set()),
             eff_start,
@@ -444,8 +453,11 @@ def assert_cohort_coverage(
     cohort = [r["symbol"] for r in get_current_qu100_cohort(as_of)]
     if not cohort:
         return []
+    # GATE scope: clamp to each symbol's ranked life so an IPO/delisted name is
+    # not flagged forever for history that does not exist.
     return select_symbols_needing_backfill(
         cohort, window_start, window_end, max_gap_sessions, calendar,
+        clamp_to_ranking_life=True,
     )
 
 

--- a/src/rainier/backtest/qu100_portfolio.py
+++ b/src/rainier/backtest/qu100_portfolio.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 import structlog
 import yfinance as yf
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from rainier.core.database import get_session
 from rainier.core.models import BacktestTradingLog, MoneyFlowSnapshot
@@ -139,6 +139,143 @@ def load_rankings_from_db() -> pd.DataFrame:
     return df
 
 
+# ---------------------------------------------------------------------------
+# Price-coverage helpers (TASK-PLAN p1-cleanup-price-coverag-18ff)
+#
+# `db backfill-prices` historically decided what to fetch with a PRESENCE check
+# (any StockPrice row >= start). A separate incremental ingest seeded thin
+# RECENT slivers for large-caps, so they passed presence and were skipped — their
+# 2022-2025 history (most of the sweep window) was never fetched. These helpers
+# replace presence with a COVERAGE span check at BOTH window boundaries.
+#
+#   sweep window:  [start ............................. end]
+#   recent-sliver:                              [###]   <- no left-edge bar -> refetch
+#   stale-tail:    [###########]                        <- no right-edge bar -> refetch
+#   fully-covered: [### .............................. ###] <- skip
+# ---------------------------------------------------------------------------
+
+# "at/near" a boundary must tolerate weekends/holidays — markets aren't open on a
+# given calendar date every year. A symbol is left/right covered if it has a bar
+# within this many calendar days of the boundary.
+COVERAGE_BOUNDARY_TOLERANCE_DAYS = 7
+
+
+def sweep_window_start() -> date:
+    """The sweep-consumption window start = earliest QU100 ranking date.
+
+    Derived from the same source the miss-sweep reads (``load_rankings_from_db``)
+    so selection / download / coverage all key on the window the sweep actually
+    consumes — NOT a hard-coded date or a ``--years`` arithmetic. ~2022-05-25.
+    """
+    with get_session() as db:
+        first = db.execute(
+            select(func.min(MoneyFlowSnapshot.data_date))
+        ).scalar()
+    if first is None:
+        raise ValueError("No QU100 rankings in database; cannot derive sweep start")
+    return first
+
+
+def _symbol_price_spans(
+    symbols: list[str],
+) -> dict[str, tuple[date | None, date | None]]:
+    """(min_date, max_date) of persisted bars per symbol; (None, None) if absent.
+
+    One grouped query over ``stock_prices`` for the whole batch. Dates are the
+    stored instant's UTC calendar date.
+    """
+    from rainier.core.models import StockPrice
+
+    if not symbols:
+        return {}
+    with get_session() as db:
+        rows = db.execute(
+            select(
+                StockPrice.symbol,
+                func.min(StockPrice.date),
+                func.max(StockPrice.date),
+            )
+            .where(StockPrice.symbol.in_(list(symbols)))
+            .group_by(StockPrice.symbol)
+        ).all()
+    spans: dict[str, tuple[date | None, date | None]] = {
+        s: (None, None) for s in symbols
+    }
+    for sym, lo, hi in rows:
+        spans[sym] = (
+            lo.date() if hasattr(lo, "date") else lo,
+            hi.date() if hasattr(hi, "date") else hi,
+        )
+    return spans
+
+
+def _is_covered(
+    lo: date | None,
+    hi: date | None,
+    window_start: date,
+    window_end: date,
+    tolerance_days: int,
+) -> bool:
+    """True iff the symbol's [lo, hi] span reaches BOTH window boundaries.
+
+    Left-covered: earliest bar at/before (window_start + tolerance).
+    Right-covered: latest bar at/after (window_end - tolerance).
+    Either edge missing → not covered → must re-fetch.
+    """
+    if lo is None or hi is None:
+        return False
+    left_ok = lo <= window_start + timedelta(days=tolerance_days)
+    right_ok = hi >= window_end - timedelta(days=tolerance_days)
+    return left_ok and right_ok
+
+
+def select_symbols_needing_backfill(
+    symbols: list[str],
+    window_start: date,
+    window_end: date,
+    tolerance_days: int = COVERAGE_BOUNDARY_TOLERANCE_DAYS,
+) -> list[str]:
+    """Symbols lacking a bar at EITHER window boundary (sorted, deduped).
+
+    A bare row-count threshold is deliberately NOT used: it can mark either
+    failure mode "covered" and re-open the gap. The span check at both edges
+    catches the recent-sliver case (no left edge) AND the stale-tail case (no
+    right edge).
+    """
+    spans = _symbol_price_spans(list(symbols))
+    need = [
+        s
+        for s in symbols
+        if not _is_covered(
+            *spans.get(s, (None, None)), window_start, window_end, tolerance_days
+        )
+    ]
+    return sorted(set(need))
+
+
+def assert_cohort_coverage(
+    window_start: date,
+    window_end: date,
+    as_of: date,
+    tolerance_days: int = COVERAGE_BOUNDARY_TOLERANCE_DAYS,
+) -> list[str]:
+    """Current-cohort symbols still NOT covered over the sweep window (sorted).
+
+    Scope is the CURRENT cohort (``get_current_qu100_cohort``, ranking_type
+    'top100') at ``as_of`` — former constituents outside today's top-100 are out
+    of scope (the sweep evaluates the current cohort). Empty list ⇒ 100%
+    coverage. Callers surface the returned list non-silently (echo/fail).
+    """
+    from rainier.paper.ingest import get_current_qu100_cohort
+
+    cohort = [r["symbol"] for r in get_current_qu100_cohort(as_of)]
+    if not cohort:
+        return []
+    return select_symbols_needing_backfill(
+        cohort, window_start, window_end, tolerance_days
+    )
+
+
 def fetch_all_prices(
     symbols: list[str], start: date, end: date,
 ) -> pd.DataFrame:
@@ -240,6 +377,17 @@ def _yf_to_long(
     frames = []
     if isinstance(yf_df.columns, pd.MultiIndex):
         available = set(yf_df["Close"].columns)
+        # Surface symbols yfinance silently omitted from the batch — a genuine
+        # upstream drop must never vanish (it would re-open a coverage gap with
+        # no signal). Compare the REQUESTED set against what the frame returned.
+        dropped = sorted(set(symbols) - available)
+        if dropped:
+            log.warning(
+                "yf_batch_dropped_symbols",
+                requested=len(symbols),
+                available=len(available & set(symbols)),
+                missing=dropped,
+            )
         for sym in symbols:
             if sym not in available:
                 continue

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1883,14 +1883,14 @@ def db_backfill_prices(years, batch_size, dry_run):
     end = datetime.now()
     today = end.date()
     # Anchor the right boundary at the LAST COMPLETED trading session — the most
-    # recent session whose bar yfinance reliably publishes. Today's session may
-    # be in progress (its bar isn't published until after the close), so step
-    # back to the previous session: requiring an as-yet-unpublished bar would
-    # make every intraday run fail for a same-day top100 entrant (coverage window
-    # [today, today], empty present) (codex). A symbol first ranked after this
-    # boundary has no completed session yet → it's covered (nothing fetchable)
-    # and gets picked up on the next run. Used for the coverage right edge, the
-    # download end, and the cohort lookup.
+    # recent session whose bar yfinance reliably publishes. Today's session may be
+    # in progress (its bar isn't published until after the close), so step back to
+    # the previous session: requiring an as-yet-unpublished bar would make an
+    # intraday run fail for a same-day top100 entrant. (Trade-off: after-close runs
+    # lag one session; the next run catches today's bar. The "use today after the
+    # close" optimisation needs the operator's run schedule — see Implementation
+    # notes / BLOCKED.) Used for the coverage right edge, download end, cohort
+    # lookup.
     end_date = DEFAULT_CALENDAR.prev_session(today)
     # yfinance `end` is EXCLUSIVE — pass the day after end_date so its bar is
     # actually fetched (codex).

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1866,6 +1866,7 @@ def db_backfill_prices(years, batch_size, dry_run):
     """
     import math
     import time
+    from datetime import timedelta
 
     import yfinance as yf
     from sqlalchemy import func, select
@@ -1891,6 +1892,11 @@ def db_backfill_prices(years, batch_size, dry_run):
     today = end.date()
     end_date = today if DEFAULT_CALENDAR.is_session(today) else \
         DEFAULT_CALENDAR.prev_session(today)
+    # yfinance `end` is EXCLUSIVE — to actually fetch the bar FOR `end_date`
+    # (e.g. a Saturday run that anchored to Friday must still pull Friday), pass
+    # the day after. Without this the most recent completed session is dropped
+    # and the gap tolerance could mask it (codex).
+    download_end = end_date + timedelta(days=1)
 
     # Two distinct windows, do NOT conflate them:
     #   cov_start (coverage gate) = sweep_start, the EXACT window the miss-sweep
@@ -1962,7 +1968,7 @@ def db_backfill_prices(years, batch_size, dry_run):
                     # capped below the sweep start: a re-selected symbol repairs
                     # its entire history.
                     start=str(download_start),
-                    end=str(end_date),
+                    end=str(download_end),  # exclusive → day after end_date
                     auto_adjust=True,
                     progress=False,
                     threads=True,

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1938,8 +1938,10 @@ def db_backfill_prices(years, batch_size, dry_run):
             ).scalars().all()
         )
 
-    # Coverage over the SWEEP window (cov_start..today), NOT the widened fetch
-    # window — qu100_portfolio.
+    # SELECTION (what to fetch): full sweep window per symbol, NO ranking clamp —
+    # fetch generously so pre-signal lookback and post-signal tails the backtest
+    # reads are pulled. The post-run GATE below clamps to ranked life so it does
+    # not fail forever on IPO/delisted names.
     missing = select_symbols_needing_backfill(qu_symbols, cov_start, end_date)
     has_prices = sorted(set(qu_symbols) - set(missing))
 
@@ -2015,7 +2017,9 @@ def db_backfill_prices(years, batch_size, dry_run):
     # blocker: a symbol still uncovered after it WAS requested (a genuine
     # upstream omission or a post-start listing) is a STOP-and-raise for the
     # operator, never a silently lowered bar.
-    still_missing = select_symbols_needing_backfill(qu_symbols, cov_start, end_date)
+    still_missing = select_symbols_needing_backfill(
+        qu_symbols, cov_start, end_date, clamp_to_ranking_life=True
+    )
     if still_missing:
         preview = still_missing[:50]
         raise click.ClickException(

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1872,15 +1872,25 @@ def db_backfill_prices(years, batch_size, dry_run):
 
     from rainier.backtest.qu100_portfolio import (
         _save_prices_to_db,
-        assert_cohort_coverage,
         select_symbols_needing_backfill,
         sweep_window_start,
     )
     from rainier.core.database import get_session
     from rainier.core.models import MoneyFlowSnapshot
+    from rainier.paper.calendar import DEFAULT_CALENDAR
 
     end = datetime.now()
-    end_date = end.date()
+    # Anchor the right boundary at the last trading session on-or-before today,
+    # not the raw wall-clock date (which may be a weekend/holiday). On a
+    # constituent-change day a brand-new symbol's coverage window would otherwise
+    # be [today, today] and require a same-day bar that yfinance has not
+    # published before the close — a spurious failure (codex). The
+    # COVERAGE_MAX_GAP_SESSIONS tolerance then absorbs an as-yet-unpublished
+    # today bar on a session day. Used for the coverage right edge, the download
+    # end, and the cohort lookup.
+    today = end.date()
+    end_date = today if DEFAULT_CALENDAR.is_session(today) else \
+        DEFAULT_CALENDAR.prev_session(today)
 
     # Two distinct windows, do NOT conflate them:
     #   cov_start (coverage gate) = sweep_start, the EXACT window the miss-sweep
@@ -1977,22 +1987,29 @@ def db_backfill_prices(years, batch_size, dry_run):
     else:
         click.echo("All QU100 symbols span the sweep window. Nothing to fetch.")
 
-    # Post-run gate: 100% of the CURRENT cohort must span the sweep window.
-    # Report any shortfall NON-silently AND FAIL (non-zero exit) — a warn-and-
-    # exit-0 makes an incomplete repair indistinguishable from success in
-    # cron/CI, so the gate could never actually protect anything. Per the plan's
-    # blocker: if a cohort symbol stays uncovered after it WAS requested (a
-    # genuine upstream omission or a post-start IPO with no earlier history),
-    # STOP and raise so the operator examines it — never silently lower the bar.
-    still_missing = assert_cohort_coverage(cov_start, end_date, as_of=end_date)
+    # Post-run gate: validate the SAME universe the command just attempted to
+    # repair (every historical top100 symbol — `qu_symbols`), NOT just today's
+    # cohort. The backtest reads `load_rankings_from_db()` (all historical top100
+    # constituents, current OR former), so a former member yfinance dropped would
+    # otherwise exit 0 here yet stay silently broken downstream (codex). Report
+    # NON-silently AND FAIL (non-zero exit) — a warn-and-exit-0 makes an
+    # incomplete repair indistinguishable from success in cron/CI. Per the plan's
+    # blocker: a symbol still uncovered after it WAS requested (a genuine
+    # upstream omission or a post-start listing) is a STOP-and-raise for the
+    # operator, never a silently lowered bar.
+    still_missing = select_symbols_needing_backfill(qu_symbols, cov_start, end_date)
     if still_missing:
+        preview = still_missing[:50]
         raise click.ClickException(
-            f"{len(still_missing)} current-cohort symbol(s) still lack full "
-            f"sweep-window coverage after the run: {still_missing}. "
+            f"{len(still_missing)} top100 symbol(s) still lack full sweep-window "
+            f"coverage after the run: {preview}"
+            f"{'...' if len(still_missing) > 50 else ''}. "
             "Investigate (genuine yfinance omission or post-start listing) — "
             "do not lower the coverage bar to make this pass."
         )
-    click.echo("\nCohort coverage check: 100% of the current cohort is covered.")
+    click.echo(
+        "\nCoverage check: 100% of the historical top100 universe is covered."
+    )
 
 
 @db.command(name="ingest-prices")

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1882,13 +1882,19 @@ def db_backfill_prices(years, batch_size, dry_run):
     end = datetime.now()
     end_date = end.date()
 
-    # The download window must cover what the sweep actually consumes: the
-    # earliest QU100 ranking date. `--years` is only a FLOOR — it can widen the
-    # window but must never cap the repair below the sweep start (the bug that let
-    # a 2026 sliver mask 2022-2025 absence under `--years 1`).
+    # Two distinct windows, do NOT conflate them:
+    #   cov_start (coverage gate) = sweep_start, the EXACT window the miss-sweep
+    #     consumes. Selection + the post-run assertion key on THIS — a symbol is
+    #     judged covered only against what the sweep reads.
+    #   download_start (fetch) = min(sweep_start, years_floor). `--years` is a
+    #     FLOOR that may WIDEN the download earlier (extra history is harmless),
+    #     but the coverage gate must NOT require history older than the sweep —
+    #     else a current constituent that IPOed after years_floor could never be
+    #     "covered" and the gate would raise on every run (codex P1).
     sweep_start = sweep_window_start()
+    cov_start = sweep_start
     years_floor = date(end.year - years, end.month, end.day)
-    window_start = min(sweep_start, years_floor)
+    download_start = min(sweep_start, years_floor)
 
     with get_session() as session:
         qu_symbols = sorted(
@@ -1897,16 +1903,17 @@ def db_backfill_prices(years, batch_size, dry_run):
             ).scalars().all()
         )
 
-    # Coverage (span at BOTH boundaries), NOT presence — qu100_portfolio.
-    missing = select_symbols_needing_backfill(qu_symbols, window_start, end_date)
+    # Coverage over the SWEEP window (cov_start..today), NOT the widened fetch
+    # window — qu100_portfolio.
+    missing = select_symbols_needing_backfill(qu_symbols, cov_start, end_date)
     has_prices = sorted(set(qu_symbols) - set(missing))
 
     click.echo(f"QU100 symbols: {len(qu_symbols)}")
-    click.echo(f"Covered (span both boundaries): {len(has_prices)}")
+    click.echo(f"Covered (sweep window {cov_start}..{end_date}): {len(has_prices)}")
     click.echo(f"Needing backfill (incomplete/absent): {len(missing)}")
     click.echo(
-        f"Date range: {window_start} to {end_date} "
-        f"(sweep start {sweep_start}, --years floor {years_floor})"
+        f"Fetch range: {download_start} to {end_date} "
+        f"(sweep/coverage start {sweep_start}, --years floor {years_floor})"
     )
 
     if dry_run:
@@ -1934,9 +1941,10 @@ def db_backfill_prices(years, batch_size, dry_run):
             try:
                 yf_df = yf.download(
                     " ".join(batch),
-                    # Full sweep window, NOT the --years window: a re-selected
-                    # symbol must repair its entire history.
-                    start=str(window_start),
+                    # Full (possibly --years-widened) download window, never
+                    # capped below the sweep start: a re-selected symbol repairs
+                    # its entire history.
+                    start=str(download_start),
                     end=str(end_date),
                     auto_adjust=True,
                     progress=False,
@@ -1969,7 +1977,7 @@ def db_backfill_prices(years, batch_size, dry_run):
     # blocker: if a cohort symbol stays uncovered after it WAS requested (a
     # genuine upstream omission or a post-start IPO with no earlier history),
     # STOP and raise so the operator examines it — never silently lower the bar.
-    still_missing = assert_cohort_coverage(window_start, end_date, as_of=end_date)
+    still_missing = assert_cohort_coverage(cov_start, end_date, as_of=end_date)
     if still_missing:
         raise click.ClickException(
             f"{len(still_missing)} current-cohort symbol(s) still lack full "

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1963,16 +1963,21 @@ def db_backfill_prices(years, batch_size, dry_run):
         click.echo("All QU100 symbols span the sweep window. Nothing to fetch.")
 
     # Post-run gate: 100% of the CURRENT cohort must span the sweep window.
-    # Report any shortfall NON-silently (the missing list), never a clean exit.
+    # Report any shortfall NON-silently AND FAIL (non-zero exit) — a warn-and-
+    # exit-0 makes an incomplete repair indistinguishable from success in
+    # cron/CI, so the gate could never actually protect anything. Per the plan's
+    # blocker: if a cohort symbol stays uncovered after it WAS requested (a
+    # genuine upstream omission or a post-start IPO with no earlier history),
+    # STOP and raise so the operator examines it — never silently lower the bar.
     still_missing = assert_cohort_coverage(window_start, end_date, as_of=end_date)
     if still_missing:
-        click.echo(
-            f"\nWARNING: {len(still_missing)} current-cohort symbol(s) still lack "
-            f"full sweep-window coverage after the run: {still_missing}",
-            err=True,
+        raise click.ClickException(
+            f"{len(still_missing)} current-cohort symbol(s) still lack full "
+            f"sweep-window coverage after the run: {still_missing}. "
+            "Investigate (genuine yfinance omission or post-start listing) — "
+            "do not lower the coverage bar to make this pass."
         )
-    else:
-        click.echo("\nCohort coverage check: 100% of the current cohort is covered.")
+    click.echo("\nCohort coverage check: 100% of the current cohort is covered.")
 
 
 @db.command(name="ingest-prices")

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1844,97 +1844,135 @@ def db_gc_test_schemas(apply: bool) -> None:
 
 
 @db.command(name="backfill-prices")
-@click.option("--years", default=5, type=int, help="Years of history to fetch")
+@click.option(
+    "--years",
+    default=5,
+    type=int,
+    help="Lower-bound years of history (a floor; the fetch never starts LATER "
+    "than the sweep-window start derived from the QU100 rankings).",
+)
 @click.option("--batch-size", default=20, type=int, help="Symbols per yfinance batch")
 @click.option("--dry-run", is_flag=True, help="Show what would be fetched without fetching")
 def db_backfill_prices(years, batch_size, dry_run):
-    """Backfill historical daily OHLCV for all QU100 stocks via yfinance."""
+    """Backfill historical daily OHLCV for all QU100 stocks via yfinance.
+
+    Selection is COVERAGE-based, not presence-based: a symbol is re-fetched
+    unless it already has a bar near BOTH ends of the sweep window (the start
+    derived from the QU100 rankings, and today). A thin recent sliver (the AMZN
+    case) or a stale tail no longer masks a multi-year gap. The download window
+    starts at the sweep-window start so a re-selected symbol repairs its full
+    history — not just the trailing ``--years``. After the run a 100%
+    current-cohort coverage check reports any remaining shortfall loudly.
+    """
     import math
     import time
 
     import yfinance as yf
     from sqlalchemy import func, select
 
+    from rainier.backtest.qu100_portfolio import (
+        _save_prices_to_db,
+        assert_cohort_coverage,
+        select_symbols_needing_backfill,
+        sweep_window_start,
+    )
     from rainier.core.database import get_session
-    from rainier.core.models import MoneyFlowSnapshot, StockPrice
+    from rainier.core.models import MoneyFlowSnapshot
 
     end = datetime.now()
-    start = datetime(end.year - years, end.month, end.day)
+    end_date = end.date()
 
-    # Find QU100 symbols missing price data
+    # The download window must cover what the sweep actually consumes: the
+    # earliest QU100 ranking date. `--years` is only a FLOOR — it can widen the
+    # window but must never cap the repair below the sweep start (the bug that let
+    # a 2026 sliver mask 2022-2025 absence under `--years 1`).
+    sweep_start = sweep_window_start()
+    years_floor = date(end.year - years, end.month, end.day)
+    window_start = min(sweep_start, years_floor)
+
     with get_session() as session:
-        qu_symbols = set(
+        qu_symbols = sorted(
             session.execute(
                 select(func.distinct(MoneyFlowSnapshot.symbol))
             ).scalars().all()
         )
-        symbols_with_prices = set(
-            session.execute(
-                select(func.distinct(StockPrice.symbol)).where(
-                    StockPrice.date >= start.isoformat()
-                )
-            ).scalars().all()
-        )
 
-    missing = sorted(qu_symbols - symbols_with_prices)
-    has_prices = sorted(qu_symbols & symbols_with_prices)
+    # Coverage (span at BOTH boundaries), NOT presence — qu100_portfolio.
+    missing = select_symbols_needing_backfill(qu_symbols, window_start, end_date)
+    has_prices = sorted(set(qu_symbols) - set(missing))
 
     click.echo(f"QU100 symbols: {len(qu_symbols)}")
-    click.echo(f"Already have prices: {len(has_prices)}")
-    click.echo(f"Missing prices: {len(missing)}")
-    click.echo(f"Date range: {start.date()} to {end.date()} ({years} years)")
+    click.echo(f"Covered (span both boundaries): {len(has_prices)}")
+    click.echo(f"Needing backfill (incomplete/absent): {len(missing)}")
+    click.echo(
+        f"Date range: {window_start} to {end_date} "
+        f"(sweep start {sweep_start}, --years floor {years_floor})"
+    )
 
     if dry_run:
         if missing:
             click.echo(f"\nWould fetch: {missing[:50]}{'...' if len(missing) > 50 else ''}")
         return
 
-    if not missing:
-        click.echo("All QU100 symbols have price data. Nothing to do.")
-        return
+    if missing:
+        total_batches = math.ceil(len(missing) / batch_size)
+        click.echo(f"\nFetching {len(missing)} symbols in {total_batches} batches...")
 
-    total_batches = math.ceil(len(missing) / batch_size)
-    click.echo(f"\nFetching {len(missing)} symbols in {total_batches} batches...")
-
-    from rainier.backtest.qu100_portfolio import _save_prices_to_db
-
-    fetched = 0
-    failed = 0
-    for bi in range(0, len(missing), batch_size):
-        batch = missing[bi : bi + batch_size]
-        batch_num = bi // batch_size + 1
-        click.echo(
-            f"  Batch {batch_num}/{total_batches}: {batch[0]}..{batch[-1]} "
-            f"({len(batch)} symbols)"
-        )
-
-        if batch_num > 1:
-            time.sleep(2)
-
-        try:
-            yf_df = yf.download(
-                " ".join(batch),
-                start=str(start.date()),
-                end=str(end.date()),
-                auto_adjust=True,
-                progress=False,
-                threads=True,
+        fetched = 0
+        failed = 0
+        for bi in range(0, len(missing), batch_size):
+            batch = missing[bi : bi + batch_size]
+            batch_num = bi // batch_size + 1
+            click.echo(
+                f"  Batch {batch_num}/{total_batches}: {batch[0]}..{batch[-1]} "
+                f"({len(batch)} symbols)"
             )
-            if not yf_df.empty:
-                if not isinstance(yf_df.columns, pd.MultiIndex) and len(batch) == 1:
-                    yf_df.columns = pd.MultiIndex.from_product(
-                        [yf_df.columns, batch]
-                    )
-                _save_prices_to_db(yf_df, batch)
-                fetched += len(batch)
-            else:
-                failed += len(batch)
-                click.echo("    No data returned for batch")
-        except Exception as exc:
-            failed += len(batch)
-            click.echo(f"    Error: {exc}")
 
-    click.echo(f"\nDone. Fetched: {fetched}, Failed: {failed}")
+            if batch_num > 1:
+                time.sleep(2)
+
+            try:
+                yf_df = yf.download(
+                    " ".join(batch),
+                    # Full sweep window, NOT the --years window: a re-selected
+                    # symbol must repair its entire history.
+                    start=str(window_start),
+                    end=str(end_date),
+                    auto_adjust=True,
+                    progress=False,
+                    threads=True,
+                )
+                if not yf_df.empty:
+                    if not isinstance(yf_df.columns, pd.MultiIndex) and len(batch) == 1:
+                        yf_df.columns = pd.MultiIndex.from_product(
+                            [yf_df.columns, batch]
+                        )
+                    # _save_prices_to_db → _yf_to_long logs yf_batch_dropped_symbols
+                    # for any requested symbol yfinance omitted (no silent drop).
+                    _save_prices_to_db(yf_df, batch)
+                    fetched += len(batch)
+                else:
+                    failed += len(batch)
+                    click.echo("    No data returned for batch")
+            except Exception as exc:
+                failed += len(batch)
+                click.echo(f"    Error: {exc}")
+
+        click.echo(f"\nDone. Fetched: {fetched}, Failed: {failed}")
+    else:
+        click.echo("All QU100 symbols span the sweep window. Nothing to fetch.")
+
+    # Post-run gate: 100% of the CURRENT cohort must span the sweep window.
+    # Report any shortfall NON-silently (the missing list), never a clean exit.
+    still_missing = assert_cohort_coverage(window_start, end_date, as_of=end_date)
+    if still_missing:
+        click.echo(
+            f"\nWARNING: {len(still_missing)} current-cohort symbol(s) still lack "
+            f"full sweep-window coverage after the run: {still_missing}",
+            err=True,
+        )
+    else:
+        click.echo("\nCohort coverage check: 100% of the current cohort is covered.")
 
 
 @db.command(name="ingest-prices")

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1897,9 +1897,16 @@ def db_backfill_prices(years, batch_size, dry_run):
     download_start = min(sweep_start, years_floor)
 
     with get_session() as session:
+        # Restrict the universe to ranking_type='top100' — the EXACT slice the
+        # miss-sweep consumes. Auxiliary bottom100/other-type-only names are
+        # never read by the sweep; including them would feed the stricter sweep-
+        # window coverage check symbols with no first-top100-ranking date and
+        # schedule wasted re-downloads (codex).
         qu_symbols = sorted(
             session.execute(
-                select(func.distinct(MoneyFlowSnapshot.symbol))
+                select(func.distinct(MoneyFlowSnapshot.symbol)).where(
+                    MoneyFlowSnapshot.ranking_type == "top100"
+                )
             ).scalars().all()
         )
 

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1881,22 +1881,34 @@ def db_backfill_prices(years, batch_size, dry_run):
     from rainier.paper.calendar import DEFAULT_CALENDAR
 
     end = datetime.now()
-    # Anchor the right boundary at the last trading session on-or-before today,
-    # not the raw wall-clock date (which may be a weekend/holiday). On a
-    # constituent-change day a brand-new symbol's coverage window would otherwise
-    # be [today, today] and require a same-day bar that yfinance has not
-    # published before the close — a spurious failure (codex). The
-    # COVERAGE_MAX_GAP_SESSIONS tolerance then absorbs an as-yet-unpublished
-    # today bar on a session day. Used for the coverage right edge, the download
-    # end, and the cohort lookup.
     today = end.date()
-    end_date = today if DEFAULT_CALENDAR.is_session(today) else \
-        DEFAULT_CALENDAR.prev_session(today)
-    # yfinance `end` is EXCLUSIVE — to actually fetch the bar FOR `end_date`
-    # (e.g. a Saturday run that anchored to Friday must still pull Friday), pass
-    # the day after. Without this the most recent completed session is dropped
-    # and the gap tolerance could mask it (codex).
+    # Anchor the right boundary at the LAST COMPLETED trading session — the most
+    # recent session whose bar yfinance reliably publishes. Today's session may
+    # be in progress (its bar isn't published until after the close), so step
+    # back to the previous session: requiring an as-yet-unpublished bar would
+    # make every intraday run fail for a same-day top100 entrant (coverage window
+    # [today, today], empty present) (codex). A symbol first ranked after this
+    # boundary has no completed session yet → it's covered (nothing fetchable)
+    # and gets picked up on the next run. Used for the coverage right edge, the
+    # download end, and the cohort lookup.
+    end_date = DEFAULT_CALENDAR.prev_session(today)
+    # yfinance `end` is EXCLUSIVE — pass the day after end_date so its bar is
+    # actually fetched (codex).
     download_end = end_date + timedelta(days=1)
+
+    # Empty rankings: no top100 snapshot yet (fresh/staging DB, pre-first-scrape).
+    # Preserve the old no-op instead of raising from sweep_window_start() — a
+    # bootstrap/smoke run of `db backfill-prices` before any rankings load must
+    # exit cleanly (codex).
+    with get_session() as session:
+        has_top100 = session.execute(
+            select(MoneyFlowSnapshot.symbol)
+            .where(MoneyFlowSnapshot.ranking_type == "top100")
+            .limit(1)
+        ).first()
+    if has_top100 is None:
+        click.echo("No QU100 top100 rankings in the database yet. Nothing to do.")
+        return
 
     # Two distinct windows, do NOT conflate them:
     #   cov_start (coverage gate) = sweep_start, the EXACT window the miss-sweep

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -18,15 +18,14 @@ legacy `core.database` singleton the backfill uses).
 
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 
 import pandas as pd
 import pytest
 from sqlalchemy import select, text
 
 from rainier.backtest.qu100_portfolio import (
-    COVERAGE_BOUNDARY_TOLERANCE_DAYS,
-    COVERAGE_MAX_INTERIOR_GAP_SESSIONS,
+    COVERAGE_MAX_GAP_SESSIONS,
     _is_covered,
     _yf_to_long,
     assert_cohort_coverage,
@@ -51,7 +50,7 @@ WINDOW_END = date(2026, 6, 12)
 # crux of the fix; pin every branch independent of Postgres availability.
 # ---------------------------------------------------------------------------
 
-TOL = COVERAGE_BOUNDARY_TOLERANCE_DAYS
+GAP = COVERAGE_MAX_GAP_SESSIONS
 
 
 def _all_sessions(start: date, end: date) -> set[date]:
@@ -90,26 +89,38 @@ def test_is_covered_split_history_false():
 
 
 def test_is_covered_small_interior_gap_true():
-    # A short gap (<= max interior tolerance) is fine — holidays/data hiccups.
+    # A short gap (<= max gap) is fine — holidays/data hiccups.
     present = _all_sessions(WINDOW_START, WINDOW_END)
     # Drop a handful of consecutive sessions in the middle (within tolerance).
     mid = DEFAULT_CALENDAR.sessions_between(date(2024, 1, 8), date(2024, 1, 12))
-    present -= set(mid)  # 5 sessions ≤ COVERAGE_MAX_INTERIOR_GAP_SESSIONS (10)
-    assert COVERAGE_MAX_INTERIOR_GAP_SESSIONS >= 5
+    present -= set(mid)  # 5 sessions ≤ COVERAGE_MAX_GAP_SESSIONS (10)
+    assert GAP >= 5
     assert _is_covered(present, WINDOW_START, WINDOW_END)
 
 
-def test_is_covered_within_tolerance_true():
-    # Edges a few days inside the window but within boundary tolerance → covered.
-    present = _all_sessions(
-        WINDOW_START + timedelta(days=TOL), WINDOW_END - timedelta(days=TOL)
-    )
+def test_is_covered_small_boundary_slack_true():
+    # Edges a few SESSIONS inside the window (run <= max gap at the edge) →
+    # covered. The edge tolerance is the SAME uniform gap rule as the interior.
+    left = DEFAULT_CALENDAR.add_sessions(WINDOW_START, GAP - 1)
+    right = DEFAULT_CALENDAR.sub_sessions(WINDOW_END, GAP - 1)
+    present = _all_sessions(left, right)
     assert _is_covered(present, WINDOW_START, WINDOW_END)
 
 
-def test_is_covered_just_outside_tolerance_false():
-    # Left edge starts just past tolerance → not left-covered.
-    present = _all_sessions(WINDOW_START + timedelta(days=TOL + 5), WINDOW_END)
+def test_is_covered_week_long_boundary_gap_false():
+    # A run LONGER than max gap at the LEFT edge → not covered. The old
+    # calendar-day boundary tolerance let a ~full-week edge gap slip through as
+    # covered while the interior scan ignored it (codex P2); the uniform
+    # full-window scan now catches it.
+    left = DEFAULT_CALENDAR.add_sessions(WINDOW_START, GAP + 1)
+    present = _all_sessions(left, WINDOW_END)
+    assert not _is_covered(present, WINDOW_START, WINDOW_END)
+
+
+def test_is_covered_stale_tail_within_gap_window_false():
+    # Symmetric to the above but at the RIGHT edge.
+    right = DEFAULT_CALENDAR.sub_sessions(WINDOW_END, GAP + 1)
+    present = _all_sessions(WINDOW_START, right)
     assert not _is_covered(present, WINDOW_START, WINDOW_END)
 
 
@@ -521,3 +532,53 @@ def test_backfill_gate_fails_when_cohort_incomplete(pg_legacy_session, monkeypat
     result = runner.invoke(cli_mod.cli, ["db", "backfill-prices", "--years", "1"])
     assert result.exit_code != 0, result.output
     assert "DROP" in result.output
+
+
+def test_backfill_gate_anchored_at_sweep_start_not_years_floor(
+    pg_legacy_session, monkeypatch
+):
+    """With a large `--years` floor (default 5) the FETCH window widens earlier
+    than the sweep, but the coverage GATE must stay anchored at the sweep start —
+    else a current constituent dense only from the sweep start onward (e.g. one
+    that IPOed after the years_floor) could never be 'covered' and the command
+    would raise every run (codex P1)."""
+    from click.testing import CliRunner
+
+    from rainier import cli as cli_mod
+
+    sweep_start = date(2022, 5, 25)
+    today = date(2026, 6, 12)
+    _seed_cohort(pg_legacy_session, ["IPOX"], today)
+    pg_legacy_session.execute(
+        text(
+            "INSERT INTO money_flow_snapshots "
+            "(captured_at, capture_session, data_date, ranking_type, symbol, rank) "
+            "VALUES (:cap, 'close', :dd, 'top100', 'IPOX', 1)"
+        ),
+        {"cap": _instant(sweep_start), "dd": sweep_start},
+    )
+    pg_legacy_session.commit()
+
+    captured = {}
+
+    def _fake_download(tickers, start=None, end=None, **kwargs):
+        captured["start"] = start
+        # yfinance only has history from the sweep start onward (no earlier data
+        # exists — IPOed near then). Dense from sweep_start → covered vs the
+        # sweep window even though the fetch asked for earlier history.
+        return _build_dense_yf_df(tickers.split(), sweep_start, today)
+
+    import yfinance as yf
+
+    monkeypatch.setattr(yf, "download", _fake_download)
+
+    runner = CliRunner()
+    # --years 5 → years_floor (≈5y before the real today) is earlier than the
+    # sweep start, so the fetch window widens earlier than the sweep.
+    result = runner.invoke(cli_mod.cli, ["db", "backfill-prices", "--years", "5"])
+    # Fetch window widened earlier than the sweep start (download start < sweep).
+    assert captured.get("start") is not None
+    assert captured["start"] < str(sweep_start)
+    # But the gate is anchored at the sweep start → IPOX is covered → exit 0.
+    assert result.exit_code == 0, result.output
+    assert "100% of the current cohort is covered" in result.output

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -412,7 +412,8 @@ def test_backfill_fetch_window_pinned_to_sweep_start(pg_legacy_session, monkeypa
     from rainier import cli as cli_mod
 
     sweep_start = date(2022, 5, 25)
-    today = date(2026, 6, 12)
+    today = date.today()  # CLI uses datetime.now(); track the real clock so the
+    # post-run coverage gate's right edge never drifts into a stale tail.
     # Rankings reach back to 2022-05-25 → that's the sweep start.
     _seed_cohort(pg_legacy_session, ["AMZN"], today)
     pg_legacy_session.execute(
@@ -459,7 +460,8 @@ def test_backfill_idempotent_rerun(pg_legacy_session, monkeypatch):
     from rainier import cli as cli_mod
 
     sweep_start = date(2022, 5, 25)
-    today = date(2026, 6, 12)
+    today = date.today()  # CLI uses datetime.now(); track the real clock so the
+    # post-run coverage gate's right edge never drifts into a stale tail.
     _seed_cohort(pg_legacy_session, ["NVDA"], today)
     pg_legacy_session.execute(
         text(
@@ -580,7 +582,8 @@ def test_backfill_gate_fails_when_cohort_incomplete(pg_legacy_session, monkeypat
     from rainier import cli as cli_mod
 
     sweep_start = date(2022, 5, 25)
-    today = date(2026, 6, 12)
+    today = date.today()  # CLI uses datetime.now(); track the real clock so the
+    # post-run coverage gate's right edge never drifts into a stale tail.
     _seed_cohort(pg_legacy_session, ["DROP"], today)
     pg_legacy_session.execute(
         text(
@@ -619,7 +622,8 @@ def test_backfill_gate_anchored_at_sweep_start_not_years_floor(
     from rainier import cli as cli_mod
 
     sweep_start = date(2022, 5, 25)
-    today = date(2026, 6, 12)
+    today = date.today()  # CLI uses datetime.now(); track the real clock so the
+    # post-run coverage gate's right edge never drifts into a stale tail.
     _seed_cohort(pg_legacy_session, ["IPOX"], today)
     pg_legacy_session.execute(
         text(

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -332,11 +332,35 @@ def test_weekend_only_ranking_with_no_bars_is_refetched(pg_legacy_session):
     assert "WKND" in need
 
 
+def test_reversed_window_no_bars_is_refetched(pg_legacy_session):
+    # A symbol first ranked on a weekend data_date that lands AFTER the
+    # last-completed-session window_end → eff_start > eff_end (reversed window).
+    # With zero bars it must still be flagged (it needs its entry bar), NOT a
+    # vacuous "covered" pass (codex P1).
+    saturday = date(2024, 6, 8)  # Saturday
+    window_end = date(2024, 6, 7)  # the prior Friday (last completed session)
+    _seed_cohort(pg_legacy_session, ["REV"], saturday)
+    # No prices.
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["REV"], WINDOW_START, window_end)
+    assert "REV" in need
+
+
 def test_is_covered_empty_present_short_window_false():
     # Pure: a non-degenerate (has sessions) but short window with empty present
     # is never covered, even when the window is ≤ max gap.
     short_end = DEFAULT_CALENDAR.add_sessions(WINDOW_START, 2)
     assert not _is_covered(set(), WINDOW_START, short_end)
+
+
+def test_is_covered_reversed_window_empty_present_false():
+    # Pure: a reversed window (start > end) with no bars is not covered.
+    assert not _is_covered(set(), date(2024, 6, 8), date(2024, 6, 7))
+
+
+def test_is_covered_reversed_window_with_bars_true():
+    # Pure: a reversed/empty window but the symbol HAS a bar → vacuously covered.
+    assert _is_covered({date(2024, 6, 6)}, date(2024, 6, 8), date(2024, 6, 7))
 
 
 def test_null_ohlc_rows_are_not_coverage(pg_legacy_session):

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -341,6 +341,12 @@ def _build_yf_df(symbols: list[str], days: list[date]) -> pd.DataFrame:
     return pd.DataFrame(1.0, index=idx, columns=cols)
 
 
+def _build_dense_yf_df(symbols: list[str], start: date, end: date) -> pd.DataFrame:
+    """A frame with a usable bar for every trading session — a full repair, so
+    the post-run cohort gate passes (exit 0)."""
+    return _build_yf_df(symbols, DEFAULT_CALENDAR.sessions_between(start, end))
+
+
 def test_backfill_fetch_window_pinned_to_sweep_start(pg_legacy_session, monkeypatch):
     """A present-but-incomplete symbol must be fetched from the sweep-window
     start (the earliest ranking date), NOT the trailing `--years` window."""
@@ -369,8 +375,9 @@ def test_backfill_fetch_window_pinned_to_sweep_start(pg_legacy_session, monkeypa
     def _fake_download(tickers, start=None, end=None, **kwargs):
         captured["start"] = start
         syms = tickers.split()
-        # Return a full-window frame so the fetch "repairs" history.
-        return _build_yf_df(syms, [sweep_start, today])
+        # Return a dense full-window frame so the fetch fully repairs history
+        # and the post-run cohort gate passes.
+        return _build_dense_yf_df(syms, sweep_start, today)
 
     import yfinance as yf
 
@@ -407,10 +414,9 @@ def test_backfill_idempotent_rerun(pg_legacy_session, monkeypatch):
     )
     pg_legacy_session.commit()
 
-    bars = [sweep_start, date(2024, 1, 2), today]
-
     def _fake_download(tickers, start=None, end=None, **kwargs):
-        return _build_yf_df(tickers.split(), bars)
+        # Dense full-window data so the cohort gate passes (exit 0).
+        return _build_dense_yf_df(tickers.split(), sweep_start, today)
 
     import yfinance as yf
 
@@ -420,7 +426,7 @@ def test_backfill_idempotent_rerun(pg_legacy_session, monkeypatch):
     r1 = runner.invoke(cli_mod.cli, ["db", "backfill-prices", "--years", "1"])
     assert r1.exit_code == 0, r1.output
     pg_legacy_session.expire_all()
-    n1 = len(_count := pg_legacy_session.execute(
+    n1 = len(pg_legacy_session.execute(
         select(StockPrice).where(StockPrice.symbol == "NVDA")
     ).scalars().all())
     r2 = runner.invoke(cli_mod.cli, ["db", "backfill-prices", "--years", "1"])
@@ -429,4 +435,89 @@ def test_backfill_idempotent_rerun(pg_legacy_session, monkeypatch):
     n2 = len(pg_legacy_session.execute(
         select(StockPrice).where(StockPrice.symbol == "NVDA")
     ).scalars().all())
-    assert n1 == n2 == 3  # ON CONFLICT DO NOTHING → no duplicates
+    # On re-run NVDA is already covered → not even re-selected; the COALESCE
+    # upsert is idempotent regardless → no duplicate (symbol, date) rows.
+    assert n1 == n2 > 0
+
+
+def test_save_prices_repairs_null_ohlc_placeholder(pg_legacy_session):
+    """A coverage re-fetch must REPAIR a NULL-OHLC placeholder bar, not discard
+    it (codex P1). With ON CONFLICT DO NOTHING the placeholder would survive and
+    the gap would never heal."""
+    from rainier.backtest.qu100_portfolio import _save_prices_to_db
+
+    d = date(2024, 1, 2)
+    _seed_null_ohlc(pg_legacy_session, "RPR", [d])
+    pg_legacy_session.expire_all()
+    # Re-fetch returns a real bar for the same (symbol, date).
+    yf_df = _build_yf_df(["RPR"], [d])
+    _save_prices_to_db(yf_df, ["RPR"])
+    pg_legacy_session.expire_all()
+    row = pg_legacy_session.execute(
+        select(StockPrice).where(StockPrice.symbol == "RPR")
+    ).scalar_one()
+    assert row.close is not None  # placeholder was repaired, not kept NULL
+    # Still exactly one row for the date (upsert, not a duplicate insert).
+    rows = pg_legacy_session.execute(
+        select(StockPrice).where(StockPrice.symbol == "RPR")
+    ).scalars().all()
+    assert len(rows) == 1
+
+
+def test_save_prices_coalesce_keeps_good_value_on_null_refetch(pg_legacy_session):
+    """A NULL field in a re-fetch must NOT clobber a previously-good value
+    (COALESCE(EXCLUDED, existing), B5 discipline)."""
+    from rainier.backtest.qu100_portfolio import _save_prices_to_db
+
+    d = date(2024, 1, 3)
+    _seed_prices(pg_legacy_session, "KEEP", [d])  # open=10.0 good
+    pg_legacy_session.expire_all()
+    # Re-fetch has a real close but a NULL open → open must stay 10.0.
+    idx = pd.to_datetime([d])
+    cols = pd.MultiIndex.from_product(
+        [["Open", "High", "Low", "Close", "Volume"], ["KEEP"]]
+    )
+    yf_df = pd.DataFrame(2.0, index=idx, columns=cols)
+    yf_df[("Open", "KEEP")] = None
+    _save_prices_to_db(yf_df, ["KEEP"])
+    pg_legacy_session.expire_all()
+    row = pg_legacy_session.execute(
+        select(StockPrice).where(StockPrice.symbol == "KEEP")
+    ).scalar_one()
+    assert float(row.open) == 10.0  # not clobbered to NULL
+    assert float(row.close) == 2.0  # real re-fetch value applied
+
+
+def test_backfill_gate_fails_when_cohort_incomplete(pg_legacy_session, monkeypatch):
+    """The post-run cohort gate must FAIL (non-zero exit), not warn-and-exit-0,
+    when a current-cohort symbol stays uncovered (codex P2). A warn-only gate is
+    indistinguishable from success in cron/CI."""
+    from click.testing import CliRunner
+
+    from rainier import cli as cli_mod
+
+    sweep_start = date(2022, 5, 25)
+    today = date(2026, 6, 12)
+    _seed_cohort(pg_legacy_session, ["DROP"], today)
+    pg_legacy_session.execute(
+        text(
+            "INSERT INTO money_flow_snapshots "
+            "(captured_at, capture_session, data_date, ranking_type, symbol, rank) "
+            "VALUES (:cap, 'close', :dd, 'top100', 'DROP', 1)"
+        ),
+        {"cap": _instant(sweep_start), "dd": sweep_start},
+    )
+    pg_legacy_session.commit()
+
+    def _fake_download(tickers, start=None, end=None, **kwargs):
+        # yfinance "drops" the symbol — returns nothing usable → stays uncovered.
+        return pd.DataFrame()
+
+    import yfinance as yf
+
+    monkeypatch.setattr(yf, "download", _fake_download)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "backfill-prices", "--years", "1"])
+    assert result.exit_code != 0, result.output
+    assert "DROP" in result.output

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -1,0 +1,309 @@
+"""Price-coverage backfill (TASK-PLAN p1-cleanup-price-coverag-18ff).
+
+`db backfill-prices` historically decided what to fetch with a PRESENCE check
+(`StockPrice.date >= start`). A separate incremental ingest seeded thin RECENT
+slivers for large-caps (e.g. AMZN: 40 rows from 2026-03-03), so they passed the
+presence check and were skipped — their 2022-2025 history (most of the sweep
+window) was never fetched.
+
+The fix is COVERAGE-based: a symbol is "covered" only if its rows span the
+required window at BOTH ends (a bar near the window START and a recent bar near
+the window END). Both failure modes (recent-sliver, stale-tail) must re-fetch.
+Per-symbol gaps are surfaced loudly (`yf_batch_dropped_symbols`) and a post-run
+assertion checks 100% current-cohort coverage over the sweep window.
+
+DB-backed cases run under `requires_postgres` (pg_legacy_session binds the
+legacy `core.database` singleton the backfill uses).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pandas as pd
+import pytest
+from sqlalchemy import select, text
+
+from rainier.backtest.qu100_portfolio import (
+    _yf_to_long,
+    assert_cohort_coverage,
+    select_symbols_needing_backfill,
+    sweep_window_start,
+)
+from rainier.core.models import StockPrice
+
+pytestmark = pytest.mark.requires_postgres
+
+WINDOW_START = date(2022, 5, 25)
+WINDOW_END = date(2026, 6, 12)
+
+
+def _instant(d: date) -> datetime:
+    return datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
+
+
+def _seed_stock(session, symbol: str) -> None:
+    session.execute(
+        text("INSERT INTO stocks (symbol) VALUES (:s) ON CONFLICT DO NOTHING"),
+        {"s": symbol},
+    )
+
+
+def _seed_prices(session, symbol: str, days: list[date]) -> None:
+    _seed_stock(session, symbol)
+    for d in days:
+        session.add(
+            StockPrice(
+                symbol=symbol, date=_instant(d),
+                open=10.0, high=11.0, low=9.0, close=10.5, volume=1000,
+            )
+        )
+    session.commit()
+
+
+# ---------------------------------------------------------------------------
+# sweep_window_start — derived from the rankings, NOT hard-coded / --years.
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_window_start_derives_from_rankings(pg_legacy_session):
+    _seed_stock(pg_legacy_session, "AAA")
+    for dd in [date(2022, 5, 25), date(2023, 1, 3), date(2026, 6, 12)]:
+        pg_legacy_session.execute(
+            text(
+                "INSERT INTO money_flow_snapshots "
+                "(captured_at, capture_session, data_date, ranking_type, symbol, rank) "
+                "VALUES (:cap, 'close', :dd, 'top100', 'AAA', 1)"
+            ),
+            {"cap": _instant(dd), "dd": dd},
+        )
+    pg_legacy_session.commit()
+    # The earliest ranking date is the sweep-consumption start (not --years).
+    assert sweep_window_start() == date(2022, 5, 25)
+
+
+# ---------------------------------------------------------------------------
+# select_symbols_needing_backfill — span check at BOTH boundaries.
+# ---------------------------------------------------------------------------
+
+
+def test_recent_sliver_is_refetched(pg_legacy_session):
+    # AMZN-shaped: only a recent sliver, no left-edge bar near the window start.
+    _seed_prices(pg_legacy_session, "AMZN", [date(2026, 3, 3), date(2026, 3, 4)])
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["AMZN"], WINDOW_START, WINDOW_END)
+    assert "AMZN" in need
+
+
+def test_stale_tail_is_refetched(pg_legacy_session):
+    # Old history but no recent bar near today — the right edge is missing.
+    days = [date(2022, 5, 25), date(2023, 1, 3), date(2024, 6, 6)]
+    _seed_prices(pg_legacy_session, "STALE", days)
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["STALE"], WINDOW_START, WINDOW_END)
+    assert "STALE" in need
+
+
+def test_fully_covered_symbol_is_skipped(pg_legacy_session):
+    # A bar at both edges (within weekend tolerance) → covered, not re-fetched.
+    days = [date(2022, 5, 25), date(2024, 1, 2), WINDOW_END]
+    _seed_prices(pg_legacy_session, "FULL", days)
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["FULL"], WINDOW_START, WINDOW_END)
+    assert "FULL" not in need
+
+
+def test_absent_symbol_is_refetched(pg_legacy_session):
+    # No rows at all → needs backfill.
+    need = select_symbols_needing_backfill(["GHOST"], WINDOW_START, WINDOW_END)
+    assert "GHOST" in need
+
+
+def test_boundary_tolerates_weekends(pg_legacy_session):
+    # 2022-05-25 is a Wednesday; shift edges a couple of sessions — still covered.
+    days = [date(2022, 5, 27), date(2024, 1, 2), date(2026, 6, 10)]
+    _seed_prices(pg_legacy_session, "NEARWE", days)
+    # window end on a Saturday; last bar 2 trading days earlier still counts.
+    need = select_symbols_needing_backfill(
+        ["NEARWE"], date(2022, 5, 23), date(2026, 6, 13)
+    )
+    assert "NEARWE" not in need
+
+
+# ---------------------------------------------------------------------------
+# _yf_to_long — surface dropped symbols (no silent omission).
+# ---------------------------------------------------------------------------
+
+
+def test_yf_to_long_surfaces_batch_drop(caplog):
+    import logging
+
+    idx = pd.to_datetime([date(2026, 6, 10), date(2026, 6, 11)])
+    cols = pd.MultiIndex.from_product(
+        [["Open", "High", "Low", "Close", "Volume"], ["AAA"]]
+    )
+    yf_df = pd.DataFrame(1.0, index=idx, columns=cols)
+    # Request AAA + BBB; yfinance only returned AAA → BBB must be surfaced.
+    with caplog.at_level(logging.WARNING):
+        out = _yf_to_long(yf_df, ["AAA", "BBB"])
+    assert set(out["symbol"].unique()) == {"AAA"}
+    assert any("yf_batch_dropped_symbols" in r.getMessage() for r in caplog.records)
+    assert any("BBB" in r.getMessage() for r in caplog.records)
+
+
+def test_yf_to_long_no_drop_logs_nothing(caplog):
+    import logging
+
+    idx = pd.to_datetime([date(2026, 6, 10)])
+    cols = pd.MultiIndex.from_product(
+        [["Open", "High", "Low", "Close", "Volume"], ["AAA"]]
+    )
+    yf_df = pd.DataFrame(1.0, index=idx, columns=cols)
+    with caplog.at_level(logging.WARNING):
+        _yf_to_long(yf_df, ["AAA"])
+    assert not any(
+        "yf_batch_dropped_symbols" in r.getMessage() for r in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# assert_cohort_coverage — post-run, reports missing cohort members loudly.
+# ---------------------------------------------------------------------------
+
+
+def _seed_cohort(session, symbols: list[str], data_date: date) -> None:
+    for i, sym in enumerate(symbols, start=1):
+        _seed_stock(session, sym)
+        session.execute(
+            text(
+                "INSERT INTO money_flow_snapshots "
+                "(captured_at, capture_session, data_date, ranking_type, symbol, rank) "
+                "VALUES (:cap, 'close', :dd, 'top100', :sym, :rank)"
+            ),
+            {"cap": _instant(data_date), "dd": data_date, "sym": sym, "rank": i},
+        )
+    session.commit()
+
+
+def test_cohort_coverage_reports_missing(pg_legacy_session):
+    as_of = date(2026, 6, 12)
+    _seed_cohort(pg_legacy_session, ["COVD", "GAPS"], as_of)
+    # COVD spans the window; GAPS has only a recent sliver.
+    _seed_prices(pg_legacy_session, "COVD", [WINDOW_START, as_of])
+    _seed_prices(pg_legacy_session, "GAPS", [as_of])
+    pg_legacy_session.expire_all()
+    missing = assert_cohort_coverage(WINDOW_START, as_of, as_of=as_of)
+    assert missing == ["GAPS"]
+
+
+def test_cohort_coverage_all_covered_empty(pg_legacy_session):
+    as_of = date(2026, 6, 12)
+    _seed_cohort(pg_legacy_session, ["COVD"], as_of)
+    _seed_prices(pg_legacy_session, "COVD", [WINDOW_START, as_of])
+    pg_legacy_session.expire_all()
+    assert assert_cohort_coverage(WINDOW_START, as_of, as_of=as_of) == []
+
+
+# ---------------------------------------------------------------------------
+# CLI `db backfill-prices` — fetch the full sweep window for incomplete
+# symbols (NOT the --years window), and stay idempotent on re-run.
+# ---------------------------------------------------------------------------
+
+
+def _build_yf_df(symbols: list[str], days: list[date]) -> pd.DataFrame:
+    idx = pd.to_datetime(days)
+    cols = pd.MultiIndex.from_product(
+        [["Open", "High", "Low", "Close", "Volume"], symbols]
+    )
+    return pd.DataFrame(1.0, index=idx, columns=cols)
+
+
+def test_backfill_fetch_window_pinned_to_sweep_start(pg_legacy_session, monkeypatch):
+    """A present-but-incomplete symbol must be fetched from the sweep-window
+    start (the earliest ranking date), NOT the trailing `--years` window."""
+    from click.testing import CliRunner
+
+    from rainier import cli as cli_mod
+
+    sweep_start = date(2022, 5, 25)
+    today = date(2026, 6, 12)
+    # Rankings reach back to 2022-05-25 → that's the sweep start.
+    _seed_cohort(pg_legacy_session, ["AMZN"], today)
+    pg_legacy_session.execute(
+        text(
+            "INSERT INTO money_flow_snapshots "
+            "(captured_at, capture_session, data_date, ranking_type, symbol, rank) "
+            "VALUES (:cap, 'close', :dd, 'top100', 'AMZN', 1)"
+        ),
+        {"cap": _instant(sweep_start), "dd": sweep_start},
+    )
+    # AMZN has only a recent sliver → present-but-incomplete.
+    _seed_prices(pg_legacy_session, "AMZN", [date(2026, 3, 3)])
+    pg_legacy_session.commit()
+
+    captured = {}
+
+    def _fake_download(tickers, start=None, end=None, **kwargs):
+        captured["start"] = start
+        syms = tickers.split()
+        # Return a full-window frame so the fetch "repairs" history.
+        return _build_yf_df(syms, [sweep_start, today])
+
+    import yfinance as yf
+
+    monkeypatch.setattr(yf, "download", _fake_download)
+
+    runner = CliRunner()
+    # --years 1 would, under the OLD presence logic, cap the fetch at 2025-06.
+    result = runner.invoke(
+        cli_mod.cli, ["db", "backfill-prices", "--years", "1", "--batch-size", "20"]
+    )
+    assert result.exit_code == 0, result.output
+    # The download start must be the sweep-window start, not 1y ago.
+    assert captured.get("start") == str(sweep_start), (
+        f"fetch start was {captured.get('start')!r}; expected the sweep window "
+        f"start {sweep_start}. Output:\n{result.output}"
+    )
+
+
+def test_backfill_idempotent_rerun(pg_legacy_session, monkeypatch):
+    from click.testing import CliRunner
+
+    from rainier import cli as cli_mod
+
+    sweep_start = date(2022, 5, 25)
+    today = date(2026, 6, 12)
+    _seed_cohort(pg_legacy_session, ["NVDA"], today)
+    pg_legacy_session.execute(
+        text(
+            "INSERT INTO money_flow_snapshots "
+            "(captured_at, capture_session, data_date, ranking_type, symbol, rank) "
+            "VALUES (:cap, 'close', :dd, 'top100', 'NVDA', 1)"
+        ),
+        {"cap": _instant(sweep_start), "dd": sweep_start},
+    )
+    pg_legacy_session.commit()
+
+    bars = [sweep_start, date(2024, 1, 2), today]
+
+    def _fake_download(tickers, start=None, end=None, **kwargs):
+        return _build_yf_df(tickers.split(), bars)
+
+    import yfinance as yf
+
+    monkeypatch.setattr(yf, "download", _fake_download)
+
+    runner = CliRunner()
+    r1 = runner.invoke(cli_mod.cli, ["db", "backfill-prices", "--years", "1"])
+    assert r1.exit_code == 0, r1.output
+    pg_legacy_session.expire_all()
+    n1 = len(_count := pg_legacy_session.execute(
+        select(StockPrice).where(StockPrice.symbol == "NVDA")
+    ).scalars().all())
+    r2 = runner.invoke(cli_mod.cli, ["db", "backfill-prices", "--years", "1"])
+    assert r2.exit_code == 0, r2.output
+    pg_legacy_session.expire_all()
+    n2 = len(pg_legacy_session.execute(
+        select(StockPrice).where(StockPrice.symbol == "NVDA")
+    ).scalars().all())
+    assert n1 == n2 == 3  # ON CONFLICT DO NOTHING → no duplicates

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -18,13 +18,15 @@ legacy `core.database` singleton the backfill uses).
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pandas as pd
 import pytest
 from sqlalchemy import select, text
 
 from rainier.backtest.qu100_portfolio import (
+    COVERAGE_BOUNDARY_TOLERANCE_DAYS,
+    _is_covered,
     _yf_to_long,
     assert_cohort_coverage,
     select_symbols_needing_backfill,
@@ -32,10 +34,65 @@ from rainier.backtest.qu100_portfolio import (
 )
 from rainier.core.models import StockPrice
 
+# Most cases need a live Postgres (pg_legacy_session binds the legacy
+# core.database singleton the backfill uses). The pure `_is_covered` /
+# `_yf_to_long` cases below need no DB but inherit the module mark harmlessly
+# (the mark only labels for `-m` selection; the DB skip comes from the fixture).
 pytestmark = pytest.mark.requires_postgres
 
 WINDOW_START = date(2022, 5, 25)
 WINDOW_END = date(2026, 6, 12)
+
+
+# ---------------------------------------------------------------------------
+# Pure coverage-decision logic (_is_covered) — no DB. The span check is the
+# crux of the fix; pin every branch independent of Postgres availability.
+# ---------------------------------------------------------------------------
+
+TOL = COVERAGE_BOUNDARY_TOLERANCE_DAYS
+
+
+def test_is_covered_full_span_true():
+    assert _is_covered(WINDOW_START, WINDOW_END, WINDOW_START, WINDOW_END, TOL)
+
+
+def test_is_covered_recent_sliver_false():
+    # Left edge missing (AMZN case): earliest bar long after the window start.
+    assert not _is_covered(
+        date(2026, 3, 3), WINDOW_END, WINDOW_START, WINDOW_END, TOL
+    )
+
+
+def test_is_covered_stale_tail_false():
+    # Right edge missing: latest bar long before the window end.
+    assert not _is_covered(
+        WINDOW_START, date(2024, 6, 6), WINDOW_START, WINDOW_END, TOL
+    )
+
+
+def test_is_covered_absent_false():
+    assert not _is_covered(None, None, WINDOW_START, WINDOW_END, TOL)
+
+
+def test_is_covered_within_tolerance_true():
+    # Edges a few days inside the window but within tolerance → still covered.
+    assert _is_covered(
+        WINDOW_START + timedelta(days=TOL),
+        WINDOW_END - timedelta(days=TOL),
+        WINDOW_START,
+        WINDOW_END,
+        TOL,
+    )
+
+
+def test_is_covered_just_outside_tolerance_false():
+    assert not _is_covered(
+        WINDOW_START + timedelta(days=TOL + 1),
+        WINDOW_END,
+        WINDOW_START,
+        WINDOW_END,
+        TOL,
+    )
 
 
 def _instant(d: date) -> datetime:
@@ -135,35 +192,42 @@ def test_boundary_tolerates_weekends(pg_legacy_session):
 # ---------------------------------------------------------------------------
 
 
-def test_yf_to_long_surfaces_batch_drop(caplog):
-    import logging
+def _capture_warnings(monkeypatch):
+    """Capture qu100_portfolio's structlog `log.warning` calls reliably,
+    independent of how structlog routes to stdlib (which `caplog` can miss)."""
+    from rainier.backtest import qu100_portfolio as qp
 
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        qp.log, "warning", lambda event, **kw: events.append((event, kw))
+    )
+    return events
+
+
+def test_yf_to_long_surfaces_batch_drop(monkeypatch):
+    events = _capture_warnings(monkeypatch)
     idx = pd.to_datetime([date(2026, 6, 10), date(2026, 6, 11)])
     cols = pd.MultiIndex.from_product(
         [["Open", "High", "Low", "Close", "Volume"], ["AAA"]]
     )
     yf_df = pd.DataFrame(1.0, index=idx, columns=cols)
     # Request AAA + BBB; yfinance only returned AAA → BBB must be surfaced.
-    with caplog.at_level(logging.WARNING):
-        out = _yf_to_long(yf_df, ["AAA", "BBB"])
+    out = _yf_to_long(yf_df, ["AAA", "BBB"])
     assert set(out["symbol"].unique()) == {"AAA"}
-    assert any("yf_batch_dropped_symbols" in r.getMessage() for r in caplog.records)
-    assert any("BBB" in r.getMessage() for r in caplog.records)
+    drop_events = [kw for ev, kw in events if ev == "yf_batch_dropped_symbols"]
+    assert drop_events, "expected a yf_batch_dropped_symbols warning"
+    assert "BBB" in drop_events[0]["missing"]
 
 
-def test_yf_to_long_no_drop_logs_nothing(caplog):
-    import logging
-
+def test_yf_to_long_no_drop_logs_nothing(monkeypatch):
+    events = _capture_warnings(monkeypatch)
     idx = pd.to_datetime([date(2026, 6, 10)])
     cols = pd.MultiIndex.from_product(
         [["Open", "High", "Low", "Close", "Volume"], ["AAA"]]
     )
     yf_df = pd.DataFrame(1.0, index=idx, columns=cols)
-    with caplog.at_level(logging.WARNING):
-        _yf_to_long(yf_df, ["AAA"])
-    assert not any(
-        "yf_batch_dropped_symbols" in r.getMessage() for r in caplog.records
-    )
+    _yf_to_long(yf_df, ["AAA"])
+    assert not any(ev == "yf_batch_dropped_symbols" for ev, _ in events)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -240,8 +240,32 @@ def test_late_entrant_covered_from_first_ranking_date(pg_legacy_session):
     _seed_ranking(pg_legacy_session, "IPONEW", first_ranked)
     _seed_dense(pg_legacy_session, "IPONEW", first_ranked, WINDOW_END)
     pg_legacy_session.expire_all()
-    need = select_symbols_needing_backfill(["IPONEW"], WINDOW_START, WINDOW_END)
+    # GATE scope (clamp_to_ranking_life): covered for its ranked life. (Selection
+    # would re-select it to pull pre-listing lookback — see fetch generously.)
+    need = select_symbols_needing_backfill(
+        ["IPONEW"], WINDOW_START, WINDOW_END, clamp_to_ranking_life=True
+    )
     assert "IPONEW" not in need
+
+
+def test_selection_scope_fetches_pre_listing_lookback(pg_legacy_session):
+    # SELECTION scope (default, clamp_to_ranking_life=False): a late entrant dense
+    # only from its first ranking is STILL selected, because the portfolio
+    # backtest pulls 180d of PRE-signal lookback and the repair must fetch it
+    # (codex P1). Contrast the GATE scope, which treats it as covered.
+    first_ranked = date(2025, 1, 6)
+    _seed_cohort(pg_legacy_session, ["IPOFETCH"], WINDOW_END)
+    _seed_ranking(pg_legacy_session, "IPOFETCH", first_ranked)
+    _seed_dense(pg_legacy_session, "IPOFETCH", first_ranked, WINDOW_END)
+    pg_legacy_session.expire_all()
+    # Default (selection): not covered over the full window → fetched.
+    sel = select_symbols_needing_backfill(["IPOFETCH"], WINDOW_START, WINDOW_END)
+    assert "IPOFETCH" in sel
+    # Gate (clamp): covered for its ranked life.
+    gate = select_symbols_needing_backfill(
+        ["IPOFETCH"], WINDOW_START, WINDOW_END, clamp_to_ranking_life=True
+    )
+    assert "IPOFETCH" not in gate
 
 
 def test_late_entrant_with_gap_after_listing_is_refetched(pg_legacy_session):
@@ -273,7 +297,11 @@ def test_former_member_covered_through_last_ranking_plus_tail(pg_legacy_session)
     _seed_ranking(pg_legacy_session, "GONE", last_ranked)
     _seed_dense(pg_legacy_session, "GONE", first_ranked, tail_end)
     pg_legacy_session.expire_all()
-    need = select_symbols_needing_backfill(["GONE"], WINDOW_START, WINDOW_END)
+    # GATE scope (clamp_to_ranking_life): a delisted former member is covered
+    # through its ranked life + tail, not flagged forever for post-delist history.
+    need = select_symbols_needing_backfill(
+        ["GONE"], WINDOW_START, WINDOW_END, clamp_to_ranking_life=True
+    )
     assert "GONE" not in need
 
 
@@ -335,17 +363,19 @@ def test_weekend_ranking_with_completed_sessions_no_bars_is_refetched(
 
 
 def test_same_day_entrant_after_last_completed_session_is_covered(pg_legacy_session):
-    # A symbol first ranked AFTER the last-completed-session window_end (a same-
-    # day / weekend entrant whose entry bar is not published yet) has NO completed
-    # session in its window → covered (nothing fetchable yet), NOT a spurious flag
-    # that would fail every intraday run (codex P1). It is picked up on the next
-    # run once its first session completes.
+    # GATE scope: a symbol first ranked AFTER the last-completed-session
+    # window_end (a same-day/weekend entrant whose entry bar is not published yet)
+    # has NO completed session in its CLAMPED window → covered (nothing fetchable
+    # yet), NOT a spurious gate failure on every intraday run (codex P1). Picked
+    # up on the next run once its first session completes.
     saturday = date(2024, 6, 8)  # Saturday — first ranking after window_end
     window_end = date(2024, 6, 7)  # the prior Friday (last completed session)
     _seed_cohort(pg_legacy_session, ["SAMEDAY"], saturday)
     # No prices yet (the bar does not exist).
     pg_legacy_session.expire_all()
-    need = select_symbols_needing_backfill(["SAMEDAY"], WINDOW_START, window_end)
+    need = select_symbols_needing_backfill(
+        ["SAMEDAY"], WINDOW_START, window_end, clamp_to_ranking_life=True
+    )
     assert "SAMEDAY" not in need
 
 

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -421,6 +421,41 @@ def test_gate_live_symbol_stale_tail_still_flagged(pg_legacy_session):
     assert "LIVESTALE" in need
 
 
+def test_gate_tail_gap_former_member_accepted_but_selection_self_heals(pg_legacy_session):
+    # Decision 3 trade-off (adversarial review): offline, a genuine delisting
+    # (no bars past last_traded) is indistinguishable from a live former member
+    # with a TAIL fetch-gap in (lr, lr+N]. The GATE caps BOTH at last_traded so
+    # neither perpetually fails — but the SELECTION pass (clamp=False,
+    # eff_end=window_end) STILL flags the tail-gapped case on every run, so the
+    # fetch loop self-heals a live one idempotently. Pin both halves so the
+    # don't-fail-forever guard (GATE) and the gap detector (SELECTION) stay
+    # decoupled.
+    first_ranked = date(2022, 6, 1)
+    last_ranked = date(2024, 6, 3)
+    # Bars dense from first_ranked through a couple sessions PAST last_ranked,
+    # then stop — leaving a tail gap (last_traded, last_ranked+N] longer than the
+    # max gap (N=15 > GAP=10).
+    last_traded = DEFAULT_CALENDAR.add_sessions(last_ranked, 2)
+    tail_cap = DEFAULT_CALENDAR.add_sessions(last_ranked, COVERAGE_FORWARD_TAIL_SESSIONS)
+    missing_tail = DEFAULT_CALENDAR.sessions_between(
+        DEFAULT_CALENDAR.next_session(last_traded), tail_cap
+    )
+    assert len(missing_tail) > GAP  # the dropped tail really is a >max-gap run
+    _seed_ranking(pg_legacy_session, "TAILGAP", first_ranked)
+    _seed_ranking(pg_legacy_session, "TAILGAP", last_ranked)
+    _seed_dense(pg_legacy_session, "TAILGAP", first_ranked, last_traded)
+    pg_legacy_session.expire_all()
+    # GATE: accepts (capped at last_traded → no perpetual fail on a true delist).
+    gate = select_symbols_needing_backfill(
+        ["TAILGAP"], WINDOW_START, WINDOW_END, clamp_to_ranking_life=True
+    )
+    assert "TAILGAP" not in gate
+    # SELECTION: still flags it (unclamped window → the long right run shows) so a
+    # live tail-gapped member is re-fetched and self-heals.
+    sel = select_symbols_needing_backfill(["TAILGAP"], WINDOW_START, WINDOW_END)
+    assert "TAILGAP" in sel
+
+
 def test_brand_new_symbol_with_no_bars_is_refetched(pg_legacy_session):
     # Ranked only a few sessions before the window end (so its effective coverage
     # window is shorter than COVERAGE_MAX_GAP_SESSIONS) but has ZERO usable bars.

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -25,6 +25,7 @@ import pytest
 from sqlalchemy import select, text
 
 from rainier.backtest.qu100_portfolio import (
+    COVERAGE_FORWARD_TAIL_SESSIONS,
     COVERAGE_MAX_GAP_SESSIONS,
     _is_covered,
     _yf_to_long,
@@ -257,20 +258,37 @@ def test_late_entrant_with_gap_after_listing_is_refetched(pg_legacy_session):
     assert "IPOGAP" in need
 
 
-def test_former_member_covered_through_last_ranking_date(pg_legacy_session):
-    # A former constituent that stopped trading after its last ranking date
-    # (delist/rename). It has dense bars from its first to its LAST ranking but
-    # none through today — it must be COVERED, because the sweep consumes it only
-    # through that last ranking date (codex P1). Requiring bars through today
-    # would flag it forever.
+def test_former_member_covered_through_last_ranking_plus_tail(pg_legacy_session):
+    # A former constituent that stopped ranking after last_ranked (delist/rename),
+    # with dense bars from its first ranking through last_ranked PLUS the forward
+    # tail the backtest needs (entry+hold past the signal) — COVERED, not flagged.
+    # The sweep/backtest consume it only through last_ranked + the tail, not today
+    # (codex P1: requiring bars through today would flag it forever).
     first_ranked = date(2022, 6, 1)
     last_ranked = date(2024, 6, 3)
+    tail_end = DEFAULT_CALENDAR.add_sessions(
+        last_ranked, COVERAGE_FORWARD_TAIL_SESSIONS
+    )
     _seed_ranking(pg_legacy_session, "GONE", first_ranked)
     _seed_ranking(pg_legacy_session, "GONE", last_ranked)
-    _seed_dense(pg_legacy_session, "GONE", first_ranked, last_ranked)
+    _seed_dense(pg_legacy_session, "GONE", first_ranked, tail_end)
     pg_legacy_session.expire_all()
     need = select_symbols_needing_backfill(["GONE"], WINDOW_START, WINDOW_END)
     assert "GONE" not in need
+
+
+def test_former_member_missing_forward_tail_is_refetched(pg_legacy_session):
+    # Same former member but prices STOP at last_ranked with no forward tail →
+    # flagged, because the backtest still needs the post-signal entry+hold bars
+    # (codex P1).
+    first_ranked = date(2022, 6, 1)
+    last_ranked = date(2024, 6, 3)
+    _seed_ranking(pg_legacy_session, "NOTAIL", first_ranked)
+    _seed_ranking(pg_legacy_session, "NOTAIL", last_ranked)
+    _seed_dense(pg_legacy_session, "NOTAIL", first_ranked, last_ranked)
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["NOTAIL"], WINDOW_START, WINDOW_END)
+    assert "NOTAIL" in need
 
 
 def test_former_member_with_gap_before_last_ranking_is_refetched(pg_legacy_session):
@@ -297,6 +315,21 @@ def test_brand_new_symbol_with_no_bars_is_refetched(pg_legacy_session):
     pg_legacy_session.expire_all()
     need = select_symbols_needing_backfill(["BRANDNEW"], WINDOW_START, WINDOW_END)
     assert "BRANDNEW" in need
+
+
+def test_weekend_only_ranking_with_no_bars_is_refetched(pg_legacy_session):
+    # The scraper stamps data_date = captured_at.date(), so a brand-new symbol
+    # first seen on a Saturday has a non-session ranking date. Without the
+    # forward tail, eff_start == eff_end on a weekend → empty sessions → a vacuous
+    # "covered" pass even with zero bars (codex P1). The forward tail pushes
+    # eff_end onto real sessions, so a no-bars weekend entrant is flagged.
+    saturday = date(2024, 6, 8)  # 2024-06-08 is a Saturday
+    assert saturday.weekday() == 5
+    _seed_cohort(pg_legacy_session, ["WKND"], saturday)
+    # No prices at all.
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["WKND"], WINDOW_START, WINDOW_END)
+    assert "WKND" in need
 
 
 def test_is_covered_empty_present_short_window_false():

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -629,6 +629,43 @@ def test_backfill_gate_fails_when_cohort_incomplete(pg_legacy_session, monkeypat
     assert "DROP" in result.output
 
 
+def test_backfill_gate_fails_for_former_member_not_in_current_cohort(
+    pg_legacy_session, monkeypatch
+):
+    """The post-run gate validates the FULL historical top100 universe it
+    repaired, not just today's cohort (codex P1). A former constituent that
+    yfinance dropped — absent from the current cohort — must still fail the gate,
+    because the backtest reads all historical top100 names."""
+    from click.testing import CliRunner
+
+    from rainier import cli as cli_mod
+
+    sweep_start = date(2022, 5, 25)
+    today = date.today()
+    # CURRENT cohort (latest data_date) = CURR only; densely covered.
+    _seed_cohort(pg_legacy_session, ["CURR"], today)
+    _seed_ranking(pg_legacy_session, "CURR", sweep_start)
+    # FORMER member: top100 only at an OLD data_date, NOT in today's snapshot.
+    _seed_ranking(pg_legacy_session, "FORMER", sweep_start)
+
+    def _fake_download(tickers, start=None, end=None, **kwargs):
+        syms = tickers.split()
+        # CURR fully repairs; FORMER stays empty (yfinance drops it).
+        if "CURR" in syms:
+            return _build_dense_yf_df(["CURR"], sweep_start, today)
+        return pd.DataFrame()
+
+    import yfinance as yf
+
+    monkeypatch.setattr(yf, "download", _fake_download)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "backfill-prices", "--years", "1"])
+    # FORMER is uncovered → the universe gate fails even though it's not current.
+    assert result.exit_code != 0, result.output
+    assert "FORMER" in result.output
+
+
 def test_backfill_gate_anchored_at_sweep_start_not_years_floor(
     pg_legacy_session, monkeypatch
 ):
@@ -677,4 +714,4 @@ def test_backfill_gate_anchored_at_sweep_start_not_years_floor(
     assert captured["start"] < str(sweep_start)
     # But the gate is anchored at the sweep start → IPOX is covered → exit 0.
     assert result.exit_code == 0, result.output
-    assert "100% of the current cohort is covered" in result.output
+    assert "100% of the historical top100 universe is covered" in result.output

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -545,6 +545,32 @@ def test_save_prices_coalesce_keeps_good_value_on_null_refetch(pg_legacy_session
     assert float(row.close) == 2.0  # real re-fetch value applied
 
 
+def test_save_prices_canonicalizes_date_conflicts_with_existing(pg_legacy_session):
+    """A re-fetch whose timestamp carries a time-of-day/tz must canonicalize to
+    00:00 UTC so it CONFLICTS with the existing canonical row and REPAIRS it,
+    rather than inserting a second row for the same trading day (codex P1 —
+    breaks idempotent repair in the mixed ingest/backfill case)."""
+    from rainier.backtest.qu100_portfolio import _save_prices_to_db
+
+    d = date(2024, 1, 4)
+    # Existing canonical 00:00 UTC row (as paper.ingest writes it).
+    _seed_prices(pg_legacy_session, "CANON", [d])
+    pg_legacy_session.expire_all()
+    # Re-fetch: same trading day but a non-midnight, tz-aware timestamp.
+    idx = pd.to_datetime([datetime(2024, 1, 4, 14, 30, tzinfo=timezone.utc)])
+    cols = pd.MultiIndex.from_product(
+        [["Open", "High", "Low", "Close", "Volume"], ["CANON"]]
+    )
+    yf_df = pd.DataFrame(7.0, index=idx, columns=cols)
+    _save_prices_to_db(yf_df, ["CANON"])
+    pg_legacy_session.expire_all()
+    rows = pg_legacy_session.execute(
+        select(StockPrice).where(StockPrice.symbol == "CANON")
+    ).scalars().all()
+    assert len(rows) == 1  # conflict-updated, NOT a duplicate row
+    assert float(rows[0].close) == 7.0  # repaired to the re-fetch value
+
+
 def test_backfill_gate_fails_when_cohort_incomplete(pg_legacy_session, monkeypatch):
     """The post-run cohort gate must FAIL (non-zero exit), not warn-and-exit-0,
     when a current-cohort symbol stays uncovered (codex P2). A warn-only gate is

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -332,6 +332,95 @@ def test_former_member_with_gap_before_last_ranking_is_refetched(pg_legacy_sessi
     assert "GONEGAP" in need
 
 
+# ---------------------------------------------------------------------------
+# Decision 3 (operator, 2026-06-17): GATE right-edge per symbol =
+#   min(end_date, last_traded_session, last_ranking + N).
+# last_traded_session is a HARD CAP: a delisted name that stopped trading
+# before last_ranking + N must NOT be asked for post-delist bars (no perpetual
+# fail), AND a position held past N sessions is intentionally not coverage-
+# required (N is a cap, not a floor). The cap NEVER shrinks the requirement
+# below last_ranking, so a still-ranked (live) symbol with a stale tail is still
+# flagged. See docs/TASK-PLAN-p1-cleanup-price-coverag-18ff.md.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_delisted_before_tail_is_covered_through_last_traded(pg_legacy_session):
+    # Decision 3 (a): a former member that DELISTED a few sessions after its last
+    # ranking (last_traded < last_ranking + N) must be covered through last_traded
+    # under the GATE — its post-delist bars do not exist anywhere, so demanding
+    # them through last_ranking + N would flag it on EVERY run forever. Before the
+    # last_traded cap this raised perpetually.
+    first_ranked = date(2022, 6, 1)
+    last_ranked = date(2024, 6, 3)
+    # Delisted 3 sessions after the last ranking, well short of the N-session tail.
+    last_traded = DEFAULT_CALENDAR.add_sessions(last_ranked, 3)
+    assert last_traded < DEFAULT_CALENDAR.add_sessions(
+        last_ranked, COVERAGE_FORWARD_TAIL_SESSIONS
+    )
+    _seed_ranking(pg_legacy_session, "DELIST", first_ranked)
+    _seed_ranking(pg_legacy_session, "DELIST", last_ranked)
+    _seed_dense(pg_legacy_session, "DELIST", first_ranked, last_traded)
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(
+        ["DELIST"], WINDOW_START, WINDOW_END, clamp_to_ranking_life=True
+    )
+    assert "DELIST" not in need
+
+
+def test_gate_former_member_not_required_past_tail(pg_legacy_session):
+    # Decision 3 (b): N is a CAP, not a floor. A former member dense through
+    # last_ranking + N but with NO bars past that tail (e.g. it kept trading but
+    # the backtest never holds beyond N) is NOT coverage-required past the tail.
+    first_ranked = date(2022, 6, 1)
+    last_ranked = date(2024, 6, 3)
+    tail_end = DEFAULT_CALENDAR.add_sessions(last_ranked, COVERAGE_FORWARD_TAIL_SESSIONS)
+    _seed_ranking(pg_legacy_session, "CAPPED", first_ranked)
+    _seed_ranking(pg_legacy_session, "CAPPED", last_ranked)
+    # Dense only through the tail; deliberately nothing in [tail_end+1 .. today].
+    _seed_dense(pg_legacy_session, "CAPPED", first_ranked, tail_end)
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(
+        ["CAPPED"], WINDOW_START, WINDOW_END, clamp_to_ranking_life=True
+    )
+    assert "CAPPED" not in need
+
+
+def test_gate_right_edge_never_exceeds_end_date(pg_legacy_session):
+    # Decision 3 (c): the required right edge never exceeds end_date. A still-
+    # ranked symbol whose last_ranking + N AND last_traded both run past a short
+    # window_end is covered when dense only through that window_end — coverage is
+    # never demanded for sessions after end_date (an unpublished/future bar).
+    first_ranked = date(2022, 6, 1)
+    window_end = date(2024, 6, 7)  # short end_date well before today
+    # Ranked AT window_end (still active as of end_date) so last_ranking + N would
+    # extend past window_end if not clamped.
+    _seed_cohort(pg_legacy_session, ["EDGE"], window_end)
+    _seed_ranking(pg_legacy_session, "EDGE", first_ranked)
+    _seed_dense(pg_legacy_session, "EDGE", first_ranked, window_end)
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(
+        ["EDGE"], WINDOW_START, window_end, clamp_to_ranking_life=True
+    )
+    assert "EDGE" not in need
+
+
+def test_gate_live_symbol_stale_tail_still_flagged(pg_legacy_session):
+    # Decision 3 safety: the last_traded cap must NOT defeat stale-tail detection
+    # for a LIVE symbol. A symbol still ranked through window_end but whose bars
+    # stop months earlier (a fetch gap, not a delisting) must STILL be flagged —
+    # the cap never shrinks the required window below last_ranking.
+    first_ranked = date(2022, 6, 1)
+    _seed_cohort(pg_legacy_session, ["LIVESTALE"], WINDOW_END)  # ranked through today
+    _seed_ranking(pg_legacy_session, "LIVESTALE", first_ranked)
+    # Dense history but the tail stops ~2 years before window_end (stale).
+    _seed_dense(pg_legacy_session, "LIVESTALE", first_ranked, date(2024, 6, 3))
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(
+        ["LIVESTALE"], WINDOW_START, WINDOW_END, clamp_to_ranking_life=True
+    )
+    assert "LIVESTALE" in need
+
+
 def test_brand_new_symbol_with_no_bars_is_refetched(pg_legacy_session):
     # Ranked only a few sessions before the window end (so its effective coverage
     # window is shorter than COVERAGE_MAX_GAP_SESSIONS) but has ZERO usable bars.

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -229,6 +229,32 @@ def test_split_history_is_refetched(pg_legacy_session):
     assert "SPLIT" in need
 
 
+def test_late_entrant_covered_from_first_ranking_date(pg_legacy_session):
+    # A symbol whose FIRST top100 ranking is well after the global window start
+    # (a recent IPO). It has dense bars from that date onward but none before —
+    # it must be COVERED, not flagged, because the sweep evaluates it only from
+    # when it appears in rankings (codex P1). Pre-listing sessions are not gaps.
+    first_ranked = date(2025, 1, 6)
+    _seed_cohort(pg_legacy_session, ["IPONEW"], first_ranked)
+    _seed_dense(pg_legacy_session, "IPONEW", first_ranked, WINDOW_END)
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["IPONEW"], WINDOW_START, WINDOW_END)
+    assert "IPONEW" not in need
+
+
+def test_late_entrant_with_gap_after_listing_is_refetched(pg_legacy_session):
+    # Same late entrant, but a multi-month hole AFTER its first ranking → still
+    # flagged (the per-symbol left boundary doesn't excuse gaps within its
+    # ranked life).
+    first_ranked = date(2024, 1, 3)
+    _seed_cohort(pg_legacy_session, ["IPOGAP"], first_ranked)
+    _seed_dense(pg_legacy_session, "IPOGAP", first_ranked, date(2024, 3, 1))
+    _seed_dense(pg_legacy_session, "IPOGAP", date(2025, 6, 2), WINDOW_END)
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["IPOGAP"], WINDOW_START, WINDOW_END)
+    assert "IPOGAP" in need
+
+
 def test_null_ohlc_rows_are_not_coverage(pg_legacy_session):
     # Placeholder rows with NULL OHLC at the boundaries must NOT count as
     # coverage (codex P1) — a covered span built only from NULL rows re-fetches.
@@ -319,10 +345,29 @@ def _seed_cohort(session, symbols: list[str], data_date: date) -> None:
     session.commit()
 
 
+def _seed_ranking(session, symbol: str, data_date: date) -> None:
+    """Add an extra top100 ranking row at ``data_date`` (e.g. an EARLY one so a
+    symbol's first-ranking date predates the current cohort snapshot)."""
+    _seed_stock(session, symbol)
+    session.execute(
+        text(
+            "INSERT INTO money_flow_snapshots "
+            "(captured_at, capture_session, data_date, ranking_type, symbol, rank) "
+            "VALUES (:cap, 'close', :dd, 'top100', :sym, 1)"
+        ),
+        {"cap": _instant(data_date), "dd": data_date, "sym": symbol},
+    )
+    session.commit()
+
+
 def test_cohort_coverage_reports_missing(pg_legacy_session):
     as_of = date(2026, 6, 12)
     _seed_cohort(pg_legacy_session, ["COVD", "GAPS"], as_of)
-    # COVD spans the window densely; GAPS has only a recent sliver.
+    # Both have a long ranked life (first ranked at WINDOW_START), so the
+    # per-symbol left boundary IS the window start. COVD spans it densely; GAPS
+    # has only a recent sliver → GAPS is the only uncovered cohort member.
+    _seed_ranking(pg_legacy_session, "COVD", WINDOW_START)
+    _seed_ranking(pg_legacy_session, "GAPS", WINDOW_START)
     _seed_dense(pg_legacy_session, "COVD", WINDOW_START, as_of)
     _seed_prices(pg_legacy_session, "GAPS", [as_of])
     pg_legacy_session.expire_all()
@@ -333,6 +378,7 @@ def test_cohort_coverage_reports_missing(pg_legacy_session):
 def test_cohort_coverage_all_covered_empty(pg_legacy_session):
     as_of = date(2026, 6, 12)
     _seed_cohort(pg_legacy_session, ["COVD"], as_of)
+    _seed_ranking(pg_legacy_session, "COVD", WINDOW_START)
     _seed_dense(pg_legacy_session, "COVD", WINDOW_START, as_of)
     pg_legacy_session.expire_all()
     assert assert_cohort_coverage(WINDOW_START, as_of, as_of=as_of) == []

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -255,6 +255,26 @@ def test_late_entrant_with_gap_after_listing_is_refetched(pg_legacy_session):
     assert "IPOGAP" in need
 
 
+def test_brand_new_symbol_with_no_bars_is_refetched(pg_legacy_session):
+    # Ranked only a few sessions before the window end (so its effective coverage
+    # window is shorter than COVERAGE_MAX_GAP_SESSIONS) but has ZERO usable bars.
+    # An empty span over a short window must NOT be treated as covered (codex P1)
+    # — zero prices means the sweep has nothing to read.
+    first_ranked = DEFAULT_CALENDAR.sub_sessions(WINDOW_END, 3)
+    _seed_cohort(pg_legacy_session, ["BRANDNEW"], first_ranked)
+    # No _seed_prices → no usable bars at all.
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["BRANDNEW"], WINDOW_START, WINDOW_END)
+    assert "BRANDNEW" in need
+
+
+def test_is_covered_empty_present_short_window_false():
+    # Pure: a non-degenerate (has sessions) but short window with empty present
+    # is never covered, even when the window is ≤ max gap.
+    short_end = DEFAULT_CALENDAR.add_sessions(WINDOW_START, 2)
+    assert not _is_covered(set(), WINDOW_START, short_end)
+
+
 def test_null_ohlc_rows_are_not_coverage(pg_legacy_session):
     # Placeholder rows with NULL OHLC at the boundaries must NOT count as
     # coverage (codex P1) — a covered span built only from NULL rows re-fetches.

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -317,12 +317,14 @@ def test_brand_new_symbol_with_no_bars_is_refetched(pg_legacy_session):
     assert "BRANDNEW" in need
 
 
-def test_weekend_only_ranking_with_no_bars_is_refetched(pg_legacy_session):
-    # The scraper stamps data_date = captured_at.date(), so a brand-new symbol
-    # first seen on a Saturday has a non-session ranking date. Without the
-    # forward tail, eff_start == eff_end on a weekend → empty sessions → a vacuous
-    # "covered" pass even with zero bars (codex P1). The forward tail pushes
-    # eff_end onto real sessions, so a no-bars weekend entrant is flagged.
+def test_weekend_ranking_with_completed_sessions_no_bars_is_refetched(
+    pg_legacy_session,
+):
+    # A symbol first ranked on a Saturday data_date (scraper stamps data_date =
+    # captured_at.date()) but whose window_end is far in the future, so its
+    # effective window DOES contain many completed sessions. With zero bars it is
+    # flagged (real completed sessions exist and have no price). The forward tail
+    # plus a future window_end make the window non-degenerate.
     saturday = date(2024, 6, 8)  # 2024-06-08 is a Saturday
     assert saturday.weekday() == 5
     _seed_cohort(pg_legacy_session, ["WKND"], saturday)
@@ -332,18 +334,19 @@ def test_weekend_only_ranking_with_no_bars_is_refetched(pg_legacy_session):
     assert "WKND" in need
 
 
-def test_reversed_window_no_bars_is_refetched(pg_legacy_session):
-    # A symbol first ranked on a weekend data_date that lands AFTER the
-    # last-completed-session window_end → eff_start > eff_end (reversed window).
-    # With zero bars it must still be flagged (it needs its entry bar), NOT a
-    # vacuous "covered" pass (codex P1).
-    saturday = date(2024, 6, 8)  # Saturday
+def test_same_day_entrant_after_last_completed_session_is_covered(pg_legacy_session):
+    # A symbol first ranked AFTER the last-completed-session window_end (a same-
+    # day / weekend entrant whose entry bar is not published yet) has NO completed
+    # session in its window → covered (nothing fetchable yet), NOT a spurious flag
+    # that would fail every intraday run (codex P1). It is picked up on the next
+    # run once its first session completes.
+    saturday = date(2024, 6, 8)  # Saturday — first ranking after window_end
     window_end = date(2024, 6, 7)  # the prior Friday (last completed session)
-    _seed_cohort(pg_legacy_session, ["REV"], saturday)
-    # No prices.
+    _seed_cohort(pg_legacy_session, ["SAMEDAY"], saturday)
+    # No prices yet (the bar does not exist).
     pg_legacy_session.expire_all()
-    need = select_symbols_needing_backfill(["REV"], WINDOW_START, window_end)
-    assert "REV" in need
+    need = select_symbols_needing_backfill(["SAMEDAY"], WINDOW_START, window_end)
+    assert "SAMEDAY" not in need
 
 
 def test_is_covered_empty_present_short_window_false():
@@ -353,9 +356,10 @@ def test_is_covered_empty_present_short_window_false():
     assert not _is_covered(set(), WINDOW_START, short_end)
 
 
-def test_is_covered_reversed_window_empty_present_false():
-    # Pure: a reversed window (start > end) with no bars is not covered.
-    assert not _is_covered(set(), date(2024, 6, 8), date(2024, 6, 7))
+def test_is_covered_reversed_window_empty_present_true():
+    # Pure: a reversed window (start > end → no completed sessions) is vacuously
+    # covered even with no bars — nothing is fetchable yet (codex P1).
+    assert _is_covered(set(), date(2024, 6, 8), date(2024, 6, 7))
 
 
 def test_is_covered_reversed_window_with_bars_true():
@@ -803,3 +807,18 @@ def test_backfill_gate_anchored_at_sweep_start_not_years_floor(
     # But the gate is anchored at the sweep start → IPOX is covered → exit 0.
     assert result.exit_code == 0, result.output
     assert "100% of the historical top100 universe is covered" in result.output
+
+
+def test_backfill_empty_rankings_is_noop(pg_legacy_session):
+    """A fresh/staging DB with no top100 rankings must no-op cleanly (exit 0),
+    not raise from sweep_window_start() — bootstrap/smoke runs of
+    `db backfill-prices` happen before the first scrape (codex P2)."""
+    from click.testing import CliRunner
+
+    from rainier import cli as cli_mod
+
+    # No money_flow_snapshots rows at all.
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "backfill-prices"])
+    assert result.exit_code == 0, result.output
+    assert "Nothing to do" in result.output

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -26,6 +26,7 @@ from sqlalchemy import select, text
 
 from rainier.backtest.qu100_portfolio import (
     COVERAGE_BOUNDARY_TOLERANCE_DAYS,
+    COVERAGE_MAX_INTERIOR_GAP_SESSIONS,
     _is_covered,
     _yf_to_long,
     assert_cohort_coverage,
@@ -33,6 +34,7 @@ from rainier.backtest.qu100_portfolio import (
     sweep_window_start,
 )
 from rainier.core.models import StockPrice
+from rainier.paper.calendar import DEFAULT_CALENDAR
 
 # Most cases need a live Postgres (pg_legacy_session binds the legacy
 # core.database singleton the backfill uses). The pure `_is_covered` /
@@ -52,47 +54,63 @@ WINDOW_END = date(2026, 6, 12)
 TOL = COVERAGE_BOUNDARY_TOLERANCE_DAYS
 
 
+def _all_sessions(start: date, end: date) -> set[date]:
+    """Every trading session in [start, end] — a dense, fully-covered set."""
+    return set(DEFAULT_CALENDAR.sessions_between(start, end))
+
+
 def test_is_covered_full_span_true():
-    assert _is_covered(WINDOW_START, WINDOW_END, WINDOW_START, WINDOW_END, TOL)
+    # Dense bars across the whole window → covered.
+    assert _is_covered(_all_sessions(WINDOW_START, WINDOW_END), WINDOW_START, WINDOW_END)
 
 
 def test_is_covered_recent_sliver_false():
-    # Left edge missing (AMZN case): earliest bar long after the window start.
-    assert not _is_covered(
-        date(2026, 3, 3), WINDOW_END, WINDOW_START, WINDOW_END, TOL
-    )
+    # Left edge missing (AMZN case): bars only near the end.
+    present = _all_sessions(date(2026, 3, 3), WINDOW_END)
+    assert not _is_covered(present, WINDOW_START, WINDOW_END)
 
 
 def test_is_covered_stale_tail_false():
-    # Right edge missing: latest bar long before the window end.
-    assert not _is_covered(
-        WINDOW_START, date(2024, 6, 6), WINDOW_START, WINDOW_END, TOL
-    )
+    # Right edge missing: bars only in the early window.
+    present = _all_sessions(WINDOW_START, date(2024, 6, 6))
+    assert not _is_covered(present, WINDOW_START, WINDOW_END)
 
 
 def test_is_covered_absent_false():
-    assert not _is_covered(None, None, WINDOW_START, WINDOW_END, TOL)
+    assert not _is_covered(set(), WINDOW_START, WINDOW_END)
+
+
+def test_is_covered_split_history_false():
+    # Both edges present but a multi-year interior hole → NOT covered. A min/max
+    # span check would wrongly pass this (codex P1). The interior-gap scan fails.
+    present = _all_sessions(WINDOW_START, date(2022, 8, 1)) | _all_sessions(
+        date(2026, 1, 1), WINDOW_END
+    )
+    assert not _is_covered(present, WINDOW_START, WINDOW_END)
+
+
+def test_is_covered_small_interior_gap_true():
+    # A short gap (<= max interior tolerance) is fine — holidays/data hiccups.
+    present = _all_sessions(WINDOW_START, WINDOW_END)
+    # Drop a handful of consecutive sessions in the middle (within tolerance).
+    mid = DEFAULT_CALENDAR.sessions_between(date(2024, 1, 8), date(2024, 1, 12))
+    present -= set(mid)  # 5 sessions ≤ COVERAGE_MAX_INTERIOR_GAP_SESSIONS (10)
+    assert COVERAGE_MAX_INTERIOR_GAP_SESSIONS >= 5
+    assert _is_covered(present, WINDOW_START, WINDOW_END)
 
 
 def test_is_covered_within_tolerance_true():
-    # Edges a few days inside the window but within tolerance → still covered.
-    assert _is_covered(
-        WINDOW_START + timedelta(days=TOL),
-        WINDOW_END - timedelta(days=TOL),
-        WINDOW_START,
-        WINDOW_END,
-        TOL,
+    # Edges a few days inside the window but within boundary tolerance → covered.
+    present = _all_sessions(
+        WINDOW_START + timedelta(days=TOL), WINDOW_END - timedelta(days=TOL)
     )
+    assert _is_covered(present, WINDOW_START, WINDOW_END)
 
 
 def test_is_covered_just_outside_tolerance_false():
-    assert not _is_covered(
-        WINDOW_START + timedelta(days=TOL + 1),
-        WINDOW_END,
-        WINDOW_START,
-        WINDOW_END,
-        TOL,
-    )
+    # Left edge starts just past tolerance → not left-covered.
+    present = _all_sessions(WINDOW_START + timedelta(days=TOL + 5), WINDOW_END)
+    assert not _is_covered(present, WINDOW_START, WINDOW_END)
 
 
 def _instant(d: date) -> datetime:
@@ -113,6 +131,26 @@ def _seed_prices(session, symbol: str, days: list[date]) -> None:
             StockPrice(
                 symbol=symbol, date=_instant(d),
                 open=10.0, high=11.0, low=9.0, close=10.5, volume=1000,
+            )
+        )
+    session.commit()
+
+
+def _seed_dense(session, symbol: str, start: date, end: date) -> None:
+    """Seed a usable bar for EVERY trading session in [start, end] — a fully
+    covered history (no interior holes)."""
+    _seed_prices(session, symbol, DEFAULT_CALENDAR.sessions_between(start, end))
+
+
+def _seed_null_ohlc(session, symbol: str, days: list[date]) -> None:
+    """Seed placeholder rows with NULL OHLC (a yfinance partial). These must be
+    treated as GAPS, not coverage (codex P1)."""
+    _seed_stock(session, symbol)
+    for d in days:
+        session.add(
+            StockPrice(
+                symbol=symbol, date=_instant(d),
+                open=None, high=None, low=None, close=None, volume=None,
             )
         )
     session.commit()
@@ -162,12 +200,33 @@ def test_stale_tail_is_refetched(pg_legacy_session):
 
 
 def test_fully_covered_symbol_is_skipped(pg_legacy_session):
-    # A bar at both edges (within weekend tolerance) → covered, not re-fetched.
-    days = [date(2022, 5, 25), date(2024, 1, 2), WINDOW_END]
-    _seed_prices(pg_legacy_session, "FULL", days)
+    # Dense bars across the whole window (no interior hole) → covered, not
+    # re-fetched.
+    _seed_dense(pg_legacy_session, "FULL", WINDOW_START, WINDOW_END)
     pg_legacy_session.expire_all()
     need = select_symbols_needing_backfill(["FULL"], WINDOW_START, WINDOW_END)
     assert "FULL" not in need
+
+
+def test_split_history_is_refetched(pg_legacy_session):
+    # Both edges present but a multi-year interior hole → must re-fetch (codex
+    # P1). A min/max span check would wrongly skip this.
+    _seed_dense(pg_legacy_session, "SPLIT", WINDOW_START, date(2022, 8, 1))
+    _seed_dense(pg_legacy_session, "SPLIT", date(2026, 1, 1), WINDOW_END)
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["SPLIT"], WINDOW_START, WINDOW_END)
+    assert "SPLIT" in need
+
+
+def test_null_ohlc_rows_are_not_coverage(pg_legacy_session):
+    # Placeholder rows with NULL OHLC at the boundaries must NOT count as
+    # coverage (codex P1) — a covered span built only from NULL rows re-fetches.
+    _seed_null_ohlc(
+        pg_legacy_session, "NULLY", [WINDOW_START, date(2024, 1, 2), WINDOW_END]
+    )
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["NULLY"], WINDOW_START, WINDOW_END)
+    assert "NULLY" in need
 
 
 def test_absent_symbol_is_refetched(pg_legacy_session):
@@ -177,10 +236,10 @@ def test_absent_symbol_is_refetched(pg_legacy_session):
 
 
 def test_boundary_tolerates_weekends(pg_legacy_session):
-    # 2022-05-25 is a Wednesday; shift edges a couple of sessions — still covered.
-    days = [date(2022, 5, 27), date(2024, 1, 2), date(2026, 6, 10)]
-    _seed_prices(pg_legacy_session, "NEARWE", days)
-    # window end on a Saturday; last bar 2 trading days earlier still counts.
+    # Dense bars whose edges sit a couple of sessions inside a weekend-bounded
+    # window — within boundary tolerance, so still covered.
+    _seed_dense(pg_legacy_session, "NEARWE", date(2022, 5, 27), date(2026, 6, 10))
+    # window start/end on weekend days; nearest bars a session or two in count.
     need = select_symbols_needing_backfill(
         ["NEARWE"], date(2022, 5, 23), date(2026, 6, 13)
     )
@@ -252,8 +311,8 @@ def _seed_cohort(session, symbols: list[str], data_date: date) -> None:
 def test_cohort_coverage_reports_missing(pg_legacy_session):
     as_of = date(2026, 6, 12)
     _seed_cohort(pg_legacy_session, ["COVD", "GAPS"], as_of)
-    # COVD spans the window; GAPS has only a recent sliver.
-    _seed_prices(pg_legacy_session, "COVD", [WINDOW_START, as_of])
+    # COVD spans the window densely; GAPS has only a recent sliver.
+    _seed_dense(pg_legacy_session, "COVD", WINDOW_START, as_of)
     _seed_prices(pg_legacy_session, "GAPS", [as_of])
     pg_legacy_session.expire_all()
     missing = assert_cohort_coverage(WINDOW_START, as_of, as_of=as_of)
@@ -263,7 +322,7 @@ def test_cohort_coverage_reports_missing(pg_legacy_session):
 def test_cohort_coverage_all_covered_empty(pg_legacy_session):
     as_of = date(2026, 6, 12)
     _seed_cohort(pg_legacy_session, ["COVD"], as_of)
-    _seed_prices(pg_legacy_session, "COVD", [WINDOW_START, as_of])
+    _seed_dense(pg_legacy_session, "COVD", WINDOW_START, as_of)
     pg_legacy_session.expire_all()
     assert assert_cohort_coverage(WINDOW_START, as_of, as_of=as_of) == []
 

--- a/tests/test_paper/test_ingest_coverage.py
+++ b/tests/test_paper/test_ingest_coverage.py
@@ -231,11 +231,12 @@ def test_split_history_is_refetched(pg_legacy_session):
 
 def test_late_entrant_covered_from_first_ranking_date(pg_legacy_session):
     # A symbol whose FIRST top100 ranking is well after the global window start
-    # (a recent IPO). It has dense bars from that date onward but none before —
-    # it must be COVERED, not flagged, because the sweep evaluates it only from
+    # (a recent IPO) and still ranked through today. Dense bars from that date
+    # onward, none before — COVERED, because the sweep evaluates it only from
     # when it appears in rankings (codex P1). Pre-listing sessions are not gaps.
     first_ranked = date(2025, 1, 6)
-    _seed_cohort(pg_legacy_session, ["IPONEW"], first_ranked)
+    _seed_cohort(pg_legacy_session, ["IPONEW"], WINDOW_END)  # still current
+    _seed_ranking(pg_legacy_session, "IPONEW", first_ranked)
     _seed_dense(pg_legacy_session, "IPONEW", first_ranked, WINDOW_END)
     pg_legacy_session.expire_all()
     need = select_symbols_needing_backfill(["IPONEW"], WINDOW_START, WINDOW_END)
@@ -243,16 +244,46 @@ def test_late_entrant_covered_from_first_ranking_date(pg_legacy_session):
 
 
 def test_late_entrant_with_gap_after_listing_is_refetched(pg_legacy_session):
-    # Same late entrant, but a multi-month hole AFTER its first ranking → still
-    # flagged (the per-symbol left boundary doesn't excuse gaps within its
-    # ranked life).
+    # A late entrant still ranked through today (first 2024-01-03, last = today's
+    # cohort) with a multi-month hole AFTER its first ranking → still flagged
+    # (the per-symbol boundaries don't excuse gaps WITHIN its ranked life).
     first_ranked = date(2024, 1, 3)
-    _seed_cohort(pg_legacy_session, ["IPOGAP"], first_ranked)
+    _seed_cohort(pg_legacy_session, ["IPOGAP"], WINDOW_END)  # still current
+    _seed_ranking(pg_legacy_session, "IPOGAP", first_ranked)
     _seed_dense(pg_legacy_session, "IPOGAP", first_ranked, date(2024, 3, 1))
     _seed_dense(pg_legacy_session, "IPOGAP", date(2025, 6, 2), WINDOW_END)
     pg_legacy_session.expire_all()
     need = select_symbols_needing_backfill(["IPOGAP"], WINDOW_START, WINDOW_END)
     assert "IPOGAP" in need
+
+
+def test_former_member_covered_through_last_ranking_date(pg_legacy_session):
+    # A former constituent that stopped trading after its last ranking date
+    # (delist/rename). It has dense bars from its first to its LAST ranking but
+    # none through today — it must be COVERED, because the sweep consumes it only
+    # through that last ranking date (codex P1). Requiring bars through today
+    # would flag it forever.
+    first_ranked = date(2022, 6, 1)
+    last_ranked = date(2024, 6, 3)
+    _seed_ranking(pg_legacy_session, "GONE", first_ranked)
+    _seed_ranking(pg_legacy_session, "GONE", last_ranked)
+    _seed_dense(pg_legacy_session, "GONE", first_ranked, last_ranked)
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["GONE"], WINDOW_START, WINDOW_END)
+    assert "GONE" not in need
+
+
+def test_former_member_with_gap_before_last_ranking_is_refetched(pg_legacy_session):
+    # Same former member but a hole BEFORE its last ranking → still flagged.
+    first_ranked = date(2022, 6, 1)
+    last_ranked = date(2024, 6, 3)
+    _seed_ranking(pg_legacy_session, "GONEGAP", first_ranked)
+    _seed_ranking(pg_legacy_session, "GONEGAP", last_ranked)
+    _seed_dense(pg_legacy_session, "GONEGAP", first_ranked, date(2022, 9, 1))
+    _seed_dense(pg_legacy_session, "GONEGAP", date(2024, 1, 2), last_ranked)
+    pg_legacy_session.expire_all()
+    need = select_symbols_needing_backfill(["GONEGAP"], WINDOW_START, WINDOW_END)
+    assert "GONEGAP" in need
 
 
 def test_brand_new_symbol_with_no_bars_is_refetched(pg_legacy_session):


### PR DESCRIPTION
## Price-coverage backfill — re-fetch present-but-incomplete symbols

`db backfill-prices` decided what to fetch with a **presence** check (any `StockPrice` row `>= start`), so a symbol with a thin recent sliver (e.g. AMZN: 40 rows from 2026-03-03) passed the check and its 2022-2025 history (most of the sweep window) was never fetched. The miss-sweep then couldn't evaluate ~15% of the cohort.

This makes the fetch decision **coverage-based**: a symbol is covered only if its usable (non-NULL OHLC) bars span the sweep window at both ends with no large interior hole. Per-symbol gaps are surfaced loudly (`yf_batch_dropped_symbols`) and a post-run gate fails (non-zero exit) on any current-cohort shortfall.

### Coverage-semantics decisions resolved (operator, 2026-06-17)

After 15 codex rounds oscillated on three windowing semantics, the operator settled them as product calls (see `docs/TASK-PLAN-p1-cleanup-price-coverag-18ff.md` → "Resolved coverage-semantics decisions"):

1. **Universe = top100 only** (the miss-sweep consumer; bottom100 short-backtest out of scope).
2. **end_date anchor = `prev_session(today)`** (intraday-safe; lags one session after close).
3. **Unlimited-hold GATE right-edge = `min(end_date, last_traded_session, last_ranking + N)`**, with N (`COVERAGE_FORWARD_TAIL_SESSIONS`) a **HARD CAP**, not a floor. Positions held beyond N sessions are intentionally not coverage-required (bounded fetch cost). This PR lands decision 3's previously-missing `last_traded` cap so a delisted former member is not asked for post-delist bars it can never have (no perpetual gate failure). Decisions 1 & 2 already held at the prior PR tip.

The `last_traded` cap is encoded as `min(window_end, last_ranking+N, max(last_ranking, last_traded))` so it never shrinks below `last_ranking`: a live stale-tail symbol stays flagged; an interior hole before the last ranking stays caught.

### Architecture (sound, kept)
- Coverage = uniform max-consecutive-missing-trading-session scan over the window (edges + interior), NOT presence/row-count. NULL-OHLC filtered. Read/write canonicalized to 00:00 UTC. COALESCE upsert repairs placeholders idempotently.
- `clamp_to_ranking_life` decouples **SELECTION** (default False — fetch generously over the full window incl. 180d pre-signal lookback) from **GATE** (True — clamp to ranked life so IPO/delisted names don't fail forever). SELECTION is the gap detector; GATE is the don't-fail-forever guard.

### Reviews
- **codex** (rounds 1-7 this finalization, 13 fix iterations across the full PR): PASS. Every residual codex P0/P1 is a re-litigation of the 3 settled operator decisions — **wontfix per operator decision 2026-06-17**: floor-vs-cap ("don't cap the tail at N" = decision-3-rejected through-end_date), universe ("backfill bottom100 / scope gate to rank≤20" — the gate serves the full top100 miss-sweep, not `run_qu100_portfolio_backtest`), and the 180d lookback (fetched by SELECTION scope). No genuinely-new correctness/security/concurrency finding.
- **/review** (gstack skill): PASS. Adversarial subagent surfaced the precise boundary of decision 3's `last_traded` cap (offline it can't distinguish a true delisting from a live former member with a tail fetch-gap). Resolved as decision 3's **documented trade-off** (operator chose cap-at-last-traded), mitigated by the SELECTION/GATE decoupling: SELECTION re-flags the tail-gapped live case every run so the fetch loop self-heals it idempotently; only a true delisting stays capped. Documented in the cap comment + pinned by `test_gate_tail_gap_former_member_accepted_but_selection_self_heals`.

### Tests added this finalization
- `test_gate_delisted_before_tail_is_covered_through_last_traded` (TDD-red on parent: delisted name was perpetually flagged)
- `test_gate_former_member_not_required_past_tail` (N is a cap)
- `test_gate_right_edge_never_exceeds_end_date`
- `test_gate_live_symbol_stale_tail_still_flagged` (cap safety)
- `test_gate_tail_gap_former_member_accepted_but_selection_self_heals` (SELECTION/GATE decoupling pin)

### Test plan
- [x] 47 coverage tests + 434 `test_paper`/`test_portfolio`/`test_backtest` green on a throwaway PG DB (never the live local DB — MEMORY P0)
- [x] `ruff check src/ tests/` clean
- [x] Decision-3 bug-fix test fails red on the parent commit
- [x] codex + /review to no-new-P0/P1

Deferred [P2]/wontfix-per-operator-decision-2026-06-17: floor-vs-cap (decision 3 — N is a hard cap), universe top100-only (decision 1), 180d pre-signal lookback (fetched by SELECTION scope).

https://claude.ai/code/session_01WN4L5YzH9nNTsGzy1vpCbj