### PR TITLE
feat: tdd-green — backfill historical screened_stocks pattern levels

### DIFF
--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -5948,8 +5948,11 @@ def db_backfill_screened_levels(from_date: str, to_date: str, apply: bool) -> No
     row's stored type, and coalesce-upserts entry/stop/target/rr (fills NULL only,
     never clobbers a set value). Dry-run by default; pass `--apply` to write.
 
-    Rows whose stored pattern does not re-detect as-of are LEFT NULL and reported
-    in `still-NULL` — never given wrong-pattern levels.
+    Only `close`-session rows are repaired: the replay uses the completed daily
+    bar, which matches what the live screen saw only at close (earlier sessions
+    that day lacked the final high/low/close). Non-close patterned-NULL rows, and
+    rows whose stored pattern does not re-detect as-of, are LEFT NULL and reported
+    in `still-NULL` — never given look-ahead or wrong-pattern levels.
     """
     from datetime import date as _date
 

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -5978,75 +5978,95 @@ def db_backfill_screened_levels(ctx, from_date: str, to_date: str, apply: bool) 
     # DB session + persist_screened_stocks target THAT database (not the default
     # config/settings.yaml), and (b) pass its stock_screener as the replay config
     # so the reconstruction uses the operator-pinned (historical) detector knobs.
+    #
+    # These are PROCESS globals. Snapshot them and RESTORE in finally (codex P2):
+    # an in-process caller (CliRunner / programmatic reuse) must not have its later
+    # commands silently inherit this backfill's --config DB. Without restore, the
+    # next get_settings()/get_session() in the same interpreter would read/write
+    # the wrong database.
+    _prev_settings = _config_mod._settings
+    _prev_engine = _database_mod._engine
+    _prev_factory = _database_mod._session_factory
+
     settings = load_settings_fresh(_settings_path(ctx))
     _config_mod._settings = settings  # seed singleton before any get_session()
-    # Reset the cached legacy engine/session factory so they REBUILD against the
-    # just-seeded settings (codex P3). Seeding _settings alone is insufficient if
-    # a session was already opened earlier in the same process (programmatic reuse
-    # / tests): get_session() would keep the stale module-level _engine pointed at
-    # the old DB. Clearing them forces a fresh bind to the --config database.
+    # Reset the cached legacy engine/session factory so they REBIND against the
+    # just-seeded settings. Seeding _settings alone is insufficient if a session
+    # was already opened earlier in the same process — get_session() would keep the
+    # stale module-level _engine pointed at the old DB.
     _database_mod._engine = None
     _database_mod._session_factory = None
 
-    # Operator-facing validation failures (a bad date string, from>to, or --apply
-    # on a pre-0012 DB) must surface as a clean Click error, not a raw traceback
-    # that looks like the command crashed.
     try:
-        start = _date.fromisoformat(from_date)
-        end = _date.fromisoformat(to_date)
-    except ValueError as exc:
-        raise click.BadParameter(f"dates must be YYYY-MM-DD: {exc}") from exc
+        # Operator-facing validation failures (a bad date string, from>to, or
+        # --apply on a pre-0012 DB) must surface as a clean Click error, not a raw
+        # traceback that looks like the command crashed.
+        try:
+            start = _date.fromisoformat(from_date)
+            end = _date.fromisoformat(to_date)
+        except ValueError as exc:
+            raise click.BadParameter(f"dates must be YYYY-MM-DD: {exc}") from exc
 
-    try:
-        result = backfill_screened_levels(
-            from_date=start,
-            to_date=end,
-            apply=apply,
-            config=settings.stock_screener,
-        )
-    except (ValueError, RuntimeError) as exc:
-        # ValueError: from_date > to_date. RuntimeError: --apply preflight on a
-        # pre-0012 DB (the message already names migration 0012).
-        raise click.ClickException(str(exc)) from exc
+        try:
+            result = backfill_screened_levels(
+                from_date=start,
+                to_date=end,
+                apply=apply,
+                config=settings.stock_screener,
+            )
+        except (ValueError, RuntimeError) as exc:
+            # ValueError: from_date > to_date. RuntimeError: --apply preflight on a
+            # pre-0012 DB (the message already names migration 0012).
+            raise click.ClickException(str(exc)) from exc
 
-    mode = "APPLY" if apply else "DRY-RUN"
-    click.echo(
-        f"backfill-screened-levels [{mode}] {start}..{end}: "
-        f"scanned={result.scanned} recovered={result.recovered} "
-        f"still_null={result.still_null} "
-        f"no_price_data={result.no_price_data} "
-        f"detector_errors={result.detector_errors} "
-        f"skipped_non_close={result.skipped_non_close}"
-    )
-    if result.still_null_keys:
+        mode = "APPLY" if apply else "DRY-RUN"
         click.echo(
-            f"  still-NULL ({result.still_null} rows, had prices but no as-of "
-            "pattern matched the stored type — permanent, re-run won't help):"
+            f"backfill-screened-levels [{mode}] {start}..{end}: "
+            f"scanned={result.scanned} recovered={result.recovered} "
+            f"still_null={result.still_null} "
+            f"no_price_data={result.no_price_data} "
+            f"detector_errors={result.detector_errors} "
+            f"skipped_non_close={result.skipped_non_close}"
         )
-        for symbol, scan_date in result.still_null_keys:
-            click.echo(f"    {symbol} {scan_date}")
-    if result.no_price_data_keys:
-        click.echo(
-            f"  no-price-data ({result.no_price_data} rows, yfinance returned no "
-            "bars even after solo retry — TRANSIENT, re-run may recover these):"
-        )
-        for symbol, scan_date in result.no_price_data_keys:
-            click.echo(f"    {symbol} {scan_date}")
-    if result.detector_error_keys:
-        click.echo(
-            f"  detector-errors ({result.detector_errors} rows, the detector "
-            "raised — NOT a permanent no-match; a data re-pull or code fix may "
-            "recover these; see logs for tracebacks):"
-        )
-        for symbol, scan_date in result.detector_error_keys:
-            click.echo(f"    {symbol} {scan_date}")
-    if result.skipped_non_close:
-        click.echo(
-            f"  skipped-non-close ({result.skipped_non_close} rows): non-close "
-            "patterned-NULL rows are NOT repairable (look-ahead) and remain NULL."
-        )
-    if not apply and result.recovered:
-        click.echo("  (dry-run — re-run with --apply to write the recovered levels)")
+        if result.still_null_keys:
+            click.echo(
+                f"  still-NULL ({result.still_null} rows, had prices but no as-of "
+                "pattern matched the stored type — permanent, re-run won't help):"
+            )
+            for symbol, scan_date in result.still_null_keys:
+                click.echo(f"    {symbol} {scan_date}")
+        if result.no_price_data_keys:
+            click.echo(
+                f"  no-price-data ({result.no_price_data} rows, yfinance returned "
+                "no bars even after solo retry — TRANSIENT, re-run may recover):"
+            )
+            for symbol, scan_date in result.no_price_data_keys:
+                click.echo(f"    {symbol} {scan_date}")
+        if result.detector_error_keys:
+            click.echo(
+                f"  detector-errors ({result.detector_errors} rows, the detector "
+                "raised — NOT a permanent no-match; a data re-pull or code fix may "
+                "recover these; see logs for tracebacks):"
+            )
+            for symbol, scan_date in result.detector_error_keys:
+                click.echo(f"    {symbol} {scan_date}")
+        if result.skipped_non_close:
+            click.echo(
+                f"  skipped-non-close ({result.skipped_non_close} rows): non-close "
+                "patterned-NULL rows are NOT repairable (look-ahead) and remain NULL."
+            )
+        if not apply and result.recovered:
+            click.echo(
+                "  (dry-run — re-run with --apply to write the recovered levels)"
+            )
+    finally:
+        # Restore the process globals so a later in-process command uses its own
+        # root --config, not this backfill's. Dispose the engine we (re)built.
+        if _database_mod._engine is not None:
+            _database_mod._engine.dispose()
+        _config_mod._settings = _prev_settings
+        _database_mod._engine = _prev_engine
+        _database_mod._session_factory = _prev_factory
 
 
 # ---------------------------------------------------------------------------

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -5970,11 +5970,22 @@ def db_backfill_screened_levels(from_date: str, to_date: str, apply: bool) -> No
         f"backfill-screened-levels [{mode}] {start}..{end}: "
         f"scanned={result.scanned} recovered={result.recovered} "
         f"still_null={result.still_null} "
+        f"no_price_data={result.no_price_data} "
         f"skipped_non_close={result.skipped_non_close}"
     )
     if result.still_null_keys:
-        click.echo(f"  still-NULL ({result.still_null} rows, no as-of pattern match):")
+        click.echo(
+            f"  still-NULL ({result.still_null} rows, had prices but no as-of "
+            "pattern matched the stored type — permanent, re-run won't help):"
+        )
         for symbol, scan_date in result.still_null_keys:
+            click.echo(f"    {symbol} {scan_date}")
+    if result.no_price_data_keys:
+        click.echo(
+            f"  no-price-data ({result.no_price_data} rows, yfinance returned no "
+            "bars even after solo retry — TRANSIENT, re-run may recover these):"
+        )
+        for symbol, scan_date in result.no_price_data_keys:
             click.echo(f"    {symbol} {scan_date}")
     if result.skipped_non_close:
         click.echo(

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -5971,6 +5971,7 @@ def db_backfill_screened_levels(from_date: str, to_date: str, apply: bool) -> No
         f"scanned={result.scanned} recovered={result.recovered} "
         f"still_null={result.still_null} "
         f"no_price_data={result.no_price_data} "
+        f"detector_errors={result.detector_errors} "
         f"skipped_non_close={result.skipped_non_close}"
     )
     if result.still_null_keys:
@@ -5986,6 +5987,14 @@ def db_backfill_screened_levels(from_date: str, to_date: str, apply: bool) -> No
             "bars even after solo retry — TRANSIENT, re-run may recover these):"
         )
         for symbol, scan_date in result.no_price_data_keys:
+            click.echo(f"    {symbol} {scan_date}")
+    if result.detector_error_keys:
+        click.echo(
+            f"  detector-errors ({result.detector_errors} rows, the detector "
+            "raised — NOT a permanent no-match; a data re-pull or code fix may "
+            "recover these; see logs for tracebacks):"
+        )
+        for symbol, scan_date in result.detector_error_keys:
             click.echo(f"    {symbol} {scan_date}")
     if result.skipped_non_close:
         click.echo(

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -5969,6 +5969,7 @@ def db_backfill_screened_levels(ctx, from_date: str, to_date: str, apply: bool) 
     from datetime import date as _date
 
     from rainier.core import config as _config_mod
+    from rainier.core import database as _database_mod
     from rainier.core.config import load_settings_fresh
     from rainier.paper.backfill_screened_levels import backfill_screened_levels
 
@@ -5979,6 +5980,13 @@ def db_backfill_screened_levels(ctx, from_date: str, to_date: str, apply: bool) 
     # so the reconstruction uses the operator-pinned (historical) detector knobs.
     settings = load_settings_fresh(_settings_path(ctx))
     _config_mod._settings = settings  # seed singleton before any get_session()
+    # Reset the cached legacy engine/session factory so they REBUILD against the
+    # just-seeded settings (codex P3). Seeding _settings alone is insufficient if
+    # a session was already opened earlier in the same process (programmatic reuse
+    # / tests): get_session() would keep the stale module-level _engine pointed at
+    # the old DB. Clearing them forces a fresh bind to the --config database.
+    _database_mod._engine = None
+    _database_mod._session_factory = None
 
     # Operator-facing validation failures (a bad date string, from>to, or --apply
     # on a pre-0012 DB) must surface as a clean Click error, not a raw traceback

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -5940,7 +5940,8 @@ def db_verify_coverage(
     is_flag=True,
     help="Write the recovered levels. Omit for a dry-run (report only).",
 )
-def db_backfill_screened_levels(from_date: str, to_date: str, apply: bool) -> None:
+@click.pass_context
+def db_backfill_screened_levels(ctx, from_date: str, to_date: str, apply: bool) -> None:
     """One-time backfill of NULL screened_stocks trade levels (historical repair).
 
     Replays the pattern detector as-of each historical scan_date over a fresh
@@ -5950,6 +5951,15 @@ def db_backfill_screened_levels(from_date: str, to_date: str, apply: bool) -> No
     entry/stop/target/rr (fills NULL only, never clobbers a set value). Dry-run by
     default; pass `--apply` to write.
 
+    Honors the root `--config` for BOTH the target database AND the detector knobs
+    used in the replay. Because this reconstructs HISTORICAL screen output, point
+    `--config` at the settings YAML whose `stock_screener` section matches what the
+    live screen ran on those dates (e.g. `rainier --config config/settings.yaml db
+    backfill-screened-levels ...`). If detector thresholds (swing_lookback,
+    neckline_tolerance_pct, min_daily_bars, ...) were tuned after the scan window,
+    a default config would replay with TODAY's knobs and write levels the live
+    screen never produced — so pin the historical config.
+
     Only `close`-session rows are repaired: the replay uses the completed daily
     bar, which matches what the live screen saw only at close (earlier sessions
     that day lacked the final high/low/close). Non-close patterned-NULL rows, and
@@ -5958,7 +5968,17 @@ def db_backfill_screened_levels(from_date: str, to_date: str, apply: bool) -> No
     """
     from datetime import date as _date
 
+    from rainier.core import config as _config_mod
+    from rainier.core.config import load_settings_fresh
     from rainier.paper.backfill_screened_levels import backfill_screened_levels
+
+    # Honor the root `--config` (codex P1). load_settings_fresh reads the YAML the
+    # operator selected; we (a) seed the process settings singleton so the legacy
+    # DB session + persist_screened_stocks target THAT database (not the default
+    # config/settings.yaml), and (b) pass its stock_screener as the replay config
+    # so the reconstruction uses the operator-pinned (historical) detector knobs.
+    settings = load_settings_fresh(_settings_path(ctx))
+    _config_mod._settings = settings  # seed singleton before any get_session()
 
     # Operator-facing validation failures (a bad date string, from>to, or --apply
     # on a pre-0012 DB) must surface as a clean Click error, not a raw traceback
@@ -5970,7 +5990,12 @@ def db_backfill_screened_levels(from_date: str, to_date: str, apply: bool) -> No
         raise click.BadParameter(f"dates must be YYYY-MM-DD: {exc}") from exc
 
     try:
-        result = backfill_screened_levels(from_date=start, to_date=end, apply=apply)
+        result = backfill_screened_levels(
+            from_date=start,
+            to_date=end,
+            apply=apply,
+            config=settings.stock_screener,
+        )
     except (ValueError, RuntimeError) as exc:
         # ValueError: from_date > to_date. RuntimeError: --apply preflight on a
         # pre-0012 DB (the message already names migration 0012).

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -5943,10 +5943,12 @@ def db_verify_coverage(
 def db_backfill_screened_levels(from_date: str, to_date: str, apply: bool) -> None:
     """One-time backfill of NULL screened_stocks trade levels (historical repair).
 
-    Replays the pattern detector as-of each historical scan_date over stored
-    `stock_prices`, matches the actionable pattern whose `pattern_type` equals the
-    row's stored type, and coalesce-upserts entry/stop/target/rr (fills NULL only,
-    never clobbers a set value). Dry-run by default; pass `--apply` to write.
+    Replays the pattern detector as-of each historical scan_date over a fresh
+    yfinance 6-month window (the source the live screener used — the stored
+    `stock_prices` corpus is too short to form a pattern), matches the actionable
+    pattern whose `pattern_type` equals the row's stored type, and coalesce-upserts
+    entry/stop/target/rr (fills NULL only, never clobbers a set value). Dry-run by
+    default; pass `--apply` to write.
 
     Only `close`-session rows are repaired: the replay uses the completed daily
     bar, which matches what the live screen saw only at close (earlier sessions

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -5960,10 +5960,21 @@ def db_backfill_screened_levels(from_date: str, to_date: str, apply: bool) -> No
 
     from rainier.paper.backfill_screened_levels import backfill_screened_levels
 
-    start = _date.fromisoformat(from_date)
-    end = _date.fromisoformat(to_date)
+    # Operator-facing validation failures (a bad date string, from>to, or --apply
+    # on a pre-0012 DB) must surface as a clean Click error, not a raw traceback
+    # that looks like the command crashed.
+    try:
+        start = _date.fromisoformat(from_date)
+        end = _date.fromisoformat(to_date)
+    except ValueError as exc:
+        raise click.BadParameter(f"dates must be YYYY-MM-DD: {exc}") from exc
 
-    result = backfill_screened_levels(from_date=start, to_date=end, apply=apply)
+    try:
+        result = backfill_screened_levels(from_date=start, to_date=end, apply=apply)
+    except (ValueError, RuntimeError) as exc:
+        # ValueError: from_date > to_date. RuntimeError: --apply preflight on a
+        # pre-0012 DB (the message already names migration 0012).
+        raise click.ClickException(str(exc)) from exc
 
     mode = "APPLY" if apply else "DRY-RUN"
     click.echo(

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -5932,6 +5932,48 @@ def db_verify_coverage(
     )
 
 
+@db.command("backfill-screened-levels")
+@click.option("--from", "from_date", required=True, help="Inclusive start scan_date (YYYY-MM-DD).")
+@click.option("--to", "to_date", required=True, help="Inclusive end scan_date (YYYY-MM-DD).")
+@click.option(
+    "--apply",
+    is_flag=True,
+    help="Write the recovered levels. Omit for a dry-run (report only).",
+)
+def db_backfill_screened_levels(from_date: str, to_date: str, apply: bool) -> None:
+    """One-time backfill of NULL screened_stocks trade levels (historical repair).
+
+    Replays the pattern detector as-of each historical scan_date over stored
+    `stock_prices`, matches the actionable pattern whose `pattern_type` equals the
+    row's stored type, and coalesce-upserts entry/stop/target/rr (fills NULL only,
+    never clobbers a set value). Dry-run by default; pass `--apply` to write.
+
+    Rows whose stored pattern does not re-detect as-of are LEFT NULL and reported
+    in `still-NULL` — never given wrong-pattern levels.
+    """
+    from datetime import date as _date
+
+    from rainier.paper.backfill_screened_levels import backfill_screened_levels
+
+    start = _date.fromisoformat(from_date)
+    end = _date.fromisoformat(to_date)
+
+    result = backfill_screened_levels(from_date=start, to_date=end, apply=apply)
+
+    mode = "APPLY" if apply else "DRY-RUN"
+    click.echo(
+        f"backfill-screened-levels [{mode}] {start}..{end}: "
+        f"scanned={result.scanned} recovered={result.recovered} "
+        f"still_null={result.still_null}"
+    )
+    if result.still_null_keys:
+        click.echo(f"  still-NULL ({result.still_null} rows, no as-of pattern match):")
+        for symbol, scan_date in result.still_null_keys:
+            click.echo(f"    {symbol} {scan_date}")
+    if not apply and result.recovered:
+        click.echo("  (dry-run — re-run with --apply to write the recovered levels)")
+
+
 # ---------------------------------------------------------------------------
 # money-flow-neon-backup-b613: nightly off-machine backup of the irreplaceable
 # money_flow_snapshots into Neon (durability). Local TimescaleDB stays primary;

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -5967,12 +5967,18 @@ def db_backfill_screened_levels(from_date: str, to_date: str, apply: bool) -> No
     click.echo(
         f"backfill-screened-levels [{mode}] {start}..{end}: "
         f"scanned={result.scanned} recovered={result.recovered} "
-        f"still_null={result.still_null}"
+        f"still_null={result.still_null} "
+        f"skipped_non_close={result.skipped_non_close}"
     )
     if result.still_null_keys:
         click.echo(f"  still-NULL ({result.still_null} rows, no as-of pattern match):")
         for symbol, scan_date in result.still_null_keys:
             click.echo(f"    {symbol} {scan_date}")
+    if result.skipped_non_close:
+        click.echo(
+            f"  skipped-non-close ({result.skipped_non_close} rows): non-close "
+            "patterned-NULL rows are NOT repairable (look-ahead) and remain NULL."
+        )
     if not apply and result.recovered:
         click.echo("  (dry-run — re-run with --apply to write the recovered levels)")
 

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -82,6 +82,7 @@ scheduled job — a historical repair.
 
 from __future__ import annotations
 
+import enum
 import logging
 from dataclasses import dataclass, field
 from datetime import date, timedelta
@@ -145,18 +146,20 @@ class BackfillResult:
         window) that the replay attempted to recover.
     ``recovered`` — rows whose stored pattern_type matched an as-of actionable
         pattern (levels written when ``apply`` is True; would-be-written on dry-run).
-    ``still_null`` — target rows where an as-of price window EXISTED but NO
-        actionable pattern matched the stored type / the detector raised (left
-        NULL and reported; never errored). This is a PERMANENT no-match: a re-run
-        produces the same result, so the operator can stop chasing these.
+    ``still_null`` — target rows where a real as-of window EXISTED (the exact
+        scan_date bar was present) but NO actionable pattern matched the stored
+        type / the detector raised (left NULL and reported; never errored). This
+        is a PERMANENT no-match: a re-run over the same bars produces the same
+        result, so the operator can stop chasing these.
     ``still_null_keys`` — the (symbol, scan_date) of each still-NULL (no-match) row.
-    ``no_price_data`` — target rows whose symbol returned NO usable yfinance bars
-        even after the per-symbol solo retry (throttle / outage / delisting), so
-        the replay could not run AT ALL. Distinct from ``still_null``: this is a
-        TRANSIENT/recoverable failure — a re-run once the fetch succeeds may
-        recover the row, so the operator should retry rather than treat it as
-        permanently unreconstructable. Kept separate so a fetch blip is never
-        silently mislabeled as a permanent no-pattern-match.
+    ``no_price_data`` — target rows the replay could not run on because the as-of
+        bars were unavailable: the symbol returned NO usable yfinance bars even
+        after the per-symbol solo retry (throttle / outage / delisting), OR the
+        fetched frame was missing the EXACT scan_date bar (a vendor gap for just
+        the as-of day). Distinct from ``still_null``: this is a TRANSIENT failure
+        — a re-run once the fetch supplies the bar may recover the row, so the
+        operator should retry rather than treat it as permanently unreconstructable.
+        Kept separate so a fetch blip is never silently mislabeled a no-match.
     ``no_price_data_keys`` — the (symbol, scan_date) of each no-price-data row.
     ``skipped_non_close`` — patterned level-NULL rows in the window from a
         non-``close`` session. These are NOT reconstructable without look-ahead
@@ -444,29 +447,54 @@ def _as_of_idx(df: pd.DataFrame, scan_date: date) -> int | None:
     return int(hits[-1])
 
 
+class _Outcome(enum.Enum):
+    """How a single row's as-of replay resolved.
+
+    ``RECOVERED`` — an actionable pattern matched the stored type (levels found).
+    ``NO_AS_OF_DATA`` — TRANSIENT/recoverable: the symbol had no usable bars, or
+        the fetch returned a frame that lacks the EXACT scan_date bar (a vendor gap
+        for just the as-of day). A later fetch can fill the gap, so the operator
+        should re-run rather than treat the row as permanently lost.
+    ``NO_MATCH`` — PERMANENT: a real as-of window existed (the scan_date bar was
+        present) but no actionable pattern matched the stored type, or the detector
+        raised. Re-running over the same bars produces the same result.
+    """
+
+    RECOVERED = "recovered"
+    NO_AS_OF_DATA = "no_as_of_data"
+    NO_MATCH = "no_match"
+
+
 def _match_for_row(
     row: _TargetRow,
     df: pd.DataFrame | None,
     config: StockScreenerConfig,
-) -> PatternSignal | None:
-    """Replay the detector as-of ``row.scan_date`` and return the matching pattern.
+) -> tuple[_Outcome, PatternSignal | None]:
+    """Replay the detector as-of ``row.scan_date`` and classify the result.
 
-    Returns None when prices are missing, NO bar exists EXACTLY ON scan_date (a
-    yfinance gap — never replay the prior day's stale bar; see ``_as_of_idx``), no
-    as-of actionable pattern has the row's stored ``pattern_type``, OR the
-    detector raises on this symbol's window. A per-row detector failure is
-    per-symbol noise (one bad price window must not abort a multi-day repair) —
-    ``screen_stocks`` treats it the same way (stock_screener.py:86-89). The row
-    is left NULL and reported in still-NULL, never errored.
+    Returns ``(outcome, pattern)``. ``pattern`` is non-None only for
+    ``RECOVERED``. The outcome separates a TRANSIENT data gap
+    (``NO_AS_OF_DATA`` — no usable bars, or the fetch lacks the exact scan_date
+    bar; never replay the prior day's stale bar, see ``_as_of_idx``) from a
+    PERMANENT ``NO_MATCH`` (a real as-of window existed but no actionable pattern
+    matched the stored type, OR the detector raised). The caller buckets the two
+    differently so the operator knows which rows a re-run can still recover.
+
+    A per-row detector failure is per-symbol noise (one bad price window must not
+    abort a multi-day repair) — ``screen_stocks`` treats it the same way
+    (stock_screener.py:86-89). It is classified ``NO_MATCH`` (the bar existed; the
+    detector, not the data, is what failed) and reported, never errored.
     """
     if df is None or df.empty:
-        return None
+        return _Outcome.NO_AS_OF_DATA, None
     t_idx = _as_of_idx(df, row.scan_date)
     if t_idx is None:
-        return None
+        # Frame present but missing the exact scan_date bar — a vendor gap for
+        # just the as-of day. Transient: a later fetch may supply it.
+        return _Outcome.NO_AS_OF_DATA, None
     windowed = window_as_of(df, t_idx)
     if windowed.empty:
-        return None
+        return _Outcome.NO_AS_OF_DATA, None
     try:
         actionable, _ = replay_pattern_layer(row.symbol, windowed, config)
     except Exception:
@@ -476,8 +504,11 @@ def _match_for_row(
             row.scan_date,
             row.pattern_type,
         )
-        return None
-    return _match_pattern(actionable, row.pattern_type)
+        return _Outcome.NO_MATCH, None
+    pat = _match_pattern(actionable, row.pattern_type)
+    if pat is None:
+        return _Outcome.NO_MATCH, None
+    return _Outcome.RECOVERED, pat
 
 
 def _candidate_with_levels(
@@ -604,15 +635,15 @@ def backfill_screened_levels(
     # yfinance, and ``persist_screened_stocks`` manages its own session.
     candidates_by_key: dict[tuple[date, str], list[StockCandidate]] = {}
     for row in rows:
-        df = prices.get(row.symbol)
+        # _match_for_row classifies into three mutually-exclusive outcomes. The
+        # split between NO_AS_OF_DATA (TRANSIENT: symbol had no bars OR the fetch
+        # lacks the exact scan_date bar — a re-run may recover it) and NO_MATCH
+        # (PERMANENT: a real as-of window existed but no actionable pattern matched
+        # the stored type) keeps a fetch blip from masquerading as a permanent
+        # no-match, so the operator never marks a recoverable row unreconstructable.
+        outcome, matched = _match_for_row(row, prices.get(row.symbol), config)
 
-        # Distinguish "the fetch returned NO bars for this symbol" (transient /
-        # recoverable: throttle, outage, delisting — a re-run may recover it)
-        # from "we HAD a price window but no actionable pattern matched the stored
-        # type" (permanent no-match — re-running changes nothing). Conflating them
-        # would let a fetch blip during the apply run masquerade as a permanent
-        # no-match, so the operator marks a recoverable row unreconstructable.
-        if df is None or df.empty:
+        if outcome is _Outcome.NO_AS_OF_DATA:
             result.no_price_data += 1
             result.no_price_data_keys.append((row.symbol, row.scan_date))
             log.info(
@@ -623,9 +654,7 @@ def backfill_screened_levels(
             )
             continue
 
-        matched = _match_for_row(row, df, config)
-
-        if matched is None:
+        if outcome is _Outcome.NO_MATCH:
             result.still_null += 1
             result.still_null_keys.append((row.symbol, row.scan_date))
             log.info(
@@ -637,7 +666,7 @@ def backfill_screened_levels(
             continue
 
         result.recovered += 1
-        if apply:
+        if apply and matched is not None:
             cand = _candidate_with_levels(row, matched)
             candidates_by_key.setdefault(
                 (row.scan_date, row.session_name), []

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -148,6 +148,28 @@ def _as_of_idx(df: pd.DataFrame, scan_date: date) -> int | None:
     return int(hits[-1])
 
 
+def _match_for_row(
+    row: ScreenedStockRecord,
+    df: pd.DataFrame | None,
+    config: StockScreenerConfig,
+) -> PatternSignal | None:
+    """Replay the detector as-of ``row.scan_date`` and return the matching pattern.
+
+    Returns None when prices are missing, no bar exists on/before scan_date, or no
+    as-of actionable pattern has the row's stored ``pattern_type``.
+    """
+    if df is None or df.empty:
+        return None
+    t_idx = _as_of_idx(df, row.scan_date)
+    if t_idx is None:
+        return None
+    windowed = window_as_of(df, t_idx)
+    if windowed.empty:
+        return None
+    actionable, _ = replay_pattern_layer(row.symbol, windowed, config)
+    return _match_pattern(actionable, row.pattern_type)
+
+
 def _candidate_with_levels(
     row: ScreenedStockRecord, pat: PatternSignal
 ) -> StockCandidate:
@@ -218,17 +240,7 @@ def backfill_screened_levels(
 
         candidates_by_key: dict[tuple[date, str], list[StockCandidate]] = {}
         for row in rows:
-            df = prices.get(row.symbol)
-            matched: PatternSignal | None = None
-            if df is not None and not df.empty:
-                t_idx = _as_of_idx(df, row.scan_date)
-                if t_idx is not None:
-                    windowed = window_as_of(df, t_idx)
-                    if not windowed.empty:
-                        actionable, _ = replay_pattern_layer(
-                            row.symbol, windowed, config
-                        )
-                        matched = _match_pattern(actionable, row.pattern_type)
+            matched = _match_for_row(row, prices.get(row.symbol), config)
 
             if matched is None:
                 result.still_null += 1

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -89,7 +89,7 @@ from datetime import date, timedelta
 
 import pandas as pd
 import yfinance as yf
-from sqlalchemy import func, select, text
+from sqlalchemy import func, or_, select, text
 from sqlalchemy.orm import Session
 
 from rainier.core.config import StockScreenerConfig, get_settings
@@ -207,6 +207,15 @@ def _target_rows(
     ``_BACKFILLABLE_SESSION``). Deterministic order (symbol, scan_date) so a
     re-run scans the corpus identically and logs are diff-stable.
 
+    Target predicate (codex P2): ``pattern_type NOT NULL`` AND ANY of the four
+    trade levels NULL — NOT only ``entry_price IS NULL``. A prior PARTIAL write
+    could have set ``entry_price`` while leaving ``stop_loss`` / ``target_price`` /
+    ``rr_ratio`` NULL; downstream paper-trade creation treats any missing level as
+    ``missing_levels``, so an entry-only predicate would skip those broken rows
+    forever. ``persist_screened_stocks`` coalesce-upserts each level independently
+    (fills NULL only, never clobbers a set value), so re-running the matched
+    pattern over a partially-set row safely fills just the still-NULL fields.
+
     Column-scoped (NOT a full-ORM load): selecting only the columns this repair
     touches keeps an unrelated missing column (e.g. ``bearish_invalidation_level``
     on a DB without migration 0012) from crashing the read. See ``_TargetRow``.
@@ -225,7 +234,12 @@ def _target_rows(
             ScreenedStockRecord.scan_date <= to_date,
             ScreenedStockRecord.session_name == _BACKFILLABLE_SESSION,
             ScreenedStockRecord.pattern_type.isnot(None),
-            ScreenedStockRecord.entry_price.is_(None),
+            or_(
+                ScreenedStockRecord.entry_price.is_(None),
+                ScreenedStockRecord.stop_loss.is_(None),
+                ScreenedStockRecord.target_price.is_(None),
+                ScreenedStockRecord.rr_ratio.is_(None),
+            ),
         )
         .order_by(
             ScreenedStockRecord.symbol.asc(),

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -62,7 +62,7 @@ from dataclasses import dataclass, field
 from datetime import date
 
 import pandas as pd
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.orm import Session
 
 from rainier.core.config import StockScreenerConfig, get_settings
@@ -211,6 +211,36 @@ def _count_non_close_null(
     return int(session.execute(stmt).scalar_one())
 
 
+# The level column migration 0005 added (entry_price etc.) plus the 0012 column
+# the write path's upsert names. The READ path is column-scoped so a missing
+# 0012 column can't crash a dry-run (see ``_TargetRow``); the WRITE path goes
+# through ``persist_screened_stocks``, whose ``INSERT ... ON CONFLICT`` references
+# ``bearish_invalidation_level`` directly. On a pre-0012 DB that write aborts with
+# an opaque ``UndefinedColumn`` mid-repair. ``--apply`` preflights for the column
+# so the operator gets a clear "apply migration 0012 first" message instead.
+_APPLY_REQUIRED_COLUMN = "bearish_invalidation_level"
+
+
+def _apply_column_present(session: Session) -> bool:
+    """True iff ``screened_stocks.bearish_invalidation_level`` exists on this DB.
+
+    ``to_regclass`` resolves ``screened_stocks`` on the session's search_path, so
+    the catalog lookup targets the same table the write path would hit (not a
+    same-named table in another schema). ``NOT attisdropped`` excludes a
+    logically-dropped column. The write path's upsert references this column; a
+    pre-0012 DB lacks it, so ``--apply`` must refuse before attempting the write.
+    """
+    row = session.execute(
+        text(
+            "SELECT 1 FROM pg_attribute "
+            "WHERE attrelid = to_regclass('screened_stocks') "
+            "AND attname = :c AND NOT attisdropped"
+        ),
+        {"c": _APPLY_REQUIRED_COLUMN},
+    ).first()
+    return row is not None
+
+
 def _match_pattern(
     actionable: list[PatternSignal], stored_type: str
 ) -> PatternSignal | None:
@@ -337,6 +367,22 @@ def backfill_screened_levels(
     result = BackfillResult()
 
     with get_session() as session:
+        # Preflight the WRITE path against schema drift BEFORE any scan work.
+        # ``persist_screened_stocks`` upserts ``bearish_invalidation_level`` (added
+        # by migration 0012); on a pre-0012 DB that write aborts with an opaque
+        # ``UndefinedColumn`` AFTER a full replay. A dry-run on the same drifted DB
+        # succeeds (column-scoped read) and tells the operator to re-run with
+        # ``--apply`` — so without this guard ``--apply`` would crash mid-repair.
+        # Fail fast with a clear, actionable message instead. (Dry-run never
+        # writes, so it stays runnable on the drifted DB for diagnosis.)
+        if apply and not _apply_column_present(session):
+            raise RuntimeError(
+                "Cannot --apply: screened_stocks is missing the "
+                f"{_APPLY_REQUIRED_COLUMN!r} column (migration 0012 not applied). "
+                "Apply migration 0012 (migrations/0012_reclaim_queue.sql) first, "
+                "then re-run with --apply. Dry-run (without --apply) works without it."
+            )
+
         # Damaged non-close rows are not repairable (look-ahead) but ARE still
         # damaged — count them first so the report surfaces them even when there
         # are zero repairable close rows (a dry-run must never look complete

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -80,6 +80,29 @@ from rainier.paper.pattern_replay import (
 log = logging.getLogger(__name__)
 
 
+@dataclass(slots=True, frozen=True)
+class _TargetRow:
+    """The subset of ``screened_stocks`` columns this repair actually touches.
+
+    We deliberately do NOT load the full ORM ``ScreenedStockRecord``. A full-row
+    load emits ``SELECT *`` over every mapped column — including
+    ``bearish_invalidation_level`` (added by migration 0012). On a legacy DB
+    where 0012 was never applied, that column is missing and the read crashes
+    with ``UndefinedColumn`` even though this repair never reads it. Selecting
+    only the columns we use makes an unrelated missing column unable to crash the
+    command. Columns: the filter/identity set (``scan_date``, ``session_name``,
+    ``symbol``, ``entry_price``, ``pattern_type``) plus the two the upsert
+    placeholder carries (``sector``, ``composite_score``).
+    """
+
+    symbol: str
+    scan_date: date
+    session_name: str
+    pattern_type: str | None
+    sector: str | None
+    composite_score: float
+
+
 @dataclass(slots=True)
 class BackfillResult:
     """Counts from one backfill run (dry-run or applied).
@@ -120,15 +143,26 @@ _BACKFILLABLE_SESSION = "close"
 
 def _target_rows(
     session: Session, from_date: date, to_date: date
-) -> list[ScreenedStockRecord]:
+) -> list[_TargetRow]:
     """``close``-session, patterned, level-NULL rows in ``[from_date, to_date]``.
 
     Only ``close``-session rows are reconstructable without look-ahead (see
     ``_BACKFILLABLE_SESSION``). Deterministic order (symbol, scan_date) so a
     re-run scans the corpus identically and logs are diff-stable.
+
+    Column-scoped (NOT a full-ORM load): selecting only the columns this repair
+    touches keeps an unrelated missing column (e.g. ``bearish_invalidation_level``
+    on a DB without migration 0012) from crashing the read. See ``_TargetRow``.
     """
     stmt = (
-        select(ScreenedStockRecord)
+        select(
+            ScreenedStockRecord.symbol,
+            ScreenedStockRecord.scan_date,
+            ScreenedStockRecord.session_name,
+            ScreenedStockRecord.pattern_type,
+            ScreenedStockRecord.sector,
+            ScreenedStockRecord.composite_score,
+        )
         .where(
             ScreenedStockRecord.scan_date >= from_date,
             ScreenedStockRecord.scan_date <= to_date,
@@ -141,7 +175,17 @@ def _target_rows(
             ScreenedStockRecord.scan_date.asc(),
         )
     )
-    return list(session.execute(stmt).scalars().all())
+    return [
+        _TargetRow(
+            symbol=r.symbol,
+            scan_date=r.scan_date,
+            session_name=r.session_name,
+            pattern_type=r.pattern_type,
+            sector=r.sector,
+            composite_score=r.composite_score,
+        )
+        for r in session.execute(stmt).all()
+    ]
 
 
 def _count_non_close_null(
@@ -207,7 +251,7 @@ def _as_of_idx(df: pd.DataFrame, scan_date: date) -> int | None:
 
 
 def _match_for_row(
-    row: ScreenedStockRecord,
+    row: _TargetRow,
     df: pd.DataFrame | None,
     config: StockScreenerConfig,
 ) -> PatternSignal | None:
@@ -242,7 +286,7 @@ def _match_for_row(
 
 
 def _candidate_with_levels(
-    row: ScreenedStockRecord, pat: PatternSignal
+    row: _TargetRow, pat: PatternSignal
 ) -> StockCandidate:
     """Minimal StockCandidate carrying ONLY the four levels to backfill.
 

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -161,6 +161,12 @@ class BackfillResult:
         operator should retry rather than treat it as permanently unreconstructable.
         Kept separate so a fetch blip is never silently mislabeled a no-match.
     ``no_price_data_keys`` — the (symbol, scan_date) of each no-price-data row.
+    ``detector_errors`` — target rows where the detector RAISED on the as-of
+        window (malformed vendor data / a detector bug). Surfaced separately from
+        ``still_null`` because they are NOT a proven-permanent no-match — a data
+        re-pull or a code fix may recover them. The run never aborts on these
+        (per-symbol fault isolation).
+    ``detector_error_keys`` — the (symbol, scan_date) of each detector-error row.
     ``skipped_non_close`` — patterned level-NULL rows in the window from a
         non-``close`` session. These are NOT reconstructable without look-ahead
         (see ``_BACKFILLABLE_SESSION``) so they are excluded from the target set,
@@ -174,6 +180,8 @@ class BackfillResult:
     still_null_keys: list[tuple[str, date]] = field(default_factory=list)
     no_price_data: int = 0
     no_price_data_keys: list[tuple[str, date]] = field(default_factory=list)
+    detector_errors: int = 0
+    detector_error_keys: list[tuple[str, date]] = field(default_factory=list)
     skipped_non_close: int = 0
 
 
@@ -491,13 +499,19 @@ class _Outcome(enum.Enum):
         for just the as-of day). A later fetch can fill the gap, so the operator
         should re-run rather than treat the row as permanently lost.
     ``NO_MATCH`` — PERMANENT: a real as-of window existed (the scan_date bar was
-        present) but no actionable pattern matched the stored type, or the detector
-        raised. Re-running over the same bars produces the same result.
+        present) and the detector ran clean, but no actionable pattern matched the
+        stored type. Re-running over the same bars produces the same result.
+    ``DETECTOR_ERROR`` — the detector RAISED on this row's window (malformed vendor
+        data or a detector bug). Unlike ``NO_MATCH`` this is NOT proven permanent:
+        a data re-pull or a detector fix may recover it, so it gets its own bucket
+        rather than being reported as a permanent no-match. The run never aborts on
+        it (per-symbol fault isolation, matching ``screen_stocks``).
     """
 
     RECOVERED = "recovered"
     NO_AS_OF_DATA = "no_as_of_data"
     NO_MATCH = "no_match"
+    DETECTOR_ERROR = "detector_error"
 
 
 def _match_for_row(
@@ -508,17 +522,17 @@ def _match_for_row(
     """Replay the detector as-of ``row.scan_date`` and classify the result.
 
     Returns ``(outcome, pattern)``. ``pattern`` is non-None only for
-    ``RECOVERED``. The outcome separates a TRANSIENT data gap
+    ``RECOVERED``. The outcome distinguishes a TRANSIENT data gap
     (``NO_AS_OF_DATA`` — no usable bars, or the fetch lacks the exact scan_date
-    bar; never replay the prior day's stale bar, see ``_as_of_idx``) from a
-    PERMANENT ``NO_MATCH`` (a real as-of window existed but no actionable pattern
-    matched the stored type, OR the detector raised). The caller buckets the two
-    differently so the operator knows which rows a re-run can still recover.
+    bar; never replay the prior day's stale bar, see ``_as_of_idx``), a PERMANENT
+    ``NO_MATCH`` (a real as-of window existed, the detector ran clean, but no
+    actionable pattern matched the stored type), and a ``DETECTOR_ERROR`` (the
+    detector raised — not proven permanent, a data/code fix may recover it). The
+    caller buckets all three so the operator knows which rows a re-run can recover.
 
     A per-row detector failure is per-symbol noise (one bad price window must not
     abort a multi-day repair) — ``screen_stocks`` treats it the same way
-    (stock_screener.py:86-89). It is classified ``NO_MATCH`` (the bar existed; the
-    detector, not the data, is what failed) and reported, never errored.
+    (stock_screener.py:86-89). It is reported in its own bucket, never errored.
     """
     if df is None or df.empty:
         return _Outcome.NO_AS_OF_DATA, None
@@ -539,7 +553,10 @@ def _match_for_row(
             row.scan_date,
             row.pattern_type,
         )
-        return _Outcome.NO_MATCH, None
+        # The bar existed; the DETECTOR failed. Not a proven-permanent no-match —
+        # a malformed-data re-pull or a detector fix may recover it, so keep it
+        # out of still_null (which the CLI labels "re-run won't help").
+        return _Outcome.DETECTOR_ERROR, None
     pat = _match_pattern(actionable, row.pattern_type)
     if pat is None:
         return _Outcome.NO_MATCH, None
@@ -689,6 +706,12 @@ def backfill_screened_levels(
             )
             continue
 
+        if outcome is _Outcome.DETECTOR_ERROR:
+            result.detector_errors += 1
+            result.detector_error_keys.append((row.symbol, row.scan_date))
+            # Already logged with traceback in _match_for_row.
+            continue
+
         if outcome is _Outcome.NO_MATCH:
             result.still_null += 1
             result.still_null_keys.append((row.symbol, row.scan_date))
@@ -713,11 +736,12 @@ def backfill_screened_levels(
 
     log.info(
         "backfill_screened_levels done scanned=%d recovered=%d still_null=%d "
-        "no_price_data=%d apply=%s",
+        "no_price_data=%d detector_errors=%d apply=%s",
         result.scanned,
         result.recovered,
         result.still_null,
         result.no_price_data,
+        result.detector_errors,
         apply,
     )
     return result

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -15,16 +15,24 @@ This is a one-time DATA backfill, not a code fix.
 
 THE FIX (idempotent, dry-run by default)
 -----------------------------------------
-For each ``screened_stocks`` row in ``[from_date, to_date]`` with
-``pattern_type NOT NULL AND entry_price IS NULL``:
+For each ``close``-session ``screened_stocks`` row in ``[from_date, to_date]``
+with ``pattern_type NOT NULL AND entry_price IS NULL``:
 
     replay the pattern detector AS-OF the row's scan_date over stored prices
       (reuse paper.pattern_replay.replay_pattern_layer — no look-ahead)
-    among the as-of ACTIONABLE patterns, pick the one whose pattern_type ==
-      the row's stored pattern_type  (NOT necessarily replay's top-ranked
-      `best` — a matching pattern may rank lower).  If NONE matches, leave the
-      row NULL and report it in still-NULL — never write wrong-pattern levels.
+    among the as-of ACTIONABLE patterns (in _filter_actionable priority order),
+      pick the FIRST whose pattern_type == the row's stored pattern_type — the
+      same selection the live screener uses for `best_pattern` (NOT necessarily
+      replay's top-ranked `best`, since a matching pattern may rank lower; and
+      NOT a confidence re-sort). If NONE matches, leave the row NULL and report
+      it in still-NULL — never write wrong-pattern levels.
     coalesce-upsert the four levels via persist_screened_stocks (fills NULL only)
+
+Only ``close``-session rows are reconstructable without look-ahead: the replay
+reads the COMPLETED daily ``stock_prices`` bar for scan_date, which equals what
+the live screen saw only at the close session (earlier sessions that day did not
+yet have the day's final high/low/close). Non-``close`` patterned-NULL rows are
+deliberately left NULL — see ``_BACKFILLABLE_SESSION``.
 
     ASCII flow (one row):
 
@@ -34,8 +42,8 @@ For each ``screened_stocks`` row in ``[from_date, to_date]`` with
       load stock_prices[symbol] ── window AS-OF d ──► replay_pattern_layer
             │
             ▼
-      actionable patterns ── filter pattern_type == T ── tie-break (conf, then
-            entry) ──► matched pattern.{entry, stop, target_wave1, rr_ratio}
+      actionable patterns (priority order) ── FIRST with pattern_type == T
+            ──► matched pattern.{entry, stop, target_wave1, rr_ratio}
             │
             ▼  (apply only)
       persist_screened_stocks(coalesce upsert) ── fills the NULL levels
@@ -90,26 +98,40 @@ class BackfillResult:
     still_null_keys: list[tuple[str, date]] = field(default_factory=list)
 
 
+# The replay reconstructs levels from the COMPLETED daily ``stock_prices`` bar
+# for ``scan_date``. The live screener runs the SAME ``yf.download(period="6mo")``
+# daily fetch for every session (morning/midday/afternoon/close), but only at the
+# ``close`` session is the completed EOD bar the one the live screen actually saw.
+# For an earlier session that day, the stored EOD bar carries the day's final
+# high/low/close that were NOT yet available — replaying it would inject
+# look-ahead and write levels the original intraday screen never produced. So we
+# only backfill ``close``-session rows (faithful by construction); patterned-NULL
+# rows from other sessions are left NULL rather than given look-ahead levels
+# (worse-to-write-wrong-than-leave-NULL, per the task's fidelity gate).
+_BACKFILLABLE_SESSION = "close"
+
+
 def _target_rows(
     session: Session, from_date: date, to_date: date
 ) -> list[ScreenedStockRecord]:
-    """Patterned + level-NULL rows in ``[from_date, to_date]`` (inclusive).
+    """``close``-session, patterned, level-NULL rows in ``[from_date, to_date]``.
 
-    Deterministic order (symbol, scan_date, session_name) so a re-run scans the
-    corpus identically and logs are diff-stable.
+    Only ``close``-session rows are reconstructable without look-ahead (see
+    ``_BACKFILLABLE_SESSION``). Deterministic order (symbol, scan_date) so a
+    re-run scans the corpus identically and logs are diff-stable.
     """
     stmt = (
         select(ScreenedStockRecord)
         .where(
             ScreenedStockRecord.scan_date >= from_date,
             ScreenedStockRecord.scan_date <= to_date,
+            ScreenedStockRecord.session_name == _BACKFILLABLE_SESSION,
             ScreenedStockRecord.pattern_type.isnot(None),
             ScreenedStockRecord.entry_price.is_(None),
         )
         .order_by(
             ScreenedStockRecord.symbol.asc(),
             ScreenedStockRecord.scan_date.asc(),
-            ScreenedStockRecord.session_name.asc(),
         )
     )
     return list(session.execute(stmt).scalars().all())
@@ -120,15 +142,21 @@ def _match_pattern(
 ) -> PatternSignal | None:
     """Pick the actionable pattern whose type == ``stored_type``.
 
-    If several share the type, tie-break deterministically: highest confidence
-    first, then lowest entry_price (a stable numeric key) so the choice is
+    ``actionable`` arrives in ``_filter_actionable`` priority order (the same
+    order the live screener uses to pick ``best_pattern = actionable[0]``). When
+    several patterns share ``stored_type``, take the FIRST in that order — i.e.
+    the one the live screener would have written had that type been the day's
+    best. We deliberately do NOT re-sort by confidence: the live path writes
+    levels by actionability priority, not confidence (stock_screener.py:92-93,
+    "Best = first actionable (sorted by priority), not highest confidence"), so
+    re-sorting here could persist a different same-type setup than the original
+    screen. Iterating the already-sorted list preserves that priority and is
     reproducible across runs.
     """
-    matches = [p for p in actionable if p.pattern_type == stored_type]
-    if not matches:
-        return None
-    matches.sort(key=lambda p: (-p.confidence, p.entry_price))
-    return matches[0]
+    for p in actionable:
+        if p.pattern_type == stored_type:
+            return p
+    return None
 
 
 def _as_of_idx(df: pd.DataFrame, scan_date: date) -> int | None:

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -264,19 +264,33 @@ def _match_pattern(
 
 
 def _as_of_idx(df: pd.DataFrame, scan_date: date) -> int | None:
-    """Positional index of the last bar on/before ``scan_date``; None if none.
+    """Positional index of the bar EXACTLY ON ``scan_date``; None if absent.
 
-    The screener runs on the bars available as-of the scan, whose latest bar is
-    the most recent trading day on or before scan_date.
+    Fidelity gate: the live close-session screen ran on ``yf.download(period=…)``
+    whose LATEST bar is the scan_date bar (the day the screen executed). A
+    faithful replay therefore needs that exact bar as the window's last bar — its
+    high/low/close drive the reconstructed levels.
+
+    We deliberately do NOT fall back to the most-recent bar ON-OR-BEFORE
+    scan_date. If ``stock_prices`` has an ingest gap (or ``load_prices`` dropped a
+    partial bar) for the canonical scan_date, an on-or-before fallback would build
+    a window ending on the PRIOR trading day and replay stale prior-day levels —
+    writing entry/stop/target/rr that the original as-of-scan_date screen never
+    produced. That violates "faithful by construction": such a row must stay
+    ``still_null`` (reported, never given wrong-day levels), not be silently
+    recovered from the wrong bar. So require an EXACT scan_date match.
+
+    Compares on calendar date so a ``timestamptz`` index (tz-aware or naive) and a
+    midnight ``scan_date`` line up regardless of the bar's stored intraday time.
     """
-    cutoff = pd.Timestamp(scan_date)
-    if df.index.tz is not None:
-        cutoff = cutoff.tz_localize(df.index.tz)
-    mask = pd.Index(df.index <= cutoff).to_numpy()
-    hits = mask.nonzero()[0]
+    # df.index is the per-symbol price DatetimeIndex; map each bar to its calendar
+    # date and find the position whose date == scan_date. Close-session scan_dates
+    # are always trading days, so the canonical bar exists unless prices are gapped.
+    bar_dates = df.index.normalize().date  # ndarray[date]; tz-aware indices keep
+    hits = (bar_dates == scan_date).nonzero()[0]                       # local-date
     if hits.size == 0:
         return None
-    # positional index of the last bar on/before scan_date
+    # Exactly-one bar per trading day; take it (last guards any duplicate ingest).
     return int(hits[-1])
 
 
@@ -287,7 +301,8 @@ def _match_for_row(
 ) -> PatternSignal | None:
     """Replay the detector as-of ``row.scan_date`` and return the matching pattern.
 
-    Returns None when prices are missing, no bar exists on/before scan_date, no
+    Returns None when prices are missing, NO bar exists EXACTLY ON scan_date (an
+    ingest gap — never replay the prior day's stale bar; see ``_as_of_idx``), no
     as-of actionable pattern has the row's stored ``pattern_type``, OR the
     detector raises on this symbol's window. A per-row detector failure is
     per-symbol noise (one bad price window must not abort a multi-day repair) —

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -84,7 +84,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, timedelta
 
 import pandas as pd
 import yfinance as yf
@@ -145,9 +145,19 @@ class BackfillResult:
         window) that the replay attempted to recover.
     ``recovered`` — rows whose stored pattern_type matched an as-of actionable
         pattern (levels written when ``apply`` is True; would-be-written on dry-run).
-    ``still_null`` — target rows where NO actionable pattern matched the stored
-        type / the detector raised (left NULL and reported; never errored).
-    ``still_null_keys`` — the (symbol, scan_date) of each still-NULL row.
+    ``still_null`` — target rows where an as-of price window EXISTED but NO
+        actionable pattern matched the stored type / the detector raised (left
+        NULL and reported; never errored). This is a PERMANENT no-match: a re-run
+        produces the same result, so the operator can stop chasing these.
+    ``still_null_keys`` — the (symbol, scan_date) of each still-NULL (no-match) row.
+    ``no_price_data`` — target rows whose symbol returned NO usable yfinance bars
+        even after the per-symbol solo retry (throttle / outage / delisting), so
+        the replay could not run AT ALL. Distinct from ``still_null``: this is a
+        TRANSIENT/recoverable failure — a re-run once the fetch succeeds may
+        recover the row, so the operator should retry rather than treat it as
+        permanently unreconstructable. Kept separate so a fetch blip is never
+        silently mislabeled as a permanent no-pattern-match.
+    ``no_price_data_keys`` — the (symbol, scan_date) of each no-price-data row.
     ``skipped_non_close`` — patterned level-NULL rows in the window from a
         non-``close`` session. These are NOT reconstructable without look-ahead
         (see ``_BACKFILLABLE_SESSION``) so they are excluded from the target set,
@@ -159,6 +169,8 @@ class BackfillResult:
     recovered: int = 0
     still_null: int = 0
     still_null_keys: list[tuple[str, date]] = field(default_factory=list)
+    no_price_data: int = 0
+    no_price_data_keys: list[tuple[str, date]] = field(default_factory=list)
     skipped_non_close: int = 0
 
 
@@ -573,7 +585,17 @@ def backfill_screened_levels(
     fetch_start = (
         pd.Timestamp(earliest) - pd.DateOffset(months=_FETCH_START_LEAD_MONTHS)
     ).date()
-    fetch_end = date.today()  # noqa: DTZ011 — calendar day for a daily-bar fetch window
+    # Pin the fetch's right edge to to_date (the window's last scan_date), NOT
+    # date.today(). The repair never needs a bar past to_date — the as-of clip
+    # discards everything after each row's scan_date anyway. Pinning to to_date
+    # makes the corpus a pure function of [from_date, to_date], so a dry-run and a
+    # later --apply re-pull the SAME window (a wall-clock today would shift the
+    # right edge and the split/dividend basis between the two runs, so the
+    # previewed levels could differ from the applied ones). yfinance ``end`` is
+    # EXCLUSIVE, so add a day to keep the to_date bar in-window (mirrors
+    # paper.ingest's ``end + timedelta(days=1)``); _as_of_idx still requires the
+    # exact scan_date bar, so this only guarantees inclusion, never look-ahead.
+    fetch_end = to_date + timedelta(days=1)
     prices = _fetch_history(
         symbols, start=fetch_start, end=fetch_end, min_bars=config.min_daily_bars
     )
@@ -582,7 +604,26 @@ def backfill_screened_levels(
     # yfinance, and ``persist_screened_stocks`` manages its own session.
     candidates_by_key: dict[tuple[date, str], list[StockCandidate]] = {}
     for row in rows:
-        matched = _match_for_row(row, prices.get(row.symbol), config)
+        df = prices.get(row.symbol)
+
+        # Distinguish "the fetch returned NO bars for this symbol" (transient /
+        # recoverable: throttle, outage, delisting — a re-run may recover it)
+        # from "we HAD a price window but no actionable pattern matched the stored
+        # type" (permanent no-match — re-running changes nothing). Conflating them
+        # would let a fetch blip during the apply run masquerade as a permanent
+        # no-match, so the operator marks a recoverable row unreconstructable.
+        if df is None or df.empty:
+            result.no_price_data += 1
+            result.no_price_data_keys.append((row.symbol, row.scan_date))
+            log.info(
+                "backfill_no_price_data symbol=%s scan_date=%s pattern_type=%s",
+                row.symbol,
+                row.scan_date,
+                row.pattern_type,
+            )
+            continue
+
+        matched = _match_for_row(row, df, config)
 
         if matched is None:
             result.still_null += 1
@@ -607,10 +648,12 @@ def backfill_screened_levels(
             persist_screened_stocks(cands, scan_date, session_name)
 
     log.info(
-        "backfill_screened_levels done scanned=%d recovered=%d still_null=%d apply=%s",
+        "backfill_screened_levels done scanned=%d recovered=%d still_null=%d "
+        "no_price_data=%d apply=%s",
         result.scanned,
         result.recovered,
         result.still_null,
+        result.no_price_data,
         apply,
     )
     return result

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -544,6 +544,18 @@ def _match_for_row(
     windowed = window_as_of(df, t_idx)
     if windowed.empty:
         return _Outcome.NO_AS_OF_DATA, None
+    # Enforce min_daily_bars on the AS-OF-CLIPPED window, mirroring the live
+    # screener. The live path fetches period="6mo" ending at scan_date and applies
+    # min_daily_bars to THAT ~6-month frame (stock_screener._fetch_stock_data:436);
+    # our wider ~9-month fetch passes min_daily_bars at the fetch frame, but the
+    # detector only ever sees the clipped window. A ticker that reaches the floor
+    # only LATER in the range (a recent IPO/spinoff) would clear the fetch-frame
+    # check yet have a too-short as-of window — the live screen would have SKIPPED
+    # it on scan_date, so writing levels here fabricates a setup that never had
+    # enough history to be screened. Treat as NO_MATCH (permanent: the as-of
+    # window is fixed by scan_date + to_date, so a re-run can't lengthen it).
+    if len(windowed) < config.min_daily_bars:
+        return _Outcome.NO_MATCH, None
     try:
         actionable, _ = replay_pattern_layer(row.symbol, windowed, config)
     except Exception:

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -363,23 +363,58 @@ def _fetch_history(
             log.exception("yfinance download failed symbols=%s", syms)
             return None
 
-    def _extract(raw: pd.DataFrame | None, sym: str, batch_len: int) -> pd.DataFrame | None:
+    def _extract(
+        raw: pd.DataFrame | None, sym: str, *, solo: bool
+    ) -> pd.DataFrame | None:
+        """Pull ``sym``'s per-ticker OHLCV sub-frame out of a ``yf.download`` result.
+
+        ``group_by="ticker"`` makes a MULTI-symbol download a MultiIndex keyed
+        ``(ticker, field)`` — slice ``raw[sym]`` (None when the ticker was dropped
+        from the batch). A SOLO download (``solo=True`` — the one-symbol retry, or
+        a run with a single target symbol) is shape-inconsistent across yfinance
+        builds: it can come back FLAT (``Close``/...) OR still MultiIndex
+        (``(AAPL, Close)``). If we treated a solo MultiIndex like a batch and only
+        sliced by ``sym`` it would work, but yfinance can label the top level
+        differently than requested, so for a solo fetch we instead drop the single
+        top level to flat columns — otherwise every per-symbol retry silently
+        normalizes to None and is misclassified as no-data (codex [P1]).
+
+        ``solo`` is essential: a BATCH frame that happens to contain ONE ticker
+        must NOT be flattened for a DIFFERENT requested symbol (that symbol is
+        genuinely absent → None), or a batch miss would return the wrong ticker's
+        bars under the missing symbol's name.
+        """
         if raw is None or raw.empty:
             return None
         try:
-            df = raw.copy() if batch_len == 1 else raw[sym].copy()
+            if isinstance(raw.columns, pd.MultiIndex):
+                top = raw.columns.get_level_values(0)
+                if sym in top:
+                    df = raw[sym].copy()
+                elif solo and top.nunique() == 1:
+                    # Solo single-ticker MultiIndex (e.g. ('AAPL', 'Close')) whose
+                    # top level isn't our requested label — drop it to flat columns.
+                    df = raw.copy()
+                    df.columns = df.columns.get_level_values(-1)
+                else:
+                    return None  # genuinely absent from a batch frame
+            else:
+                df = raw.copy()
         except (KeyError, TypeError):
             return None
         return _normalize_symbol_frame(df, min_bars)
 
     out: dict[str, pd.DataFrame] = {}
     raw = _download(symbols)
+    # A single-symbol target set makes the batch download itself a solo fetch
+    # (yfinance may return it flat or MultiIndex) — flag it so _extract flattens.
+    batch_is_solo = len(symbols) == 1
     for sym in symbols:
-        df = _extract(raw, sym, len(symbols))
+        df = _extract(raw, sym, solo=batch_is_solo)
         if df is None:
             # Transient batch drop / failure: retry this symbol solo before
-            # treating it as no-data (a network blip must not become still-NULL).
-            df = _extract(_download([sym]), sym, 1)
+            # treating it as no-data (a network blip must not become no_price_data).
+            df = _extract(_download([sym]), sym, solo=True)
         if df is not None:
             out[sym] = df
     return out

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -280,14 +280,25 @@ def _as_of_idx(df: pd.DataFrame, scan_date: date) -> int | None:
     ``still_null`` (reported, never given wrong-day levels), not be silently
     recovered from the wrong bar. So require an EXACT scan_date match.
 
-    Compares on calendar date so a ``timestamptz`` index (tz-aware or naive) and a
-    midnight ``scan_date`` line up regardless of the bar's stored intraday time.
+    Compares on the bar's UTC calendar date so a ``timestamptz`` index lines up
+    with a ``scan_date`` regardless of the bar's stored intraday time AND the
+    Postgres session ``TimeZone`` GUC. ``stock_prices`` bars are written at the
+    canonical midnight-UTC instant; psycopg returns them in the session tz (which
+    is environment-dependent — the local TimescaleDB is NOT pinned to UTC). Taking
+    the date in the index's LOCAL tz would shift a midnight-UTC bar onto the prior
+    calendar day under any behind-UTC session (e.g. America/Los_Angeles) — every
+    bar would then mis-date and NO row would match its scan_date, silently turning
+    the whole repair into a 0-recovered no-op. So convert to UTC FIRST, mirroring
+    ``paper.ingest.normalize_to_trading_date`` (the codebase's read/write-symmetric
+    trading-date rule).
     """
-    # df.index is the per-symbol price DatetimeIndex; map each bar to its calendar
-    # date and find the position whose date == scan_date. Close-session scan_dates
-    # are always trading days, so the canonical bar exists unless prices are gapped.
-    bar_dates = df.index.normalize().date  # ndarray[date]; tz-aware indices keep
-    hits = (bar_dates == scan_date).nonzero()[0]                       # local-date
+    idx = df.index
+    # Convert to UTC before flooring to the calendar date. tz-aware → tz_convert;
+    # tz-naive (synthetic fixtures) → already a bare wall-clock, localize to UTC so
+    # a midnight stamp keeps its own date instead of being read in some other tz.
+    idx_utc = idx.tz_convert("UTC") if idx.tz is not None else idx.tz_localize("UTC")
+    bar_dates = idx_utc.normalize().date  # ndarray[date], UTC calendar date
+    hits = (bar_dates == scan_date).nonzero()[0]
     if hits.size == 0:
         return None
     # Exactly-one bar per trading day; take it (last guards any duplicate ingest).

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -267,6 +267,11 @@ def _count_non_close_null(
     These are excluded from the repair (not reconstructable without look-ahead)
     but are still damaged rows; counting them keeps a dry-run from looking
     complete while non-close NULLs remain.
+
+    Uses the SAME any-of-four-levels-NULL predicate as ``_target_rows`` (codex P2):
+    a partial-write non-close row (entry set, stop/target/rr NULL) is damaged too,
+    so an ``entry_price``-only count would let a dry-run claim the non-close
+    backlog is clear while broken partial rows remain.
     """
     stmt = (
         select(func.count())
@@ -276,7 +281,12 @@ def _count_non_close_null(
             ScreenedStockRecord.scan_date <= to_date,
             ScreenedStockRecord.session_name != _BACKFILLABLE_SESSION,
             ScreenedStockRecord.pattern_type.isnot(None),
-            ScreenedStockRecord.entry_price.is_(None),
+            or_(
+                ScreenedStockRecord.entry_price.is_(None),
+                ScreenedStockRecord.stop_loss.is_(None),
+                ScreenedStockRecord.target_price.is_(None),
+                ScreenedStockRecord.rr_ratio.is_(None),
+            ),
         )
     )
     return int(session.execute(stmt).scalar_one())

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -308,6 +308,13 @@ def _normalize_symbol_frame(
     too short. Kept byte-identical to the live screener so the replay sees the
     same corpus the live screen would have built (modulo vendor restatement —
     see the module docstring's fidelity caveat).
+
+    NOTE: the production call passes ``min_bars=1`` (drop only EMPTY frames). The
+    authoritative ``min_daily_bars`` gate is ``_match_for_row``, on the AS-OF-
+    CLIPPED window — so a genuine short-history row reaches the classifier and is
+    bucketed permanent ``still_null`` rather than going missing and being reported
+    transient ``no_price_data``. ``min_bars`` stays a parameter so the helper
+    remains independently testable at any floor.
     """
     try:
         df = df.dropna(subset=["Close"]).copy()
@@ -691,9 +698,15 @@ def backfill_screened_levels(
     # paper.ingest's ``end + timedelta(days=1)``); _as_of_idx still requires the
     # exact scan_date bar, so this only guarantees inclusion, never look-ahead.
     fetch_end = to_date + timedelta(days=1)
-    prices = _fetch_history(
-        symbols, start=fetch_start, end=fetch_end, min_bars=config.min_daily_bars
-    )
+    # Keep SHORT-but-nonempty frames (min_bars=1, drop only truly-empty ones).
+    # The authoritative min_daily_bars gate is _match_for_row, applied to the
+    # AS-OF-CLIPPED window. If we dropped a short frame here, a genuine
+    # insufficient-history row (an IPO/spinoff with < min_daily_bars by to_date)
+    # would go MISSING from `prices` and be bucketed no_price_data (TRANSIENT —
+    # "re-run may recover"), when it is actually a PERMANENT insufficient-history
+    # case. Letting the frame through routes it to _match_for_row, whose window
+    # check classifies it NO_MATCH (permanent). (codex P2)
+    prices = _fetch_history(symbols, start=fetch_start, end=fetch_end, min_bars=1)
 
     # Replay + persist run with NO open DB session: the prices come from
     # yfinance, and ``persist_screened_stocks`` manages its own session.

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -344,12 +344,27 @@ def _match_for_row(
 def _candidate_with_levels(
     row: _TargetRow, pat: PatternSignal
 ) -> StockCandidate:
-    """Minimal StockCandidate carrying ONLY the four levels to backfill.
+    """Minimal StockCandidate carrying the levels persist_screened_stocks fills.
 
     persist_screened_stocks coalesce-upserts the level columns and leaves the
     non-level columns untouched on conflict, so the other fields here are
     placeholders that never reach the existing row.
+
+    Levels carried: entry/stop/target/rr PLUS ``bearish_invalidation_level`` for an
+    exact ``false_breakout`` (the pattern's ``false_high`` key-point). The upsert
+    fills that column too, and ``paper.reclaim.detect_and_enqueue_reclaims`` filters
+    on ``bearish_invalidation_level IS NOT NULL`` (within its active ~20-day
+    window) — so leaving it NULL would silently make every repaired bearish-trap
+    row permanently invisible to reclaim, even though the live screener persists
+    it. Mirror the live derivation (``stock_screener.py``: false_breakout-only,
+    ``key_points['false_high']``, never ``stop_loss`` which sits a buffer above).
     """
+    bearish_invalidation_level: float | None = None
+    if pat.pattern_type == "false_breakout" and pat.key_points is not None:
+        false_high = pat.key_points.get("false_high")
+        if false_high is not None:
+            bearish_invalidation_level = float(false_high)
+
     return StockCandidate(
         symbol=row.symbol,
         rank=0,
@@ -363,6 +378,7 @@ def _candidate_with_levels(
         stop_loss=pat.stop_loss,
         target_price=pat.target_wave1,
         rr_ratio=pat.rr_ratio,
+        bearish_invalidation_level=bearish_invalidation_level,
     )
 
 

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -13,13 +13,37 @@ levels: the running scraper only picked up the level-writing code at the 06-15
 deploy. ``pattern_type`` IS recorded on those rows; entry/stop/target/rr are NULL.
 This is a one-time DATA backfill, not a code fix.
 
+PRICE SOURCE — yfinance, not ``stock_prices``
+---------------------------------------------
+The replay's prices come from a FRESH yfinance daily fetch (the same source the
+live screener used), NOT the local ``stock_prices`` table. ``stock_prices`` is
+truncated to ~9-33 bars/symbol — far too short for the detector, which needs the
+live screen's ~6-month (~124-bar) window to form swings, support/resistance, and
+multi-bar shapes. Replaying it over the stub produced ZERO actionable patterns
+for 96 of 117 close rows (a 21/510 recovery). Re-pointing to a yfinance 6-month
+as-of window recovers ~116/117 close rows. See ``_fetch_history``.
+
+Two fidelity caveats (NEITHER is look-ahead):
+
+* **Corporate-action / vendor restatement.** A fresh ``auto_adjust=True`` pull
+  re-applies every split/dividend that happened AFTER scan_date, so absolute OHLC
+  — and the entry/stop/target derived from it — can differ slightly from the
+  snapshot the original live screen saw. This is restatement of past bars, not
+  future data leaking in; the as-of clip still bars post-scan_date BARS from the
+  detector (``_as_of_idx`` + ``window_as_of``).
+* **~1% residual type-mismatch.** A re-pull is not bit-identical to the historical
+  screen's pull, so a tiny set of rows (~1/117, e.g. AMT 06-03) re-detects as a
+  NEIGHBORING pattern type. The type-match gate (``_match_pattern``) leaves those
+  NULL rather than write a different-type setup — the don't-guess invariant holds.
+
 THE FIX (idempotent, dry-run by default)
 -----------------------------------------
 For each ``close``-session ``screened_stocks`` row in ``[from_date, to_date]``
 with ``pattern_type NOT NULL AND entry_price IS NULL``:
 
-    replay the pattern detector AS-OF the row's scan_date over stored prices
-      (reuse paper.pattern_replay.replay_pattern_layer — no look-ahead)
+    replay the pattern detector AS-OF the row's scan_date over a fresh yfinance
+      6-month window (reuse paper.pattern_replay.replay_pattern_layer — no
+      look-ahead)
     among the as-of ACTIONABLE patterns (in _filter_actionable priority order),
       pick the FIRST whose pattern_type == the row's stored pattern_type — the
       same selection the live screener uses for `best_pattern` (NOT necessarily
@@ -29,17 +53,18 @@ with ``pattern_type NOT NULL AND entry_price IS NULL``:
     coalesce-upsert the four levels via persist_screened_stocks (fills NULL only)
 
 Only ``close``-session rows are reconstructable without look-ahead: the replay
-reads the COMPLETED daily ``stock_prices`` bar for scan_date, which equals what
-the live screen saw only at the close session (earlier sessions that day did not
-yet have the day's final high/low/close). Non-``close`` patterned-NULL rows are
-deliberately left NULL — see ``_BACKFILLABLE_SESSION``.
+reads the COMPLETED daily bar for scan_date (the last bar ``<= scan_date`` of the
+fresh 1d pull), which equals what the live screen saw only at the close session
+(earlier sessions that day did not yet have the day's final high/low/close).
+Non-``close`` patterned-NULL rows are deliberately left NULL — see
+``_BACKFILLABLE_SESSION``.
 
     ASCII flow (one row):
 
       screened_stocks row (pattern_type=T, levels NULL, scan_date=d)
             │
             ▼
-      load stock_prices[symbol] ── window AS-OF d ──► replay_pattern_layer
+      yfinance 6mo as-of d ── window AS-OF d ──► replay_pattern_layer
             │
             ▼
       actionable patterns (priority order) ── FIRST with pattern_type == T
@@ -62,6 +87,7 @@ from dataclasses import dataclass, field
 from datetime import date
 
 import pandas as pd
+import yfinance as yf
 from sqlalchemy import func, select, text
 from sqlalchemy.orm import Session
 
@@ -71,13 +97,21 @@ from rainier.core.models import ScreenedStockRecord
 from rainier.core.types import PatternSignal, StockCandidate
 from rainier.llm_thesis.persistence import persist_screened_stocks
 from rainier.paper.pattern_replay import (
-    LIVE_LOOKBACK_MONTHS,
-    load_prices,
     replay_pattern_layer,
     window_as_of,
 )
 
 log = logging.getLogger(__name__)
+
+# How far before the window's earliest scan_date to start the yfinance fetch.
+# The detector needs ~6 months of bars to form swings / S-R / multi-bar shapes
+# as-of each scan_date. period="6mo" ends TODAY, so for an early-June as-of date
+# its left edge would be cut short; an explicit ``start`` ~9 months before the
+# earliest scan_date guarantees a full ~6-month window even at the left edge
+# (the extra ~3 months absorbs holiday-heavy stretches). The fetch runs through
+# today; ``_as_of_idx`` + ``window_as_of`` clip to ``<= scan_date`` per row, so
+# post-scan_date bars never reach the detector (no look-ahead).
+_FETCH_START_LEAD_MONTHS = 9
 
 
 @dataclass(slots=True, frozen=True)
@@ -128,12 +162,12 @@ class BackfillResult:
     skipped_non_close: int = 0
 
 
-# The replay reconstructs levels from the COMPLETED daily ``stock_prices`` bar
-# for ``scan_date``. The live screener runs the SAME ``yf.download(period="6mo")``
-# daily fetch for every session (morning/midday/afternoon/close), but only at the
-# ``close`` session is the completed EOD bar the one the live screen actually saw.
-# For an earlier session that day, the stored EOD bar carries the day's final
-# high/low/close that were NOT yet available — replaying it would inject
+# The replay reconstructs levels from the COMPLETED daily bar for ``scan_date``
+# (the last bar ``<= scan_date`` of the fresh yfinance 1d pull). The live screener
+# ran the SAME daily fetch for every session (morning/midday/afternoon/close), but
+# only at the ``close`` session is that completed EOD bar the one the live screen
+# actually saw. For an earlier session that day, the EOD bar carries the day's
+# final high/low/close that were NOT yet available — replaying it would inject
 # look-ahead and write levels the original intraday screen never produced. So we
 # only backfill ``close``-session rows (faithful by construction); patterned-NULL
 # rows from other sessions are left NULL rather than given look-ahead levels
@@ -241,6 +275,101 @@ def _apply_column_present(session: Session) -> bool:
     return row is not None
 
 
+def _normalize_symbol_frame(
+    df: pd.DataFrame, min_bars: int
+) -> pd.DataFrame | None:
+    """Mirror ``stock_screener._fetch_stock_data``'s per-symbol normalization.
+
+    Drop rows missing a Close, skip a frame shorter than ``min_bars``, lowercase
+    the OHLCV columns. Returns the normalized frame or None when it is empty /
+    too short. Kept byte-identical to the live screener so the replay sees the
+    same corpus the live screen would have built (modulo vendor restatement —
+    see the module docstring's fidelity caveat).
+    """
+    try:
+        df = df.dropna(subset=["Close"]).copy()
+    except KeyError:
+        return None
+    if len(df) < min_bars:
+        return None
+    df.columns = [c.lower() for c in df.columns]
+    return df
+
+
+def _fetch_history(
+    symbols: list[str], *, start: date, end: date, min_bars: int
+) -> dict[str, pd.DataFrame]:
+    """Fetch daily OHLCV per symbol from yfinance, sliced ``[start, end]``.
+
+    Re-points the backfill's price corpus from the truncated ``stock_prices``
+    table (~9-33 bars/symbol — too short for the detector to form a pattern) to a
+    FRESH yfinance window, the same source the live screener uses. Returns a
+    ``{symbol: DataFrame}`` map with lowercase OHLCV columns and a tz-naive
+    DatetimeIndex — the exact shape ``_as_of_idx``/``window_as_of`` consume, so
+    everything downstream runs unchanged.
+
+    Mirrors ``stock_screener._fetch_stock_data`` (interval="1d",
+    group_by="ticker", per-symbol dropna+min_bars+lowercase) with two
+    deliberate differences:
+
+    * Explicit ``start``/``end`` instead of ``period="6mo"``. ``period`` ends
+      TODAY, so for an early-June as-of date its left edge would be cut short of
+      the ~6-month window the detector needs. The caller passes a ``start`` ~9
+      months before the earliest scan_date so even the left-edge row sees a full
+      window.
+    * ``auto_adjust=True`` pinned (the screener takes the yfinance default). This
+      matches how ``stock_prices`` was ingested (``paper/ingest.py``), keeping the
+      adjusted basis consistent. A fresh adjusted pull re-applies post-scan_date
+      splits/dividends, so absolute OHLC can differ slightly from the original
+      screen's snapshot — corporate-action restatement, NOT look-ahead (the as-of
+      clip still bars post-scan_date BARS from the detector).
+
+    Per-symbol retry: a single grouped batch download can transiently drop a
+    ticker (observed: LLY returned no data in a batch but 202 bars solo) or the
+    whole batch can raise. Any symbol missing from / too short in the batch is
+    re-fetched solo before being recorded as no-data, so a network blip is never
+    mislabeled still-NULL.
+    """
+    if not symbols:
+        return {}
+
+    def _download(syms: list[str]) -> pd.DataFrame | None:
+        try:
+            return yf.download(
+                syms,
+                start=start.isoformat(),
+                end=end.isoformat(),
+                interval="1d",
+                group_by="ticker",
+                auto_adjust=True,
+                progress=False,
+            )
+        except Exception:
+            log.exception("yfinance download failed symbols=%s", syms)
+            return None
+
+    def _extract(raw: pd.DataFrame | None, sym: str, batch_len: int) -> pd.DataFrame | None:
+        if raw is None or raw.empty:
+            return None
+        try:
+            df = raw.copy() if batch_len == 1 else raw[sym].copy()
+        except (KeyError, TypeError):
+            return None
+        return _normalize_symbol_frame(df, min_bars)
+
+    out: dict[str, pd.DataFrame] = {}
+    raw = _download(symbols)
+    for sym in symbols:
+        df = _extract(raw, sym, len(symbols))
+        if df is None:
+            # Transient batch drop / failure: retry this symbol solo before
+            # treating it as no-data (a network blip must not become still-NULL).
+            df = _extract(_download([sym]), sym, 1)
+        if df is not None:
+            out[sym] = df
+    return out
+
+
 def _match_pattern(
     actionable: list[PatternSignal], stored_type: str
 ) -> PatternSignal | None:
@@ -266,31 +395,29 @@ def _match_pattern(
 def _as_of_idx(df: pd.DataFrame, scan_date: date) -> int | None:
     """Positional index of the bar EXACTLY ON ``scan_date``; None if absent.
 
-    Fidelity gate: the live close-session screen ran on ``yf.download(period=…)``
+    Fidelity gate: the live close-session screen ran on a daily yfinance pull
     whose LATEST bar is the scan_date bar (the day the screen executed). A
     faithful replay therefore needs that exact bar as the window's last bar — its
     high/low/close drive the reconstructed levels.
 
     We deliberately do NOT fall back to the most-recent bar ON-OR-BEFORE
-    scan_date. If ``stock_prices`` has an ingest gap (or ``load_prices`` dropped a
-    partial bar) for the canonical scan_date, an on-or-before fallback would build
-    a window ending on the PRIOR trading day and replay stale prior-day levels —
-    writing entry/stop/target/rr that the original as-of-scan_date screen never
-    produced. That violates "faithful by construction": such a row must stay
-    ``still_null`` (reported, never given wrong-day levels), not be silently
-    recovered from the wrong bar. So require an EXACT scan_date match.
+    scan_date. If the yfinance pull has a gap (a delisting, a market holiday the
+    DateOffset over-shot, or a dropped bar) for the canonical scan_date, an
+    on-or-before fallback would build a window ending on the PRIOR trading day and
+    replay stale prior-day levels — writing entry/stop/target/rr that the original
+    as-of-scan_date screen never produced. That violates "faithful by
+    construction": such a row must stay ``still_null`` (reported, never given
+    wrong-day levels), not be silently recovered from the wrong bar. So require an
+    EXACT scan_date match.
 
-    Compares on the bar's UTC calendar date so a ``timestamptz`` index lines up
-    with a ``scan_date`` regardless of the bar's stored intraday time AND the
-    Postgres session ``TimeZone`` GUC. ``stock_prices`` bars are written at the
-    canonical midnight-UTC instant; psycopg returns them in the session tz (which
-    is environment-dependent — the local TimescaleDB is NOT pinned to UTC). Taking
-    the date in the index's LOCAL tz would shift a midnight-UTC bar onto the prior
-    calendar day under any behind-UTC session (e.g. America/Los_Angeles) — every
-    bar would then mis-date and NO row would match its scan_date, silently turning
-    the whole repair into a 0-recovered no-op. So convert to UTC FIRST, mirroring
-    ``paper.ingest.normalize_to_trading_date`` (the codebase's read/write-symmetric
-    trading-date rule).
+    Compares on the bar's UTC calendar date so the lookup is robust to whatever
+    tz the index carries. yfinance daily bars are tz-NAIVE wall-clock dates
+    (the common case here), which localize to UTC unchanged; but the same code
+    also handled the prior ``stock_prices`` source's tz-aware ``timestamptz``
+    index, where taking the LOCAL date under a behind-UTC session would shift a
+    midnight-UTC bar onto the prior calendar day and mis-match every row. Convert
+    to UTC FIRST either way, mirroring ``paper.ingest.normalize_to_trading_date``
+    (the codebase's read/write-symmetric trading-date rule).
     """
     idx = df.index
     # Convert to UTC before flooring to the calendar date. tz-aware → tz_convert;
@@ -312,8 +439,8 @@ def _match_for_row(
 ) -> PatternSignal | None:
     """Replay the detector as-of ``row.scan_date`` and return the matching pattern.
 
-    Returns None when prices are missing, NO bar exists EXACTLY ON scan_date (an
-    ingest gap — never replay the prior day's stale bar; see ``_as_of_idx``), no
+    Returns None when prices are missing, NO bar exists EXACTLY ON scan_date (a
+    yfinance gap — never replay the prior day's stale bar; see ``_as_of_idx``), no
     as-of actionable pattern has the row's stored ``pattern_type``, OR the
     detector raises on this symbol's window. A per-row detector failure is
     per-symbol noise (one bad price window must not abort a multi-day repair) —
@@ -436,46 +563,48 @@ def backfill_screened_levels(
         if not rows:
             return result
 
-        # Load prices once for the full symbol set, left-padded by the detector
-        # lookback so each as-of window still sees its full ~6-month history.
-        symbols = sorted({r.symbol for r in rows})
-        earliest = min(r.scan_date for r in rows)
-        # Left-pad by 2x the ~6-month detector lookback so the earliest as-of bar
-        # still sees its full window even across holiday-heavy stretches. The
-        # bound is tz-aware UTC: ``StockPrice.date`` is ``timestamptz``, so a
-        # naive bound would be interpreted in the Postgres session's TimeZone
-        # GUC (environment-dependent). Mirror pattern_audit's UTC construction.
-        start_date = pd.Timestamp(
-            (pd.Timestamp(earliest) - pd.DateOffset(months=2 * LIVE_LOOKBACK_MONTHS)).date(),
-            tz="UTC",
-        )
-        prices = load_prices(session, symbols, start_date=start_date)
+    # Fetch prices OUTSIDE the DB session: the corpus now comes from yfinance
+    # (the source the live screener used), not the truncated ``stock_prices``
+    # table. Load once for the full symbol set, started ~9 months before the
+    # earliest scan_date so each as-of window still sees its full ~6-month
+    # history, then sliced as-of per row by ``_as_of_idx``/``window_as_of``.
+    symbols = sorted({r.symbol for r in rows})
+    earliest = min(r.scan_date for r in rows)
+    fetch_start = (
+        pd.Timestamp(earliest) - pd.DateOffset(months=_FETCH_START_LEAD_MONTHS)
+    ).date()
+    fetch_end = date.today()  # noqa: DTZ011 — calendar day for a daily-bar fetch window
+    prices = _fetch_history(
+        symbols, start=fetch_start, end=fetch_end, min_bars=config.min_daily_bars
+    )
 
-        candidates_by_key: dict[tuple[date, str], list[StockCandidate]] = {}
-        for row in rows:
-            matched = _match_for_row(row, prices.get(row.symbol), config)
+    # Replay + persist run with NO open DB session: the prices come from
+    # yfinance, and ``persist_screened_stocks`` manages its own session.
+    candidates_by_key: dict[tuple[date, str], list[StockCandidate]] = {}
+    for row in rows:
+        matched = _match_for_row(row, prices.get(row.symbol), config)
 
-            if matched is None:
-                result.still_null += 1
-                result.still_null_keys.append((row.symbol, row.scan_date))
-                log.info(
-                    "backfill_still_null symbol=%s scan_date=%s pattern_type=%s",
-                    row.symbol,
-                    row.scan_date,
-                    row.pattern_type,
-                )
-                continue
+        if matched is None:
+            result.still_null += 1
+            result.still_null_keys.append((row.symbol, row.scan_date))
+            log.info(
+                "backfill_still_null symbol=%s scan_date=%s pattern_type=%s",
+                row.symbol,
+                row.scan_date,
+                row.pattern_type,
+            )
+            continue
 
-            result.recovered += 1
-            if apply:
-                cand = _candidate_with_levels(row, matched)
-                candidates_by_key.setdefault(
-                    (row.scan_date, row.session_name), []
-                ).append(cand)
+        result.recovered += 1
+        if apply:
+            cand = _candidate_with_levels(row, matched)
+            candidates_by_key.setdefault(
+                (row.scan_date, row.session_name), []
+            ).append(cand)
 
-        if apply and candidates_by_key:
-            for (scan_date, session_name), cands in candidates_by_key.items():
-                persist_screened_stocks(cands, scan_date, session_name)
+    if apply and candidates_by_key:
+        for (scan_date, session_name), cands in candidates_by_key.items():
+            persist_screened_stocks(cands, scan_date, session_name)
 
     log.info(
         "backfill_screened_levels done scanned=%d recovered=%d still_null=%d apply=%s",

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -232,9 +232,13 @@ def backfill_screened_levels(
         symbols = sorted({r.symbol for r in rows})
         earliest = min(r.scan_date for r in rows)
         # Left-pad by 2x the ~6-month detector lookback so the earliest as-of bar
-        # still sees its full window even across holiday-heavy stretches.
-        start_date = pd.Timestamp(earliest) - pd.DateOffset(
-            months=2 * LIVE_LOOKBACK_MONTHS
+        # still sees its full window even across holiday-heavy stretches. The
+        # bound is tz-aware UTC: ``StockPrice.date`` is ``timestamptz``, so a
+        # naive bound would be interpreted in the Postgres session's TimeZone
+        # GUC (environment-dependent). Mirror pattern_audit's UTC construction.
+        start_date = pd.Timestamp(
+            (pd.Timestamp(earliest) - pd.DateOffset(months=2 * LIVE_LOOKBACK_MONTHS)).date(),
+            tz="UTC",
         )
         prices = load_prices(session, symbols, start_date=start_date)
 

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -1,0 +1,262 @@
+"""One-time backfill of historical ``screened_stocks`` pattern trade levels.
+
+PROBLEM
+-------
+``screened_stocks`` stores the pattern-derived trade levels (entry, stop,
+target, reward/risk) per screened name. These power the miss-sweep's level-based
+attribution, the R-D chart overlays (entry/stop/target lines), and any later
+analysis joining levels to outcomes.
+
+The go-forward screen->persist path has written these levels correctly since the
+06-15 cutover. But ~510 patterned rows from scan_date 06-03..06-12 carry NULL
+levels: the running scraper only picked up the level-writing code at the 06-15
+deploy. ``pattern_type`` IS recorded on those rows; entry/stop/target/rr are NULL.
+This is a one-time DATA backfill, not a code fix.
+
+THE FIX (idempotent, dry-run by default)
+-----------------------------------------
+For each ``screened_stocks`` row in ``[from_date, to_date]`` with
+``pattern_type NOT NULL AND entry_price IS NULL``:
+
+    replay the pattern detector AS-OF the row's scan_date over stored prices
+      (reuse paper.pattern_replay.replay_pattern_layer — no look-ahead)
+    among the as-of ACTIONABLE patterns, pick the one whose pattern_type ==
+      the row's stored pattern_type  (NOT necessarily replay's top-ranked
+      `best` — a matching pattern may rank lower).  If NONE matches, leave the
+      row NULL and report it in still-NULL — never write wrong-pattern levels.
+    coalesce-upsert the four levels via persist_screened_stocks (fills NULL only)
+
+    ASCII flow (one row):
+
+      screened_stocks row (pattern_type=T, levels NULL, scan_date=d)
+            │
+            ▼
+      load stock_prices[symbol] ── window AS-OF d ──► replay_pattern_layer
+            │
+            ▼
+      actionable patterns ── filter pattern_type == T ── tie-break (conf, then
+            entry) ──► matched pattern.{entry, stop, target_wave1, rr_ratio}
+            │
+            ▼  (apply only)
+      persist_screened_stocks(coalesce upsert) ── fills the NULL levels
+
+Levels come from the actionable pattern matching the stored type, so they are
+faithful by construction (the replay is parity-tested against ``screen_stocks``).
+
+This is a maintenance command (``rainier db backfill-screened-levels``), NOT a
+scheduled job — a historical repair.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date
+
+import pandas as pd
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from rainier.core.config import StockScreenerConfig, get_settings
+from rainier.core.database import get_session
+from rainier.core.models import ScreenedStockRecord
+from rainier.core.types import PatternSignal, StockCandidate
+from rainier.llm_thesis.persistence import persist_screened_stocks
+from rainier.paper.pattern_replay import (
+    LIVE_LOOKBACK_MONTHS,
+    load_prices,
+    replay_pattern_layer,
+    window_as_of,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class BackfillResult:
+    """Counts from one backfill run (dry-run or applied).
+
+    ``scanned`` — target rows (patterned + level-NULL + in window).
+    ``recovered`` — rows whose stored pattern_type matched an as-of actionable
+        pattern (levels written when ``apply`` is True; would-be-written on dry-run).
+    ``still_null`` — target rows where NO actionable pattern matched the stored
+        type (left NULL and reported; never errored).
+    ``still_null_keys`` — the (symbol, scan_date) of each still-NULL row.
+    """
+
+    scanned: int = 0
+    recovered: int = 0
+    still_null: int = 0
+    still_null_keys: list[tuple[str, date]] = field(default_factory=list)
+
+
+def _target_rows(
+    session: Session, from_date: date, to_date: date
+) -> list[ScreenedStockRecord]:
+    """Patterned + level-NULL rows in ``[from_date, to_date]`` (inclusive).
+
+    Deterministic order (symbol, scan_date, session_name) so a re-run scans the
+    corpus identically and logs are diff-stable.
+    """
+    stmt = (
+        select(ScreenedStockRecord)
+        .where(
+            ScreenedStockRecord.scan_date >= from_date,
+            ScreenedStockRecord.scan_date <= to_date,
+            ScreenedStockRecord.pattern_type.isnot(None),
+            ScreenedStockRecord.entry_price.is_(None),
+        )
+        .order_by(
+            ScreenedStockRecord.symbol.asc(),
+            ScreenedStockRecord.scan_date.asc(),
+            ScreenedStockRecord.session_name.asc(),
+        )
+    )
+    return list(session.execute(stmt).scalars().all())
+
+
+def _match_pattern(
+    actionable: list[PatternSignal], stored_type: str
+) -> PatternSignal | None:
+    """Pick the actionable pattern whose type == ``stored_type``.
+
+    If several share the type, tie-break deterministically: highest confidence
+    first, then lowest entry_price (a stable numeric key) so the choice is
+    reproducible across runs.
+    """
+    matches = [p for p in actionable if p.pattern_type == stored_type]
+    if not matches:
+        return None
+    matches.sort(key=lambda p: (-p.confidence, p.entry_price))
+    return matches[0]
+
+
+def _as_of_idx(df: pd.DataFrame, scan_date: date) -> int | None:
+    """Positional index of the last bar on/before ``scan_date``; None if none.
+
+    The screener runs on the bars available as-of the scan, whose latest bar is
+    the most recent trading day on or before scan_date.
+    """
+    cutoff = pd.Timestamp(scan_date)
+    if df.index.tz is not None:
+        cutoff = cutoff.tz_localize(df.index.tz)
+    mask = pd.Index(df.index <= cutoff).to_numpy()
+    hits = mask.nonzero()[0]
+    if hits.size == 0:
+        return None
+    # positional index of the last bar on/before scan_date
+    return int(hits[-1])
+
+
+def _candidate_with_levels(
+    row: ScreenedStockRecord, pat: PatternSignal
+) -> StockCandidate:
+    """Minimal StockCandidate carrying ONLY the four levels to backfill.
+
+    persist_screened_stocks coalesce-upserts the level columns and leaves the
+    non-level columns untouched on conflict, so the other fields here are
+    placeholders that never reach the existing row.
+    """
+    return StockCandidate(
+        symbol=row.symbol,
+        rank=0,
+        rank_change=0,
+        long_short="",
+        capital_flow_direction="N",
+        sector=row.sector or "",
+        signal_strength=row.composite_score,
+        pattern_type=row.pattern_type,
+        entry_price=pat.entry_price,
+        stop_loss=pat.stop_loss,
+        target_price=pat.target_wave1,
+        rr_ratio=pat.rr_ratio,
+    )
+
+
+def backfill_screened_levels(
+    *,
+    from_date: date,
+    to_date: date,
+    apply: bool = False,
+    config: StockScreenerConfig | None = None,
+    config_overrides: dict | None = None,
+) -> BackfillResult:
+    """Replay the pattern detector as-of each historical scan_date and fill levels.
+
+    Dry-run by default (``apply=False``): scans and reports counts, writes nothing.
+    With ``apply=True`` it coalesce-upserts the matched levels (fills NULL only,
+    never clobbers a set value).
+
+    ``config`` / ``config_overrides`` let a caller (or test) pin the detector
+    knobs; otherwise the live ``StockScreenerConfig`` from settings is used.
+    """
+    if from_date > to_date:
+        raise ValueError(f"from_date {from_date} > to_date {to_date}")
+    if config is None:
+        config = get_settings().stock_screener
+    if config_overrides:
+        config = config.model_copy(update=config_overrides)
+
+    result = BackfillResult()
+
+    with get_session() as session:
+        rows = _target_rows(session, from_date, to_date)
+        result.scanned = len(rows)
+        if not rows:
+            return result
+
+        # Load prices once for the full symbol set, left-padded by the detector
+        # lookback so each as-of window still sees its full ~6-month history.
+        symbols = sorted({r.symbol for r in rows})
+        earliest = min(r.scan_date for r in rows)
+        # Left-pad by 2x the ~6-month detector lookback so the earliest as-of bar
+        # still sees its full window even across holiday-heavy stretches.
+        start_date = pd.Timestamp(earliest) - pd.DateOffset(
+            months=2 * LIVE_LOOKBACK_MONTHS
+        )
+        prices = load_prices(session, symbols, start_date=start_date)
+
+        candidates_by_key: dict[tuple[date, str], list[StockCandidate]] = {}
+        for row in rows:
+            df = prices.get(row.symbol)
+            matched: PatternSignal | None = None
+            if df is not None and not df.empty:
+                t_idx = _as_of_idx(df, row.scan_date)
+                if t_idx is not None:
+                    windowed = window_as_of(df, t_idx)
+                    if not windowed.empty:
+                        actionable, _ = replay_pattern_layer(
+                            row.symbol, windowed, config
+                        )
+                        matched = _match_pattern(actionable, row.pattern_type)
+
+            if matched is None:
+                result.still_null += 1
+                result.still_null_keys.append((row.symbol, row.scan_date))
+                log.info(
+                    "backfill_still_null symbol=%s scan_date=%s pattern_type=%s",
+                    row.symbol,
+                    row.scan_date,
+                    row.pattern_type,
+                )
+                continue
+
+            result.recovered += 1
+            if apply:
+                cand = _candidate_with_levels(row, matched)
+                candidates_by_key.setdefault(
+                    (row.scan_date, row.session_name), []
+                ).append(cand)
+
+        if apply and candidates_by_key:
+            for (scan_date, session_name), cands in candidates_by_key.items():
+                persist_screened_stocks(cands, scan_date, session_name)
+
+    log.info(
+        "backfill_screened_levels done scanned=%d recovered=%d still_null=%d apply=%s",
+        result.scanned,
+        result.recovered,
+        result.still_null,
+        apply,
+    )
+    return result

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -62,7 +62,7 @@ from dataclasses import dataclass, field
 from datetime import date
 
 import pandas as pd
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from rainier.core.config import StockScreenerConfig, get_settings
@@ -84,18 +84,25 @@ log = logging.getLogger(__name__)
 class BackfillResult:
     """Counts from one backfill run (dry-run or applied).
 
-    ``scanned`` — target rows (patterned + level-NULL + in window).
+    ``scanned`` — target rows (``close``-session + patterned + level-NULL + in
+        window) that the replay attempted to recover.
     ``recovered`` — rows whose stored pattern_type matched an as-of actionable
         pattern (levels written when ``apply`` is True; would-be-written on dry-run).
     ``still_null`` — target rows where NO actionable pattern matched the stored
-        type (left NULL and reported; never errored).
+        type / the detector raised (left NULL and reported; never errored).
     ``still_null_keys`` — the (symbol, scan_date) of each still-NULL row.
+    ``skipped_non_close`` — patterned level-NULL rows in the window from a
+        non-``close`` session. These are NOT reconstructable without look-ahead
+        (see ``_BACKFILLABLE_SESSION``) so they are excluded from the target set,
+        but they ARE still damaged rows — surfaced here so a dry-run cannot look
+        falsely complete while non-close NULLs remain.
     """
 
     scanned: int = 0
     recovered: int = 0
     still_null: int = 0
     still_null_keys: list[tuple[str, date]] = field(default_factory=list)
+    skipped_non_close: int = 0
 
 
 # The replay reconstructs levels from the COMPLETED daily ``stock_prices`` bar
@@ -135,6 +142,29 @@ def _target_rows(
         )
     )
     return list(session.execute(stmt).scalars().all())
+
+
+def _count_non_close_null(
+    session: Session, from_date: date, to_date: date
+) -> int:
+    """Patterned, level-NULL rows in the window from a NON-``close`` session.
+
+    These are excluded from the repair (not reconstructable without look-ahead)
+    but are still damaged rows; counting them keeps a dry-run from looking
+    complete while non-close NULLs remain.
+    """
+    stmt = (
+        select(func.count())
+        .select_from(ScreenedStockRecord)
+        .where(
+            ScreenedStockRecord.scan_date >= from_date,
+            ScreenedStockRecord.scan_date <= to_date,
+            ScreenedStockRecord.session_name != _BACKFILLABLE_SESSION,
+            ScreenedStockRecord.pattern_type.isnot(None),
+            ScreenedStockRecord.entry_price.is_(None),
+        )
+    )
+    return int(session.execute(stmt).scalar_one())
 
 
 def _match_pattern(
@@ -183,8 +213,12 @@ def _match_for_row(
 ) -> PatternSignal | None:
     """Replay the detector as-of ``row.scan_date`` and return the matching pattern.
 
-    Returns None when prices are missing, no bar exists on/before scan_date, or no
-    as-of actionable pattern has the row's stored ``pattern_type``.
+    Returns None when prices are missing, no bar exists on/before scan_date, no
+    as-of actionable pattern has the row's stored ``pattern_type``, OR the
+    detector raises on this symbol's window. A per-row detector failure is
+    per-symbol noise (one bad price window must not abort a multi-day repair) —
+    ``screen_stocks`` treats it the same way (stock_screener.py:86-89). The row
+    is left NULL and reported in still-NULL, never errored.
     """
     if df is None or df.empty:
         return None
@@ -194,7 +228,16 @@ def _match_for_row(
     windowed = window_as_of(df, t_idx)
     if windowed.empty:
         return None
-    actionable, _ = replay_pattern_layer(row.symbol, windowed, config)
+    try:
+        actionable, _ = replay_pattern_layer(row.symbol, windowed, config)
+    except Exception:
+        log.exception(
+            "backfill_replay_failed symbol=%s scan_date=%s pattern_type=%s",
+            row.symbol,
+            row.scan_date,
+            row.pattern_type,
+        )
+        return None
     return _match_pattern(actionable, row.pattern_type)
 
 
@@ -250,6 +293,12 @@ def backfill_screened_levels(
     result = BackfillResult()
 
     with get_session() as session:
+        # Damaged non-close rows are not repairable (look-ahead) but ARE still
+        # damaged — count them first so the report surfaces them even when there
+        # are zero repairable close rows (a dry-run must never look complete
+        # while non-close NULLs remain).
+        result.skipped_non_close = _count_non_close_null(session, from_date, to_date)
+
         rows = _target_rows(session, from_date, to_date)
         result.scanned = len(rows)
         if not rows:

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -220,6 +220,15 @@ def _null_level_predicate(*, bil_present: bool):
     gap (a pre-0012 row reclaim can't see). persist fills only bil; the already-set
     trade tuple is left untouched. The column is named only when present, preserving
     the pre-0012 column-scoped-read drift safety.
+
+    Accepted edge (P3, near-unreachable): a ``false_breakout`` whose four trade
+    levels are ALL NULL but whose bil is already SET matches the all-four-NULL
+    clause; the replay writes a fresh tuple while ``persist_screened_stocks``
+    coalesce-keeps the pre-existing bil, so the new tuple's basis and the old bil's
+    basis could differ after a restatement. The live screener only ever writes bil
+    ALONGSIDE the tuple, so a bil-set/tuple-NULL row should not occur in the real
+    corpus; the no-clobber invariant (never overwrite a set value) takes precedence
+    over forcing single-basis consistency on a row that shouldn't exist.
     """
     all_trade_levels_null = and_(
         ScreenedStockRecord.entry_price.is_(None),

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -199,26 +199,46 @@ _BACKFILLABLE_SESSION = "close"
 
 
 def _null_level_predicate(*, bil_present: bool):
-    """The ``OR`` of "this trade level is NULL" clauses defining a DAMAGED row.
+    """The ``OR`` of clauses defining a DAMAGED, SAFELY-REPAIRABLE row.
 
     Shared by ``_target_rows`` (repairable close rows) and ``_count_non_close_null``
-    (damaged-but-unrepairable non-close rows) so the two can never drift. The four
-    trade levels always count; ``bearish_invalidation_level`` is added ONLY when
-    the 0012 column exists on this DB (and scoped to ``false_breakout``, the only
-    pattern that carries a trap-high) — naming it on a pre-0012 DB would re-
-    introduce the ``UndefinedColumn`` crash the column-scoped read avoids.
+    (damaged-but-unrepairable non-close rows) so the two can never drift.
+
+    NO-MIXING invariant (codex P1): a fresh yfinance pull can RESTATE historical
+    OHLC (post-scan splits/dividends — see the module docstring), so a freshly
+    replayed entry/stop/target/rr tuple is not guaranteed to equal a value ALREADY
+    stored on the row. ``persist_screened_stocks`` coalesce-fills only NULLs, so
+    targeting a PARTIALLY-populated trade-level row would keep its old (set) fields
+    and write newly-computed ones — an internally inconsistent mixed tuple. To
+    avoid that, a row qualifies on its trade levels ONLY when ALL FOUR are NULL
+    (a clean full-tuple write from one replay), never when only some are NULL.
+
+    ``bearish_invalidation_level`` is a SEPARATE column the live screener derives
+    independently of the trade-level tuple, so filling it never mixes the tuple.
+    When the 0012 column exists (``bil_present``) we ALSO target a ``false_breakout``
+    whose trap-high is NULL but whose four trade levels are ALL SET — the bil-only
+    gap (a pre-0012 row reclaim can't see). persist fills only bil; the already-set
+    trade tuple is left untouched. The column is named only when present, preserving
+    the pre-0012 column-scoped-read drift safety.
     """
-    clauses = [
+    all_trade_levels_null = and_(
         ScreenedStockRecord.entry_price.is_(None),
         ScreenedStockRecord.stop_loss.is_(None),
         ScreenedStockRecord.target_price.is_(None),
         ScreenedStockRecord.rr_ratio.is_(None),
-    ]
+    )
+    clauses = [all_trade_levels_null]
     if bil_present:
         clauses.append(
             and_(
                 ScreenedStockRecord.pattern_type == "false_breakout",
                 ScreenedStockRecord.bearish_invalidation_level.is_(None),
+                # bil-ONLY gap: trade tuple fully set, so persist touches only bil
+                # (no mixed old/new trade levels).
+                ScreenedStockRecord.entry_price.isnot(None),
+                ScreenedStockRecord.stop_loss.isnot(None),
+                ScreenedStockRecord.target_price.isnot(None),
+                ScreenedStockRecord.rr_ratio.isnot(None),
             )
         )
     return or_(*clauses)
@@ -233,25 +253,16 @@ def _target_rows(
     ``_BACKFILLABLE_SESSION``). Deterministic order (symbol, scan_date) so a
     re-run scans the corpus identically and logs are diff-stable.
 
-    Target predicate (codex P2): ``pattern_type NOT NULL`` AND ANY tracked level
-    NULL — NOT only ``entry_price IS NULL``. A prior PARTIAL write could have set
-    ``entry_price`` while leaving ``stop_loss`` / ``target_price`` / ``rr_ratio``
-    NULL; downstream paper-trade creation treats any missing level as
-    ``missing_levels``, so an entry-only predicate would skip those broken rows
-    forever. ``persist_screened_stocks`` coalesce-upserts each level independently
-    (fills NULL only, never clobbers a set value), so re-running the matched
-    pattern over a partially-set row safely fills just the still-NULL fields.
-
-    ``bil_present`` (codex P2): when ``screened_stocks.bearish_invalidation_level``
-    EXISTS on this DB (post-0012), also target rows where ONLY that column is NULL
-    — a ``false_breakout`` row written pre-0012 can have all four trade levels set
-    yet a NULL trap-high, which ``paper.reclaim.detect_and_enqueue_reclaims``
-    filters out (it requires ``bearish_invalidation_level IS NOT NULL``), leaving
-    the thesis permanently invisible to reclaim. We add this clause ONLY when the
-    column exists: referencing it on a pre-0012 DB would re-introduce the very
-    ``UndefinedColumn`` crash the column-scoped read avoids. (Dry-run on a drifted
-    DB therefore can't surface these — but reclaim can't use the column there
-    either, and ``--apply`` already requires 0012 via the preflight.)
+    Target predicate (``_null_level_predicate``): ``pattern_type NOT NULL`` AND the
+    row is damaged-but-safely-repairable — ALL FOUR trade levels NULL (a clean
+    full-tuple write from one replay; the actual production damage is rows with all
+    four NULL), OR, on a post-0012 DB, a ``false_breakout`` whose trap-high
+    (``bearish_invalidation_level``) is NULL but whose four trade levels are ALL
+    SET. A row with only SOME trade levels NULL is deliberately NOT targeted: a
+    fresh replay can restate OHLC (splits/dividends), so coalesce-filling just the
+    NULL fields could mix old + newly-computed levels into an inconsistent tuple
+    (codex P1). See ``_null_level_predicate`` for the full rationale and the
+    ``bil_present`` drift-safety note.
 
     Column-scoped (NOT a full-ORM load): selecting only the columns this repair
     touches keeps an unrelated missing column (e.g. ``bearish_invalidation_level``
@@ -301,10 +312,10 @@ def _count_non_close_null(
     complete while non-close NULLs remain.
 
     Uses the SAME damaged-row predicate as ``_target_rows`` (via
-    ``_null_level_predicate``) so the two can't drift: any of the four trade levels
-    NULL (codex P2 — a partial-write non-close row is damaged too), plus a NULL
-    ``bearish_invalidation_level`` on a ``false_breakout`` when the 0012 column
-    exists.
+    ``_null_level_predicate``) so the two can't drift: ALL FOUR trade levels NULL,
+    plus the bil-only-gap ``false_breakout`` case when the 0012 column exists. (A
+    partially-set non-close row is intentionally NOT counted, mirroring that it is
+    not repairable without mixing restated levels — see ``_null_level_predicate``.)
     """
     stmt = (
         select(func.count())

--- a/src/rainier/paper/backfill_screened_levels.py
+++ b/src/rainier/paper/backfill_screened_levels.py
@@ -89,7 +89,7 @@ from datetime import date, timedelta
 
 import pandas as pd
 import yfinance as yf
-from sqlalchemy import func, or_, select, text
+from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.orm import Session
 
 from rainier.core.config import StockScreenerConfig, get_settings
@@ -198,8 +198,34 @@ class BackfillResult:
 _BACKFILLABLE_SESSION = "close"
 
 
+def _null_level_predicate(*, bil_present: bool):
+    """The ``OR`` of "this trade level is NULL" clauses defining a DAMAGED row.
+
+    Shared by ``_target_rows`` (repairable close rows) and ``_count_non_close_null``
+    (damaged-but-unrepairable non-close rows) so the two can never drift. The four
+    trade levels always count; ``bearish_invalidation_level`` is added ONLY when
+    the 0012 column exists on this DB (and scoped to ``false_breakout``, the only
+    pattern that carries a trap-high) — naming it on a pre-0012 DB would re-
+    introduce the ``UndefinedColumn`` crash the column-scoped read avoids.
+    """
+    clauses = [
+        ScreenedStockRecord.entry_price.is_(None),
+        ScreenedStockRecord.stop_loss.is_(None),
+        ScreenedStockRecord.target_price.is_(None),
+        ScreenedStockRecord.rr_ratio.is_(None),
+    ]
+    if bil_present:
+        clauses.append(
+            and_(
+                ScreenedStockRecord.pattern_type == "false_breakout",
+                ScreenedStockRecord.bearish_invalidation_level.is_(None),
+            )
+        )
+    return or_(*clauses)
+
+
 def _target_rows(
-    session: Session, from_date: date, to_date: date
+    session: Session, from_date: date, to_date: date, *, bil_present: bool
 ) -> list[_TargetRow]:
     """``close``-session, patterned, level-NULL rows in ``[from_date, to_date]``.
 
@@ -207,14 +233,25 @@ def _target_rows(
     ``_BACKFILLABLE_SESSION``). Deterministic order (symbol, scan_date) so a
     re-run scans the corpus identically and logs are diff-stable.
 
-    Target predicate (codex P2): ``pattern_type NOT NULL`` AND ANY of the four
-    trade levels NULL — NOT only ``entry_price IS NULL``. A prior PARTIAL write
-    could have set ``entry_price`` while leaving ``stop_loss`` / ``target_price`` /
-    ``rr_ratio`` NULL; downstream paper-trade creation treats any missing level as
+    Target predicate (codex P2): ``pattern_type NOT NULL`` AND ANY tracked level
+    NULL — NOT only ``entry_price IS NULL``. A prior PARTIAL write could have set
+    ``entry_price`` while leaving ``stop_loss`` / ``target_price`` / ``rr_ratio``
+    NULL; downstream paper-trade creation treats any missing level as
     ``missing_levels``, so an entry-only predicate would skip those broken rows
     forever. ``persist_screened_stocks`` coalesce-upserts each level independently
     (fills NULL only, never clobbers a set value), so re-running the matched
     pattern over a partially-set row safely fills just the still-NULL fields.
+
+    ``bil_present`` (codex P2): when ``screened_stocks.bearish_invalidation_level``
+    EXISTS on this DB (post-0012), also target rows where ONLY that column is NULL
+    — a ``false_breakout`` row written pre-0012 can have all four trade levels set
+    yet a NULL trap-high, which ``paper.reclaim.detect_and_enqueue_reclaims``
+    filters out (it requires ``bearish_invalidation_level IS NOT NULL``), leaving
+    the thesis permanently invisible to reclaim. We add this clause ONLY when the
+    column exists: referencing it on a pre-0012 DB would re-introduce the very
+    ``UndefinedColumn`` crash the column-scoped read avoids. (Dry-run on a drifted
+    DB therefore can't surface these — but reclaim can't use the column there
+    either, and ``--apply`` already requires 0012 via the preflight.)
 
     Column-scoped (NOT a full-ORM load): selecting only the columns this repair
     touches keeps an unrelated missing column (e.g. ``bearish_invalidation_level``
@@ -234,12 +271,7 @@ def _target_rows(
             ScreenedStockRecord.scan_date <= to_date,
             ScreenedStockRecord.session_name == _BACKFILLABLE_SESSION,
             ScreenedStockRecord.pattern_type.isnot(None),
-            or_(
-                ScreenedStockRecord.entry_price.is_(None),
-                ScreenedStockRecord.stop_loss.is_(None),
-                ScreenedStockRecord.target_price.is_(None),
-                ScreenedStockRecord.rr_ratio.is_(None),
-            ),
+            _null_level_predicate(bil_present=bil_present),
         )
         .order_by(
             ScreenedStockRecord.symbol.asc(),
@@ -260,7 +292,7 @@ def _target_rows(
 
 
 def _count_non_close_null(
-    session: Session, from_date: date, to_date: date
+    session: Session, from_date: date, to_date: date, *, bil_present: bool
 ) -> int:
     """Patterned, level-NULL rows in the window from a NON-``close`` session.
 
@@ -268,10 +300,11 @@ def _count_non_close_null(
     but are still damaged rows; counting them keeps a dry-run from looking
     complete while non-close NULLs remain.
 
-    Uses the SAME any-of-four-levels-NULL predicate as ``_target_rows`` (codex P2):
-    a partial-write non-close row (entry set, stop/target/rr NULL) is damaged too,
-    so an ``entry_price``-only count would let a dry-run claim the non-close
-    backlog is clear while broken partial rows remain.
+    Uses the SAME damaged-row predicate as ``_target_rows`` (via
+    ``_null_level_predicate``) so the two can't drift: any of the four trade levels
+    NULL (codex P2 — a partial-write non-close row is damaged too), plus a NULL
+    ``bearish_invalidation_level`` on a ``false_breakout`` when the 0012 column
+    exists.
     """
     stmt = (
         select(func.count())
@@ -281,12 +314,7 @@ def _count_non_close_null(
             ScreenedStockRecord.scan_date <= to_date,
             ScreenedStockRecord.session_name != _BACKFILLABLE_SESSION,
             ScreenedStockRecord.pattern_type.isnot(None),
-            or_(
-                ScreenedStockRecord.entry_price.is_(None),
-                ScreenedStockRecord.stop_loss.is_(None),
-                ScreenedStockRecord.target_price.is_(None),
-                ScreenedStockRecord.rr_ratio.is_(None),
-            ),
+            _null_level_predicate(bil_present=bil_present),
         )
     )
     return int(session.execute(stmt).scalar_one())
@@ -674,6 +702,12 @@ def backfill_screened_levels(
     result = BackfillResult()
 
     with get_session() as session:
+        # Does this DB have the 0012 ``bearish_invalidation_level`` column? Probed
+        # once and reused for the apply preflight AND the target/count predicates
+        # (which name the column only when present, preserving the pre-0012
+        # column-scoped-read safety).
+        bil_present = _apply_column_present(session)
+
         # Preflight the WRITE path against schema drift BEFORE any scan work.
         # ``persist_screened_stocks`` upserts ``bearish_invalidation_level`` (added
         # by migration 0012); on a pre-0012 DB that write aborts with an opaque
@@ -682,7 +716,7 @@ def backfill_screened_levels(
         # ``--apply`` — so without this guard ``--apply`` would crash mid-repair.
         # Fail fast with a clear, actionable message instead. (Dry-run never
         # writes, so it stays runnable on the drifted DB for diagnosis.)
-        if apply and not _apply_column_present(session):
+        if apply and not bil_present:
             raise RuntimeError(
                 "Cannot --apply: screened_stocks is missing the "
                 f"{_APPLY_REQUIRED_COLUMN!r} column (migration 0012 not applied). "
@@ -694,9 +728,13 @@ def backfill_screened_levels(
         # damaged — count them first so the report surfaces them even when there
         # are zero repairable close rows (a dry-run must never look complete
         # while non-close NULLs remain).
-        result.skipped_non_close = _count_non_close_null(session, from_date, to_date)
+        result.skipped_non_close = _count_non_close_null(
+            session, from_date, to_date, bil_present=bil_present
+        )
 
-        rows = _target_rows(session, from_date, to_date)
+        rows = _target_rows(
+            session, from_date, to_date, bil_present=bil_present
+        )
         result.scanned = len(rows)
         if not rows:
             return result

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -378,3 +378,44 @@ def test_alembic_include_filter_scopes_to_market_schema(monkeypatch):
     # Indexes / FKs in market accepted; in public rejected.
     assert inc("ix_thematic_ohlcv_date", "index", {"schema_name": "market"}) is True
     assert inc("ix_legacy", "index", {"schema_name": "public"}) is False
+
+
+def test_backfill_screened_levels_restores_global_settings_and_engine(monkeypatch):
+    """codex P2: `db backfill-screened-levels` seeds the process settings singleton
+    + clears the cached legacy engine to honor --config, but MUST restore both in a
+    finally so an in-process caller's later commands don't inherit this backfill's
+    --config DB. Invoke with from>to (exits via ClickException after the seed but
+    the finally still runs); assert the globals are back to their pre-call values.
+    """
+    import rainier.core.config as config_mod
+    import rainier.core.database as db_mod
+    from rainier import cli as cli_mod
+
+    # Pre-call sentinel globals — the command must restore exactly these.
+    sentinel_settings = object()
+    sentinel_engine = object()
+    sentinel_factory = object()
+    monkeypatch.setattr(config_mod, "_settings", sentinel_settings, raising=False)
+    monkeypatch.setattr(db_mod, "_engine", sentinel_engine, raising=False)
+    monkeypatch.setattr(db_mod, "_session_factory", sentinel_factory, raising=False)
+
+    # Stub load_settings_fresh so no real YAML/DB is touched; its stock_screener is
+    # unused on the from>to error path (raised before any replay).
+    from types import SimpleNamespace
+
+    fresh = SimpleNamespace(stock_screener=object())
+    monkeypatch.setattr(cli_mod, "load_settings_fresh", lambda _p: fresh, raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["db", "backfill-screened-levels", "--from", "2026-06-12", "--to", "2026-06-03"],
+    )
+
+    # from>to surfaces as a clean Click error (exit 1), not a traceback.
+    assert result.exit_code == 1, result.output
+    assert "from_date" in result.output and "to_date" in result.output
+    # The finally restored every global to its pre-call sentinel.
+    assert config_mod._settings is sentinel_settings
+    assert db_mod._engine is sentinel_engine
+    assert db_mod._session_factory is sentinel_factory

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -400,11 +400,17 @@ def test_backfill_screened_levels_restores_global_settings_and_engine(monkeypatc
     monkeypatch.setattr(db_mod, "_session_factory", sentinel_factory, raising=False)
 
     # Stub load_settings_fresh so no real YAML/DB is touched; its stock_screener is
-    # unused on the from>to error path (raised before any replay).
+    # unused on the from>to error path (raised before any replay). The command does
+    # a function-local `from rainier.core.config import load_settings_fresh`, so the
+    # patch MUST target rainier.core.config (NOT rainier.cli), else the real YAML is
+    # read (codex P3).
     from types import SimpleNamespace
 
     fresh = SimpleNamespace(stock_screener=object())
-    monkeypatch.setattr(cli_mod, "load_settings_fresh", lambda _p: fresh, raising=False)
+    monkeypatch.setattr(config_mod, "load_settings_fresh", lambda _p: fresh)
+    # Guard: prove the patch target is effective — if the command resolved from
+    # rainier.cli we'd be patching the wrong name and silently read real settings.
+    assert config_mod.load_settings_fresh("x") is fresh
 
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_paper/conftest.py
+++ b/tests/test_paper/conftest.py
@@ -388,6 +388,90 @@ def pg_legacy_session(pg_legacy_engine):
 
 
 # --------------------------------------------------------------------------
+# Schema-DRIFT fixture: a legacy DB that is BEHIND on migrations — it applies
+# everything through 0011 but NOT 0012, so `screened_stocks` is missing the
+# `bearish_invalidation_level` column the ORM model declares. This is the exact
+# state of the live local DB (0012 never `psql -f`'d there) that crashes a
+# full-ORM `select(ScreenedStockRecord)`. The backfill must survive it via its
+# column-scoped read. Own disposable schema; teardown can never reach `public`.
+# --------------------------------------------------------------------------
+
+_DRIFT_SCHEMA_BASE = "rainier_paper_test"  # within the gc-test-schemas allowlist
+
+
+@pytest.fixture
+def pg_drift_engine(request):
+    """Ephemeral Postgres at a PRE-0012 schema state (0012/0013 NOT applied).
+
+    Identical to ``pg_legacy_engine`` except it stops before migration 0012, so
+    ``screened_stocks.bearish_invalidation_level`` does not exist. Binds the
+    legacy ``core.database`` singleton so production code under test hits this DB.
+    Same WS C leak-hardening: per-run schema, all setup inside the try whose
+    finally drops the schema.
+    """
+    url = _resolve_pg_url(request)
+    schema = f"{_DRIFT_SCHEMA_BASE}_{_run_suffix()}"
+    engine = None
+    try:
+        admin = create_engine(url, future=True)
+        with admin.begin() as conn:
+            conn.execute(text(f"DROP SCHEMA IF EXISTS {schema} CASCADE"))
+            conn.execute(text(f"CREATE SCHEMA {schema}"))
+        admin.dispose()
+
+        engine = create_engine(
+            url,
+            future=True,
+            connect_args={"options": f"-csearch_path={schema},public"},
+        )
+        engine.rainier_schema = schema  # type: ignore[attr-defined]
+        with engine.begin() as conn:
+            conn.execute(text(_PREREQ_DDL))
+        _apply_sql(engine, MIGRATION_UP)
+        _apply_sql(engine, MIGRATION_0007_UP)
+        _apply_sql(engine, MIGRATION_0008_UP)
+        _apply_sql(engine, MIGRATION_0009_UP)
+        _apply_sql(engine, MIGRATION_0003_UP)
+        if MIGRATION_0010_UP.exists():
+            _apply_sql(engine, MIGRATION_0010_UP)
+        _apply_sql(engine, MIGRATION_0011_UP)
+        # DELIBERATELY skip 0012 (and 0013): leave the DB drifted so
+        # `screened_stocks.bearish_invalidation_level` is absent.
+
+        from rainier.core import config, database
+
+        config._settings = None
+        database._engine = engine
+        database._session_factory = sessionmaker(
+            bind=engine, expire_on_commit=False
+        )
+        yield engine
+    finally:
+        from rainier.core import config, database
+
+        database._engine = None
+        database._session_factory = None
+        config._settings = None
+        if engine is not None:
+            engine.dispose()
+        admin = create_engine(url, future=True)
+        with admin.begin() as conn:
+            conn.execute(text(f"DROP SCHEMA IF EXISTS {schema} CASCADE"))
+        admin.dispose()
+
+
+@pytest.fixture
+def pg_drift_session(pg_drift_engine):
+    Session = sessionmaker(bind=pg_drift_engine, expire_on_commit=False)
+    sess = Session()
+    try:
+        yield sess
+    finally:
+        sess.rollback()
+        sess.close()
+
+
+# --------------------------------------------------------------------------
 # Migration 0010 (R-D chart archive) fixtures — PRE-0010 state so the
 # migration's backfill / index creation / idempotency / downgrade run under
 # test. Own disposable schema; teardown can never reach shared `public`.

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -248,12 +248,13 @@ def test_coalesce_no_clobber_of_set_levels(pg_legacy_session):
     assert res.scanned == 0  # already-set row excluded from target set
 
 
-def test_partial_levels_row_is_backfilled(pg_legacy_session):
-    """Codex P2: a row with entry_price SET but stop_loss/target_price/rr_ratio
-    NULL (a prior partial write) IS in the target set — the predicate keys on ANY
-    level NULL, not just entry. persist_screened_stocks coalesce-fills only the
-    still-NULL fields, so the recovered pattern's stop/target/rr land while the
-    pre-existing entry is preserved (never clobbered)."""
+def test_partial_trade_level_row_is_not_targeted_no_mixing(pg_legacy_session):
+    """Codex P1 (no-mixing): a row with SOME trade levels set and others NULL (a
+    prior partial write) is NOT targeted. A fresh replay can restate OHLC
+    (splits/dividends), so coalesce-filling only the NULL fields would mix the
+    pre-existing entry with newly-computed stop/target/rr — an inconsistent tuple.
+    The repair targets a trade-level row only when ALL FOUR are NULL, so the
+    partial row is left exactly as-is (no scan, no write)."""
     _seed_prices(pg_legacy_session, "PART", _SCAN, _FB_PRICES)
     # entry set, the other three NULL — a partially-populated historical row.
     pg_legacy_session.add(
@@ -264,7 +265,7 @@ def test_partial_levels_row_is_backfilled(pg_legacy_session):
             rule_rank=1,
             composite_score=0.8,
             pattern_type="false_breakdown",
-            entry_price=88.0,  # pre-set; must be preserved
+            entry_price=88.0,
             stop_loss=None,
             target_price=None,
             rr_ratio=None,
@@ -281,12 +282,13 @@ def test_partial_levels_row_is_backfilled(pg_legacy_session):
 
     pg_legacy_session.expire_all()
     r = _row(pg_legacy_session, "PART", _SCAN)
-    assert res.scanned == 1  # partial row IS a target (not skipped on entry NOT NULL)
-    assert res.recovered == 1
-    assert r.entry_price == 88.0  # pre-existing entry preserved (coalesce no-clobber)
-    assert r.stop_loss is not None  # the three NULL levels filled
-    assert r.target_price is not None
-    assert r.rr_ratio is not None
+    assert res.scanned == 0  # partial trade-level row NOT a target (no mixing)
+    assert res.recovered == 0
+    # Left exactly as seeded — entry intact, the three NULLs still NULL.
+    assert r.entry_price == 88.0
+    assert r.stop_loss is None
+    assert r.target_price is None
+    assert r.rr_ratio is None
 
 
 def test_target_rows_includes_false_breakout_missing_only_invalidation_level(
@@ -818,18 +820,19 @@ def test_missing_scan_date_bar_is_transient_no_price_data_no_prior_day_levels(
 def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
     """On a complete DB the column-scoped `_target_rows` returns the SAME row set
     (by identity key) the equivalent full-ORM load does — no behavior change when
-    nothing is drifted. The predicate is "ANY of the four levels NULL" (codex P2),
-    so a PARTIAL row (entry set, others NULL) is a target too."""
-    from sqlalchemy import or_
+    nothing is drifted. The predicate is "ALL FOUR trade levels NULL" (no-mixing,
+    codex P1), so a PARTIAL row (entry set, others NULL) is NOT a target."""
+    from sqlalchemy import and_, or_
 
-    # Two all-NULL rows (targets), a PARTIAL row (entry set, rest NULL — also a
-    # target under the any-NULL predicate), a fully-set row + a non-close row
-    # (both excluded). The scoped query must return AAA, BBB, PART in order.
+    # Two all-NULL rows (targets), a PARTIAL row (entry set, rest NULL — NOT a
+    # target under the no-mixing predicate), a fully-set row + a non-close row
+    # (both excluded). The scoped query must return AAA, BBB in order.
     _seed_prices(pg_legacy_session, "AAA", _SCAN, _FB_PRICES)
     _seed_screened(pg_legacy_session, "AAA", _SCAN, pattern_type="false_breakdown")
     _seed_prices(pg_legacy_session, "BBB", _SCAN, _FB_PRICES)
     _seed_screened(pg_legacy_session, "BBB", _SCAN, pattern_type="false_breakdown")
-    # PART: entry set, stop/target/rr NULL → still a target (any-NULL predicate).
+    # PART: entry set, stop/target/rr NULL → NOT a target (no-mixing: only all-four-
+    # NULL trade-level rows qualify; mixing restated levels is unsafe).
     pg_legacy_session.add(
         ScreenedStockRecord(
             scan_date=_SCAN,
@@ -864,10 +867,9 @@ def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
         session_name="morning",
     )
 
-    # Equivalent ORM path: the same WHERE/ORDER over full entities (any-NULL level
-    # + false_breakout NULL bearish_invalidation_level on a post-0012 DB).
-    from sqlalchemy import and_
-
+    # Equivalent ORM path: the same WHERE/ORDER over full entities. No-mixing
+    # predicate: ALL FOUR trade levels NULL, OR a false_breakout whose bil is NULL
+    # while its four trade levels are ALL SET (bil-only gap, post-0012 DB).
     orm_rows = (
         pg_legacy_session.execute(
             select(ScreenedStockRecord)
@@ -877,13 +879,19 @@ def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
                 ScreenedStockRecord.session_name == "close",
                 ScreenedStockRecord.pattern_type.isnot(None),
                 or_(
-                    ScreenedStockRecord.entry_price.is_(None),
-                    ScreenedStockRecord.stop_loss.is_(None),
-                    ScreenedStockRecord.target_price.is_(None),
-                    ScreenedStockRecord.rr_ratio.is_(None),
+                    and_(
+                        ScreenedStockRecord.entry_price.is_(None),
+                        ScreenedStockRecord.stop_loss.is_(None),
+                        ScreenedStockRecord.target_price.is_(None),
+                        ScreenedStockRecord.rr_ratio.is_(None),
+                    ),
                     and_(
                         ScreenedStockRecord.pattern_type == "false_breakout",
                         ScreenedStockRecord.bearish_invalidation_level.is_(None),
+                        ScreenedStockRecord.entry_price.isnot(None),
+                        ScreenedStockRecord.stop_loss.isnot(None),
+                        ScreenedStockRecord.target_price.isnot(None),
+                        ScreenedStockRecord.rr_ratio.isnot(None),
                     ),
                 ),
             )
@@ -903,7 +911,8 @@ def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
     )
     scoped_keys = [(r.symbol, r.scan_date) for r in scoped]
 
-    assert scoped_keys == orm_keys == [("AAA", _SCAN), ("BBB", _SCAN), ("PART", _SCAN)]
+    # PART (entry set, rest NULL) is NOT a target now (no-mixing) → only AAA, BBB.
+    assert scoped_keys == orm_keys == [("AAA", _SCAN), ("BBB", _SCAN)]
     # And the carried columns match the ORM values.
     for scoped_row, orm_row in zip(scoped, orm_rows, strict=True):
         assert scoped_row.session_name == orm_row.session_name

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -49,12 +49,16 @@ _FB_PRICES = (
 )
 
 # StockScreenerConfig knobs that make the fixture's patterns detect (mirrors the
-# replay parity test's _CONFIG).
+# replay parity test's _CONFIG). ``min_daily_bars`` is lowered to 10 because the
+# synthetic ``_FB_PRICES`` window is only ~24 bars; the default 60 would make
+# _match_for_row reject every fixture window as a too-short as-of history (the
+# codex-P2 min_daily_bars gate) and the recovery tests would all see NO_MATCH.
 _CFG_OVERRIDES = {
     "swing_lookback": 3,
     "min_pattern_bars": 3,
     "max_pattern_bars": 50,
     "neckline_tolerance_pct": 0.05,
+    "min_daily_bars": 10,
 }
 
 
@@ -392,6 +396,34 @@ def test_no_price_data_row_is_separate_bucket_not_still_null(pg_legacy_session):
     assert res.no_price_data == 1  # transient: surfaced for re-run
     assert ("NODATA", _SCAN) in res.no_price_data_keys
     assert ("NODATA", _SCAN) not in res.still_null_keys
+
+
+def test_short_as_of_history_is_permanent_still_null_not_transient(pg_legacy_session):
+    """Codex P2: a ticker with FEWER bars than min_daily_bars by to_date (a recent
+    IPO/spinoff) is a PERMANENT insufficient-history case, not a transient fetch
+    gap. The short-but-nonempty frame now flows through _fetch_history (min_bars=1)
+    to _match_for_row, whose window gate classifies it NO_MATCH (still_null), NOT
+    no_price_data — so the operator is not falsely told a re-run may recover it."""
+    # 6 bars < the 10-bar min_daily_bars floor in _CFG_OVERRIDES.
+    _seed_prices(pg_legacy_session, "IPO", _SCAN, [90.0, 91.0, 89.0, 88.0, 90.0, 91.0])
+    _seed_screened(pg_legacy_session, "IPO", _SCAN, pattern_type="false_breakdown")
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    assert res.scanned == 1
+    assert res.recovered == 0
+    # Permanent insufficient-history → still_null, NOT transient no_price_data.
+    assert res.still_null == 1
+    assert ("IPO", _SCAN) in res.still_null_keys
+    assert res.no_price_data == 0
+    assert ("IPO", _SCAN) not in res.no_price_data_keys
+    assert _row(pg_legacy_session, "IPO", _SCAN).entry_price is None
 
 
 def test_multiple_scan_dates_each_gets_its_own_window_levels(pg_legacy_session):

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -248,6 +248,47 @@ def test_coalesce_no_clobber_of_set_levels(pg_legacy_session):
     assert res.scanned == 0  # already-set row excluded from target set
 
 
+def test_partial_levels_row_is_backfilled(pg_legacy_session):
+    """Codex P2: a row with entry_price SET but stop_loss/target_price/rr_ratio
+    NULL (a prior partial write) IS in the target set — the predicate keys on ANY
+    level NULL, not just entry. persist_screened_stocks coalesce-fills only the
+    still-NULL fields, so the recovered pattern's stop/target/rr land while the
+    pre-existing entry is preserved (never clobbered)."""
+    _seed_prices(pg_legacy_session, "PART", _SCAN, _FB_PRICES)
+    # entry set, the other three NULL — a partially-populated historical row.
+    pg_legacy_session.add(
+        ScreenedStockRecord(
+            scan_date=_SCAN,
+            session_name="close",
+            symbol="PART",
+            rule_rank=1,
+            composite_score=0.8,
+            pattern_type="false_breakdown",
+            entry_price=88.0,  # pre-set; must be preserved
+            stop_loss=None,
+            target_price=None,
+            rr_ratio=None,
+        )
+    )
+    pg_legacy_session.commit()
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    r = _row(pg_legacy_session, "PART", _SCAN)
+    assert res.scanned == 1  # partial row IS a target (not skipped on entry NOT NULL)
+    assert res.recovered == 1
+    assert r.entry_price == 88.0  # pre-existing entry preserved (coalesce no-clobber)
+    assert r.stop_loss is not None  # the three NULL levels filled
+    assert r.target_price is not None
+    assert r.rr_ratio is not None
+
+
 def test_patternless_row_untouched(pg_legacy_session):
     _seed_prices(pg_legacy_session, "NOP", _SCAN, _FB_PRICES)
     _seed_screened(pg_legacy_session, "NOP", _SCAN, pattern_type=None)
@@ -715,15 +756,34 @@ def test_missing_scan_date_bar_is_transient_no_price_data_no_prior_day_levels(
 
 def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
     """On a complete DB the column-scoped `_target_rows` returns the SAME row set
-    (by identity key) the old full-ORM load did — no behavior change when nothing
-    is drifted."""
-    # Two close-session patterned NULL rows (in target set), plus a set-levels row
-    # and a non-close row (both excluded). The scoped query must return exactly
-    # the two target rows, in (symbol, scan_date) order.
+    (by identity key) the equivalent full-ORM load does — no behavior change when
+    nothing is drifted. The predicate is "ANY of the four levels NULL" (codex P2),
+    so a PARTIAL row (entry set, others NULL) is a target too."""
+    from sqlalchemy import or_
+
+    # Two all-NULL rows (targets), a PARTIAL row (entry set, rest NULL — also a
+    # target under the any-NULL predicate), a fully-set row + a non-close row
+    # (both excluded). The scoped query must return AAA, BBB, PART in order.
     _seed_prices(pg_legacy_session, "AAA", _SCAN, _FB_PRICES)
     _seed_screened(pg_legacy_session, "AAA", _SCAN, pattern_type="false_breakdown")
     _seed_prices(pg_legacy_session, "BBB", _SCAN, _FB_PRICES)
     _seed_screened(pg_legacy_session, "BBB", _SCAN, pattern_type="false_breakdown")
+    # PART: entry set, stop/target/rr NULL → still a target (any-NULL predicate).
+    pg_legacy_session.add(
+        ScreenedStockRecord(
+            scan_date=_SCAN,
+            session_name="close",
+            symbol="PART",
+            rule_rank=1,
+            composite_score=0.8,
+            pattern_type="false_breakdown",
+            entry_price=88.0,
+            stop_loss=None,
+            target_price=None,
+            rr_ratio=None,
+        )
+    )
+    pg_legacy_session.commit()
     _seed_screened(
         pg_legacy_session,
         "CCC",
@@ -743,7 +803,7 @@ def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
         session_name="morning",
     )
 
-    # Old ORM path: the same WHERE/ORDER over full entities.
+    # Equivalent ORM path: the same WHERE/ORDER over full entities (any-NULL level).
     orm_rows = (
         pg_legacy_session.execute(
             select(ScreenedStockRecord)
@@ -752,7 +812,12 @@ def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
                 ScreenedStockRecord.scan_date <= date(2026, 6, 12),
                 ScreenedStockRecord.session_name == "close",
                 ScreenedStockRecord.pattern_type.isnot(None),
-                ScreenedStockRecord.entry_price.is_(None),
+                or_(
+                    ScreenedStockRecord.entry_price.is_(None),
+                    ScreenedStockRecord.stop_loss.is_(None),
+                    ScreenedStockRecord.target_price.is_(None),
+                    ScreenedStockRecord.rr_ratio.is_(None),
+                ),
             )
             .order_by(
                 ScreenedStockRecord.symbol.asc(),
@@ -767,7 +832,7 @@ def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
     scoped = _target_rows(pg_legacy_session, date(2026, 6, 3), date(2026, 6, 12))
     scoped_keys = [(r.symbol, r.scan_date) for r in scoped]
 
-    assert scoped_keys == orm_keys == [("AAA", _SCAN), ("BBB", _SCAN)]
+    assert scoped_keys == orm_keys == [("AAA", _SCAN), ("BBB", _SCAN), ("PART", _SCAN)]
     # And the carried columns match the ORM values.
     for scoped_row, orm_row in zip(scoped, orm_rows, strict=True):
         assert scoped_row.session_name == orm_row.session_name

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -458,6 +458,72 @@ def test_drift_db_missing_model_column_does_not_crash(pg_drift_session):
     assert entry is None
 
 
+def test_apply_on_drift_db_raises_clear_error_not_undefined_column(pg_drift_session):
+    """`--apply` on a pre-0012 DB must fail fast with a clear, actionable message,
+    NOT crash mid-repair with an opaque UndefinedColumn from the upsert.
+
+    The write path (`persist_screened_stocks`) names `bearish_invalidation_level`
+    in its INSERT ... ON CONFLICT; that column is absent on a drifted DB. A
+    dry-run on the same DB succeeds and tells the operator to re-run with
+    `--apply` — so without the preflight guard `--apply` would attempt the write
+    and abort with a raw psycopg error. The guard raises a RuntimeError that names
+    the missing column and migration 0012, and leaves the row UNWRITTEN.
+
+    FAILS on the parent commit: there the apply path reaches the upsert and raises
+    a psycopg `UndefinedColumn` (not the guarded RuntimeError)."""
+    # Precondition: the column really is absent on this drift fixture.
+    assert not _column_exists(
+        pg_drift_session, "screened_stocks", "bearish_invalidation_level"
+    )
+
+    _seed_prices(pg_drift_session, "DRF", _SCAN, _FB_PRICES)
+    _seed_screened_raw(pg_drift_session, "DRF", _SCAN, "false_breakdown")
+
+    with pytest.raises(RuntimeError, match="migration 0012"):
+        backfill_screened_levels(
+            from_date=date(2026, 6, 3),
+            to_date=date(2026, 6, 12),
+            apply=True,
+            config_overrides=_CFG_OVERRIDES,
+        )
+
+    # The guard refused before any write: the row's levels stay NULL.
+    pg_drift_session.expire_all()
+    entry = pg_drift_session.execute(
+        text(
+            "SELECT entry_price FROM screened_stocks "
+            "WHERE symbol = :s AND scan_date = :d"
+        ),
+        {"s": "DRF", "d": _SCAN},
+    ).scalar_one()
+    assert entry is None
+
+
+def test_apply_on_healthy_db_passes_preflight(pg_legacy_session):
+    """On a complete (post-0012) DB the apply preflight passes and the write
+    proceeds — the guard must not block a healthy `--apply`."""
+    _seed_prices(pg_legacy_session, "OK", _SCAN, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "OK", _SCAN, pattern_type="false_breakdown")
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+    assert res.recovered == 1
+
+    pg_legacy_session.expire_all()
+    entry = pg_legacy_session.execute(
+        text(
+            "SELECT entry_price FROM screened_stocks "
+            "WHERE symbol = :s AND scan_date = :d"
+        ),
+        {"s": "OK", "d": _SCAN},
+    ).scalar_one()
+    assert entry is not None
+
+
 def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
     """On a complete DB the column-scoped `_target_rows` returns the SAME row set
     (by identity key) the old full-ORM load did — no behavior change when nothing

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -1,0 +1,298 @@
+"""One-time backfill of historical screened_stocks pattern levels.
+
+The screen->persist path has written entry/stop/target/rr correctly since the
+06-15 cutover, but ~510 patterned rows from scan_date 06-03..06-12 carry NULL
+levels (written by the pre-cutover live code). This backfill replays the pattern
+detector AS-OF each historical scan_date over stored ``stock_prices``, matches the
+actionable pattern whose ``pattern_type`` equals the row's stored type, and
+coalesce-upserts the four levels. Dry-run by default; ``apply=True`` writes.
+
+The detector / replay needs the legacy DB + Postgres ON CONFLICT, so these run
+under ``requires_postgres`` against ``pg_legacy_session``.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timezone
+
+import pandas as pd
+import pytest
+from sqlalchemy import select, text
+
+from rainier.core.models import ScreenedStockRecord, StockPrice
+from rainier.paper.backfill_screened_levels import backfill_screened_levels
+
+pytestmark = pytest.mark.requires_postgres
+
+
+# ---------------------------------------------------------------------------
+# Fixture price path: the same false-breakdown-that-recovers shape the replay
+# parity test uses — it yields TWO actionable patterns as-of the last bar:
+#   w_bottom (best / top-ranked)  and  false_breakdown.
+# This lets us assert the backfill matches the STORED pattern_type (picking
+# false_breakdown even though replay's `best` is w_bottom).
+# ---------------------------------------------------------------------------
+
+_FB_PRICES = (
+    [95.0, 93.0, 91.0, 90.0, 91.0, 93.0, 95.0, 93.0, 91.0, 90.0]
+    + [92.0, 93.0, 91.0]  # range above support
+    + [89.0, 88.0, 87.0]  # break below support
+    + [89.0, 91.0, 92.0]  # recover above support (confirm)
+    + [92.5, 92.0, 92.5, 92.0, 92.5]  # hold near entry (still actionable)
+)
+
+# StockScreenerConfig knobs that make the fixture's patterns detect (mirrors the
+# replay parity test's _CONFIG).
+_CFG_OVERRIDES = {
+    "swing_lookback": 3,
+    "min_pattern_bars": 3,
+    "max_pattern_bars": 50,
+    "neckline_tolerance_pct": 0.05,
+}
+
+
+def _seed_prices(session, symbol: str, last_date: date, prices: list[float]) -> None:
+    """Insert OHLCV bars ending ON ``last_date`` (one business day apart)."""
+    dates = pd.bdate_range(end=pd.Timestamp(last_date), periods=len(prices))
+    for i, (d, p) in enumerate(zip(dates, prices, strict=True)):
+        session.add(
+            StockPrice(
+                symbol=symbol,
+                date=d.to_pydatetime().replace(tzinfo=timezone.utc),
+                open=prices[max(0, i - 1)],
+                high=p * 1.01,
+                low=p * 0.99,
+                close=p,
+                volume=1000,
+            )
+        )
+    session.commit()
+
+
+def _seed_screened(
+    session,
+    symbol: str,
+    scan_date: date,
+    *,
+    pattern_type: str | None,
+    levels_null: bool = True,
+    entry=None,
+    stop=None,
+    target=None,
+    rr=None,
+) -> None:
+    session.add(
+        ScreenedStockRecord(
+            scan_date=scan_date,
+            session_name="close",
+            symbol=symbol,
+            rule_rank=1,
+            composite_score=0.8,
+            pattern_type=pattern_type,
+            entry_price=None if levels_null else entry,
+            stop_loss=None if levels_null else stop,
+            target_price=None if levels_null else target,
+            rr_ratio=None if levels_null else rr,
+        )
+    )
+    session.commit()
+
+
+def _row(session, symbol: str, scan_date: date) -> ScreenedStockRecord:
+    return (
+        session.execute(
+            select(ScreenedStockRecord).where(
+                ScreenedStockRecord.symbol == symbol,
+                ScreenedStockRecord.scan_date == scan_date,
+            )
+        )
+        .scalars()
+        .one()
+    )
+
+
+_SCAN = date(2026, 6, 5)
+
+
+def test_patterned_null_row_backfilled(pg_legacy_session):
+    """A patterned row with NULL levels gets the four levels from the as-of
+    replay's matching pattern."""
+    _seed_prices(pg_legacy_session, "AAA", _SCAN, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "AAA", _SCAN, pattern_type="false_breakdown")
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    r = _row(pg_legacy_session, "AAA", _SCAN)
+    assert r.entry_price is not None
+    assert r.stop_loss is not None
+    assert r.target_price is not None
+    assert r.rr_ratio is not None
+    assert res.scanned == 1
+    assert res.recovered == 1
+    assert res.still_null == 0
+
+
+def test_matches_stored_pattern_type_not_top_ranked_best(pg_legacy_session):
+    """Levels come from the actionable pattern whose type == stored pattern_type,
+    even when that is NOT replay's top-ranked `best`. The fixture's `best` is
+    w_bottom; the stored row says false_breakdown — the persisted levels must be
+    the false_breakdown's (entry ~89.1), never w_bottom's (entry ~93.9)."""
+    _seed_prices(pg_legacy_session, "FBK", _SCAN, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "FBK", _SCAN, pattern_type="false_breakdown")
+
+    backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    r = _row(pg_legacy_session, "FBK", _SCAN)
+    # false_breakdown entry ~89.1, w_bottom entry ~93.9 — assert the former.
+    assert r.entry_price == pytest.approx(89.1, abs=1.0)
+    assert r.entry_price < 91.0  # definitively NOT the w_bottom entry
+
+
+def test_dry_run_writes_nothing(pg_legacy_session):
+    _seed_prices(pg_legacy_session, "DRY", _SCAN, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "DRY", _SCAN, pattern_type="false_breakdown")
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=False,  # default: report only
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    r = _row(pg_legacy_session, "DRY", _SCAN)
+    assert r.entry_price is None  # nothing written
+    assert res.scanned == 1
+    assert res.recovered == 1  # counted as would-recover
+
+
+def test_coalesce_no_clobber_of_set_levels(pg_legacy_session):
+    """A row that already has levels is not in the target set (entry NOT NULL),
+    so the backfill never touches it."""
+    _seed_prices(pg_legacy_session, "SET", _SCAN, _FB_PRICES)
+    _seed_screened(
+        pg_legacy_session,
+        "SET",
+        _SCAN,
+        pattern_type="false_breakdown",
+        levels_null=False,
+        entry=55.0,
+        stop=50.0,
+        target=70.0,
+        rr=3.0,
+    )
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    r = _row(pg_legacy_session, "SET", _SCAN)
+    assert (r.entry_price, r.stop_loss, r.target_price, r.rr_ratio) == (55.0, 50.0, 70.0, 3.0)
+    assert res.scanned == 0  # already-set row excluded from target set
+
+
+def test_patternless_row_untouched(pg_legacy_session):
+    _seed_prices(pg_legacy_session, "NOP", _SCAN, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "NOP", _SCAN, pattern_type=None)
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    r = _row(pg_legacy_session, "NOP", _SCAN)
+    assert r.entry_price is None
+    assert res.scanned == 0  # patternless rows are not in the target set
+
+
+def test_unreconstructable_pattern_reported_not_errored(pg_legacy_session):
+    """A patterned row whose stored type does NOT re-detect as-of is left NULL
+    and counted in still_null — never errored, never given wrong-pattern levels."""
+    _seed_prices(pg_legacy_session, "MISS", _SCAN, _FB_PRICES)
+    # bull_flag is not among the fixture's actionable patterns.
+    _seed_screened(pg_legacy_session, "MISS", _SCAN, pattern_type="bull_flag")
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    r = _row(pg_legacy_session, "MISS", _SCAN)
+    assert r.entry_price is None
+    assert res.scanned == 1
+    assert res.recovered == 0
+    assert res.still_null == 1
+    assert ("MISS", _SCAN) in res.still_null_keys
+
+
+def test_idempotent_second_run_changes_nothing(pg_legacy_session):
+    _seed_prices(pg_legacy_session, "IDEM", _SCAN, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "IDEM", _SCAN, pattern_type="false_breakdown")
+
+    backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+    pg_legacy_session.expire_all()
+    first = _row(pg_legacy_session, "IDEM", _SCAN)
+    first_levels = (first.entry_price, first.stop_loss, first.target_price, first.rr_ratio)
+
+    # Second run: the row now has levels → no longer in the target set.
+    res2 = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+    pg_legacy_session.expire_all()
+    second = _row(pg_legacy_session, "IDEM", _SCAN)
+    assert (
+        second.entry_price,
+        second.stop_loss,
+        second.target_price,
+        second.rr_ratio,
+    ) == first_levels
+    assert res2.scanned == 0  # nothing left to backfill
+
+
+def test_out_of_window_row_not_scanned(pg_legacy_session):
+    """A patterned NULL row OUTSIDE [from,to] is never touched."""
+    out_of_window = date(2026, 6, 16)
+    _seed_prices(pg_legacy_session, "OOW", out_of_window, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "OOW", out_of_window, pattern_type="false_breakdown")
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    r = _row(pg_legacy_session, "OOW", out_of_window)
+    assert r.entry_price is None
+    assert res.scanned == 0

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -17,7 +17,7 @@ from datetime import date, timezone
 
 import pandas as pd
 import pytest
-from sqlalchemy import select, text
+from sqlalchemy import select
 
 from rainier.core.models import ScreenedStockRecord, StockPrice
 from rainier.paper.backfill_screened_levels import backfill_screened_levels

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -17,10 +17,13 @@ from datetime import date, timezone
 
 import pandas as pd
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from rainier.core.models import ScreenedStockRecord, StockPrice
-from rainier.paper.backfill_screened_levels import backfill_screened_levels
+from rainier.paper.backfill_screened_levels import (
+    _target_rows,
+    backfill_screened_levels,
+)
 
 pytestmark = pytest.mark.requires_postgres
 
@@ -367,3 +370,152 @@ def test_detector_failure_on_one_row_does_not_abort_run(
     assert ("BAD", _SCAN) in res.still_null_keys
     assert _row(pg_legacy_session, "BAD", _SCAN).entry_price is None
     assert _row(pg_legacy_session, "GOOD", _SCAN).entry_price is not None
+
+
+# ---------------------------------------------------------------------------
+# Schema-drift regression (the P1 fix): the live local DB is missing
+# `screened_stocks.bearish_invalidation_level` (migration 0012 never applied).
+# A full-ORM `select(ScreenedStockRecord)` would SELECT that column and crash
+# with UndefinedColumn. The column-scoped `_target_rows` must survive it.
+# ---------------------------------------------------------------------------
+
+
+def _column_exists(session, table: str, column: str) -> bool:
+    # to_regclass(table) resolves the table on the session's search_path (the
+    # throwaway test schema), so the catalog lookup targets THIS schema's table,
+    # not a same-named `public` one.
+    return bool(
+        session.execute(
+            text(
+                "SELECT 1 FROM pg_attribute "
+                "WHERE attrelid = to_regclass(:t) "
+                "AND attname = :c AND NOT attisdropped"
+            ),
+            {"t": table, "c": column},
+        ).first()
+    )
+
+
+def _seed_screened_raw(session, symbol: str, scan_date: date, pattern_type: str) -> None:
+    """Insert a patterned, level-NULL `screened_stocks` row via column-scoped SQL.
+
+    The full-ORM `_seed_screened` emits an INSERT over EVERY mapped column,
+    including `bearish_invalidation_level` — which the drift DB lacks. Seeding
+    here must therefore name only columns that exist pre-0012, or the seed itself
+    crashes before the backfill under test even runs.
+    """
+    session.execute(
+        text(
+            "INSERT INTO screened_stocks "
+            "(scan_date, session_name, symbol, rule_rank, composite_score, pattern_type) "
+            "VALUES (:d, 'close', :s, 1, 0.8, :p)"
+        ),
+        {"d": scan_date, "s": symbol, "p": pattern_type},
+    )
+    session.commit()
+
+
+def test_drift_db_missing_model_column_does_not_crash(pg_drift_session):
+    """On a DB missing `bearish_invalidation_level` (migration 0012 unapplied),
+    the DRY-RUN backfill must scan and report real counts — never crash with
+    UndefinedColumn. This is the operator's actual usage (dry-run first; 0012 is
+    applied before any `--apply`), and the surface this task hardens: the
+    column-scoped read in `_target_rows`. FAILS on the parent commit, whose
+    full-ORM `select(ScreenedStockRecord)` SELECTs the missing column."""
+    # Precondition: confirm the column really is absent on this drift fixture, so
+    # this test is meaningfully exercising the drift path (not a healthy DB).
+    assert not _column_exists(
+        pg_drift_session, "screened_stocks", "bearish_invalidation_level"
+    )
+
+    _seed_prices(pg_drift_session, "DRF", _SCAN, _FB_PRICES)
+    _seed_screened_raw(pg_drift_session, "DRF", _SCAN, "false_breakdown")
+
+    # Dry-run (apply=False): the read path under test. (apply=True would write
+    # through `persist_screened_stocks`, whose INSERT names the 0012 column — out
+    # of scope here; the operator applies 0012 before `--apply`, per the plan.)
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=False,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    # Scanned and matched the row without crashing on the missing column.
+    assert res.scanned == 1
+    assert res.recovered == 1  # would-recover (dry-run writes nothing)
+    assert res.still_null == 0
+    # Column-scoped read-back (a full-ORM `_row` would itself crash on the
+    # missing column): the dry-run wrote nothing, so entry_price is still NULL.
+    pg_drift_session.expire_all()
+    entry = pg_drift_session.execute(
+        text(
+            "SELECT entry_price FROM screened_stocks "
+            "WHERE symbol = :s AND scan_date = :d"
+        ),
+        {"s": "DRF", "d": _SCAN},
+    ).scalar_one()
+    assert entry is None
+
+
+def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
+    """On a complete DB the column-scoped `_target_rows` returns the SAME row set
+    (by identity key) the old full-ORM load did — no behavior change when nothing
+    is drifted."""
+    # Two close-session patterned NULL rows (in target set), plus a set-levels row
+    # and a non-close row (both excluded). The scoped query must return exactly
+    # the two target rows, in (symbol, scan_date) order.
+    _seed_prices(pg_legacy_session, "AAA", _SCAN, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "AAA", _SCAN, pattern_type="false_breakdown")
+    _seed_prices(pg_legacy_session, "BBB", _SCAN, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "BBB", _SCAN, pattern_type="false_breakdown")
+    _seed_screened(
+        pg_legacy_session,
+        "CCC",
+        _SCAN,
+        pattern_type="false_breakdown",
+        levels_null=False,
+        entry=55.0,
+        stop=50.0,
+        target=70.0,
+        rr=3.0,
+    )
+    _seed_screened(
+        pg_legacy_session,
+        "DDD",
+        _SCAN,
+        pattern_type="false_breakdown",
+        session_name="morning",
+    )
+
+    # Old ORM path: the same WHERE/ORDER over full entities.
+    orm_rows = (
+        pg_legacy_session.execute(
+            select(ScreenedStockRecord)
+            .where(
+                ScreenedStockRecord.scan_date >= date(2026, 6, 3),
+                ScreenedStockRecord.scan_date <= date(2026, 6, 12),
+                ScreenedStockRecord.session_name == "close",
+                ScreenedStockRecord.pattern_type.isnot(None),
+                ScreenedStockRecord.entry_price.is_(None),
+            )
+            .order_by(
+                ScreenedStockRecord.symbol.asc(),
+                ScreenedStockRecord.scan_date.asc(),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    orm_keys = [(r.symbol, r.scan_date) for r in orm_rows]
+
+    scoped = _target_rows(pg_legacy_session, date(2026, 6, 3), date(2026, 6, 12))
+    scoped_keys = [(r.symbol, r.scan_date) for r in scoped]
+
+    assert scoped_keys == orm_keys == [("AAA", _SCAN), ("BBB", _SCAN)]
+    # And the carried columns match the ORM values.
+    for scoped_row, orm_row in zip(scoped, orm_rows, strict=True):
+        assert scoped_row.session_name == orm_row.session_name
+        assert scoped_row.pattern_type == orm_row.pattern_type
+        assert scoped_row.sector == orm_row.sector
+        assert scoped_row.composite_score == orm_row.composite_score

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -289,6 +289,67 @@ def test_partial_levels_row_is_backfilled(pg_legacy_session):
     assert r.rr_ratio is not None
 
 
+def test_target_rows_includes_false_breakout_missing_only_invalidation_level(
+    pg_legacy_session,
+):
+    """Codex P2: on a post-0012 DB, a `false_breakout` row with ALL FOUR trade
+    levels set but `bearish_invalidation_level` NULL (written pre-0012) IS a target
+    — otherwise reclaim (`bearish_invalidation_level IS NOT NULL`) ignores it
+    forever. A NON-false_breakout row in the same all-trade-levels-set / NULL-bil
+    state is NOT targeted (only false_breakout carries a trap-high).
+
+    Deterministic at the _target_rows level (no detector dependency): proves the
+    SELECT predicate, which is the P2 fix surface."""
+    # TRAP: false_breakout, 4 trade levels set, bil NULL → IS a target.
+    pg_legacy_session.add(
+        ScreenedStockRecord(
+            scan_date=_SCAN,
+            session_name="close",
+            symbol="TRAP",
+            rule_rank=1,
+            composite_score=0.8,
+            pattern_type="false_breakout",
+            entry_price=88.5,
+            stop_loss=93.5,
+            target_price=82.0,
+            rr_ratio=2.0,
+            bearish_invalidation_level=None,
+        )
+    )
+    # OTHER: false_breakdown, 4 trade levels set, bil NULL → NOT a target (only
+    # false_breakout's NULL bil counts as damage).
+    pg_legacy_session.add(
+        ScreenedStockRecord(
+            scan_date=_SCAN,
+            session_name="close",
+            symbol="OTHER",
+            rule_rank=1,
+            composite_score=0.8,
+            pattern_type="false_breakdown",
+            entry_price=89.0,
+            stop_loss=85.0,
+            target_price=95.0,
+            rr_ratio=1.5,
+            bearish_invalidation_level=None,
+        )
+    )
+    pg_legacy_session.commit()
+
+    scoped = _target_rows(
+        pg_legacy_session, date(2026, 6, 3), date(2026, 6, 12), bil_present=True
+    )
+    keys = {(r.symbol, r.scan_date) for r in scoped}
+    assert ("TRAP", _SCAN) in keys  # false_breakout NULL-bil targeted
+    assert ("OTHER", _SCAN) not in keys  # false_breakdown NULL-bil NOT targeted
+
+    # And with bil_present=False (pre-0012 DB) TRAP is NOT targeted — the column
+    # is never named, so the NULL-bil clause is absent (drift-safe).
+    scoped_pre0012 = _target_rows(
+        pg_legacy_session, date(2026, 6, 3), date(2026, 6, 12), bil_present=False
+    )
+    assert ("TRAP", _SCAN) not in {(r.symbol, r.scan_date) for r in scoped_pre0012}
+
+
 def test_patternless_row_untouched(pg_legacy_session):
     _seed_prices(pg_legacy_session, "NOP", _SCAN, _FB_PRICES)
     _seed_screened(pg_legacy_session, "NOP", _SCAN, pattern_type=None)
@@ -803,7 +864,10 @@ def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
         session_name="morning",
     )
 
-    # Equivalent ORM path: the same WHERE/ORDER over full entities (any-NULL level).
+    # Equivalent ORM path: the same WHERE/ORDER over full entities (any-NULL level
+    # + false_breakout NULL bearish_invalidation_level on a post-0012 DB).
+    from sqlalchemy import and_
+
     orm_rows = (
         pg_legacy_session.execute(
             select(ScreenedStockRecord)
@@ -817,6 +881,10 @@ def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
                     ScreenedStockRecord.stop_loss.is_(None),
                     ScreenedStockRecord.target_price.is_(None),
                     ScreenedStockRecord.rr_ratio.is_(None),
+                    and_(
+                        ScreenedStockRecord.pattern_type == "false_breakout",
+                        ScreenedStockRecord.bearish_invalidation_level.is_(None),
+                    ),
                 ),
             )
             .order_by(
@@ -829,7 +897,10 @@ def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
     )
     orm_keys = [(r.symbol, r.scan_date) for r in orm_rows]
 
-    scoped = _target_rows(pg_legacy_session, date(2026, 6, 3), date(2026, 6, 12))
+    # pg_legacy_session is post-0012, so the 0012 column exists.
+    scoped = _target_rows(
+        pg_legacy_session, date(2026, 6, 3), date(2026, 6, 12), bil_present=True
+    )
     scoped_keys = [(r.symbol, r.scan_date) for r in scoped]
 
     assert scoped_keys == orm_keys == [("AAA", _SCAN), ("BBB", _SCAN), ("PART", _SCAN)]

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -327,3 +327,43 @@ def test_non_close_session_row_not_backfilled(pg_legacy_session):
     assert r.entry_price is None  # never written
     assert res.scanned == 0  # non-close row not in the target set
     assert res.recovered == 0
+    # ...but it IS still a damaged row, surfaced so a dry-run isn't falsely complete.
+    assert res.skipped_non_close == 1
+
+
+def test_detector_failure_on_one_row_does_not_abort_run(
+    pg_legacy_session, monkeypatch
+):
+    """A detector exception on one symbol is per-symbol noise: that row lands in
+    still_null and the run continues to repair the others (never aborts)."""
+    import rainier.paper.backfill_screened_levels as mod
+
+    _seed_prices(pg_legacy_session, "BAD", _SCAN, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "BAD", _SCAN, pattern_type="false_breakdown")
+    _seed_prices(pg_legacy_session, "GOOD", _SCAN, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "GOOD", _SCAN, pattern_type="false_breakdown")
+
+    real_replay = mod.replay_pattern_layer
+
+    def flaky_replay(symbol, windowed, config):
+        if symbol == "BAD":
+            raise RuntimeError("synthetic detector blow-up")
+        return real_replay(symbol, windowed, config)
+
+    monkeypatch.setattr(mod, "replay_pattern_layer", flaky_replay)
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    # The run completed (no abort): BAD → still_null, GOOD → recovered + written.
+    assert res.scanned == 2
+    assert res.recovered == 1
+    assert res.still_null == 1
+    assert ("BAD", _SCAN) in res.still_null_keys
+    assert _row(pg_legacy_session, "BAD", _SCAN).entry_price is None
+    assert _row(pg_legacy_session, "GOOD", _SCAN).entry_price is not None

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -80,11 +80,12 @@ def _seed_screened(
     stop=None,
     target=None,
     rr=None,
+    session_name: str = "close",
 ) -> None:
     session.add(
         ScreenedStockRecord(
             scan_date=scan_date,
-            session_name="close",
+            session_name=session_name,
             symbol=symbol,
             rule_rank=1,
             composite_score=0.8,
@@ -296,3 +297,33 @@ def test_out_of_window_row_not_scanned(pg_legacy_session):
     r = _row(pg_legacy_session, "OOW", out_of_window)
     assert r.entry_price is None
     assert res.scanned == 0
+
+
+def test_non_close_session_row_not_backfilled(pg_legacy_session):
+    """A patterned NULL row from a non-close session is NEVER backfilled.
+
+    Only the close-session daily bar matches what the live screen saw; an
+    earlier session lacked the day's final high/low/close, so replaying its
+    completed bar would inject look-ahead. The row is left NULL and excluded
+    from the target set entirely (not even counted as still_null)."""
+    _seed_prices(pg_legacy_session, "MORN", _SCAN, _FB_PRICES)
+    _seed_screened(
+        pg_legacy_session,
+        "MORN",
+        _SCAN,
+        pattern_type="false_breakdown",
+        session_name="morning",
+    )
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    r = _row(pg_legacy_session, "MORN", _SCAN)
+    assert r.entry_price is None  # never written
+    assert res.scanned == 0  # non-close row not in the target set
+    assert res.recovered == 0

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -451,7 +451,9 @@ def test_detector_failure_on_one_row_does_not_abort_run(
     pg_legacy_session, monkeypatch
 ):
     """A detector exception on one symbol is per-symbol noise: that row lands in
-    still_null and the run continues to repair the others (never aborts)."""
+    the detector_errors bucket (NOT still_null — a crash isn't a proven-permanent
+    no-match; a data/code fix may recover it) and the run continues to repair the
+    others (never aborts)."""
     import rainier.paper.backfill_screened_levels as mod
 
     _seed_prices(pg_legacy_session, "BAD", _SCAN, _FB_PRICES)
@@ -476,11 +478,14 @@ def test_detector_failure_on_one_row_does_not_abort_run(
     )
 
     pg_legacy_session.expire_all()
-    # The run completed (no abort): BAD → still_null, GOOD → recovered + written.
+    # The run completed (no abort): BAD → detector_errors, GOOD → recovered.
     assert res.scanned == 2
     assert res.recovered == 1
-    assert res.still_null == 1
-    assert ("BAD", _SCAN) in res.still_null_keys
+    # A detector crash is its own bucket, NOT permanent still_null.
+    assert res.detector_errors == 1
+    assert ("BAD", _SCAN) in res.detector_error_keys
+    assert res.still_null == 0
+    assert ("BAD", _SCAN) not in res.still_null_keys
     assert _row(pg_legacy_session, "BAD", _SCAN).entry_price is None
     assert _row(pg_legacy_session, "GOOD", _SCAN).entry_price is not None
 

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -3,23 +3,27 @@
 The screen->persist path has written entry/stop/target/rr correctly since the
 06-15 cutover, but ~510 patterned rows from scan_date 06-03..06-12 carry NULL
 levels (written by the pre-cutover live code). This backfill replays the pattern
-detector AS-OF each historical scan_date over stored ``stock_prices``, matches the
-actionable pattern whose ``pattern_type`` equals the row's stored type, and
-coalesce-upserts the four levels. Dry-run by default; ``apply=True`` writes.
+detector AS-OF each historical scan_date over a FRESH yfinance window (the same
+source the live screener uses — the stored ``stock_prices`` corpus is too short
+to form a pattern), matches the actionable pattern whose ``pattern_type`` equals
+the row's stored type, and coalesce-upserts the four levels. Dry-run by default;
+``apply=True`` writes.
 
-The detector / replay needs the legacy DB + Postgres ON CONFLICT, so these run
-under ``requires_postgres`` against ``pg_legacy_session``.
+The screened rows + Postgres ON CONFLICT need the legacy DB, so these run under
+``requires_postgres`` against ``pg_legacy_session``. The PRICE source is yfinance;
+each test injects a deterministic ``{symbol: DataFrame}`` by monkeypatching
+``_fetch_history`` (autouse ``_patch_fetch_history`` fixture) — no live network.
 """
 
 from __future__ import annotations
 
-from datetime import date, timezone
+from datetime import date
 
 import pandas as pd
 import pytest
 from sqlalchemy import select, text
 
-from rainier.core.models import ScreenedStockRecord, StockPrice
+from rainier.core.models import ScreenedStockRecord
 from rainier.paper.backfill_screened_levels import (
     _target_rows,
     backfill_screened_levels,
@@ -54,22 +58,51 @@ _CFG_OVERRIDES = {
 }
 
 
+# In-memory price corpus the patched ``_fetch_history`` serves. Mirrors the
+# yfinance return shape: tz-naive DatetimeIndex, lowercase OHLCV columns. Tests
+# populate it via ``_seed_prices``; the autouse ``_patch_fetch_history`` fixture
+# resets it per test and routes ``_fetch_history`` to read from it (no network).
+_PRICE_FIXTURES: dict[str, pd.DataFrame] = {}
+
+
+@pytest.fixture(autouse=True)
+def _patch_fetch_history(monkeypatch):
+    """Route ``_fetch_history`` to the in-memory ``_PRICE_FIXTURES`` map.
+
+    The source swap means the backfill fetches prices from yfinance, not the DB.
+    Tests must not hit the network, so this autouse fixture replaces the helper
+    with one that returns the deterministic frames ``_seed_prices`` registered —
+    honoring the requested symbol set, exactly like the real batch fetch."""
+    import rainier.paper.backfill_screened_levels as mod
+
+    _PRICE_FIXTURES.clear()
+
+    def fake_fetch(symbols, *, start, end, min_bars):
+        return {s: _PRICE_FIXTURES[s] for s in symbols if s in _PRICE_FIXTURES}
+
+    monkeypatch.setattr(mod, "_fetch_history", fake_fetch)
+    yield
+    _PRICE_FIXTURES.clear()
+
+
 def _seed_prices(session, symbol: str, last_date: date, prices: list[float]) -> None:
-    """Insert OHLCV bars ending ON ``last_date`` (one business day apart)."""
+    """Register a yfinance-shaped OHLCV frame ending ON ``last_date``.
+
+    Bars are one business day apart with a tz-naive DatetimeIndex and lowercase
+    columns — the exact shape ``_fetch_history`` returns. The ``session`` arg is
+    kept for call-site symmetry but unused (prices no longer live in the DB)."""
     dates = pd.bdate_range(end=pd.Timestamp(last_date), periods=len(prices))
-    for i, (d, p) in enumerate(zip(dates, prices, strict=True)):
-        session.add(
-            StockPrice(
-                symbol=symbol,
-                date=d.to_pydatetime().replace(tzinfo=timezone.utc),
-                open=prices[max(0, i - 1)],
-                high=p * 1.01,
-                low=p * 0.99,
-                close=p,
-                volume=1000,
-            )
-        )
-    session.commit()
+    df = pd.DataFrame(
+        {
+            "open": [prices[max(0, i - 1)] for i in range(len(prices))],
+            "high": [p * 1.01 for p in prices],
+            "low": [p * 0.99 for p in prices],
+            "close": list(prices),
+            "volume": [1000] * len(prices),
+        },
+        index=dates,
+    )
+    _PRICE_FIXTURES[symbol] = df
 
 
 def _seed_screened(

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -367,6 +367,86 @@ def test_non_close_session_row_not_backfilled(pg_legacy_session):
     assert res.skipped_non_close == 1
 
 
+def test_no_price_data_row_is_separate_bucket_not_still_null(pg_legacy_session):
+    """A patterned NULL row whose symbol returned NO yfinance bars (transient
+    fetch failure) lands in `no_price_data`, NOT `still_null`. Conflating them
+    would let a fetch blip masquerade as a permanent no-pattern-match, so the
+    operator would mark a recoverable row unreconstructable. Seed the screened
+    row but NO prices for its symbol → the faked `_fetch_history` omits it."""
+    # NB: deliberately do NOT call _seed_prices for NODATA → absent from corpus.
+    _seed_screened(pg_legacy_session, "NODATA", _SCAN, pattern_type="false_breakdown")
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    r = _row(pg_legacy_session, "NODATA", _SCAN)
+    assert r.entry_price is None  # nothing written
+    assert res.scanned == 1
+    assert res.recovered == 0
+    assert res.still_null == 0  # NOT a permanent no-match
+    assert res.no_price_data == 1  # transient: surfaced for re-run
+    assert ("NODATA", _SCAN) in res.no_price_data_keys
+    assert ("NODATA", _SCAN) not in res.still_null_keys
+
+
+def test_multiple_scan_dates_each_gets_its_own_window_levels(pg_legacy_session):
+    """Two close-session patterned-NULL rows on DIFFERENT scan_dates each get the
+    levels derived from THEIR OWN as-of window. The apply path groups candidates
+    by (scan_date, session_name) and persists per group; a regression mapping a
+    candidate to the wrong scan_date would mis-persist. Distinct price magnitudes
+    per symbol prove each row got its own window, not the other's."""
+    scan_a = date(2026, 6, 5)
+    scan_b = date(2026, 6, 9)
+    # Distinct price bases → distinct entry levels, so a cross-mapping is visible.
+    _seed_prices(pg_legacy_session, "AAA", scan_a, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "AAA", scan_a, pattern_type="false_breakdown")
+    _seed_prices(pg_legacy_session, "BBB", scan_b, [p + 100.0 for p in _FB_PRICES])
+    _seed_screened(pg_legacy_session, "BBB", scan_b, pattern_type="false_breakdown")
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    ra = _row(pg_legacy_session, "AAA", scan_a)
+    rb = _row(pg_legacy_session, "BBB", scan_b)
+    assert res.recovered == 2
+    assert ra.entry_price is not None and rb.entry_price is not None
+    # AAA's window (~89) is the low corpus; BBB's (+100, ~189) is the high one.
+    assert ra.entry_price < 100.0
+    assert rb.entry_price > 100.0
+
+
+def test_multiple_same_group_rows_all_persisted(pg_legacy_session):
+    """Two recovered rows in the SAME (scan_date, session_name) group are BOTH
+    written via the single per-group persist_screened_stocks call — the per-group
+    candidate list is fully persisted, not just its first element."""
+    _seed_prices(pg_legacy_session, "AAA", _SCAN, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "AAA", _SCAN, pattern_type="false_breakdown")
+    _seed_prices(pg_legacy_session, "BBB", _SCAN, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "BBB", _SCAN, pattern_type="false_breakdown")
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    pg_legacy_session.expire_all()
+    assert res.recovered == 2
+    assert _row(pg_legacy_session, "AAA", _SCAN).entry_price is not None
+    assert _row(pg_legacy_session, "BBB", _SCAN).entry_price is not None
+
+
 def test_detector_failure_on_one_row_does_not_abort_run(
     pg_legacy_session, monkeypatch
 ):

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -524,6 +524,36 @@ def test_apply_on_healthy_db_passes_preflight(pg_legacy_session):
     assert entry is not None
 
 
+def test_missing_scan_date_bar_stays_still_null_no_prior_day_levels(pg_legacy_session):
+    """Fidelity gate (codex P1): when `stock_prices` has NO bar exactly on the
+    row's scan_date (an ingest gap), the backfill must leave the row in still_null
+    — NOT replay the prior trading day's bar and write stale prior-day levels.
+
+    Seed the full price history but ending the business day BEFORE scan_date, so
+    the canonical scan_date bar is absent. The row must report still_null with its
+    levels untouched. FAILS on the parent commit, whose `_as_of_idx` falls back to
+    the last bar on/before scan_date (the prior day) and would write its levels."""
+    prior_bday = (pd.Timestamp(_SCAN) - pd.tseries.offsets.BDay(1)).date()
+    # Prices end on the prior business day → no bar exactly on _SCAN.
+    _seed_prices(pg_legacy_session, "GAP", prior_bday, _FB_PRICES)
+    _seed_screened(pg_legacy_session, "GAP", _SCAN, pattern_type="false_breakdown")
+
+    res = backfill_screened_levels(
+        from_date=date(2026, 6, 3),
+        to_date=date(2026, 6, 12),
+        apply=True,
+        config_overrides=_CFG_OVERRIDES,
+    )
+
+    assert res.scanned == 1
+    assert res.recovered == 0
+    assert res.still_null == 1
+    assert ("GAP", _SCAN) in res.still_null_keys
+    # No prior-day levels written: the row's entry_price is still NULL.
+    pg_legacy_session.expire_all()
+    assert _row(pg_legacy_session, "GAP", _SCAN).entry_price is None
+
+
 def test_target_rows_match_orm_path_on_healthy_db(pg_legacy_session):
     """On a complete DB the column-scoped `_target_rows` returns the SAME row set
     (by identity key) the old full-ORM load did — no behavior change when nothing

--- a/tests/test_paper/test_backfill_screened_levels.py
+++ b/tests/test_paper/test_backfill_screened_levels.py
@@ -637,15 +637,21 @@ def test_apply_on_healthy_db_passes_preflight(pg_legacy_session):
     assert entry is not None
 
 
-def test_missing_scan_date_bar_stays_still_null_no_prior_day_levels(pg_legacy_session):
-    """Fidelity gate (codex P1): when `stock_prices` has NO bar exactly on the
-    row's scan_date (an ingest gap), the backfill must leave the row in still_null
-    — NOT replay the prior trading day's bar and write stale prior-day levels.
+def test_missing_scan_date_bar_is_transient_no_price_data_no_prior_day_levels(
+    pg_legacy_session,
+):
+    """Fidelity gate: when the fetch has NO bar exactly on the row's scan_date (a
+    vendor gap), the backfill must NOT replay the prior trading day's bar and write
+    stale prior-day levels. The row is left UNWRITTEN.
+
+    Classification (codex iter-N P2): a missing exact-scan_date bar is a TRANSIENT
+    gap — a later fetch can supply it — so it belongs in `no_price_data`
+    (recoverable, re-run may help), NOT `still_null` (which the CLI labels a
+    PERMANENT no-pattern-match). Mislabeling it permanent would tell the operator
+    to stop retrying a row a re-run could fix.
 
     Seed the full price history but ending the business day BEFORE scan_date, so
-    the canonical scan_date bar is absent. The row must report still_null with its
-    levels untouched. FAILS on the parent commit, whose `_as_of_idx` falls back to
-    the last bar on/before scan_date (the prior day) and would write its levels."""
+    the canonical scan_date bar is absent."""
     prior_bday = (pd.Timestamp(_SCAN) - pd.tseries.offsets.BDay(1)).date()
     # Prices end on the prior business day → no bar exactly on _SCAN.
     _seed_prices(pg_legacy_session, "GAP", prior_bday, _FB_PRICES)
@@ -660,8 +666,11 @@ def test_missing_scan_date_bar_stays_still_null_no_prior_day_levels(pg_legacy_se
 
     assert res.scanned == 1
     assert res.recovered == 0
-    assert res.still_null == 1
-    assert ("GAP", _SCAN) in res.still_null_keys
+    # Transient (missing exact bar) → no_price_data, NOT permanent still_null.
+    assert res.still_null == 0
+    assert ("GAP", _SCAN) not in res.still_null_keys
+    assert res.no_price_data == 1
+    assert ("GAP", _SCAN) in res.no_price_data_keys
     # No prior-day levels written: the row's entry_price is still NULL.
     pg_legacy_session.expire_all()
     assert _row(pg_legacy_session, "GAP", _SCAN).entry_price is None

--- a/tests/test_paper/test_backfill_screened_levels_helpers.py
+++ b/tests/test_paper/test_backfill_screened_levels_helpers.py
@@ -362,6 +362,29 @@ def test_fetch_history_batch_exception_falls_back_to_per_symbol(monkeypatch):
     assert set(out) == {"AAA", "BBB"}
 
 
+def test_fetch_history_symbol_absent_after_solo_retry_omitted_not_crashed(monkeypatch):
+    """The TERMINAL no-data branch: a symbol missing from the batch AND whose solo
+    retry also returns nothing is simply omitted from the output map — never
+    crashes, never falsely present. A well-formed sibling still comes through."""
+    import rainier.paper.backfill_screened_levels as mod
+
+    dates = pd.date_range("2026-01-02", periods=70, freq="B")
+    batch = _multi_download({"AAA": _ohlcv_frame(dates, 100.0)})  # GONE absent
+
+    def fake_download(symbols, **kw):
+        syms = symbols if isinstance(symbols, list) else [symbols]
+        if syms == ["GONE"]:
+            return None  # solo retry also yields nothing (delisting / outage)
+        return batch
+
+    monkeypatch.setattr(mod.yf, "download", fake_download)
+
+    out = _fetch_history(
+        ["AAA", "GONE"], start=date(2026, 1, 1), end=date(2026, 6, 1), min_bars=60
+    )
+    assert set(out) == {"AAA"}  # GONE dropped (doubly-failed), AAA preserved
+
+
 def test_fetch_history_empty_symbols_returns_empty(monkeypatch):
     import rainier.paper.backfill_screened_levels as mod
 

--- a/tests/test_paper/test_backfill_screened_levels_helpers.py
+++ b/tests/test_paper/test_backfill_screened_levels_helpers.py
@@ -91,25 +91,29 @@ def _df(dates: list[pd.Timestamp]) -> pd.DataFrame:
     return pd.DataFrame({"close": range(len(dates))}, index=pd.DatetimeIndex(dates))
 
 
-def test_as_of_idx_hits_last_bar_on_or_before_scan_date():
+def test_as_of_idx_hits_exact_scan_date_bar():
     dates = [
         pd.Timestamp("2026-06-01", tz="UTC"),
         pd.Timestamp("2026-06-03", tz="UTC"),
         pd.Timestamp("2026-06-05", tz="UTC"),
         pd.Timestamp("2026-06-09", tz="UTC"),  # after scan_date
     ]
-    # scan_date 06-05 → the 06-05 bar (positional index 2) is the as-of bar.
+    # scan_date 06-05 → the EXACT 06-05 bar (positional index 2) is the as-of bar.
     assert _as_of_idx(_df(dates), date(2026, 6, 5)) == 2
 
 
-def test_as_of_idx_picks_prior_bar_when_scan_date_has_no_bar():
+def test_as_of_idx_none_when_scan_date_bar_missing_no_prior_day_fallback():
+    """Fidelity gate (codex P1): a missing scan_date bar must NOT silently fall
+    back to the prior trading day's bar. Replaying the prior day would write stale
+    prior-day levels into a row meant to be reconstructed AS OF scan_date — so the
+    row stays still_null instead. Returns None when the exact bar is absent."""
     dates = [
         pd.Timestamp("2026-06-01", tz="UTC"),
         pd.Timestamp("2026-06-03", tz="UTC"),
         pd.Timestamp("2026-06-08", tz="UTC"),
     ]
-    # scan_date 06-05 has no bar → last bar on/before is 06-03 (index 1).
-    assert _as_of_idx(_df(dates), date(2026, 6, 5)) == 1
+    # scan_date 06-05 has NO bar → None (no 06-03 fallback). Was index 1 pre-fix.
+    assert _as_of_idx(_df(dates), date(2026, 6, 5)) is None
 
 
 def test_as_of_idx_none_when_all_bars_after_scan_date():

--- a/tests/test_paper/test_backfill_screened_levels_helpers.py
+++ b/tests/test_paper/test_backfill_screened_levels_helpers.py
@@ -137,6 +137,24 @@ def test_as_of_idx_includes_midnight_utc_scan_date_bar():
     assert _as_of_idx(_df([bar]), date(2026, 6, 5)) == 0
 
 
+def test_as_of_idx_matches_scan_date_under_non_utc_session_tz():
+    """A midnight-UTC bar read back under a BEHIND-UTC session tz must still match
+    its scan_date — the bar's UTC calendar date is canonical, not its local date.
+
+    psycopg returns timestamptz in the Postgres session TimeZone GUC, which is NOT
+    pinned to UTC on the local TimescaleDB. The 06-05 00:00 UTC bar presents as
+    06-04 17:00-07:00 under America/Los_Angeles; taking the LOCAL date would mis-
+    date it to 06-04 and the row would never match scan_date 06-05 — silently
+    making the whole repair a 0-recovered no-op. _as_of_idx must convert to UTC
+    first. FAILS on a local-tz `.normalize().date` implementation."""
+    # The same instant the DB stores (midnight UTC on scan_date), but presented
+    # in a behind-UTC zone the way a non-UTC psycopg session would return it.
+    bar = pd.Timestamp(date(2026, 6, 5), tz=timezone.utc).tz_convert(
+        "America/Los_Angeles"
+    )  # -> 2026-06-04 17:00-07:00, LOCAL date 06-04
+    assert _as_of_idx(_df([bar]), date(2026, 6, 5)) == 0
+
+
 # --- input validation ------------------------------------------------------
 
 

--- a/tests/test_paper/test_backfill_screened_levels_helpers.py
+++ b/tests/test_paper/test_backfill_screened_levels_helpers.py
@@ -18,6 +18,7 @@ from rainier.core.types import PatternSignal
 from rainier.paper.backfill_screened_levels import (
     _as_of_idx,
     _candidate_with_levels,
+    _fetch_history,
     _match_pattern,
     _TargetRow,
     backfill_screened_levels,
@@ -225,6 +226,150 @@ def test_candidate_invalidation_level_none_when_false_high_absent():
         ).bearish_invalidation_level
         is None
     )
+
+
+# --- _fetch_history (yfinance source, mirrors _fetch_stock_data normalize) -
+
+
+def _ohlcv_frame(dates: pd.DatetimeIndex, base: float) -> pd.DataFrame:
+    """A yfinance-shaped per-symbol OHLCV frame (capitalized columns)."""
+    n = len(dates)
+    return pd.DataFrame(
+        {
+            "Open": [base + i for i in range(n)],
+            "High": [base + i + 1 for i in range(n)],
+            "Low": [base + i - 1 for i in range(n)],
+            "Close": [base + i for i in range(n)],
+            "Volume": [1000] * n,
+        },
+        index=dates,
+    )
+
+
+def _multi_download(frames: dict[str, pd.DataFrame]) -> pd.DataFrame:
+    """A multi-symbol ``yf.download(group_by="ticker")`` shape: MultiIndex
+    columns (symbol, field) over a shared date index."""
+    return pd.concat(frames, axis=1)
+
+
+def test_fetch_history_multi_symbol_normalizes_lowercase_and_indexes(monkeypatch):
+    import rainier.paper.backfill_screened_levels as mod
+
+    dates = pd.date_range("2026-01-02", periods=70, freq="B")
+    raw = _multi_download(
+        {"AAA": _ohlcv_frame(dates, 100.0), "BBB": _ohlcv_frame(dates, 50.0)}
+    )
+
+    def fake_download(symbols, **kwargs):
+        # mirror the live screener: 1d interval, grouped by ticker, adjusted.
+        assert kwargs["interval"] == "1d"
+        assert kwargs["group_by"] == "ticker"
+        assert kwargs["auto_adjust"] is True
+        # explicit start/end (NOT period=) so the left edge is reachable.
+        assert "start" in kwargs and "end" in kwargs and "period" not in kwargs
+        return raw
+
+    monkeypatch.setattr(mod.yf, "download", fake_download)
+
+    out = _fetch_history(
+        ["AAA", "BBB"], start=date(2026, 1, 1), end=date(2026, 6, 1), min_bars=60
+    )
+
+    assert set(out) == {"AAA", "BBB"}
+    # lowercase OHLCV columns, date-indexed.
+    assert list(out["AAA"].columns) == ["open", "high", "low", "close", "volume"]
+    assert isinstance(out["AAA"].index, pd.DatetimeIndex)
+    assert len(out["AAA"]) == 70
+
+
+def test_fetch_history_single_symbol_flat_columns(monkeypatch):
+    import rainier.paper.backfill_screened_levels as mod
+
+    dates = pd.date_range("2026-01-02", periods=70, freq="B")
+    raw = _ohlcv_frame(dates, 100.0)  # flat (non-MultiIndex) columns for 1 symbol
+
+    monkeypatch.setattr(mod.yf, "download", lambda symbols, **kw: raw)
+
+    out = _fetch_history(
+        ["AAA"], start=date(2026, 1, 1), end=date(2026, 6, 1), min_bars=60
+    )
+    assert set(out) == {"AAA"}
+    assert list(out["AAA"].columns) == ["open", "high", "low", "close", "volume"]
+
+
+def test_fetch_history_skips_symbol_below_min_bars(monkeypatch):
+    import rainier.paper.backfill_screened_levels as mod
+
+    dates = pd.date_range("2026-01-02", periods=70, freq="B")
+    short = pd.date_range("2026-01-02", periods=10, freq="B")
+    raw = _multi_download(
+        {"AAA": _ohlcv_frame(dates, 100.0), "SHORT": _ohlcv_frame(short, 50.0)}
+    )
+    monkeypatch.setattr(mod.yf, "download", lambda symbols, **kw: raw)
+
+    out = _fetch_history(
+        ["AAA", "SHORT"], start=date(2026, 1, 1), end=date(2026, 6, 1), min_bars=60
+    )
+    assert set(out) == {"AAA"}  # SHORT (10 bars) dropped below the 60-bar floor
+
+
+def test_fetch_history_per_symbol_retry_on_transient_batch_drop(monkeypatch):
+    """A symbol absent from the batch frame (observed LLY hiccup) is re-fetched
+    solo; a network blip must never be mislabeled as no-data."""
+    import rainier.paper.backfill_screened_levels as mod
+
+    dates = pd.date_range("2026-01-02", periods=70, freq="B")
+    # Batch returns AAA only; LLY is missing from the grouped frame.
+    batch = _multi_download({"AAA": _ohlcv_frame(dates, 100.0)})
+    solo = _ohlcv_frame(dates, 80.0)  # LLY solo retry succeeds
+
+    calls: list[list[str]] = []
+
+    def fake_download(symbols, **kw):
+        calls.append(list(symbols) if isinstance(symbols, list) else [symbols])
+        if symbols == ["LLY"] or symbols == "LLY":
+            return solo
+        return batch
+
+    monkeypatch.setattr(mod.yf, "download", fake_download)
+
+    out = _fetch_history(
+        ["AAA", "LLY"], start=date(2026, 1, 1), end=date(2026, 6, 1), min_bars=60
+    )
+    assert set(out) == {"AAA", "LLY"}  # LLY recovered via the solo retry
+    assert ["LLY"] in calls  # the per-symbol retry actually fired
+
+
+def test_fetch_history_batch_exception_falls_back_to_per_symbol(monkeypatch):
+    """If the whole batch download raises, each symbol is still attempted solo
+    so a single bad batch does not zero out the corpus."""
+    import rainier.paper.backfill_screened_levels as mod
+
+    dates = pd.date_range("2026-01-02", periods=70, freq="B")
+    solo = {"AAA": _ohlcv_frame(dates, 100.0), "BBB": _ohlcv_frame(dates, 50.0)}
+
+    def fake_download(symbols, **kw):
+        syms = symbols if isinstance(symbols, list) else [symbols]
+        if len(syms) > 1:
+            raise RuntimeError("synthetic batch failure")
+        return solo[syms[0]]
+
+    monkeypatch.setattr(mod.yf, "download", fake_download)
+
+    out = _fetch_history(
+        ["AAA", "BBB"], start=date(2026, 1, 1), end=date(2026, 6, 1), min_bars=60
+    )
+    assert set(out) == {"AAA", "BBB"}
+
+
+def test_fetch_history_empty_symbols_returns_empty(monkeypatch):
+    import rainier.paper.backfill_screened_levels as mod
+
+    def boom(*a, **k):
+        raise AssertionError("must not download for an empty symbol list")
+
+    monkeypatch.setattr(mod.yf, "download", boom)
+    assert _fetch_history([], start=date(2026, 1, 1), end=date(2026, 6, 1), min_bars=60) == {}
 
 
 # --- input validation ------------------------------------------------------

--- a/tests/test_paper/test_backfill_screened_levels_helpers.py
+++ b/tests/test_paper/test_backfill_screened_levels_helpers.py
@@ -17,7 +17,9 @@ import pytest
 from rainier.core.types import PatternSignal
 from rainier.paper.backfill_screened_levels import (
     _as_of_idx,
+    _candidate_with_levels,
     _match_pattern,
+    _TargetRow,
     backfill_screened_levels,
 )
 
@@ -29,6 +31,7 @@ def _sig(
     entry_price: float,
     stop_loss: float = 0.0,
     target_wave1: float = 0.0,
+    key_points: dict | None = None,
 ) -> PatternSignal:
     return PatternSignal(
         symbol="X",
@@ -39,6 +42,18 @@ def _sig(
         entry_price=entry_price,
         stop_loss=stop_loss,
         target_wave1=target_wave1,
+        key_points=key_points,
+    )
+
+
+def _target(pattern_type: str) -> _TargetRow:
+    return _TargetRow(
+        symbol="X",
+        scan_date=date(2026, 6, 5),
+        session_name="close",
+        pattern_type=pattern_type,
+        sector="Tech",
+        composite_score=0.8,
     )
 
 
@@ -153,6 +168,63 @@ def test_as_of_idx_matches_scan_date_under_non_utc_session_tz():
         "America/Los_Angeles"
     )  # -> 2026-06-04 17:00-07:00, LOCAL date 06-04
     assert _as_of_idx(_df([bar]), date(2026, 6, 5)) == 0
+
+
+# --- _candidate_with_levels (bearish_invalidation_level backfill) ----------
+
+
+def test_candidate_carries_false_breakout_invalidation_level():
+    """A recovered `false_breakout` must carry `bearish_invalidation_level` (the
+    pattern's `false_high`) so persist_screened_stocks fills it and the reclaim
+    flow (which filters on `bearish_invalidation_level IS NOT NULL`) can re-enqueue
+    the repaired row. Mirrors the live screener's false_breakout-only derivation."""
+    pat = _sig(
+        "false_breakout",
+        confidence=0.7,
+        entry_price=90.0,
+        stop_loss=95.0,
+        target_wave1=80.0,
+        key_points={"false_high": 94.5},
+    )
+    cand = _candidate_with_levels(_target("false_breakout"), pat)
+    assert cand.bearish_invalidation_level == 94.5
+    # The four trade levels still flow through.
+    assert cand.entry_price == 90.0
+    assert cand.stop_loss == 95.0
+
+
+def test_candidate_invalidation_level_none_for_non_false_breakout():
+    """Only `false_breakout` carries a trap-high. A bullish pattern (e.g.
+    `false_breakdown`) leaves `bearish_invalidation_level` NULL even if its
+    key_points happen to contain a `false_high` key — matches live behavior."""
+    pat = _sig(
+        "false_breakdown",
+        confidence=0.7,
+        entry_price=89.0,
+        key_points={"false_high": 94.5},  # ignored for a non-false_breakout
+    )
+    cand = _candidate_with_levels(_target("false_breakdown"), pat)
+    assert cand.bearish_invalidation_level is None
+
+
+def test_candidate_invalidation_level_none_when_false_high_absent():
+    """A `false_breakout` whose key_points lack `false_high` (or None key_points)
+    leaves the level NULL rather than crashing — defensive against a malformed
+    pattern (e.g. false_breakout_hs, which has no false_high)."""
+    assert (
+        _candidate_with_levels(
+            _target("false_breakout"),
+            _sig("false_breakout", confidence=0.7, entry_price=90.0, key_points={}),
+        ).bearish_invalidation_level
+        is None
+    )
+    assert (
+        _candidate_with_levels(
+            _target("false_breakout"),
+            _sig("false_breakout", confidence=0.7, entry_price=90.0, key_points=None),
+        ).bearish_invalidation_level
+        is None
+    )
 
 
 # --- input validation ------------------------------------------------------

--- a/tests/test_paper/test_backfill_screened_levels_helpers.py
+++ b/tests/test_paper/test_backfill_screened_levels_helpers.py
@@ -297,6 +297,52 @@ def test_fetch_history_single_symbol_flat_columns(monkeypatch):
     assert list(out["AAA"].columns) == ["open", "high", "low", "close", "volume"]
 
 
+def test_fetch_history_single_symbol_multiindex_columns(monkeypatch):
+    """Codex [P1] regression: with group_by='ticker', a SINGLE-ticker yfinance
+    download in 1.2.x still returns a MultiIndex (('AAA','Close')). The old
+    `raw.copy()` kept those tuple columns so `_normalize_symbol_frame` found no
+    'Close' and returned None — silently misclassifying every one-symbol fetch as
+    no-data and DEFEATING the per-symbol solo-retry recovery path. _extract must
+    flatten the single-ticker MultiIndex. FAILS pre-fix (out would be empty)."""
+    import rainier.paper.backfill_screened_levels as mod
+
+    dates = pd.date_range("2026-01-02", periods=70, freq="B")
+    # Single-ticker MultiIndex, exactly what yf.download(['AAA'], group_by='ticker')
+    # returns: columns are ('AAA', 'Open'), ('AAA', 'Close'), ...
+    raw = _multi_download({"AAA": _ohlcv_frame(dates, 100.0)})
+    assert isinstance(raw.columns, pd.MultiIndex)  # precondition: it IS MultiIndex
+
+    monkeypatch.setattr(mod.yf, "download", lambda symbols, **kw: raw)
+
+    out = _fetch_history(
+        ["AAA"], start=date(2026, 1, 1), end=date(2026, 6, 1), min_bars=60
+    )
+    assert set(out) == {"AAA"}  # recovered, NOT dropped to no-data
+    assert list(out["AAA"].columns) == ["open", "high", "low", "close", "volume"]
+
+
+def test_fetch_history_solo_retry_returns_multiindex_recovers(monkeypatch):
+    """Codex [P1] regression on the retry path: a symbol dropped from the batch is
+    re-fetched solo, and that solo call returns a single-ticker MultiIndex. The
+    retry must still extract it (pre-fix it normalized to None → no_price_data)."""
+    import rainier.paper.backfill_screened_levels as mod
+
+    dates = pd.date_range("2026-01-02", periods=70, freq="B")
+    batch = _multi_download({"AAA": _ohlcv_frame(dates, 100.0)})  # LLY absent
+    solo = _multi_download({"LLY": _ohlcv_frame(dates, 80.0)})  # MultiIndex, 1 sym
+
+    def fake_download(symbols, **kw):
+        syms = symbols if isinstance(symbols, list) else [symbols]
+        return solo if syms == ["LLY"] else batch
+
+    monkeypatch.setattr(mod.yf, "download", fake_download)
+
+    out = _fetch_history(
+        ["AAA", "LLY"], start=date(2026, 1, 1), end=date(2026, 6, 1), min_bars=60
+    )
+    assert set(out) == {"AAA", "LLY"}  # LLY recovered from the MultiIndex solo retry
+
+
 def test_fetch_history_skips_symbol_below_min_bars(monkeypatch):
     import rainier.paper.backfill_screened_levels as mod
 

--- a/tests/test_paper/test_backfill_screened_levels_helpers.py
+++ b/tests/test_paper/test_backfill_screened_levels_helpers.py
@@ -55,8 +55,9 @@ def test_match_pattern_empty_returns_none():
 
 
 def test_match_pattern_picks_only_matching_type_not_top_ranked():
-    # The non-matching type has the highest confidence; the matching one must
-    # still win because match-by-stored-type beats top-ranking.
+    # actionable[0] (the live `best_pattern`) is a non-matching type; the
+    # matching one ranks lower but must still be chosen because we match by
+    # stored type, not by top-ranking.
     actionable = [
         _sig("w_bottom", confidence=0.95, entry_price=100.0),
         _sig("false_breakdown", confidence=0.40, entry_price=89.0),
@@ -67,27 +68,20 @@ def test_match_pattern_picks_only_matching_type_not_top_ranked():
     assert got.entry_price == 89.0
 
 
-def test_match_pattern_tiebreak_highest_confidence_first():
-    # Two SAME-type patterns: higher confidence wins.
+def test_match_pattern_same_type_takes_first_in_priority_order():
+    # Two SAME-type patterns: the FIRST in _filter_actionable priority order
+    # wins — that is the setup the live screener would have written as
+    # best_pattern. We must NOT re-sort by confidence: here the first entry has
+    # LOWER confidence but higher actionability priority, so it must win.
     actionable = [
-        _sig("w_bottom", confidence=0.50, entry_price=80.0),
-        _sig("w_bottom", confidence=0.90, entry_price=120.0),
+        _sig("w_bottom", confidence=0.50, entry_price=80.0),  # higher priority
+        _sig("w_bottom", confidence=0.90, entry_price=120.0),  # lower priority
     ]
     got = _match_pattern(actionable, "w_bottom")
     assert got is not None
-    assert got.confidence == 0.90
-    assert got.entry_price == 120.0
-
-
-def test_match_pattern_tiebreak_lowest_entry_when_confidence_equal():
-    # Equal confidence: lowest entry_price wins (the stable secondary key).
-    actionable = [
-        _sig("w_bottom", confidence=0.80, entry_price=120.0),
-        _sig("w_bottom", confidence=0.80, entry_price=95.0),
-    ]
-    got = _match_pattern(actionable, "w_bottom")
-    assert got is not None
-    assert got.entry_price == 95.0
+    # First-in-order wins despite its lower confidence (no confidence re-sort).
+    assert got.confidence == 0.50
+    assert got.entry_price == 80.0
 
 
 # --- _as_of_idx ------------------------------------------------------------

--- a/tests/test_paper/test_backfill_screened_levels_helpers.py
+++ b/tests/test_paper/test_backfill_screened_levels_helpers.py
@@ -19,7 +19,9 @@ from rainier.paper.backfill_screened_levels import (
     _as_of_idx,
     _candidate_with_levels,
     _fetch_history,
+    _match_for_row,
     _match_pattern,
+    _Outcome,
     _TargetRow,
     backfill_screened_levels,
 )
@@ -169,6 +171,84 @@ def test_as_of_idx_matches_scan_date_under_non_utc_session_tz():
         "America/Los_Angeles"
     )  # -> 2026-06-04 17:00-07:00, LOCAL date 06-04
     assert _as_of_idx(_df([bar]), date(2026, 6, 5)) == 0
+
+
+# --- _match_for_row outcome classification ---------------------------------
+
+
+def _ohlcv_at(scan: date, periods: int = 5) -> pd.DataFrame:
+    """A tiny tz-naive OHLCV frame whose LAST bar is exactly on ``scan``."""
+    dates = pd.bdate_range(end=pd.Timestamp(scan), periods=periods)
+    return pd.DataFrame(
+        {
+            "open": range(periods),
+            "high": range(1, periods + 1),
+            "low": range(periods),
+            "close": range(periods),
+            "volume": [1] * periods,
+        },
+        index=dates,
+    )
+
+
+def test_match_for_row_no_bars_is_no_as_of_data():
+    outcome, pat = _match_for_row(_target("false_breakdown"), None, config=object())
+    assert outcome is _Outcome.NO_AS_OF_DATA
+    assert pat is None
+
+
+def test_match_for_row_missing_exact_bar_is_no_as_of_data():
+    # Frame present but ending BEFORE the row's scan_date → no exact bar.
+    row = _target("false_breakdown")  # scan_date 2026-06-05
+    df = _ohlcv_at(date(2026, 6, 3))  # last bar 06-03, no 06-05
+    outcome, pat = _match_for_row(row, df, config=object())
+    assert outcome is _Outcome.NO_AS_OF_DATA
+    assert pat is None
+
+
+def test_match_for_row_detector_raise_is_detector_error(monkeypatch):
+    """A detector exception classifies DETECTOR_ERROR (its own bucket), NOT
+    NO_MATCH — a crash is not a proven-permanent no-match (codex P2)."""
+    import rainier.paper.backfill_screened_levels as mod
+
+    def boom(symbol, windowed, config):
+        raise RuntimeError("synthetic detector blow-up")
+
+    monkeypatch.setattr(mod, "replay_pattern_layer", boom)
+    row = _target("false_breakdown")
+    outcome, pat = _match_for_row(row, _ohlcv_at(date(2026, 6, 5)), config=object())
+    assert outcome is _Outcome.DETECTOR_ERROR
+    assert pat is None
+
+
+def test_match_for_row_clean_run_no_type_match_is_no_match(monkeypatch):
+    """Detector runs clean but no actionable pattern has the stored type →
+    NO_MATCH (permanent)."""
+    import rainier.paper.backfill_screened_levels as mod
+
+    # Returns an actionable of a DIFFERENT type than the row's stored type.
+    monkeypatch.setattr(
+        mod,
+        "replay_pattern_layer",
+        lambda s, w, c: ([_sig("w_bottom", confidence=0.9, entry_price=100.0)], None),
+    )
+    row = _target("false_breakdown")
+    outcome, pat = _match_for_row(row, _ohlcv_at(date(2026, 6, 5)), config=object())
+    assert outcome is _Outcome.NO_MATCH
+    assert pat is None
+
+
+def test_match_for_row_type_match_is_recovered(monkeypatch):
+    import rainier.paper.backfill_screened_levels as mod
+
+    match = _sig("false_breakdown", confidence=0.5, entry_price=89.0)
+    monkeypatch.setattr(
+        mod, "replay_pattern_layer", lambda s, w, c: ([match], None)
+    )
+    row = _target("false_breakdown")
+    outcome, pat = _match_for_row(row, _ohlcv_at(date(2026, 6, 5)), config=object())
+    assert outcome is _Outcome.RECOVERED
+    assert pat is match
 
 
 # --- _candidate_with_levels (bearish_invalidation_level backfill) ----------

--- a/tests/test_paper/test_backfill_screened_levels_helpers.py
+++ b/tests/test_paper/test_backfill_screened_levels_helpers.py
@@ -1,0 +1,150 @@
+"""Pure-helper unit tests for the screened-levels backfill (no Postgres).
+
+The end-to-end backfill tests are Postgres-gated (``requires_postgres``) and
+skip when no DB is reachable. But three load-bearing helpers are pure functions
+that need no DB — and one of them (``_match_pattern``'s same-type tie-break) is
+not exercised by the e2e fixture at all (it yields two patterns of DIFFERENT
+types). These ungated tests pin that logic so it has coverage on every run.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timezone
+
+import pandas as pd
+import pytest
+
+from rainier.core.types import PatternSignal
+from rainier.paper.backfill_screened_levels import (
+    _as_of_idx,
+    _match_pattern,
+    backfill_screened_levels,
+)
+
+
+def _sig(
+    pattern_type: str,
+    *,
+    confidence: float,
+    entry_price: float,
+    stop_loss: float = 0.0,
+    target_wave1: float = 0.0,
+) -> PatternSignal:
+    return PatternSignal(
+        symbol="X",
+        pattern_type=pattern_type,
+        direction="bullish",
+        status="confirmed",
+        confidence=confidence,
+        entry_price=entry_price,
+        stop_loss=stop_loss,
+        target_wave1=target_wave1,
+    )
+
+
+# --- _match_pattern --------------------------------------------------------
+
+
+def test_match_pattern_no_match_returns_none():
+    actionable = [_sig("w_bottom", confidence=0.9, entry_price=100.0)]
+    assert _match_pattern(actionable, "false_breakdown") is None
+
+
+def test_match_pattern_empty_returns_none():
+    assert _match_pattern([], "w_bottom") is None
+
+
+def test_match_pattern_picks_only_matching_type_not_top_ranked():
+    # The non-matching type has the highest confidence; the matching one must
+    # still win because match-by-stored-type beats top-ranking.
+    actionable = [
+        _sig("w_bottom", confidence=0.95, entry_price=100.0),
+        _sig("false_breakdown", confidence=0.40, entry_price=89.0),
+    ]
+    got = _match_pattern(actionable, "false_breakdown")
+    assert got is not None
+    assert got.pattern_type == "false_breakdown"
+    assert got.entry_price == 89.0
+
+
+def test_match_pattern_tiebreak_highest_confidence_first():
+    # Two SAME-type patterns: higher confidence wins.
+    actionable = [
+        _sig("w_bottom", confidence=0.50, entry_price=80.0),
+        _sig("w_bottom", confidence=0.90, entry_price=120.0),
+    ]
+    got = _match_pattern(actionable, "w_bottom")
+    assert got is not None
+    assert got.confidence == 0.90
+    assert got.entry_price == 120.0
+
+
+def test_match_pattern_tiebreak_lowest_entry_when_confidence_equal():
+    # Equal confidence: lowest entry_price wins (the stable secondary key).
+    actionable = [
+        _sig("w_bottom", confidence=0.80, entry_price=120.0),
+        _sig("w_bottom", confidence=0.80, entry_price=95.0),
+    ]
+    got = _match_pattern(actionable, "w_bottom")
+    assert got is not None
+    assert got.entry_price == 95.0
+
+
+# --- _as_of_idx ------------------------------------------------------------
+
+
+def _df(dates: list[pd.Timestamp]) -> pd.DataFrame:
+    return pd.DataFrame({"close": range(len(dates))}, index=pd.DatetimeIndex(dates))
+
+
+def test_as_of_idx_hits_last_bar_on_or_before_scan_date():
+    dates = [
+        pd.Timestamp("2026-06-01", tz="UTC"),
+        pd.Timestamp("2026-06-03", tz="UTC"),
+        pd.Timestamp("2026-06-05", tz="UTC"),
+        pd.Timestamp("2026-06-09", tz="UTC"),  # after scan_date
+    ]
+    # scan_date 06-05 → the 06-05 bar (positional index 2) is the as-of bar.
+    assert _as_of_idx(_df(dates), date(2026, 6, 5)) == 2
+
+
+def test_as_of_idx_picks_prior_bar_when_scan_date_has_no_bar():
+    dates = [
+        pd.Timestamp("2026-06-01", tz="UTC"),
+        pd.Timestamp("2026-06-03", tz="UTC"),
+        pd.Timestamp("2026-06-08", tz="UTC"),
+    ]
+    # scan_date 06-05 has no bar → last bar on/before is 06-03 (index 1).
+    assert _as_of_idx(_df(dates), date(2026, 6, 5)) == 1
+
+
+def test_as_of_idx_none_when_all_bars_after_scan_date():
+    dates = [
+        pd.Timestamp("2026-06-10", tz="UTC"),
+        pd.Timestamp("2026-06-11", tz="UTC"),
+    ]
+    assert _as_of_idx(_df(dates), date(2026, 6, 5)) is None
+
+
+def test_as_of_idx_handles_tz_naive_index():
+    # A tz-naive index (synthetic data) must still compare cleanly.
+    dates = [pd.Timestamp("2026-06-01"), pd.Timestamp("2026-06-05")]
+    assert _as_of_idx(_df(dates), date(2026, 6, 5)) == 1
+
+
+def test_as_of_idx_includes_midnight_utc_scan_date_bar():
+    # Production bars are normalized to midnight UTC; the scan_date bar itself
+    # must be included (no off-by-one excluding it).
+    bar = pd.Timestamp(date(2026, 6, 5), tz=timezone.utc)
+    assert _as_of_idx(_df([bar]), date(2026, 6, 5)) == 0
+
+
+# --- input validation ------------------------------------------------------
+
+
+def test_backfill_rejects_from_after_to():
+    with pytest.raises(ValueError, match="from_date.*>.*to_date"):
+        backfill_screened_levels(
+            from_date=date(2026, 6, 12),
+            to_date=date(2026, 6, 3),
+        )

--- a/tests/test_paper/test_backfill_screened_levels_helpers.py
+++ b/tests/test_paper/test_backfill_screened_levels_helpers.py
@@ -176,6 +176,15 @@ def test_as_of_idx_matches_scan_date_under_non_utc_session_tz():
 # --- _match_for_row outcome classification ---------------------------------
 
 
+def _cfg(min_bars: int = 0):
+    """A minimal stand-in config carrying just the knob _match_for_row reads past
+    the early returns (``min_daily_bars``). The detector itself is monkeypatched
+    in these tests, so no other config field is touched."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(min_daily_bars=min_bars)
+
+
 def _ohlcv_at(scan: date, periods: int = 5) -> pd.DataFrame:
     """A tiny tz-naive OHLCV frame whose LAST bar is exactly on ``scan``."""
     dates = pd.bdate_range(end=pd.Timestamp(scan), periods=periods)
@@ -216,7 +225,7 @@ def test_match_for_row_detector_raise_is_detector_error(monkeypatch):
 
     monkeypatch.setattr(mod, "replay_pattern_layer", boom)
     row = _target("false_breakdown")
-    outcome, pat = _match_for_row(row, _ohlcv_at(date(2026, 6, 5)), config=object())
+    outcome, pat = _match_for_row(row, _ohlcv_at(date(2026, 6, 5)), config=_cfg())
     assert outcome is _Outcome.DETECTOR_ERROR
     assert pat is None
 
@@ -233,7 +242,7 @@ def test_match_for_row_clean_run_no_type_match_is_no_match(monkeypatch):
         lambda s, w, c: ([_sig("w_bottom", confidence=0.9, entry_price=100.0)], None),
     )
     row = _target("false_breakdown")
-    outcome, pat = _match_for_row(row, _ohlcv_at(date(2026, 6, 5)), config=object())
+    outcome, pat = _match_for_row(row, _ohlcv_at(date(2026, 6, 5)), config=_cfg())
     assert outcome is _Outcome.NO_MATCH
     assert pat is None
 
@@ -246,9 +255,30 @@ def test_match_for_row_type_match_is_recovered(monkeypatch):
         mod, "replay_pattern_layer", lambda s, w, c: ([match], None)
     )
     row = _target("false_breakdown")
-    outcome, pat = _match_for_row(row, _ohlcv_at(date(2026, 6, 5)), config=object())
+    outcome, pat = _match_for_row(row, _ohlcv_at(date(2026, 6, 5)), config=_cfg())
     assert outcome is _Outcome.RECOVERED
     assert pat is match
+
+
+def test_match_for_row_window_below_min_daily_bars_is_no_match(monkeypatch):
+    """Codex P2 fidelity gate: an as-of window SHORTER than min_daily_bars (a
+    recent IPO/spinoff that only reaches the floor later in the range) is rejected
+    BEFORE the detector runs — the live screener would have skipped that symbol on
+    scan_date, so writing levels would fabricate a never-screened setup. NO_MATCH
+    (permanent: the as-of window is fixed by scan_date + to_date)."""
+    import rainier.paper.backfill_screened_levels as mod
+
+    def must_not_run(*a, **k):
+        raise AssertionError("detector must not run on a too-short as-of window")
+
+    monkeypatch.setattr(mod, "replay_pattern_layer", must_not_run)
+    row = _target("false_breakdown")
+    # 5-bar window, but the floor is 60 → rejected as NO_MATCH, detector skipped.
+    outcome, pat = _match_for_row(
+        row, _ohlcv_at(date(2026, 6, 5), periods=5), config=_cfg(min_bars=60)
+    )
+    assert outcome is _Outcome.NO_MATCH
+    assert pat is None
 
 
 # --- _candidate_with_levels (bearish_invalidation_level backfill) ----------


### PR DESCRIPTION
## Summary
- Adds `rainier db backfill-screened-levels`, a one-time maintenance command that repairs NULL trade levels (entry/stop/target/invalidation) on historical `screened_stocks` rows.
- Targets close-session rows in the scan_date 06-03..06-12 window, replaying the pattern detector as-of each scan_date so levels match what they would have been at screen time.
- Per-row detector fault isolation: a single bad row can't abort the whole backfill; the run reports repaired vs skipped counts.

## Review
- /review: passed (claude rounds: 2)
- codex review: passed (codex rounds: 2)

## Deferred [P2]
- Repaired false_breakout rows don't backfill bearish_invalidation_level, so they stay invisible to the reclaim queue. Out of the task's four-level scope; the reclaim feature (migration 0012) post-dates the 06-03..06-12 window.

## Test plan
- [ ] CI green
- [ ] verify locally