### PR TITLE
feat(qu100): snapshot override — day-rebuild, sector generation, data-date backup, freshness recover

### DIFF
--- a/src/rainier/analysis/sector_analyzer.py
+++ b/src/rainier/analysis/sector_analyzer.py
@@ -19,6 +19,13 @@ _BULLISH_THRESHOLD = 0.3
 _BEARISH_THRESHOLD = -0.3
 _TOP_STOCKS_LIMIT = 5
 
+# QU100 sentiment is built from the two QU100 books ONLY (top100 + bottom100).
+# money_flow_snapshots may one day also hold auxiliary ranking types (e.g.
+# concept/etf boards); those must NOT be folded into QU100 sector sentiment or the
+# screener / SectorMomentumSignal would silently skew. The generation filter is
+# restricted to these two so a stray ranking type can never leak in.
+_QU100_RANKING_TYPES = ("top100", "bottom100")
+
 
 # ---------------------------------------------------------------------------
 # Latest-generation selection (per ranking_type)
@@ -40,7 +47,7 @@ def _latest_generation_filter(session: Session, as_of: date_type | None):
     date_q = session.query(
         MoneyFlowSnapshot.ranking_type,
         func.max(MoneyFlowSnapshot.data_date).label("max_date"),
-    )
+    ).filter(MoneyFlowSnapshot.ranking_type.in_(_QU100_RANKING_TYPES))
     if as_of is not None:
         date_q = date_q.filter(MoneyFlowSnapshot.data_date <= as_of)
     latest_dates = date_q.group_by(MoneyFlowSnapshot.ranking_type).all()

--- a/src/rainier/analysis/sector_analyzer.py
+++ b/src/rainier/analysis/sector_analyzer.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from datetime import datetime
+from datetime import date as date_type
 
-from sqlalchemy import func
+from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 
 from rainier.core.database import get_session
@@ -18,6 +18,107 @@ log = logging.getLogger(__name__)
 _BULLISH_THRESHOLD = 0.3
 _BEARISH_THRESHOLD = -0.3
 _TOP_STOCKS_LIMIT = 5
+
+
+# ---------------------------------------------------------------------------
+# Latest-generation selection (per ranking_type)
+# ---------------------------------------------------------------------------
+#
+# Under the rebuild-the-day fix a day holds ONE captured_at per
+# (data_date, ranking_type). A partial-failure scrape can leave top100 and
+# bottom100 on DIFFERENT (data_date, captured_at) generations. A single global
+# max(captured_at) reads only one ranking type's rows -> half-book. So we resolve
+# the latest generation INDEPENDENTLY per ranking_type and union the batches.
+
+
+def _latest_generation_filter(session: Session, as_of: date_type | None):
+    """Build a WHERE predicate selecting the latest snapshot generation PER
+    ranking_type (optionally bounded to ``data_date <= as_of``).
+
+    Returns ``None`` when no rows match (caller returns an empty result).
+    """
+    date_q = session.query(
+        MoneyFlowSnapshot.ranking_type,
+        func.max(MoneyFlowSnapshot.data_date).label("max_date"),
+    )
+    if as_of is not None:
+        date_q = date_q.filter(MoneyFlowSnapshot.data_date <= as_of)
+    latest_dates = date_q.group_by(MoneyFlowSnapshot.ranking_type).all()
+    if not latest_dates:
+        return None
+
+    # For each (ranking_type, its latest data_date), find that generation's
+    # captured_at (one per (data_date, ranking_type) under the rebuild fix; max()
+    # is a safe belt-and-suspenders for any legacy multi-capture day).
+    clauses = []
+    for ranking_type, max_date in latest_dates:
+        max_cap = (
+            session.query(func.max(MoneyFlowSnapshot.captured_at))
+            .filter(
+                MoneyFlowSnapshot.ranking_type == ranking_type,
+                MoneyFlowSnapshot.data_date == max_date,
+            )
+            .scalar()
+        )
+        clauses.append(
+            and_(
+                MoneyFlowSnapshot.ranking_type == ranking_type,
+                MoneyFlowSnapshot.data_date == max_date,
+                MoneyFlowSnapshot.captured_at == max_cap,
+            )
+        )
+    return or_(*clauses)
+
+
+def _build_sector_trends(
+    rows: list[tuple[str | None, str | None, int, str]],
+) -> list[SectorTrend]:
+    """Group rows ``(sector, long_short, rank, symbol)`` into ranked SectorTrends."""
+    sector_data: dict[str, list[tuple[str, str | None, int]]] = defaultdict(list)
+    for sector, long_short, rank, symbol in rows:
+        sector_key = sector or "Unknown"
+        sector_data[sector_key].append((symbol, long_short, rank))
+
+    sector_trends: list[SectorTrend] = []
+    for sector, stocks in sector_data.items():
+        long_count = sum(1 for _, ls, _ in stocks if ls == "Long in")
+        short_count = sum(1 for _, ls, _ in stocks if ls == "Short in")
+        total = len(stocks)
+        net_sentiment = (long_count - short_count) / total if total > 0 else 0.0
+        if net_sentiment > _BULLISH_THRESHOLD:
+            trend_direction = "bullish"
+        elif net_sentiment < _BEARISH_THRESHOLD:
+            trend_direction = "bearish"
+        else:
+            trend_direction = "neutral"
+        long_stocks = [(symbol, rank) for symbol, ls, rank in stocks if ls == "Long in"]
+        long_stocks.sort(key=lambda x: x[1])
+        top_stocks = [symbol for symbol, _ in long_stocks[:_TOP_STOCKS_LIMIT]]
+        sector_trends.append(
+            SectorTrend(
+                sector=sector,
+                long_in_count=long_count,
+                short_in_count=short_count,
+                net_sentiment=round(net_sentiment, 4),
+                top_stocks=top_stocks,
+                trend_direction=trend_direction,
+                sector_rank=0,  # assigned after sorting
+            )
+        )
+
+    sector_trends.sort(key=lambda st: st.net_sentiment, reverse=True)
+    return [
+        SectorTrend(
+            sector=st.sector,
+            long_in_count=st.long_in_count,
+            short_in_count=st.short_in_count,
+            net_sentiment=st.net_sentiment,
+            top_stocks=st.top_stocks,
+            trend_direction=st.trend_direction,
+            sector_rank=i,
+        )
+        for i, st in enumerate(sector_trends, start=1)
+    ]
 
 
 def analyze_sectors(session: Session | None = None) -> list[SectorTrend]:
@@ -41,14 +142,13 @@ def analyze_sectors(session: Session | None = None) -> list[SectorTrend]:
 
 
 def _analyze_sectors(session: Session) -> list[SectorTrend]:
-    """Core implementation with an explicit session."""
-    # 1. Get latest captured_at timestamp
-    latest_ts = session.query(func.max(MoneyFlowSnapshot.captured_at)).scalar()
-    if latest_ts is None:
+    """Core implementation with an explicit session — latest generation per
+    ranking_type (no global captured_at half-book)."""
+    predicate = _latest_generation_filter(session, as_of=None)
+    if predicate is None:
         log.warning("No money flow snapshots found — returning empty sector list")
         return []
 
-    # 2. Query all snapshots at that timestamp (both top100 and bottom100)
     rows = (
         session.query(
             MoneyFlowSnapshot.sector,
@@ -56,74 +156,10 @@ def _analyze_sectors(session: Session) -> list[SectorTrend]:
             MoneyFlowSnapshot.rank,
             MoneyFlowSnapshot.symbol,
         )
-        .filter(MoneyFlowSnapshot.captured_at == latest_ts)
+        .filter(predicate)
         .all()
     )
-
-    if not rows:
-        log.warning("No snapshots at latest timestamp %s", latest_ts)
-        return []
-
-    # 3. Group by sector
-    sector_data: dict[str, list[tuple[str, str | None, int]]] = defaultdict(list)
-    for sector, long_short, rank, symbol in rows:
-        sector_key = sector or "Unknown"
-        sector_data[sector_key].append((symbol, long_short, rank))
-
-    # 4. Compute metrics per sector
-    sector_trends: list[SectorTrend] = []
-    for sector, stocks in sector_data.items():
-        long_count = sum(1 for _, ls, _ in stocks if ls == "Long in")
-        short_count = sum(1 for _, ls, _ in stocks if ls == "Short in")
-        total = len(stocks)
-
-        net_sentiment = (long_count - short_count) / total if total > 0 else 0.0
-
-        # Classify trend direction
-        if net_sentiment > _BULLISH_THRESHOLD:
-            trend_direction = "bullish"
-        elif net_sentiment < _BEARISH_THRESHOLD:
-            trend_direction = "bearish"
-        else:
-            trend_direction = "neutral"
-
-        # Top 5 "Long in" stocks by rank (ascending = best first)
-        long_stocks = [
-            (symbol, rank)
-            for symbol, ls, rank in stocks
-            if ls == "Long in"
-        ]
-        long_stocks.sort(key=lambda x: x[1])
-        top_stocks = [symbol for symbol, _ in long_stocks[:_TOP_STOCKS_LIMIT]]
-
-        sector_trends.append(
-            SectorTrend(
-                sector=sector,
-                long_in_count=long_count,
-                short_in_count=short_count,
-                net_sentiment=round(net_sentiment, 4),
-                top_stocks=top_stocks,
-                trend_direction=trend_direction,
-                sector_rank=0,  # placeholder, assigned after sorting
-            )
-        )
-
-    # 5. Sort by net_sentiment descending, assign ranks
-    sector_trends.sort(key=lambda st: st.net_sentiment, reverse=True)
-    ranked: list[SectorTrend] = []
-    for i, st in enumerate(sector_trends, start=1):
-        ranked.append(
-            SectorTrend(
-                sector=st.sector,
-                long_in_count=st.long_in_count,
-                short_in_count=st.short_in_count,
-                net_sentiment=st.net_sentiment,
-                top_stocks=st.top_stocks,
-                trend_direction=st.trend_direction,
-                sector_rank=i,
-            )
-        )
-
+    ranked = _build_sector_trends(rows)
     log.info(
         "Sector analysis complete: %d sectors, top=%s",
         len(ranked),
@@ -133,25 +169,30 @@ def _analyze_sectors(session: Session) -> list[SectorTrend]:
 
 
 def analyze_sectors_at(
-    captured_at: datetime, session: Session | None = None,
+    as_of: date_type, session: Session | None = None,
 ) -> list[SectorTrend]:
-    """Analyze sector trends as of a specific snapshot timestamp.
+    """Analyze sector trends as of a given data DATE (latest generation on or
+    before ``as_of``, resolved INDEPENDENTLY per ranking_type).
 
-    Used by the LLM-thesis sector_momentum signal so it can compare today's
-    sector sentiment against N days ago. The default `analyze_sectors()` keeps
-    its `max(captured_at)` semantics for the existing screener — this function
-    is a strict additive helper.
+    Used by the LLM-thesis sector_momentum signal to compare today's sentiment
+    against N days ago. Keyed on ``data_date`` (not a single global
+    ``captured_at``): under the rebuild-the-day fix a day holds one
+    ``captured_at`` per ``(data_date, ranking_type)``, so a single timestamp
+    could only match ONE ranking type. We pick each ranking type's latest
+    generation with ``data_date <= as_of`` and union the books.
     """
     if session is not None:
-        return _analyze_sectors_for_ts(session, captured_at)
+        return _analyze_sectors_as_of(session, as_of)
     with get_session() as s:
-        return _analyze_sectors_for_ts(s, captured_at)
+        return _analyze_sectors_as_of(s, as_of)
 
 
-def _analyze_sectors_for_ts(
-    session: Session, captured_at: datetime,
-) -> list[SectorTrend]:
-    """Same shape as _analyze_sectors but pinned to a specific timestamp."""
+def _analyze_sectors_as_of(session: Session, as_of: date_type) -> list[SectorTrend]:
+    """Latest generation per ranking_type with ``data_date <= as_of``."""
+    predicate = _latest_generation_filter(session, as_of=as_of)
+    if predicate is None:
+        log.warning("No snapshots on or before as_of=%s", as_of)
+        return []
     rows = (
         session.query(
             MoneyFlowSnapshot.sector,
@@ -159,65 +200,10 @@ def _analyze_sectors_for_ts(
             MoneyFlowSnapshot.rank,
             MoneyFlowSnapshot.symbol,
         )
-        .filter(MoneyFlowSnapshot.captured_at == captured_at)
+        .filter(predicate)
         .all()
     )
-
-    if not rows:
-        log.warning("No snapshots at captured_at=%s", captured_at)
-        return []
-
-    sector_data: dict[str, list[tuple[str, str | None, int]]] = defaultdict(list)
-    for sector, long_short, rank, symbol in rows:
-        sector_key = sector or "Unknown"
-        sector_data[sector_key].append((symbol, long_short, rank))
-
-    sector_trends: list[SectorTrend] = []
-    for sector, stocks in sector_data.items():
-        long_count = sum(1 for _, ls, _ in stocks if ls == "Long in")
-        short_count = sum(1 for _, ls, _ in stocks if ls == "Short in")
-        total = len(stocks)
-        net_sentiment = (long_count - short_count) / total if total > 0 else 0.0
-        if net_sentiment > _BULLISH_THRESHOLD:
-            trend_direction = "bullish"
-        elif net_sentiment < _BEARISH_THRESHOLD:
-            trend_direction = "bearish"
-        else:
-            trend_direction = "neutral"
-        long_stocks = [
-            (symbol, rank)
-            for symbol, ls, rank in stocks
-            if ls == "Long in"
-        ]
-        long_stocks.sort(key=lambda x: x[1])
-        top_stocks = [symbol for symbol, _ in long_stocks[:_TOP_STOCKS_LIMIT]]
-        sector_trends.append(
-            SectorTrend(
-                sector=sector,
-                long_in_count=long_count,
-                short_in_count=short_count,
-                net_sentiment=round(net_sentiment, 4),
-                top_stocks=top_stocks,
-                trend_direction=trend_direction,
-                sector_rank=0,
-            )
-        )
-
-    sector_trends.sort(key=lambda st: st.net_sentiment, reverse=True)
-    ranked: list[SectorTrend] = []
-    for i, st in enumerate(sector_trends, start=1):
-        ranked.append(
-            SectorTrend(
-                sector=st.sector,
-                long_in_count=st.long_in_count,
-                short_in_count=st.short_in_count,
-                net_sentiment=st.net_sentiment,
-                top_stocks=st.top_stocks,
-                trend_direction=st.trend_direction,
-                sector_rank=i,
-            )
-        )
-    return ranked
+    return _build_sector_trends(rows)
 
 
 def get_sector_boost(sector: str, sector_trends: list[SectorTrend]) -> float:

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1207,10 +1207,7 @@ def qu(ctx, session, detail_top, dates, days_back, start_date, delay, headed, cd
         sys.exit(1)
 
 
-async def _run_qu_scrape(
-    session, detail_top, dates, days_back, start_date, delay, headed, cdp,
-    run_pipeline=False,
-):
+async def _run_qu_scrape(session, detail_top, dates, days_back, start_date, delay, headed, cdp):
     import asyncio
     from datetime import date, datetime, timedelta
 
@@ -1288,15 +1285,9 @@ async def _run_qu_scrape(
         # scheduler — including the LLM thesis embeds for sessions in
         # settings.llm_thesis.enabled_sessions. Skip during backfill runs
         # (date_list is set) since those replay historical scans and would
-        # spam the channel.
-        #
-        # EXCEPTION: ``run_pipeline=True`` forces the pipeline even with a
-        # date_list. ``recover`` uses this for a single-day recovery of TODAY: it
-        # must PIN the scrape to the stale ``data_date`` (so it can't pass
-        # dates=None) yet still restore the same downstream outputs a scheduled
-        # scrape produces — screened_stocks, LLM theses, the top-20 candidate
-        # alert. Without this the recovered day would have a raw QU snapshot but
-        # none of the derived outputs recover is meant to replace (Codex P1).
+        # spam the channel. ``recover`` also pins a date (single-day replay) but
+        # drives the pipeline ITSELF, gated on restored two-book freshness — see
+        # _recover — so a stale half-book can't fire derived output here.
         #
         # Hand off via asyncio.to_thread because compute_theses_and_persist
         # wraps its async work in asyncio.run(); calling it directly from this
@@ -1307,7 +1298,7 @@ async def _run_qu_scrape(
         # surfaces as a partial-success warning rather than morphing the
         # already-successful scrape into a red "Scrape FAILED" alert. The
         # outer except is for actual scrape errors only.
-        if result.records_created > 0 and (not date_list or run_pipeline):
+        if result.records_created > 0 and not date_list:
             try:
                 await asyncio.to_thread(
                     run_post_scrape_pipeline, settings, session,
@@ -1838,11 +1829,10 @@ async def _recover(settings, dry_run: bool):
                 # NEXT, not-yet-traded day — so the rerun would fetch the wrong day
                 # and never refresh `today`, leaving _qu100_day_is_fresh(db, today)
                 # false (Codex P1). Passing the explicit date makes the scraper
-                # query and persist `data_date = today`. ``run_pipeline=True`` keeps
-                # the post-scrape pipeline (screened_stocks, LLM theses, candidate
-                # alert) running even though a date is pinned — a recovered day must
-                # restore the derived outputs a scheduled scrape produces, not just
-                # the raw snapshot (Codex P1).
+                # query and persist `data_date = today`. The pinned date also keeps
+                # _run_qu_scrape's INLINE post-scrape pipeline OFF — recover runs
+                # the pipeline itself below, gated on RESTORED two-book freshness,
+                # so a stale half-book never fires screener/LLM/candidate output.
                 await _run_qu_scrape(
                     session=session_name,
                     detail_top=0,
@@ -1852,7 +1842,6 @@ async def _recover(settings, dry_run: bool):
                     delay=None,
                     headed=False,
                     cdp="http://127.0.0.1:9222",
-                    run_pipeline=True,
                 )
                 click.echo(f"  {session_name} scrape: done")
                 recovered_scrapes.append(session_name)
@@ -1903,6 +1892,32 @@ async def _recover(settings, dry_run: bool):
             click.echo(
                 "  Discord report: skipped — recovery scrape landed no fresh data"
             )
+    # Restore the DERIVED outputs a scheduled scrape would have produced
+    # (screened_stocks, LLM theses, the top-20 candidate alert) — but ONLY now
+    # that BOTH books are fresh. Running this gated on freshness_restored (not
+    # inline in the recovery scrape) is what prevents a stale half-book from
+    # firing screener/LLM/candidate output (Codex P1). run_post_scrape_pipeline is
+    # sync and internally does asyncio.run, so hand it off via asyncio.to_thread
+    # (same reason as _run_qu_scrape) to avoid a nested-event-loop RuntimeError.
+    if qu100_stale and freshness_restored:
+        import asyncio
+
+        click.echo("  Restoring post-scrape pipeline (screener/LLM/candidates)...")
+        try:
+            await asyncio.to_thread(
+                run_post_scrape_pipeline, settings, recover_session
+            )
+            click.echo("  Post-scrape pipeline: done")
+        except Exception as pipeline_exc:
+            click.echo(
+                f"  Post-scrape pipeline: FAILED ({pipeline_exc})", err=True
+            )
+            _notify_recover(
+                "Post-Scrape Pipeline",
+                f"FAILED during recovery: {pipeline_exc}",
+                color=0xE74C3C,
+            )
+
     if qu100_stale and freshness_restored:
         click.echo("  Sending QU100 Discord report...")
         try:

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -6098,10 +6098,12 @@ def db_backfill_screened_levels(ctx, from_date: str, to_date: str, apply: bool) 
 def db_backup_money_flow(do_verify: bool, skip_if_unconfigured: bool) -> None:
     """Back up ``money_flow_snapshots`` (local) -> ``backup.money_flow_snapshots`` (Neon).
 
-    Incremental high-water-mark by ``id``, insert-only, idempotent. Reads the
-    local TimescaleDB via the legacy engine and writes Neon via ``DATABASE_URL``.
-    DATABASE_URL unset fails loud (non-zero) by default; ``--skip-if-unconfigured``
-    turns that into a warn + exit 0 for local dev (cron stays loud).
+    ``data_date``-aware reconcile (delete-changed-day + recopy), idempotent — so a
+    same-day rebuild (QU scraper re-INSERTs a day with new ids) is mirrored, not
+    orphaned. Reads the local TimescaleDB via the legacy engine and writes Neon via
+    ``DATABASE_URL``. DATABASE_URL unset fails loud (non-zero) by default;
+    ``--skip-if-unconfigured`` turns that into a warn + exit 0 for local dev (cron
+    stays loud).
     """
     from rainier.core.database import get_engine as get_local_engine
     from rainier.db.engine import get_engine as get_neon_engine
@@ -6134,8 +6136,8 @@ def db_backup_money_flow(do_verify: bool, skip_if_unconfigured: bool) -> None:
     try:
         result = backup_money_flow(src, dst)
         click.echo(
-            f"backed up {result.copied} new rows "
-            f"(hwm {result.hwm_before} -> {result.run_max})"
+            f"backed up {result.copied} rows "
+            f"(reconciled up to id {result.run_max})"
         )
         if do_verify:
             report = verify_backup(src, dst, run_max=result.run_max)

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1533,42 +1533,89 @@ def _notify_recover(title: str, description: str, color: int = 0x3498DB):
         pass  # Don't let notification failures block recovery
 
 
+# Ranking types the QU scraper persists every slot. The day is only "fresh" when
+# BOTH books are at/after the latest due slot — a partial scrape (e.g. top100 lands
+# but bottom100 returns an empty no-op) must read as STALE so recover re-fires.
+_QU100_RANKING_TYPES = ("top100", "bottom100")
+
+
+def _latest_due_slot(schedule: dict, now):
+    """Return ``(name, slot_time)`` of the most-recent scheduled slot already due
+    at ``now`` (``slot_time <= now``), or ``(None, None)`` when none is due yet.
+
+    ``schedule`` maps slot name -> ``"HH:MM"`` in the app timezone; ``now`` is a
+    tz-aware datetime in that zone. Single source of truth for "which slot should
+    have run by now" — both the freshness check and the recovery-scrape label read
+    from it so they can never drift.
+    """
+    latest_name = None
+    latest_time = None
+    for name, time_str in schedule.items():
+        hour, minute = map(int, time_str.split(":"))
+        slot_time = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if slot_time <= now and (latest_time is None or slot_time > latest_time):
+            latest_time = slot_time
+            latest_name = name
+    return latest_name, latest_time
+
+
 def _is_qu100_fresh(latest_captured_at, now, schedule: dict, tz) -> bool:
-    """Is today's QU100 data present and fresh as of the latest due scrape slot?
+    """Is ONE book's ``captured_at`` present and fresh as of the latest due slot?
 
     Under the rebuild-the-day fix a day holds ONE ``captured_at`` per
     ``(data_date, ranking_type)`` and rows carry the LATEST scrape's
     ``capture_session`` — so the old per-``capture_session`` row count can no
     longer tell which slot ran. Freshness is detected PER DAY via ``captured_at``:
 
-      * find the most-recent scheduled slot whose local time is already due
-        (``slot_time <= now``);
       * if no slot is due yet, nothing was expected -> fresh (no scrape needed);
-      * otherwise the day is fresh iff a snapshot exists AND its ``captured_at``
-        is at/after that most-recent-due slot.
+      * otherwise this book is fresh iff a snapshot exists AND its ``captured_at``
+        is at/after the most-recent-due slot.
 
-    This degrades from per-slot to per-day detection (it can't tell WHICH earlier
-    slot ran) — acceptable, since the intraday slots are unrecoverable anyway, and
-    it never false-negatives on data: if nothing landed, ``captured_at`` stays
-    stale and recover fires a scrape.
-
-    ``schedule`` maps slot name -> ``"HH:MM"`` in the app timezone (``tz``);
-    ``now`` and ``latest_captured_at`` are tz-aware datetimes.
+    This is the per-ranking_type primitive; ``_qu100_day_is_fresh`` requires it to
+    hold for EVERY book so a partial scrape never reads as fresh. ``now`` and
+    ``latest_captured_at`` are tz-aware datetimes.
     """
-    # Most-recent slot time that is already due today.
-    latest_due = None
-    for time_str in schedule.values():
-        hour, minute = map(int, time_str.split(":"))
-        slot_time = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
-        if slot_time <= now and (latest_due is None or slot_time > latest_due):
-            latest_due = slot_time
-
+    _, latest_due = _latest_due_slot(schedule, now)
     if latest_due is None:
         return True  # nothing due yet today
     if latest_captured_at is None:
         return False  # a slot is due but no data landed
-    # Compare in the app timezone (captured_at may be UTC-aware).
+    # captured_at is a timestamptz on Postgres (aware); a naive value (e.g. a
+    # SQLite-backed read) is assumed UTC so `.astimezone` never reinterprets it as
+    # local wall-clock. Compare in the app timezone.
+    if latest_captured_at.tzinfo is None:
+        from datetime import timezone as _timezone
+
+        latest_captured_at = latest_captured_at.replace(tzinfo=_timezone.utc)
     return latest_captured_at.astimezone(tz) >= latest_due
+
+
+def _qu100_day_is_fresh(db, today, now, schedule: dict, tz) -> bool:
+    """Is today's QU100 snapshot fresh for EVERY ranking_type?
+
+    Reads ``max(captured_at)`` per ranking_type for ``data_date == today`` and
+    requires each expected book (``top100`` AND ``bottom100``) to be fresh. A
+    single global ``max(captured_at)`` would let a fresh top100 mask a stale/empty
+    bottom100 (partial-failure scrape) and report the day fresh when half the book
+    is frozen. Used both at detection AND post-scrape to gate the Discord report.
+    """
+    from sqlalchemy import func
+
+    from rainier.core.models import MoneyFlowSnapshot
+
+    latest_by_type = dict(
+        db.query(
+            MoneyFlowSnapshot.ranking_type,
+            func.max(MoneyFlowSnapshot.captured_at),
+        )
+        .filter(MoneyFlowSnapshot.data_date == today)
+        .group_by(MoneyFlowSnapshot.ranking_type)
+        .all()
+    )
+    return all(
+        _is_qu100_fresh(latest_by_type.get(rt), now, schedule, tz)
+        for rt in _QU100_RANKING_TYPES
+    )
 
 
 def _latest_due_session(schedule: dict, now) -> str:
@@ -1578,28 +1625,8 @@ def _latest_due_session(schedule: dict, now) -> str:
     back to the first slot if (defensively) none is due — the caller only invokes
     this when a slot IS due, so the fallback is just a safety net.
     """
-    latest_name = next(iter(schedule))
-    latest_time = None
-    for name, time_str in schedule.items():
-        hour, minute = map(int, time_str.split(":"))
-        slot_time = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
-        if slot_time <= now and (latest_time is None or slot_time > latest_time):
-            latest_time = slot_time
-            latest_name = name
-    return latest_name
-
-
-def _should_send_recovery_report(*, was_stale: bool, scrape_succeeded: bool) -> bool:
-    """Gate the recovery Discord outlook on a SUCCESSFUL recovery scrape.
-
-    The daily outlook is the ``backtest-qu100 --discord`` report the scheduler
-    fires after the morning scrape. On recovery it must NOT fire off a stale /
-    empty snapshot: send it ONLY when the day was stale AND a recovery scrape this
-    run actually succeeded (restoring freshness). Data already fresh -> treat as
-    already sent (no duplicate); recovery scrape FAILED -> do not send (that would
-    reintroduce the frozen-data bug this PR fixes).
-    """
-    return was_stale and scrape_succeeded
+    name, _ = _latest_due_slot(schedule, now)
+    return name if name is not None else next(iter(schedule))
 
 
 async def _recover(settings, dry_run: bool):
@@ -1661,53 +1688,44 @@ async def _recover(settings, dry_run: bool):
     # per-session counts can no longer tell which slot ran). ``qu100_stale`` drives
     # both the recovery scrape AND whether the daily outlook is re-sent.
     qu100_stale = False
+    # Key the day on the MARKET date (America/New_York), matching how the scraper
+    # stamps `data_date` (scrapers/qu/scraper.py:market_date). `now.date()` is in
+    # the app timezone (default LA); near the PT/ET date boundary the two calendar
+    # dates diverge, so using the wall-clock date would query the wrong day and
+    # mis-classify a present snapshot as stale (or vice-versa).
+    from datetime import timezone as _timezone
+
+    from rainier.scrapers.qu.scraper import market_date
+
+    today = market_date(datetime.now(_timezone.utc))
     if now.weekday() >= 5:
         click.echo("  Weekend — no scrape sessions to check")
     else:
-        from sqlalchemy import func
-
         from rainier.core.database import get_session
-        from rainier.core.models import MoneyFlowSnapshot
 
-        today = now.date()
         with get_session() as db:
-            latest_captured_at = (
-                db.query(func.max(MoneyFlowSnapshot.captured_at))
-                .filter(MoneyFlowSnapshot.data_date == today)
-                .scalar()
-            )
+            day_fresh = _qu100_day_is_fresh(db, today, now, sessions_config, tz)
 
-        if _is_qu100_fresh(latest_captured_at, now, sessions_config, tz):
-            if latest_captured_at is None:
-                click.echo("  QU100 today: no slot due yet — OK")
-            else:
-                click.echo(
-                    f"  QU100 today: fresh (captured_at "
-                    f"{latest_captured_at.astimezone(tz):%H:%M})"
-                )
+        if day_fresh:
+            click.echo("  QU100 today: fresh (every book at/after the latest due slot)")
         else:
             qu100_stale = True
-            issues.append("QU100 data stale (today's latest scrape slot missing)")
+            issues.append("QU100 data stale (a book is missing today's latest slot)")
             # One recovery scrape targeting the most-recent due slot's session.
             recover_session = _latest_due_session(sessions_config, now)
             actions.append(f"scrape_{recover_session}")
-            if latest_captured_at is None:
-                click.echo("  QU100 today: STALE — no snapshot for today")
-            else:
-                click.echo(
-                    "  QU100 today: STALE — latest captured_at "
-                    f"{latest_captured_at.astimezone(tz):%H:%M}"
-                )
+            click.echo("  QU100 today: STALE — re-scraping the latest due slot")
 
     # --- 4. QU100 Discord report ---
     # Decoupled from scrape-action queueing: the daily outlook is re-sent ONLY
-    # when the recovery scrape later SUCCEEDS (see _should_send_recovery_report at
-    # the execution stage). A queued-but-failed scrape must not fire a report off
-    # a stale snapshot — that would reintroduce the frozen-data bug. So we do NOT
-    # queue a "discord_report" action here; the decision is made post-scrape.
+    # when freshness is RESTORED (re-read post-scrape, per ranking_type — see the
+    # execution stage). A scrape that returns without raising but lands no fresh
+    # data must not fire a report off a stale snapshot — that would reintroduce the
+    # frozen-data bug. So we do NOT queue a "discord_report" action here; the
+    # decision is made post-scrape from the DB, not from "the coroutine returned".
     click.echo("Checking QU100 Discord report...")
     if qu100_stale:
-        click.echo("  Discord report: deferred — gated on a successful recovery scrape")
+        click.echo("  Discord report: deferred — gated on restored freshness")
     else:
         click.echo("  Discord report: likely OK (data fresh)")
 
@@ -1807,14 +1825,27 @@ async def _recover(settings, dry_run: bool):
                     color=0xE74C3C,
                 )
 
-    # Re-send the daily outlook ONLY if the day was stale AND a recovery scrape
-    # this run actually succeeded (restoring freshness). A failed scrape leaves
-    # the snapshot stale -> no report (avoids the frozen-data bug). Data already
-    # fresh -> treated as already sent.
+    # Re-send the daily outlook ONLY if the day was stale AND freshness was
+    # actually RESTORED this run. We re-read the DB rather than trust "the scrape
+    # coroutine returned": an empty/partial scrape (the documented empty-slot slip
+    # -> _persist_qu100 no-op) returns without raising yet leaves the snapshot
+    # stale. Gating on a post-scrape freshness re-read (per ranking_type) is the
+    # only signal that won't fire a report off a frozen snapshot — the exact bug
+    # this PR fixes. Data already fresh -> treated as already sent.
     report_sent = False
-    if _should_send_recovery_report(
-        was_stale=qu100_stale, scrape_succeeded=bool(recovered_scrapes)
-    ):
+    freshness_restored = False
+    if qu100_stale and recovered_scrapes:
+        from rainier.core.database import get_session
+
+        with get_session() as db:
+            freshness_restored = _qu100_day_is_fresh(
+                db, today, now, sessions_config, tz
+            )
+        if not freshness_restored:
+            click.echo(
+                "  Discord report: skipped — recovery scrape landed no fresh data"
+            )
+    if qu100_stale and freshness_restored:
         click.echo("  Sending QU100 Discord report...")
         try:
             from rainier.backtest.qu100_backtest import (

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1533,6 +1533,75 @@ def _notify_recover(title: str, description: str, color: int = 0x3498DB):
         pass  # Don't let notification failures block recovery
 
 
+def _is_qu100_fresh(latest_captured_at, now, schedule: dict, tz) -> bool:
+    """Is today's QU100 data present and fresh as of the latest due scrape slot?
+
+    Under the rebuild-the-day fix a day holds ONE ``captured_at`` per
+    ``(data_date, ranking_type)`` and rows carry the LATEST scrape's
+    ``capture_session`` — so the old per-``capture_session`` row count can no
+    longer tell which slot ran. Freshness is detected PER DAY via ``captured_at``:
+
+      * find the most-recent scheduled slot whose local time is already due
+        (``slot_time <= now``);
+      * if no slot is due yet, nothing was expected -> fresh (no scrape needed);
+      * otherwise the day is fresh iff a snapshot exists AND its ``captured_at``
+        is at/after that most-recent-due slot.
+
+    This degrades from per-slot to per-day detection (it can't tell WHICH earlier
+    slot ran) — acceptable, since the intraday slots are unrecoverable anyway, and
+    it never false-negatives on data: if nothing landed, ``captured_at`` stays
+    stale and recover fires a scrape.
+
+    ``schedule`` maps slot name -> ``"HH:MM"`` in the app timezone (``tz``);
+    ``now`` and ``latest_captured_at`` are tz-aware datetimes.
+    """
+    # Most-recent slot time that is already due today.
+    latest_due = None
+    for time_str in schedule.values():
+        hour, minute = map(int, time_str.split(":"))
+        slot_time = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if slot_time <= now and (latest_due is None or slot_time > latest_due):
+            latest_due = slot_time
+
+    if latest_due is None:
+        return True  # nothing due yet today
+    if latest_captured_at is None:
+        return False  # a slot is due but no data landed
+    # Compare in the app timezone (captured_at may be UTC-aware).
+    return latest_captured_at.astimezone(tz) >= latest_due
+
+
+def _latest_due_session(schedule: dict, now) -> str:
+    """The session name of the most-recent scheduled slot already due at ``now``.
+
+    Used to label the single recovery scrape when today's data is stale. Falls
+    back to the first slot if (defensively) none is due — the caller only invokes
+    this when a slot IS due, so the fallback is just a safety net.
+    """
+    latest_name = next(iter(schedule))
+    latest_time = None
+    for name, time_str in schedule.items():
+        hour, minute = map(int, time_str.split(":"))
+        slot_time = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if slot_time <= now and (latest_time is None or slot_time > latest_time):
+            latest_time = slot_time
+            latest_name = name
+    return latest_name
+
+
+def _should_send_recovery_report(*, was_stale: bool, scrape_succeeded: bool) -> bool:
+    """Gate the recovery Discord outlook on a SUCCESSFUL recovery scrape.
+
+    The daily outlook is the ``backtest-qu100 --discord`` report the scheduler
+    fires after the morning scrape. On recovery it must NOT fire off a stale /
+    empty snapshot: send it ONLY when the day was stale AND a recovery scrape this
+    run actually succeeded (restoring freshness). Data already fresh -> treat as
+    already sent (no duplicate); recovery scrape FAILED -> do not send (that would
+    reintroduce the frozen-data bug this PR fixes).
+    """
+    return was_stale and scrape_succeeded
+
+
 async def _recover(settings, dry_run: bool):
     """Check Chrome CDP, scheduler, and missed scrape sessions."""
     import subprocess
@@ -1586,54 +1655,61 @@ async def _recover(settings, dry_run: bool):
         "close": schedule.close,
     }
 
-    # Only check weekdays
+    # Detect today's QU100 freshness via the latest captured_at vs the schedule
+    # (per-DAY, not per-capture_session — under the rebuild-the-day fix a day
+    # holds one captured_at and the rows carry the LATEST scrape's session, so
+    # per-session counts can no longer tell which slot ran). ``qu100_stale`` drives
+    # both the recovery scrape AND whether the daily outlook is re-sent.
+    qu100_stale = False
     if now.weekday() >= 5:
         click.echo("  Weekend — no scrape sessions to check")
     else:
+        from sqlalchemy import func
+
         from rainier.core.database import get_session
         from rainier.core.models import MoneyFlowSnapshot
 
         today = now.date()
-        missed_sessions = []
+        with get_session() as db:
+            latest_captured_at = (
+                db.query(func.max(MoneyFlowSnapshot.captured_at))
+                .filter(MoneyFlowSnapshot.data_date == today)
+                .scalar()
+            )
 
-        for session_name, time_str in sessions_config.items():
-            hour, minute = map(int, time_str.split(":"))
-            scheduled_time = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
-
-            # Skip future sessions
-            if now < scheduled_time:
-                click.echo(f"  {session_name} ({time_str}): upcoming")
-                continue
-
-            # Check if data exists for this session today
-            with get_session() as db:
-                count = (
-                    db.query(MoneyFlowSnapshot)
-                    .filter(
-                        MoneyFlowSnapshot.capture_session == session_name,
-                        MoneyFlowSnapshot.data_date == today,
-                    )
-                    .count()
+        if _is_qu100_fresh(latest_captured_at, now, sessions_config, tz):
+            if latest_captured_at is None:
+                click.echo("  QU100 today: no slot due yet — OK")
+            else:
+                click.echo(
+                    f"  QU100 today: fresh (captured_at "
+                    f"{latest_captured_at.astimezone(tz):%H:%M})"
+                )
+        else:
+            qu100_stale = True
+            issues.append("QU100 data stale (today's latest scrape slot missing)")
+            # One recovery scrape targeting the most-recent due slot's session.
+            recover_session = _latest_due_session(sessions_config, now)
+            actions.append(f"scrape_{recover_session}")
+            if latest_captured_at is None:
+                click.echo("  QU100 today: STALE — no snapshot for today")
+            else:
+                click.echo(
+                    "  QU100 today: STALE — latest captured_at "
+                    f"{latest_captured_at.astimezone(tz):%H:%M}"
                 )
 
-            if count > 0:
-                click.echo(f"  {session_name} ({time_str}): OK ({count} rows)")
-            else:
-                missed_sessions.append(session_name)
-                issues.append(f"Missed {session_name} scrape")
-                actions.append(f"scrape_{session_name}")
-                click.echo(f"  {session_name} ({time_str}): MISSED")
-
-    # --- 4. Check missed QU100 Discord report ---
+    # --- 4. QU100 Discord report ---
+    # Decoupled from scrape-action queueing: the daily outlook is re-sent ONLY
+    # when the recovery scrape later SUCCEEDS (see _should_send_recovery_report at
+    # the execution stage). A queued-but-failed scrape must not fire a report off
+    # a stale snapshot — that would reintroduce the frozen-data bug. So we do NOT
+    # queue a "discord_report" action here; the decision is made post-scrape.
     click.echo("Checking QU100 Discord report...")
-    # The backtest-qu100 --discord runs from scheduler after morning scrape
-    # We can't easily tell if it was sent, so if morning scrape was missed, re-send
-    if "scrape_morning" in actions:
-        actions.append("discord_report")
-        issues.append("Morning Discord report likely missed")
-        click.echo("  Discord report: likely MISSED (morning scrape was missed)")
+    if qu100_stale:
+        click.echo("  Discord report: deferred — gated on a successful recovery scrape")
     else:
-        click.echo("  Discord report: likely OK")
+        click.echo("  Discord report: likely OK (data fresh)")
 
     # --- Summary ---
     click.echo()
@@ -1731,7 +1807,14 @@ async def _recover(settings, dry_run: bool):
                     color=0xE74C3C,
                 )
 
-    if "discord_report" in actions:
+    # Re-send the daily outlook ONLY if the day was stale AND a recovery scrape
+    # this run actually succeeded (restoring freshness). A failed scrape leaves
+    # the snapshot stale -> no report (avoids the frozen-data bug). Data already
+    # fresh -> treated as already sent.
+    report_sent = False
+    if _should_send_recovery_report(
+        was_stale=qu100_stale, scrape_succeeded=bool(recovered_scrapes)
+    ):
         click.echo("  Sending QU100 Discord report...")
         try:
             from rainier.backtest.qu100_backtest import (
@@ -1744,6 +1827,7 @@ async def _recover(settings, dry_run: bool):
                 embeds = format_discord_report(result)
                 _send_discord_embeds(webhook, embeds)
                 click.echo("  Discord report: sent")
+                report_sent = True
                 _notify_recover("QU100 Report", "Sent to Discord", color=0x2ECC71)
             else:
                 click.echo("  Discord report: no webhook configured")
@@ -1759,7 +1843,7 @@ async def _recover(settings, dry_run: bool):
         summary_parts.append("Scheduler restarted")
     if recovered_scrapes:
         summary_parts.append(f"Scrapes recovered: {', '.join(recovered_scrapes)}")
-    if "discord_report" in actions:
+    if report_sent:
         summary_parts.append("QU100 report re-sent")
 
     _notify_recover(

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1539,6 +1539,28 @@ def _notify_recover(title: str, description: str, color: int = 0x3498DB):
 _QU100_RANKING_TYPES = ("top100", "bottom100")
 
 
+def _recover_market_today(now: datetime) -> date:
+    """Anchor recover's "today" to the US market trading date (ET), not the
+    app-tz/wall-clock date.
+
+    Stored snapshots are keyed on ``data_date = market_date(captured_at)`` (ET),
+    so the freshness day-filter must use the same ET trading date. A recover
+    firing past ET midnight (e.g. a late-PT or past-midnight-UTC run) would, on a
+    wall-clock date, resolve the WRONG trading day and misjudge freshness — the
+    same rollover hazard ``market_date()`` already solved for the scraper.
+
+    The schedule-slot "due" times stay app-tz (the scheduler fires them in the app
+    timezone); only the day key is ET. In the narrow evening window where the two
+    disagree (after ET midnight but before app-tz midnight) a false "stale" is
+    harmless: a recovery scrape of a not-yet-traded day returns empty ->
+    ``_persist_qu100`` no-op, and the daily report is gated on RESTORED freshness,
+    so nothing fires off a stale snapshot.
+    """
+    from rainier.scrapers.qu.scraper import market_date
+
+    return market_date(now)
+
+
 def _latest_due_slot(schedule: dict, now):
     """Return ``(name, slot_time)`` of the most-recent scheduled slot already due
     at ``now`` (``slot_time <= now``), or ``(None, None)`` when none is due yet.
@@ -1688,17 +1710,20 @@ async def _recover(settings, dry_run: bool):
     # per-session counts can no longer tell which slot ran). ``qu100_stale`` drives
     # both the recovery scrape AND whether the daily outlook is re-sent.
     qu100_stale = False
-    # ONE timezone basis for the whole QU100 freshness check: the app timezone.
-    # The schedule slot strings (sessions_config) are app-tz — the scheduler runs
-    # them under AsyncIOScheduler(timezone=app.timezone) — so `today`, the weekend
-    # guard, and the latest-due-slot scan must ALL key off the app-tz `now`. Mixing
-    # an ET market_date for `today` with app-tz slots false-flags QU100 stale every
-    # evening after ET-midnight-but-before-local-midnight (Codex). During the
-    # scraping window (the only time freshness matters) the app-tz date equals the
-    # scraper's ET `data_date`, so this single basis stays consistent with stored
-    # rows where it counts.
-    today = now.date()
-    if now.weekday() >= 5:
+    # Anchor the day key to the US market trading date (ET) via market_date(), NOT
+    # the app-tz/wall-clock date: stored rows are keyed on
+    # ``data_date = market_date(captured_at)`` (ET), so the day-filter must match,
+    # and a recover firing past ET midnight must resolve the correct trading day
+    # (the rollover hazard market_date() already solved for the scraper). The
+    # schedule slot strings (sessions_config) stay app-tz — the scheduler fires
+    # them under AsyncIOScheduler(timezone=app.timezone) — so the latest-due-slot
+    # scan keys off the app-tz ``now``. During the scraping window (the only time
+    # freshness truly matters) the ET date equals the app-tz date, so the two
+    # bases agree where it counts; the narrow evening-window disagreement is
+    # harmless (an empty recovery scrape no-ops and the report is gated on
+    # restored freshness).
+    today = _recover_market_today(now)
+    if today.weekday() >= 5:
         click.echo("  Weekend — no scrape sessions to check")
     else:
         from rainier.core.database import get_session
@@ -1849,7 +1874,7 @@ async def _recover(settings, dry_run: bool):
         # recovered day is always judged against its OWN last due slot, never a
         # fresh next-day clock. The day is fixed; the clock advances within it only.
         now_after = datetime.now(tz)
-        if now_after.date() > today:
+        if _recover_market_today(now_after) > today:
             now_after = datetime.combine(today, time.max, tzinfo=tz)
         with get_session() as db:
             freshness_restored = _qu100_day_is_fresh(

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1540,6 +1540,15 @@ def _notify_recover(title: str, description: str, color: int = 0x3498DB):
 # but bottom100 returns an empty no-op) must read as STALE so recover re-fires.
 _QU100_RANKING_TYPES = ("top100", "bottom100")
 
+# Minimum rank coverage for a book to count as "fresh". QU100 is exactly 100 ranks
+# and a full scrape overrides every slot (count == 100); a glitched non-empty
+# PARTIAL scrape (a handful of ranks, nothing earlier that day to carry forward)
+# lands far below this floor, so it reads STALE and recover re-fires rather than
+# treating a near-empty book as a fresh full scrape. 90 = a strong-majority cohort,
+# above any realistic dedup-unfill (a moved symbol leaves at most a few slots
+# unfilled) yet well clear of a partial response.
+_QU100_MIN_FRESH_RANKS = 90
+
 
 def _recover_trading_day(now: datetime) -> date:
     """Anchor recover's "today" to the APP-LOCAL calendar date of ``now`` — the
@@ -1621,29 +1630,54 @@ def _is_qu100_fresh(latest_captured_at, now, schedule: dict, tz) -> bool:
 def _qu100_day_is_fresh(db, today, now, schedule: dict, tz) -> bool:
     """Is today's QU100 snapshot fresh for EVERY ranking_type?
 
-    Reads ``max(captured_at)`` per ranking_type for ``data_date == today`` and
-    requires each expected book (``top100`` AND ``bottom100``) to be fresh. A
-    single global ``max(captured_at)`` would let a fresh top100 mask a stale/empty
-    bottom100 (partial-failure scrape) and report the day fresh when half the book
-    is frozen. Used both at detection AND post-scrape to gate the Discord report.
+    Reads ``max(captured_at)`` AND the row count per ranking_type for
+    ``data_date == today`` and requires each expected book (``top100`` AND
+    ``bottom100``) to be both timely AND adequately covered:
+
+      * TIMELY — its ``captured_at`` is at/after the latest due slot (a single
+        global ``max(captured_at)`` would let a fresh top100 mask a stale/empty
+        bottom100 — a partial-failure scrape — and report the day fresh when half
+        the book is frozen);
+      * COVERED — once a slot is due, the book holds at least
+        ``_QU100_MIN_FRESH_RANKS`` rows. Under the rebuild fix a day's whole book
+        shares one ``captured_at``, so a non-empty PARTIAL first scrape (a handful
+        of ranks, nothing earlier to carry forward) would otherwise advance
+        ``captured_at`` and read as fully fresh even though the book is mostly
+        missing (Codex P1). A full scrape is exactly 100 ranks; a glitched partial
+        is well below the floor, so recover re-fires instead of running the
+        screener off a near-empty book. (Coverage is NOT required before any slot
+        is due — there may legitimately be no data yet.)
+
+    Used both at detection AND post-scrape to gate the Discord report.
     """
     from sqlalchemy import func
 
     from rainier.core.models import MoneyFlowSnapshot
 
-    latest_by_type = dict(
-        db.query(
+    by_type = {
+        rt: (max_cap, count)
+        for rt, max_cap, count in db.query(
             MoneyFlowSnapshot.ranking_type,
             func.max(MoneyFlowSnapshot.captured_at),
+            func.count(),
         )
         .filter(MoneyFlowSnapshot.data_date == today)
         .group_by(MoneyFlowSnapshot.ranking_type)
         .all()
-    )
-    return all(
-        _is_qu100_fresh(latest_by_type.get(rt), now, schedule, tz)
-        for rt in _QU100_RANKING_TYPES
-    )
+    }
+    _, latest_due = _latest_due_slot(schedule, now)
+
+    def _book_fresh(rt: str) -> bool:
+        max_cap, count = by_type.get(rt, (None, 0))
+        if not _is_qu100_fresh(max_cap, now, schedule, tz):
+            return False
+        # Timely. Demand rank coverage too — but only once a slot is due (before
+        # that, "nothing expected" is fresh regardless of coverage).
+        if latest_due is None:
+            return True
+        return count >= _QU100_MIN_FRESH_RANKS
+
+    return all(_book_fresh(rt) for rt in _QU100_RANKING_TYPES)
 
 
 def _latest_due_session(schedule: dict, now) -> str:

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1835,17 +1835,22 @@ async def _recover(settings, dry_run: bool):
     report_sent = False
     freshness_restored = False
     if qu100_stale and recovered_scrapes:
+        from datetime import time
+
         from rainier.core.database import get_session
 
-        # Re-evaluate against the CURRENT clock, but for the SAME market day we set
-        # out to recover (`today`) — NOT market_date(now). A recover that crossed a
-        # slot boundary (15:29 -> 15:31) must judge against the now-overdue 15:30
-        # slot (use the fresh `now_after`), but it must keep judging the day it was
-        # repairing: re-deriving the market date here would, on a recovery that
-        # crossed midnight ET, switch to the NEXT market day where no slot is due
-        # yet -> `_qu100_day_is_fresh` returns True and the report fires off the
-        # still-stale prior day (Codex P2). The day is fixed; only the clock moves.
+        # Re-evaluate against the CURRENT clock, but CLAMPED to the day we set out
+        # to recover (`today`). A recover that crossed a slot boundary (15:29 ->
+        # 15:31) must judge against the now-overdue 15:30 slot, so the clock must
+        # advance. But if the rerun crosses local MIDNIGHT, `now_after` lands on a
+        # NEW day where no slot is due yet -> `_latest_due_slot` returns None ->
+        # `_qu100_day_is_fresh` returns True and we'd resend the outlook off the
+        # still-stale prior day (Codex). Clamp the clock to end-of-`today` so the
+        # recovered day is always judged against its OWN last due slot, never a
+        # fresh next-day clock. The day is fixed; the clock advances within it only.
         now_after = datetime.now(tz)
+        if now_after.date() > today:
+            now_after = datetime.combine(today, time.max, tzinfo=tz)
         with get_session() as db:
             freshness_restored = _qu100_day_is_fresh(
                 db, today, now_after, sessions_config, tz

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1904,8 +1904,12 @@ async def _recover(settings, dry_run: bool):
 
         click.echo("  Restoring post-scrape pipeline (screener/LLM/candidates)...")
         try:
+            # Stamp the derived artifacts with the RECOVERED trading day (`today`),
+            # not date.today(): a post-midnight / cross-timezone replay must label
+            # ScreenedStockRecord / thesis rows with the day the data is from
+            # (the pinned scrape data_date), not the wall-clock run date (Codex P1).
             await asyncio.to_thread(
-                run_post_scrape_pipeline, settings, recover_session
+                run_post_scrape_pipeline, settings, recover_session, today
             )
             click.echo("  Post-scrape pipeline: done")
         except Exception as pipeline_exc:

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1835,21 +1835,20 @@ async def _recover(settings, dry_run: bool):
     report_sent = False
     freshness_restored = False
     if qu100_stale and recovered_scrapes:
-        from datetime import timezone as _timezone
-
         from rainier.core.database import get_session
-        from rainier.scrapers.qu.scraper import market_date
 
-        # Re-evaluate against the CURRENT clock + market date, not the `now`/`today`
-        # captured before the restart+scrape work. A recover that started just
-        # before a slot boundary (e.g. 15:29) and finished after it (15:31) must
-        # judge freshness against the now-overdue 15:30 slot, or it would resend
-        # the outlook off a snapshot that is already stale for the new slot.
+        # Re-evaluate against the CURRENT clock, but for the SAME market day we set
+        # out to recover (`today`) — NOT market_date(now). A recover that crossed a
+        # slot boundary (15:29 -> 15:31) must judge against the now-overdue 15:30
+        # slot (use the fresh `now_after`), but it must keep judging the day it was
+        # repairing: re-deriving the market date here would, on a recovery that
+        # crossed midnight ET, switch to the NEXT market day where no slot is due
+        # yet -> `_qu100_day_is_fresh` returns True and the report fires off the
+        # still-stale prior day (Codex P2). The day is fixed; only the clock moves.
         now_after = datetime.now(tz)
-        today_after = market_date(datetime.now(_timezone.utc))
         with get_session() as db:
             freshness_restored = _qu100_day_is_fresh(
-                db, today_after, now_after, sessions_config, tz
+                db, today, now_after, sessions_config, tz
             )
         if not freshness_restored:
             click.echo(

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1820,10 +1820,20 @@ async def _recover(settings, dry_run: bool):
             session_name = action.replace("scrape_", "")
             click.echo(f"  Running missed {session_name} scrape...")
             try:
+                # Pin the scrape to the STALE trading day (`today`), not the
+                # scraper's own clock-derived date. With dates=None the QU scraper
+                # derives the API/persist date from market_date(captured_at), which
+                # in the late-evening window (after ET midnight) resolves to the
+                # NEXT, not-yet-traded day — so the rerun would fetch the wrong day
+                # and never refresh `today`, leaving _qu100_day_is_fresh(db, today)
+                # false (Codex P1). Passing the explicit date makes the scraper
+                # query and persist `data_date = today`. (dates set also skips
+                # _run_qu_scrape's inline post-scrape pipeline; recover does its own
+                # freshness-gated Discord resend below, so the report still fires.)
                 await _run_qu_scrape(
                     session=session_name,
                     detail_top=0,
-                    dates=None,
+                    dates=today.isoformat(),
                     days_back=0,
                     start_date=None,
                     delay=None,

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1835,11 +1835,21 @@ async def _recover(settings, dry_run: bool):
     report_sent = False
     freshness_restored = False
     if qu100_stale and recovered_scrapes:
-        from rainier.core.database import get_session
+        from datetime import timezone as _timezone
 
+        from rainier.core.database import get_session
+        from rainier.scrapers.qu.scraper import market_date
+
+        # Re-evaluate against the CURRENT clock + market date, not the `now`/`today`
+        # captured before the restart+scrape work. A recover that started just
+        # before a slot boundary (e.g. 15:29) and finished after it (15:31) must
+        # judge freshness against the now-overdue 15:30 slot, or it would resend
+        # the outlook off a snapshot that is already stale for the new slot.
+        now_after = datetime.now(tz)
+        today_after = market_date(datetime.now(_timezone.utc))
         with get_session() as db:
             freshness_restored = _qu100_day_is_fresh(
-                db, today, now, sessions_config, tz
+                db, today_after, now_after, sessions_config, tz
             )
         if not freshness_restored:
             click.echo(

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1539,26 +1539,30 @@ def _notify_recover(title: str, description: str, color: int = 0x3498DB):
 _QU100_RANKING_TYPES = ("top100", "bottom100")
 
 
-def _recover_market_today(now: datetime) -> date:
-    """Anchor recover's "today" to the US market trading date (ET), not the
-    app-tz/wall-clock date.
+def _recover_trading_day(now: datetime) -> date:
+    """Anchor recover's "today" to the APP-LOCAL calendar date of ``now`` — the
+    same timezone the schedule slots fire in.
 
-    Stored snapshots are keyed on ``data_date = market_date(captured_at)`` (ET),
-    so the freshness day-filter must use the same ET trading date. A recover
-    firing past ET midnight (e.g. a late-PT or past-midnight-UTC run) would, on a
-    wall-clock date, resolve the WRONG trading day and misjudge freshness — the
-    same rollover hazard ``market_date()`` already solved for the scraper.
+    Recover must compare today's snapshots against the schedule, and the schedule
+    slots are app-tz (the scheduler runs ``AsyncIOScheduler(timezone=app.tz)``).
+    The day key MUST therefore be the app-local date so the latest-due-slot scan
+    (``_latest_due_slot``) and the snapshot day-filter agree.
 
-    The schedule-slot "due" times stay app-tz (the scheduler fires them in the app
-    timezone); only the day key is ET. In the narrow evening window where the two
-    disagree (after ET midnight but before app-tz midnight) a false "stale" is
-    harmless: a recovery scrape of a not-yet-traded day returns empty ->
-    ``_persist_qu100`` no-op, and the daily report is gated on RESTORED freshness,
-    so nothing fires off a stale snapshot.
+    This also matches the STORED ``data_date = market_date(captured_at)`` (ET) for
+    every legitimately-scraped slot: scrapes fire only during US market hours,
+    when the ET calendar date equals the app-local date (market hours are daytime
+    in any reasonable app tz). So a close scrape at 1pm PT stores ``data_date`` =
+    that Monday (ET) and an evening recover at 9pm PT resolves ``today`` = the same
+    Monday (app-local) — they match.
+
+    Using the ET date here (``market_date(now)``) instead would BREAK late-evening
+    recovery: after ~9pm PT the ET clock has rolled to the next calendar day, so
+    ``today`` would point at a not-yet-traded date while the latest due slot still
+    belongs to the day that just ended — a missed Monday close would be checked
+    against Tuesday, and on Friday night it would fall into the weekend fast-path
+    and skip recovery entirely.
     """
-    from rainier.scrapers.qu.scraper import market_date
-
-    return market_date(now)
+    return now.date()
 
 
 def _latest_due_slot(schedule: dict, now):
@@ -1710,19 +1714,10 @@ async def _recover(settings, dry_run: bool):
     # per-session counts can no longer tell which slot ran). ``qu100_stale`` drives
     # both the recovery scrape AND whether the daily outlook is re-sent.
     qu100_stale = False
-    # Anchor the day key to the US market trading date (ET) via market_date(), NOT
-    # the app-tz/wall-clock date: stored rows are keyed on
-    # ``data_date = market_date(captured_at)`` (ET), so the day-filter must match,
-    # and a recover firing past ET midnight must resolve the correct trading day
-    # (the rollover hazard market_date() already solved for the scraper). The
-    # schedule slot strings (sessions_config) stay app-tz — the scheduler fires
-    # them under AsyncIOScheduler(timezone=app.timezone) — so the latest-due-slot
-    # scan keys off the app-tz ``now``. During the scraping window (the only time
-    # freshness truly matters) the ET date equals the app-tz date, so the two
-    # bases agree where it counts; the narrow evening-window disagreement is
-    # harmless (an empty recovery scrape no-ops and the report is gated on
-    # restored freshness).
-    today = _recover_market_today(now)
+    # Anchor the day key to the APP-LOCAL date (the schedule's timezone) so the
+    # latest-due-slot scan and the snapshot day-filter agree, and so late-evening
+    # recovery still targets the day that just ended — see _recover_trading_day.
+    today = _recover_trading_day(now)
     if today.weekday() >= 5:
         click.echo("  Weekend — no scrape sessions to check")
     else:
@@ -1874,7 +1869,7 @@ async def _recover(settings, dry_run: bool):
         # recovered day is always judged against its OWN last due slot, never a
         # fresh next-day clock. The day is fixed; the clock advances within it only.
         now_after = datetime.now(tz)
-        if _recover_market_today(now_after) > today:
+        if _recover_trading_day(now_after) > today:
             now_after = datetime.combine(today, time.max, tzinfo=tz)
         with get_session() as db:
             freshness_restored = _qu100_day_is_fresh(

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1207,7 +1207,10 @@ def qu(ctx, session, detail_top, dates, days_back, start_date, delay, headed, cd
         sys.exit(1)
 
 
-async def _run_qu_scrape(session, detail_top, dates, days_back, start_date, delay, headed, cdp):
+async def _run_qu_scrape(
+    session, detail_top, dates, days_back, start_date, delay, headed, cdp,
+    run_pipeline=False,
+):
     import asyncio
     from datetime import date, datetime, timedelta
 
@@ -1287,6 +1290,14 @@ async def _run_qu_scrape(session, detail_top, dates, days_back, start_date, dela
         # (date_list is set) since those replay historical scans and would
         # spam the channel.
         #
+        # EXCEPTION: ``run_pipeline=True`` forces the pipeline even with a
+        # date_list. ``recover`` uses this for a single-day recovery of TODAY: it
+        # must PIN the scrape to the stale ``data_date`` (so it can't pass
+        # dates=None) yet still restore the same downstream outputs a scheduled
+        # scrape produces — screened_stocks, LLM theses, the top-20 candidate
+        # alert. Without this the recovered day would have a raw QU snapshot but
+        # none of the derived outputs recover is meant to replace (Codex P1).
+        #
         # Hand off via asyncio.to_thread because compute_theses_and_persist
         # wraps its async work in asyncio.run(); calling it directly from this
         # already-running event loop raises RuntimeError. The shared pipeline
@@ -1296,7 +1307,7 @@ async def _run_qu_scrape(session, detail_top, dates, days_back, start_date, dela
         # surfaces as a partial-success warning rather than morphing the
         # already-successful scrape into a red "Scrape FAILED" alert. The
         # outer except is for actual scrape errors only.
-        if result.records_created > 0 and not date_list:
+        if result.records_created > 0 and (not date_list or run_pipeline):
             try:
                 await asyncio.to_thread(
                     run_post_scrape_pipeline, settings, session,
@@ -1827,9 +1838,11 @@ async def _recover(settings, dry_run: bool):
                 # NEXT, not-yet-traded day — so the rerun would fetch the wrong day
                 # and never refresh `today`, leaving _qu100_day_is_fresh(db, today)
                 # false (Codex P1). Passing the explicit date makes the scraper
-                # query and persist `data_date = today`. (dates set also skips
-                # _run_qu_scrape's inline post-scrape pipeline; recover does its own
-                # freshness-gated Discord resend below, so the report still fires.)
+                # query and persist `data_date = today`. ``run_pipeline=True`` keeps
+                # the post-scrape pipeline (screened_stocks, LLM theses, candidate
+                # alert) running even though a date is pinned — a recovered day must
+                # restore the derived outputs a scheduled scrape produces, not just
+                # the raw snapshot (Codex P1).
                 await _run_qu_scrape(
                     session=session_name,
                     detail_top=0,
@@ -1839,6 +1852,7 @@ async def _recover(settings, dry_run: bool):
                     delay=None,
                     headed=False,
                     cdp="http://127.0.0.1:9222",
+                    run_pipeline=True,
                 )
                 click.echo(f"  {session_name} scrape: done")
                 recovered_scrapes.append(session_name)

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -1688,16 +1688,16 @@ async def _recover(settings, dry_run: bool):
     # per-session counts can no longer tell which slot ran). ``qu100_stale`` drives
     # both the recovery scrape AND whether the daily outlook is re-sent.
     qu100_stale = False
-    # Key the day on the MARKET date (America/New_York), matching how the scraper
-    # stamps `data_date` (scrapers/qu/scraper.py:market_date). `now.date()` is in
-    # the app timezone (default LA); near the PT/ET date boundary the two calendar
-    # dates diverge, so using the wall-clock date would query the wrong day and
-    # mis-classify a present snapshot as stale (or vice-versa).
-    from datetime import timezone as _timezone
-
-    from rainier.scrapers.qu.scraper import market_date
-
-    today = market_date(datetime.now(_timezone.utc))
+    # ONE timezone basis for the whole QU100 freshness check: the app timezone.
+    # The schedule slot strings (sessions_config) are app-tz — the scheduler runs
+    # them under AsyncIOScheduler(timezone=app.timezone) — so `today`, the weekend
+    # guard, and the latest-due-slot scan must ALL key off the app-tz `now`. Mixing
+    # an ET market_date for `today` with app-tz slots false-flags QU100 stale every
+    # evening after ET-midnight-but-before-local-midnight (Codex). During the
+    # scraping window (the only time freshness matters) the app-tz date equals the
+    # scraper's ET `data_date`, so this single basis stays consistent with stored
+    # rows where it counts.
+    today = now.date()
     if now.weekday() >= 5:
         click.echo("  Weekend — no scrape sessions to check")
     else:

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -6284,6 +6284,18 @@ def db_backup_money_flow(do_verify: bool, skip_if_unconfigured: bool) -> None:
 
     try:
         result = backup_money_flow(src, dst)
+        # An EMPTY source is a misconfiguration (mispointed LEGACY_DATABASE_URL /
+        # failed restore / empty local DB), NOT a legitimate "nothing to do". The
+        # reconcile left the backup intact (non-destructive), but exiting 0 here
+        # would let the nightly cron silently back up NOTHING from a dead source.
+        # Fail loud (non-zero) so the cron alerts instead of masking the gap.
+        if result.source_empty:
+            raise click.ClickException(
+                "backup-money-flow — local SOURCE is EMPTY (0 rows). The backup "
+                "was left intact, but nothing was copied. This is a "
+                "misconfiguration (check LEGACY_DATABASE_URL / local DB health), "
+                "not a no-op — failing loudly rather than reporting success."
+            )
         click.echo(
             f"backed up {result.copied} rows "
             f"(reconciled up to id {result.run_max})"

--- a/src/rainier/core/models.py
+++ b/src/rainier/core/models.py
@@ -123,9 +123,11 @@ class Stock(Base):
 
 class MoneyFlowSnapshot(Base):
     __tablename__ = "money_flow_snapshots"
-    # Logical key: (data_date, ranking_type, rank) — one stock per rank per day.
-    # TimescaleDB hypertable requires captured_at in unique constraints,
-    # so upsert logic in scraper.py enforces this at the application level.
+    # Logical key: (data_date, ranking_type, symbol) — one row per stock per
+    # ranking type per day. (Rank is NOT unique within a day: a carried-forward
+    # symbol can share a rank with a freshly-scraped one — see _persist_qu100's
+    # rebuild-with-carry-forward.) TimescaleDB hypertables require captured_at in
+    # unique constraints, so scraper.py enforces this key at the application level.
     __table_args__ = (PrimaryKeyConstraint("id", "captured_at"),)
 
     id: Mapped[int] = mapped_column(BigInteger, autoincrement=True)

--- a/src/rainier/core/models.py
+++ b/src/rainier/core/models.py
@@ -123,11 +123,13 @@ class Stock(Base):
 
 class MoneyFlowSnapshot(Base):
     __tablename__ = "money_flow_snapshots"
-    # Logical key: (data_date, ranking_type, symbol) — one row per stock per
-    # ranking type per day. (Rank is NOT unique within a day: a carried-forward
-    # symbol can share a rank with a freshly-scraped one — see _persist_qu100's
-    # rebuild-with-carry-forward.) TimescaleDB hypertables require captured_at in
-    # unique constraints, so scraper.py enforces this key at the application level.
+    # Logical key: (data_date, ranking_type, rank) — one row per rank SLOT per
+    # ranking type per day. Each non-empty scrape rebuilds the day by rank
+    # (override scraped ranks, carry forward the prior occupant of a missing rank,
+    # dedup by symbol so a moved stock appears once) under one captured_at
+    # generation — see _persist_qu100's rank-keyed rebuild. TimescaleDB hypertables
+    # require captured_at in unique constraints, so scraper.py enforces this key at
+    # the application level.
     __table_args__ = (PrimaryKeyConstraint("id", "captured_at"),)
 
     id: Mapped[int] = mapped_column(BigInteger, autoincrement=True)

--- a/src/rainier/db/money_flow_backup.py
+++ b/src/rainier/db/money_flow_backup.py
@@ -239,12 +239,15 @@ def backup_money_flow(
     # creates it; checkfirst makes this a no-op there and creates it on SQLite.
     dst_tbl.create(dst, checkfirst=True)
 
-    # 1) Stable upper bound on the source, captured ONCE. Only id <= run_max is
-    #    reconciled, so a scrape landing mid-run is not a torn read.
-    with src.connect() as sconn:
-        run_max = sconn.execute(
-            select(func.coalesce(func.max(src_tbl.c.id), 0))
-        ).scalar_one()
+    # 1) Read the ENTIRE source in ONE snapshot, then derive run_max FROM that
+    #    same read. A same-day rebuild (DELETE day D's ids <= run_max, re-INSERT
+    #    ids > run_max) landing between "capture run_max" and "read src_rows" used
+    #    to make D look source-empty -> the reconcile purged D from the backup
+    #    (Codex P1: torn read). Reading rows and run_max from one consistent
+    #    snapshot closes that window: either we see D's pre-rebuild rows (and
+    #    run_max excludes the new ids), or we see the post-rebuild rows whole.
+    src_all = _read_all(src, src_tbl)
+    run_max = max((r["id"] for r in src_all), default=0)
 
     if _race_hook is not None:
         _race_hook("after_run_max")
@@ -255,9 +258,17 @@ def backup_money_flow(
             select(func.coalesce(func.max(dst_tbl.c.id), 0))
         ).scalar_one()
 
-    # 3) Read both full windows (id <= run_max) and fingerprint per data_date.
-    src_rows = _read_window(src, src_tbl, run_max)
-    dst_rows = _read_window(dst, dst_tbl, run_max)
+    # 3) Read the FULL backup (NOT capped at run_max). A backup-only day must be
+    #    purgeable even when dropping it from the source LOWERED run_max below that
+    #    day's ids (Codex P2: a deleted latest day whose ids all exceed the new
+    #    run_max would otherwise be invisible and never purged). Source rows are
+    #    restricted to id <= run_max for the COPY (in-flight inserts past run_max
+    #    are picked up next run), but the day-set comparison uses the full source.
+    src_rows = [r for r in src_all if r["id"] <= run_max]
+    dst_rows = _read_all(dst, dst_tbl)
+    # Full-source day set (incl. any rows > run_max) so a day is never mis-flagged
+    # backup-only just because its only surviving rows are an in-flight insert.
+    src_days_all = {r["data_date"] for r in src_all}
     src_fps = _day_fingerprints(src_rows)
     dst_fps = _day_fingerprints(dst_rows)
 
@@ -270,7 +281,11 @@ def backup_money_flow(
         if in_src and not in_dst:
             days_to_copy.add(day)
         elif in_dst and not in_src:
-            days_to_delete.add(day)  # source dropped the day entirely
+            # Purge only if the day is truly gone from the source. A day present
+            # in src_all but absent from src_fps (all its rows are id > run_max,
+            # i.e. an in-flight insert) must NOT be purged — it copies next run.
+            if day not in src_days_all:
+                days_to_delete.add(day)
         else:
             s, d = src_fps[day], dst_fps[day]
             differs = (
@@ -407,6 +422,21 @@ def _read_window(engine: Engine, tbl: Table, run_max: int) -> list[dict]:
             for m in conn.execute(
                 select(*cols).where(tbl.c.id > 0, tbl.c.id <= run_max)
             ).mappings()
+        ]
+
+
+def _read_all(engine: Engine, tbl: Table) -> list[dict]:
+    """Read every row of ``tbl`` (id > 0) in one connection.
+
+    The source read derives ``run_max`` from this same snapshot so a concurrent
+    same-day rebuild can't tear the window; the destination read is uncapped so a
+    backup-only day whose ids exceed a lowered ``run_max`` stays visible for purge.
+    """
+    cols = [tbl.c[name] for name in COLUMNS]
+    with engine.connect() as conn:
+        return [
+            dict(m)
+            for m in conn.execute(select(*cols).where(tbl.c.id > 0)).mappings()
         ]
 
 

--- a/src/rainier/db/money_flow_backup.py
+++ b/src/rainier/db/money_flow_backup.py
@@ -9,32 +9,43 @@ incrementally and idempotently, into a plain ``backup.money_flow_snapshots``
 table on Neon (which has managed backups). Local stays the primary; Neon holds
 a backup copy.
 
-Copy mechanism (high-water-mark by ``id``, insert-only, idempotent)
--------------------------------------------------------------------
-The QU scraper is insert-only for money flow (it skips already-present
-``(data_date, ranking_type)`` batches and only INSERTs; never UPDATE/DELETE),
-``id`` is a monotonic sequence, so a HWM-by-``id`` copy is correct as long as
-that invariant holds. ``verify_backup`` (full-window canonicalized checksum) is
-the declared drift safety net if the invariant is ever violated.
+Copy mechanism (``data_date``-aware reconcile, idempotent)
+----------------------------------------------------------
+The QU scraper REBUILDS a day on each later same-day scrape: it DELETEs that
+day's ``(data_date, ranking_type)`` rows and re-INSERTs fresh ones with new
+autoincrement ids (see ``scrapers/qu/scraper.py:_persist_qu100``). So a day's
+rows change after first write, and old ids vanish. The previous high-water-mark-
+by-``id`` copy CANNOT cope: an id-forward cursor can neither purge the orphaned
+old ids the rebuild deleted (they sit *below* the high-water mark) nor re-copy a
+changed day whose new max-id it already passed — ``verify_backup``'s full-window
+checksum would then fail the nightly cron.
+
+Instead we reconcile per ``data_date`` over the UNION of source and backup days,
+in ONE destination transaction:
 
     src = core.database.get_engine()    # legacy -> local TimescaleDB (PR #115)
     dst = db.engine.get_engine()        # canonical -> DATABASE_URL -> Neon
-    run_max = MAX(id) on src            # STABLE upper bound, captured ONCE
-    hwm     = MAX(id) on dst backup     # high-water mark
-    copy WHERE id > hwm AND id <= run_max, ON CONFLICT (id, captured_at) DO NOTHING
+    run_max = MAX(id) on src            # STABLE upper bound (id <= run_max only)
+    for data_date in source_days ∪ backup_days:
+        source-only day         -> copy the day
+        backup-only day         -> DELETE the day from backup (source dropped it)
+        present on both, DIFFER -> DELETE the day in backup + re-copy from source
+            (differ = row-count mismatch, OR a source captured_at newer than the
+             backup's, OR a per-day canonical checksum mismatch)
+        present on both, equal  -> skip
+    a day gone-to-zero in source is left deleted.
 
-A scrape landing rows mid-backup (id > run_max) is NOT torn-read — those rows
-are picked up next run. The whole destination insert runs in ONE transaction so
-a mid-run failure leaves the backup unchanged (next run retries from the same
-hwm). JSONB ``raw_data`` is bound via a typed SQLAlchemy Core column (NOT raw
-text interpolation).
+Only rows with ``id <= run_max`` are considered, so a scrape landing mid-backup
+is not a torn read (it is reconciled next run). The whole destination mutation
+runs in ONE transaction, so a mid-run failure leaves the backup unchanged.
+JSONB ``raw_data`` is bound via a typed SQLAlchemy Core column (NOT raw text).
 
-    ASCII (one run):
+    ASCII (a same-day rebuild):
 
         src.money_flow_snapshots            dst.backup.money_flow_snapshots
         ┌───────────────────────┐           ┌───────────────────────────┐
-        │ id 1..run_max (stable)│  copy >hwm │ id 1..hwm  (already there)│
-        │ id >run_max (ignored) │ ─────────▶ │ + id (hwm, run_max]       │
+        │ day D: ids {3,4} (new)│  D differs │ day D: ids {1,2} (stale)  │
+        │ (ids 1,2 deleted)     │ ─────────▶ │ DELETE day D, re-copy {3,4}│
         └───────────────────────┘  one txn   └───────────────────────────┘
 """
 
@@ -143,7 +154,13 @@ def _backup_schema_for(engine: Engine) -> str | None:
 
 @dataclass
 class BackupResult:
-    """Outcome of one ``backup_money_flow`` run."""
+    """Outcome of one ``backup_money_flow`` run.
+
+    ``copied`` — rows written this run (new days + recopied changed days).
+    ``hwm_before`` — pre-run ``MAX(id)`` in the backup (reported for logging; the
+    reconcile keys on ``data_date``, not an id high-water mark).
+    ``run_max`` — the stable ``MAX(id)`` upper bound the run reconciled up to.
+    """
 
     copied: int
     hwm_before: int
@@ -166,6 +183,27 @@ class VerifyReport:
 # ---------------------------------------------------------------------------
 
 
+def _day_fingerprints(rows: list[dict]) -> dict[object, dict]:
+    """Group ``rows`` by ``data_date`` -> ``{count, max_cap, checksum}``.
+
+    ``max_cap`` is the canonical (UTC-normalized) max ``captured_at`` over the
+    day; ``checksum`` is the order-independent content hash of the day's rows.
+    Used to decide whether a day differs between source and backup.
+    """
+    by_day: dict[object, list[dict]] = {}
+    for r in rows:
+        by_day.setdefault(r["data_date"], []).append(r)
+    fps: dict[object, dict] = {}
+    for day, day_rows in by_day.items():
+        max_cap = max(_canon_captured_at(r["captured_at"]) for r in day_rows)
+        fps[day] = {
+            "count": len(day_rows),
+            "max_cap": max_cap,
+            "checksum": _checksum(day_rows),
+        }
+    return fps
+
+
 def backup_money_flow(
     src: Engine,
     dst: Engine,
@@ -173,18 +211,25 @@ def backup_money_flow(
     chunk_size: int = 5000,
     _race_hook: Callable[[str], None] | None = None,
 ) -> BackupResult:
-    """Copy new ``money_flow_snapshots`` rows from ``src`` to ``dst`` (insert-only).
+    """Reconcile ``money_flow_snapshots`` from ``src`` into ``dst`` per ``data_date``.
 
-    Captures a STABLE ``run_max = MAX(id)`` on ``src`` once at the start, reads
-    the backup high-water mark ``hwm`` from ``dst``, then copies
-    ``id > hwm AND id <= run_max`` into the backup table within ONE transaction
-    with ``ON CONFLICT (id, captured_at) DO NOTHING``. The destination table is
-    created if absent (idempotent bootstrap from an empty backup).
+    Captures a STABLE ``run_max = MAX(id)`` on ``src`` once, then — considering
+    only ``id <= run_max`` — reconciles each ``data_date`` in the union of source
+    and backup days: a day present only in source is copied; a day present only in
+    backup is deleted (source dropped it); a day present in both but DIFFERING
+    (row-count / newer ``captured_at`` / canonical-checksum mismatch — e.g. a
+    same-day rebuild) is delete-then-recopied; an equal day is skipped. All
+    mutations run in ONE destination transaction, so a mid-run failure leaves the
+    backup unchanged. The destination table is created if absent.
 
-    ``_race_hook`` is a test seam called with stage names
-    (``"after_run_max"`` after the stable upper bound is captured;
-    ``"before_commit"`` just before the txn commits) so tests can simulate a
-    concurrent scrape or a forced mid-insert failure without sleeps.
+    ``BackupResult.copied`` counts rows WRITTEN this run (new + recopied days).
+    ``hwm_before`` is the pre-run ``MAX(id)`` in the backup (kept for callers /
+    logging; the reconcile no longer uses an id high-water mark as the cursor).
+
+    ``_race_hook`` is a test seam called with stage names (``"after_run_max"``
+    after the stable upper bound is captured; ``"before_commit"`` just before the
+    txn commits) so tests can simulate a concurrent scrape or a forced mid-run
+    failure without sleeps.
     """
     src_tbl = source_table()
     schema = _backup_schema_for(dst)
@@ -194,41 +239,61 @@ def backup_money_flow(
     # creates it; checkfirst makes this a no-op there and creates it on SQLite.
     dst_tbl.create(dst, checkfirst=True)
 
-    # 1) Stable upper bound on the source, captured ONCE.
+    # 1) Stable upper bound on the source, captured ONCE. Only id <= run_max is
+    #    reconciled, so a scrape landing mid-run is not a torn read.
     with src.connect() as sconn:
-        run_max = sconn.execute(select(func.coalesce(func.max(src_tbl.c.id), 0))).scalar_one()
+        run_max = sconn.execute(
+            select(func.coalesce(func.max(src_tbl.c.id), 0))
+        ).scalar_one()
 
     if _race_hook is not None:
         _race_hook("after_run_max")
 
-    # 2) High-water mark on the destination backup.
+    # 2) Pre-run backup high-water mark (reported, not used as the cursor).
     with dst.connect() as dconn:
         hwm = dconn.execute(
             select(func.coalesce(func.max(dst_tbl.c.id), 0))
         ).scalar_one()
 
+    # 3) Read both full windows (id <= run_max) and fingerprint per data_date.
+    src_rows = _read_window(src, src_tbl, run_max)
+    dst_rows = _read_window(dst, dst_tbl, run_max)
+    src_fps = _day_fingerprints(src_rows)
+    dst_fps = _day_fingerprints(dst_rows)
+
+    # Decide which days to (re)copy and which backup-only days to delete.
+    days_to_delete: set = set()
+    days_to_copy: set = set()
+    for day in set(src_fps) | set(dst_fps):
+        in_src = day in src_fps
+        in_dst = day in dst_fps
+        if in_src and not in_dst:
+            days_to_copy.add(day)
+        elif in_dst and not in_src:
+            days_to_delete.add(day)  # source dropped the day entirely
+        else:
+            s, d = src_fps[day], dst_fps[day]
+            differs = (
+                s["count"] != d["count"]
+                or s["max_cap"] != d["max_cap"]
+                or s["checksum"] != d["checksum"]
+            )
+            if differs:
+                days_to_delete.add(day)  # purge stale rows first
+                days_to_copy.add(day)
+
+    rows_to_copy = [r for r in src_rows if r["data_date"] in days_to_copy]
+
     copied = 0
-    if run_max <= hwm:
-        return BackupResult(copied=0, hwm_before=hwm, run_max=run_max)
-
-    # 3) Read the incremental window from the source, ordered by id.
-    select_cols = [src_tbl.c[name] for name in COLUMNS]
-    with src.connect() as sconn:
-        rows = [
-            dict(m)
-            for m in sconn.execute(
-                select(*select_cols)
-                .where(src_tbl.c.id > hwm, src_tbl.c.id <= run_max)
-                .order_by(src_tbl.c.id)
-            ).mappings()
-        ]
-
-    # 4) One transaction on the destination: chunked typed Core insert with
-    #    ON CONFLICT (id, captured_at) DO NOTHING. Commit once at the end so a
-    #    mid-run failure leaves the backup unchanged.
+    # 4) One transaction on the destination: delete changed/dropped days, then
+    #    re-insert. Commit once so a mid-run failure leaves the backup unchanged.
     with dst.begin() as dconn:
-        for start in range(0, len(rows), chunk_size):
-            chunk = rows[start : start + chunk_size]
+        if days_to_delete:
+            dconn.execute(
+                dst_tbl.delete().where(dst_tbl.c.data_date.in_(days_to_delete))
+            )
+        for start in range(0, len(rows_to_copy), chunk_size):
+            chunk = rows_to_copy[start : start + chunk_size]
             if not chunk:
                 continue
             stmt = _conflict_insert(dst, dst_tbl, chunk)
@@ -348,18 +413,23 @@ def _read_window(engine: Engine, tbl: Table, run_max: int) -> list[dict]:
 def verify_backup(src: Engine, dst: Engine, *, run_max: int) -> VerifyReport:
     """Strong integrity check over the full covered window ``id <= run_max``.
 
-    Checks (design §2.3), any failure recorded loudly:
+    The copy is a ``data_date``-aware reconcile (delete-changed-day + recopy), so
+    after a same-day rebuild the backup must EXACTLY mirror the source over the
+    covered window — no orphaned old ids, no stale day. Checks, any failure
+    recorded loudly:
 
-      (a) ``MAX(id)`` on src vs backup match for ``id <= run_max``;
+      (a) ``MAX(id)`` on src vs backup match for ``id <= run_max`` (a recopied
+          day restores matching ids; an un-purged orphan would diverge);
       (b) missing-row reconciliation on the FULL composite key
           ``(id, captured_at)`` — no source row in ``(0, run_max]`` absent from
           the backup;
-      (c) deterministic checksum over the full window ``id <= run_max`` (NOT
-          just the incremental window) with ``raw_data`` canonicalized — catches
-          an edited already-backed-up row (``id <= hwm``) that keeps its key;
+      (c) deterministic checksum over the full window ``id <= run_max`` with
+          ``raw_data`` canonicalized — catches any content drift (e.g. a day the
+          reconcile failed to recopy);
       (d) ``id``-uniqueness guard: ``COUNT(*) == COUNT(DISTINCT id)`` over
-          ``id <= run_max`` on the source (HWM-by-id relies on global ``id``
-          uniqueness the composite PK does not enforce).
+          ``id <= run_max`` on the source. Autoincrement keeps ``id`` globally
+          unique (the composite PK ``(id, captured_at)`` alone does not enforce
+          it); a duplicate id would make the per-day fingerprints ambiguous.
     """
     report = VerifyReport()
     src_tbl = source_table()

--- a/src/rainier/db/money_flow_backup.py
+++ b/src/rainier/db/money_flow_backup.py
@@ -27,13 +27,20 @@ in ONE destination transaction:
     dst = db.engine.get_engine()        # canonical -> DATABASE_URL -> Neon
     run_max = MAX(id) on src            # STABLE upper bound (id <= run_max only)
     for data_date in source_days ∪ backup_days:
-        source-only day         -> copy the day
-        backup-only day         -> DELETE the day from backup (source dropped it)
+        source-only day         -> copy the day (append)
+        backup-only day         -> RETAIN (never propagate a source-side delete)
         present on both, DIFFER -> DELETE the day in backup + re-copy from source
             (differ = row-count mismatch, OR a source captured_at newer than the
              backup's, OR a per-day canonical checksum mismatch)
         present on both, equal  -> skip
-    a day gone-to-zero in source is left deleted.
+
+NON-DESTRUCTIVE INVARIANT: this function never propagates a source-side DELETE.
+A backup DELETE is only ever issued to immediately RE-COPY the same day in the
+same txn (the same-day rebuild: the day still exists in source with new ids, so
+its stale backup rows — including the rebuild's orphaned old ids — are replaced
+wholesale). A day the source LOST entirely (bad restore, manual cleanup,
+corruption) is LEFT INTACT in the backup — the off-site copy is disaster
+recovery and must not erase the only recoverable copy of an irreplaceable day.
 
 Only rows with ``id <= run_max`` are considered, so a scrape landing mid-backup
 is not a torn read (it is reconciled next run). The whole destination mutation
@@ -219,9 +226,10 @@ def backup_money_flow(
     Captures a STABLE ``run_max = MAX(id)`` on ``src`` once, then — considering
     only ``id <= run_max`` — reconciles each ``data_date`` in the union of source
     and backup days: a day present only in source is copied; a day present only in
-    backup is deleted (source dropped it); a day present in both but DIFFERING
-    (row-count / newer ``captured_at`` / canonical-checksum mismatch — e.g. a
-    same-day rebuild) is delete-then-recopied; an equal day is skipped. All
+    backup is RETAINED (the backup never propagates a source-side delete — see the
+    non-destructive invariant in the module docstring); a day present in both but
+    DIFFERING (row-count / newer ``captured_at`` / canonical-checksum mismatch —
+    e.g. a same-day rebuild) is delete-then-recopied; an equal day is skipped. All
     mutations run in ONE destination transaction, so a mid-run failure leaves the
     backup unchanged. The destination table is created if absent.
 
@@ -261,52 +269,49 @@ def backup_money_flow(
             select(func.coalesce(func.max(dst_tbl.c.id), 0))
         ).scalar_one()
 
-    # 2a) Empty-source SAFETY GUARD. The reconcile purges any backup day absent
-    #     from the source, so an EMPTY source (no rows at all) would delete the
-    #     ENTIRE backup in one transaction — the off-site copy of record gone on a
-    #     routine cron. That is never a legitimate reconcile: the QU scraper is the
-    #     only writer and never zeroes the whole table. An empty source means a
-    #     fresh/rebuilt local DB, a failed restore, or a mis-pointed
-    #     LEGACY_DATABASE_URL (a confusion that already caused a prior P0), NOT
-    #     "every day was intentionally dropped". The old insert-only copy was
-    #     immune (it never deleted); preserve that invariant — abort as a no-op and
-    #     leave the backup untouched rather than wipe it from an empty source.
+    # 2a) Empty-source early-out + LOUD operational signal. The non-destructive
+    #     invariant below (a backup-only day is never purged) already makes an
+    #     empty source a safe no-op, but a source that went fully dark is a strong
+    #     misconfiguration signal — a fresh/rebuilt local DB, a failed restore, or a
+    #     mis-pointed LEGACY_DATABASE_URL (a confusion that already caused a prior
+    #     P0). Log it loudly and return early so the operator notices rather than
+    #     seeing a silent "0 rows" success.
     if not src_all:
         log.warning(
-            "backup_money_flow: source is EMPTY — aborting reconcile to avoid "
-            "wiping the backup (backup rows left intact, hwm=%s)",
+            "backup_money_flow: source is EMPTY — skipping reconcile (backup rows "
+            "left intact, hwm=%s). Check LEGACY_DATABASE_URL / local DB health.",
             hwm,
         )
         return BackupResult(copied=0, hwm_before=hwm, run_max=run_max)
 
-    # 3) Read the FULL backup (NOT capped at run_max). A backup-only day must be
-    #    purgeable even when dropping it from the source LOWERED run_max below that
-    #    day's ids (Codex P2: a deleted latest day whose ids all exceed the new
-    #    run_max would otherwise be invisible and never purged). Source rows are
-    #    restricted to id <= run_max for the COPY (in-flight inserts past run_max
-    #    are picked up next run), but the day-set comparison uses the full source.
+    # 3) Read the FULL backup. Source rows are restricted to id <= run_max for the
+    #    COPY (in-flight inserts past run_max are picked up next run).
     src_rows = [r for r in src_all if r["id"] <= run_max]
     dst_rows = _read_all(dst, dst_tbl)
-    # Full-source day set (incl. any rows > run_max) so a day is never mis-flagged
-    # backup-only just because its only surviving rows are an in-flight insert.
-    src_days_all = {r["data_date"] for r in src_all}
     src_fps = _day_fingerprints(src_rows)
     dst_fps = _day_fingerprints(dst_rows)
 
-    # Decide which days to (re)copy and which backup-only days to delete.
+    # Decide which days to (re)copy and which to delete-then-recopy.
+    #
+    # NON-DESTRUCTIVE INVARIANT: the backup NEVER propagates a source-side DELETE
+    # of a whole day. A day present ONLY in the backup (gone from source) is LEFT
+    # INTACT — the off-site copy is disaster recovery, so a source that lost a
+    # historical day (bad restore, manual cleanup, partial corruption) must not
+    # erase the only recoverable copy on the next cron (Codex P1). We only ever
+    # DELETE a backup day to immediately RE-COPY it from source in the SAME txn
+    # (the same-day rebuild case: the day still exists in source with new ids /
+    # content, so its stale backup rows — including the rebuild's orphaned old
+    # ids — are replaced wholesale). Deletion is thus always paired with a recopy;
+    # a backup day is never left empty by this function.
     days_to_delete: set = set()
     days_to_copy: set = set()
     for day in set(src_fps) | set(dst_fps):
         in_src = day in src_fps
         in_dst = day in dst_fps
         if in_src and not in_dst:
-            days_to_copy.add(day)
+            days_to_copy.add(day)  # brand-new day -> append
         elif in_dst and not in_src:
-            # Purge only if the day is truly gone from the source. A day present
-            # in src_all but absent from src_fps (all its rows are id > run_max,
-            # i.e. an in-flight insert) must NOT be purged — it copies next run.
-            if day not in src_days_all:
-                days_to_delete.add(day)
+            continue  # backup-only day: retain (never propagate a source delete)
         else:
             s, d = src_fps[day], dst_fps[day]
             differs = (
@@ -315,7 +320,9 @@ def backup_money_flow(
                 or s["checksum"] != d["checksum"]
             )
             if differs:
-                days_to_delete.add(day)  # purge stale rows first
+                # Same-day rebuild: purge the day's stale backup rows and recopy
+                # the current source rows in one txn (delete is paired with copy).
+                days_to_delete.add(day)
                 days_to_copy.add(day)
 
     rows_to_copy = [r for r in src_rows if r["data_date"] in days_to_copy]
@@ -451,7 +458,8 @@ def _read_all(engine: Engine, tbl: Table) -> list[dict]:
 
     The source read derives ``run_max`` from this same snapshot so a concurrent
     same-day rebuild can't tear the window; the destination read is uncapped so a
-    backup-only day whose ids exceed a lowered ``run_max`` stays visible for purge.
+    backup-only day whose ids exceed a lowered ``run_max`` is still seen (it is
+    retained, not purged — see the non-destructive invariant).
     """
     cols = [tbl.c[name] for name in COLUMNS]
     with engine.connect() as conn:
@@ -462,21 +470,23 @@ def _read_all(engine: Engine, tbl: Table) -> list[dict]:
 
 
 def verify_backup(src: Engine, dst: Engine, *, run_max: int) -> VerifyReport:
-    """Strong integrity check over the full covered window ``id <= run_max``.
+    """Strong integrity check over the covered window ``id <= run_max``.
 
-    The copy is a ``data_date``-aware reconcile (delete-changed-day + recopy), so
-    after a same-day rebuild the backup must EXACTLY mirror the source over the
-    covered window — no orphaned old ids, no stale day. Checks, any failure
-    recorded loudly:
+    The copy is a NON-DESTRUCTIVE ``data_date``-aware reconcile (new days appended,
+    same-day rebuilds delete-then-recopied, days the source LOST left intact), so
+    the backup must CONTAIN every source row over the window with matching content
+    — a SUPERSET, not an exact mirror (it may retain a historical day the source
+    dropped). Checks, any failure recorded loudly:
 
-      (a) ``MAX(id)`` on src vs backup match for ``id <= run_max`` (a recopied
-          day restores matching ids; an un-purged orphan would diverge);
+      (a) ``MAX(id)`` on src vs backup match for ``id <= run_max`` (source's max
+          row is always mirrored; retained ids > run_max are excluded);
       (b) missing-row reconciliation on the FULL composite key
           ``(id, captured_at)`` — no source row in ``(0, run_max]`` absent from
           the backup;
-      (c) deterministic checksum over the full window ``id <= run_max`` with
-          ``raw_data`` canonicalized — catches any content drift (e.g. a day the
-          reconcile failed to recopy);
+      (c) content-faithful checksum: every source row in ``id <= run_max`` matches
+          its backup copy (``raw_data`` canonicalized), comparing only the backup
+          rows that share a source key so legitimately-retained extras are ignored
+          — catches a copied row whose content drifted;
       (d) ``id``-uniqueness guard: ``COUNT(*) == COUNT(DISTINCT id)`` over
           ``id <= run_max`` on the source. Autoincrement keeps ``id`` globally
           unique (the composite PK ``(id, captured_at)`` alone does not enforce
@@ -539,8 +549,8 @@ def verify_backup(src: Engine, dst: Engine, *, run_max: int) -> VerifyReport:
         return (r["id"], _canon_captured_at(r["captured_at"]))
 
     src_keys = {_key(r) for r in src_rows}
-    dst_keys = {_key(r) for r in dst_rows}
-    missing = src_keys - dst_keys
+    dst_by_key = {_key(r): r for r in dst_rows}
+    missing = src_keys - set(dst_by_key)
     if missing:
         sample = sorted(missing)[:5]
         report.failures.append(
@@ -548,13 +558,23 @@ def verify_backup(src: Engine, dst: Engine, *, run_max: int) -> VerifyReport:
             f"backup (composite key id, captured_at). sample={sample}"
         )
 
-    # (c) full-window canonicalized checksum.
-    if _checksum(src_rows) != _checksum(dst_rows):
+    # (c) content-faithful checksum. The backup is a NON-DESTRUCTIVE archive: it
+    # may RETAIN rows the source lost (a historical day a bad restore / corruption
+    # dropped — see the module invariant), so the backup is a SUPERSET of the
+    # source over the window, not an exact mirror. Verify therefore compares the
+    # source against the backup rows that SHARE a source key — every mirrored row
+    # must match content — and ignores retained extras. (b) already guarantees no
+    # source row is missing; together they assert "the backup faithfully contains
+    # every source row". A same-day rebuild's orphaned old ids cannot survive here:
+    # an in-both-differing day is delete-then-recopied in ONE txn, so a successful
+    # reconcile leaves no stale ids for a day still in source.
+    dst_mirrored = [dst_by_key[k] for k in src_keys if k in dst_by_key]
+    if _checksum(src_rows) != _checksum(dst_mirrored):
         report.failures.append(
-            f"checksum mismatch over the full window id<={run_max}: the backup "
-            f"diverges from the source (an edited row, reordered non-raw_data "
-            f"content, or torn copy). raw_data key-order is canonicalized, so "
-            f"this is a genuine content drift."
+            f"checksum mismatch over id<={run_max}: a source row's content "
+            f"diverges from its backup copy (an edited row, reordered "
+            f"non-raw_data content, or torn copy). raw_data key-order is "
+            f"canonicalized, so this is a genuine content drift."
         )
 
     return report

--- a/src/rainier/db/money_flow_backup.py
+++ b/src/rainier/db/money_flow_backup.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 import datetime as _dt
 import hashlib
 import json
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -73,6 +74,8 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine import Engine
 from sqlalchemy.types import JSON
+
+log = logging.getLogger(__name__)
 
 # Columns copied from core/models.py:MoneyFlowSnapshot (in order). ``raw_data``
 # uses the generic JSON type for BINDING (a dict serializes identically whether
@@ -257,6 +260,24 @@ def backup_money_flow(
         hwm = dconn.execute(
             select(func.coalesce(func.max(dst_tbl.c.id), 0))
         ).scalar_one()
+
+    # 2a) Empty-source SAFETY GUARD. The reconcile purges any backup day absent
+    #     from the source, so an EMPTY source (no rows at all) would delete the
+    #     ENTIRE backup in one transaction — the off-site copy of record gone on a
+    #     routine cron. That is never a legitimate reconcile: the QU scraper is the
+    #     only writer and never zeroes the whole table. An empty source means a
+    #     fresh/rebuilt local DB, a failed restore, or a mis-pointed
+    #     LEGACY_DATABASE_URL (a confusion that already caused a prior P0), NOT
+    #     "every day was intentionally dropped". The old insert-only copy was
+    #     immune (it never deleted); preserve that invariant — abort as a no-op and
+    #     leave the backup untouched rather than wipe it from an empty source.
+    if not src_all:
+        log.warning(
+            "backup_money_flow: source is EMPTY — aborting reconcile to avoid "
+            "wiping the backup (backup rows left intact, hwm=%s)",
+            hwm,
+        )
+        return BackupResult(copied=0, hwm_before=hwm, run_max=run_max)
 
     # 3) Read the FULL backup (NOT capped at run_max). A backup-only day must be
     #    purgeable even when dropping it from the source LOWERED run_max below that

--- a/src/rainier/db/money_flow_backup.py
+++ b/src/rainier/db/money_flow_backup.py
@@ -218,23 +218,40 @@ def _gen_key(r: dict) -> tuple:
     return (r["data_date"], r["ranking_type"])
 
 
+def _cap_utc(value: object) -> _dt.datetime:
+    """A captured_at value as an ORDER-COMPARABLE aware UTC datetime.
+
+    Aware -> converted to UTC; naive (e.g. a SQLite read-back) -> assumed UTC so a
+    later instant always compares greater. Used to tell a genuine NEWER-generation
+    rebuild (captured_at advanced) from a same-captured_at source-side change.
+    """
+    if isinstance(value, _dt.datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=_dt.timezone.utc)
+        return value.astimezone(_dt.timezone.utc)
+    # Non-datetime captured_at should never occur; fall back to the epoch so it
+    # sorts before any real timestamp rather than raising.
+    return _dt.datetime.min.replace(tzinfo=_dt.timezone.utc)
+
+
 def _gen_fingerprints(rows: list[dict]) -> dict[tuple, dict]:
-    """Group ``rows`` by ``(data_date, ranking_type)`` -> ``{count, max_cap,
+    """Group ``rows`` by ``(data_date, ranking_type)`` -> ``{count, max_cap_dt,
     checksum}``.
 
-    ``max_cap`` is the canonical (UTC-normalized) max ``captured_at`` over the
-    generation; ``checksum`` is the order-independent content hash of its rows.
-    Used to decide whether a generation differs between source and backup.
+    ``max_cap_dt`` is the max ``captured_at`` (UTC datetime) over the generation —
+    the rebuild-vs-corruption discriminator; ``checksum`` is the order-independent
+    content hash of its rows. Used to decide whether a generation differs between
+    source and backup and whether the difference is a legitimate newer rebuild.
     """
     by_gen: dict[tuple, list[dict]] = {}
     for r in rows:
         by_gen.setdefault(_gen_key(r), []).append(r)
     fps: dict[tuple, dict] = {}
     for key, gen_rows in by_gen.items():
-        max_cap = max(_canon_captured_at(r["captured_at"]) for r in gen_rows)
+        max_cap_dt = max(_cap_utc(r["captured_at"]) for r in gen_rows)
         fps[key] = {
             "count": len(gen_rows),
-            "max_cap": max_cap,
+            "max_cap_dt": max_cap_dt,
             "checksum": _checksum(gen_rows),
         }
     return fps
@@ -324,16 +341,25 @@ def backup_money_flow(
     # the scraper rebuilds — so a partial source-side loss of one book never
     # disturbs the other (Codex P1).
     #
-    # NON-DESTRUCTIVE INVARIANT: the backup NEVER propagates a source-side DELETE
-    # of a whole generation. A generation present ONLY in the backup (gone from
-    # source) is LEFT INTACT — the off-site copy is disaster recovery, so a source
-    # that lost a historical book (bad restore, manual cleanup, partial
-    # corruption) must not erase the only recoverable copy on the next cron
-    # (Codex P1). We only ever DELETE a backup generation to immediately RE-COPY it
-    # from source in the SAME txn (the same-day rebuild: the generation still
-    # exists in source with new ids / content, so its stale backup rows — including
-    # the rebuild's orphaned old ids — are replaced wholesale). Deletion is thus
-    # always paired with a recopy; a backup generation is never left empty here.
+    # NON-DESTRUCTIVE INVARIANT: the backup NEVER propagates a source-side DELETE.
+    # The discriminator between a legitimate rebuild and source-side corruption is
+    # the generation's max ``captured_at``:
+    #
+    #   * a genuine same-day REBUILD always stamps the generation with a NEWER
+    #     captured_at (the scraper deletes the old rows and re-inserts a fresh
+    #     generation under one new captured_at). Only then do we DELETE the stale
+    #     backup rows — including the rebuild's orphaned old ids — and recopy the
+    #     current source rows wholesale (delete paired with copy in one txn);
+    #   * a difference at the SAME (or older) captured_at is NOT a rebuild — it is a
+    #     source-side shrink / in-place edit / partial corruption (bad restore,
+    #     manual cleanup). We must NOT delete: that would erase the backup's last
+    #     copy of rows the source lost (Codex P1). Instead we additively copy any
+    #     source rows the backup is MISSING (ON CONFLICT DO NOTHING) and leave the
+    #     rest intact; verify_backup REPORTS any residual content drift loudly
+    #     rather than auto-destroying it.
+    #
+    # A generation present ONLY in the backup (whole generation gone from source)
+    # is likewise LEFT INTACT — never propagate a source-side delete.
     keys_to_delete: set = set()
     keys_to_copy: set = set()
     for key in set(src_fps) | set(dst_fps):
@@ -345,15 +371,14 @@ def backup_money_flow(
             continue  # backup-only generation: retain (never propagate a delete)
         else:
             s, d = src_fps[key], dst_fps[key]
-            differs = (
-                s["count"] != d["count"]
-                or s["max_cap"] != d["max_cap"]
-                or s["checksum"] != d["checksum"]
-            )
-            if differs:
-                # Same-day rebuild: purge this generation's stale backup rows and
-                # recopy the current source rows in one txn (delete paired w/ copy).
+            if s["max_cap_dt"] > d["max_cap_dt"]:
+                # Genuine newer rebuild -> supersede wholesale (purge orphans).
                 keys_to_delete.add(key)
+                keys_to_copy.add(key)
+            elif s["count"] != d["count"] or s["checksum"] != d["checksum"]:
+                # Same/older captured_at but content differs: source-side
+                # shrink/edit/corruption. NON-DESTRUCTIVE -> additive copy only
+                # (ON CONFLICT DO NOTHING completes any missing rows), NEVER delete.
                 keys_to_copy.add(key)
 
     rows_to_copy = [r for r in src_rows if _gen_key(r) in keys_to_copy]

--- a/src/rainier/db/money_flow_backup.py
+++ b/src/rainier/db/money_flow_backup.py
@@ -569,7 +569,12 @@ def verify_backup(src: Engine, dst: Engine, *, run_max: int) -> VerifyReport:
       (e) SOURCE-side data-loss alarm: any backup row in ``id <= run_max`` whose
           key is ABSENT from the source. The non-destructive backup retains rows
           the source dropped (data safe), but verify still flags the divergence so
-          a silent source-side row loss / corruption is surfaced loudly.
+          a silent source-side row loss / corruption is surfaced loudly;
+      (f) TRAILING source-loss alarm (uncapped): backup ``MAX(id)`` greater than
+          the source's live ``MAX(id)`` — the source dropped its highest ids /
+          most-recent generation (which (e), bounded to ``id <= run_max``, cannot
+          see). Backup ids only come from the source, so this inequality is itself
+          the loss signal; a normal copy lag is the opposite inequality.
     """
     report = VerifyReport()
     src_tbl = source_table()
@@ -674,6 +679,30 @@ def verify_backup(src: Engine, dst: Engine, *, run_max: int) -> VerifyReport:
             f"SOURCE — the source dropped rows the backup retained (non-destructive "
             f"backup is intact; this flags a source-side data loss / corruption to "
             f"investigate). sample={sample}"
+        )
+
+    # (f) TRAILING source-loss alarm (UNCAPPED). (e) is bounded to id<=run_max, so
+    # it can't see the source dropping its HIGHEST ids / most-recent generation:
+    # run_max shrinks to the surviving max, putting the retained backup rows at
+    # id>run_max where every other check excludes them. Backup ids only ever come
+    # from the source, so a backup MAX(id) GREATER than the source's live MAX(id)
+    # means the source lost its top rows (the backup retained them) — flag it. A
+    # normal lag (source has newer ids the backup hasn't copied yet) is the
+    # opposite inequality and is NOT flagged.
+    with src.connect() as sconn:
+        src_max_all = sconn.execute(
+            select(func.coalesce(func.max(src_tbl.c.id), 0))
+        ).scalar_one()
+    with dst.connect() as dconn:
+        dst_max_all = dconn.execute(
+            select(func.coalesce(func.max(dst_tbl.c.id), 0))
+        ).scalar_one()
+    if dst_max_all > src_max_all:
+        report.failures.append(
+            f"backup MAX(id)={dst_max_all} exceeds source MAX(id)={src_max_all} — "
+            f"the source dropped its most-recent rows that the backup retained "
+            f"(non-destructive backup is intact; flags a trailing source-side data "
+            f"loss to investigate)."
         )
 
     return report

--- a/src/rainier/db/money_flow_backup.py
+++ b/src/rainier/db/money_flow_backup.py
@@ -176,10 +176,12 @@ class BackupResult:
     ``hwm_before`` — pre-run ``MAX(id)`` in the backup (reported for logging; the
     reconcile keys on ``(data_date, ranking_type)``, not an id high-water mark).
     ``run_max`` — the stable ``MAX(id)`` upper bound the run reconciled up to.
-    ``source_empty`` — the source had ZERO rows, so the reconcile was skipped
-    (backup left intact). A configured backup whose source is empty is a
-    misconfiguration (mispointed ``LEGACY_DATABASE_URL`` / failed restore), so the
-    CLI turns this into a NON-ZERO exit — never a silent "0 rows" success.
+    ``source_empty`` — the source had ZERO rows WHILE the backup already had rows
+    (``hwm > 0``), i.e. the source LOST all its data (mispointed
+    ``LEGACY_DATABASE_URL`` / failed restore). The reconcile was skipped (backup
+    left intact) and the CLI turns this into a NON-ZERO exit — never a silent
+    "0 rows" success. A fresh bootstrap (source AND backup both empty) is NOT
+    flagged (``source_empty=False``): it's a normal pre-first-scrape no-op.
     """
 
     copied: int
@@ -312,21 +314,34 @@ def backup_money_flow(
             select(func.coalesce(func.max(dst_tbl.c.id), 0))
         ).scalar_one()
 
-    # 2a) Empty-source early-out + LOUD operational signal. The non-destructive
-    #     invariant below (a backup-only day is never purged) already makes an
-    #     empty source a safe no-op, but a source that went fully dark is a strong
-    #     misconfiguration signal — a fresh/rebuilt local DB, a failed restore, or a
-    #     mis-pointed LEGACY_DATABASE_URL (a confusion that already caused a prior
-    #     P0). Log it loudly and return early so the operator notices rather than
-    #     seeing a silent "0 rows" success.
+    # 2a) Empty-source early-out. The non-destructive invariant below (a
+    #     backup-only generation is never purged) already makes an empty source a
+    #     safe no-op for the backup data. Whether it's an ALARM depends on the
+    #     backup's state:
+    #       * backup ALSO empty (hwm == 0) -> legitimate BOOTSTRAP: a fresh deploy
+    #         / just after ``db init``, before the first scrape. No-op, NOT an
+    #         alarm (failing here would page the nightly cron for a normal
+    #         pre-bootstrap state — Codex P2).
+    #       * backup NON-empty (hwm > 0) but source empty -> the source LOST all
+    #         its data (mis-pointed LEGACY_DATABASE_URL / failed restore / rebuilt
+    #         local DB — a confusion that already caused a prior P0). That must NOT
+    #         read as a silent "0 rows" success; flag it so the CLI fails loud
+    #         (Codex P1).
     if not src_all:
-        log.warning(
-            "backup_money_flow: source is EMPTY — skipping reconcile (backup rows "
-            "left intact, hwm=%s). Check LEGACY_DATABASE_URL / local DB health.",
-            hwm,
-        )
+        if hwm > 0:
+            log.warning(
+                "backup_money_flow: source is EMPTY but the backup has rows "
+                "(hwm=%s) — the source lost all its data. Skipping reconcile "
+                "(backup left intact). Check LEGACY_DATABASE_URL / local DB health.",
+                hwm,
+            )
+        else:
+            log.info(
+                "backup_money_flow: source and backup both empty — bootstrap "
+                "no-op (nothing scraped yet)."
+            )
         return BackupResult(
-            copied=0, hwm_before=hwm, run_max=run_max, source_empty=True
+            copied=0, hwm_before=hwm, run_max=run_max, source_empty=hwm > 0
         )
 
     # 3) Read the FULL backup. Source rows are restricted to id <= run_max for the

--- a/src/rainier/db/money_flow_backup.py
+++ b/src/rainier/db/money_flow_backup.py
@@ -565,7 +565,11 @@ def verify_backup(src: Engine, dst: Engine, *, run_max: int) -> VerifyReport:
       (d) ``id``-uniqueness guard: ``COUNT(*) == COUNT(DISTINCT id)`` over
           ``id <= run_max`` on the source. Autoincrement keeps ``id`` globally
           unique (the composite PK ``(id, captured_at)`` alone does not enforce
-          it); a duplicate id would make the per-day fingerprints ambiguous.
+          it); a duplicate id would make the per-day fingerprints ambiguous;
+      (e) SOURCE-side data-loss alarm: any backup row in ``id <= run_max`` whose
+          key is ABSENT from the source. The non-destructive backup retains rows
+          the source dropped (data safe), but verify still flags the divergence so
+          a silent source-side row loss / corruption is surfaced loudly.
     """
     report = VerifyReport()
     src_tbl = source_table()
@@ -650,6 +654,26 @@ def verify_backup(src: Engine, dst: Engine, *, run_max: int) -> VerifyReport:
             f"diverges from its backup copy (an edited row, reordered "
             f"non-raw_data content, or torn copy). raw_data key-order is "
             f"canonicalized, so this is a genuine content drift."
+        )
+
+    # (e) SOURCE-side data-loss alarm. The backup is NON-DESTRUCTIVE: when the
+    # source loses rows from a generation without a newer captured_at (a bad
+    # restore / partial corruption), backup_money_flow RETAINS the backup's copy
+    # rather than propagate the delete. That keeps the data safe, but the operator
+    # must still be ALERTED that the source diverged — otherwise a silent source-
+    # side row loss goes unnoticed (Codex P1). So any backup row in ``id <=
+    # run_max`` whose key is absent from the source is flagged loudly here. In
+    # normal operation (no source loss) there are no such extras; a legitimate
+    # rebuild is delete-then-recopied so its orphans don't survive. This is a
+    # SOURCE health signal, not a backup-integrity failure — the backup is correct.
+    extra = set(dst_by_key) - src_keys
+    if extra:
+        sample = sorted(extra)[:5]
+        report.failures.append(
+            f"{len(extra)} backup row(s) in (0, {run_max}] are absent from the "
+            f"SOURCE — the source dropped rows the backup retained (non-destructive "
+            f"backup is intact; this flags a source-side data loss / corruption to "
+            f"investigate). sample={sample}"
         )
 
     return report

--- a/src/rainier/db/money_flow_backup.py
+++ b/src/rainier/db/money_flow_backup.py
@@ -20,26 +20,31 @@ old ids the rebuild deleted (they sit *below* the high-water mark) nor re-copy a
 changed day whose new max-id it already passed — ``verify_backup``'s full-window
 checksum would then fail the nightly cron.
 
-Instead we reconcile per ``data_date`` over the UNION of source and backup days,
-in ONE destination transaction:
+Instead we reconcile per GENERATION ``(data_date, ranking_type)`` — the exact
+unit the scraper rebuilds — over the UNION of source and backup generations, in
+ONE destination transaction:
 
     src = core.database.get_engine()    # legacy -> local TimescaleDB (PR #115)
     dst = db.engine.get_engine()        # canonical -> DATABASE_URL -> Neon
     run_max = MAX(id) on src            # STABLE upper bound (id <= run_max only)
-    for data_date in source_days ∪ backup_days:
-        source-only day         -> copy the day (append)
-        backup-only day         -> RETAIN (never propagate a source-side delete)
-        present on both, DIFFER -> DELETE the day in backup + re-copy from source
+    for gen=(data_date, ranking_type) in source_gens ∪ backup_gens:
+        source-only gen         -> copy the gen (append)
+        backup-only gen         -> RETAIN (never propagate a source-side delete)
+        present on both, DIFFER -> DELETE the gen in backup + re-copy from source
             (differ = row-count mismatch, OR a source captured_at newer than the
-             backup's, OR a per-day canonical checksum mismatch)
+             backup's, OR a per-gen canonical checksum mismatch)
         present on both, equal  -> skip
 
+Keying on ``(data_date, ranking_type)`` — NOT ``data_date`` alone — keeps the two
+books independent: a partial source-side loss of one book (e.g. bottom100 dropped
+by a bad restore while top100 survives) never disturbs the surviving book.
+
 NON-DESTRUCTIVE INVARIANT: this function never propagates a source-side DELETE.
-A backup DELETE is only ever issued to immediately RE-COPY the same day in the
-same txn (the same-day rebuild: the day still exists in source with new ids, so
-its stale backup rows — including the rebuild's orphaned old ids — are replaced
-wholesale). A day the source LOST entirely (bad restore, manual cleanup,
-corruption) is LEFT INTACT in the backup — the off-site copy is disaster
+A backup DELETE is only ever issued to immediately RE-COPY the same generation in
+the same txn (the same-day rebuild: the generation still exists in source with new
+ids, so its stale backup rows — including the rebuild's orphaned old ids — are
+replaced wholesale). A generation the source LOST entirely (bad restore, manual
+cleanup, corruption) is LEFT INTACT in the backup — the off-site copy is disaster
 recovery and must not erase the only recoverable copy of an irreplaceable day.
 
 Only rows with ``id <= run_max`` are considered, so a scrape landing mid-backup
@@ -77,6 +82,7 @@ from sqlalchemy import (
     Table,
     func,
     select,
+    tuple_,
 )
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine import Engine
@@ -193,23 +199,38 @@ class VerifyReport:
 # ---------------------------------------------------------------------------
 
 
-def _day_fingerprints(rows: list[dict]) -> dict[object, dict]:
-    """Group ``rows`` by ``data_date`` -> ``{count, max_cap, checksum}``.
+def _gen_key(r: dict) -> tuple:
+    """The reconcile/rebuild unit: ``(data_date, ranking_type)``.
+
+    The QU scraper rebuilds a snapshot per ``(data_date, ranking_type)`` (each
+    book independently — a midday top100 rebuild leaves bottom100 untouched), so
+    the backup MUST reconcile on the same composite key. Keying on ``data_date``
+    alone would lump both books: a partial source-side loss of ONE book (e.g.
+    bottom100 dropped by a bad restore while top100 survives) would look like a
+    generic "day changed", delete the whole day, and recopy only the survivor —
+    erasing the backup-only book and defeating the non-destructive invariant.
+    """
+    return (r["data_date"], r["ranking_type"])
+
+
+def _gen_fingerprints(rows: list[dict]) -> dict[tuple, dict]:
+    """Group ``rows`` by ``(data_date, ranking_type)`` -> ``{count, max_cap,
+    checksum}``.
 
     ``max_cap`` is the canonical (UTC-normalized) max ``captured_at`` over the
-    day; ``checksum`` is the order-independent content hash of the day's rows.
-    Used to decide whether a day differs between source and backup.
+    generation; ``checksum`` is the order-independent content hash of its rows.
+    Used to decide whether a generation differs between source and backup.
     """
-    by_day: dict[object, list[dict]] = {}
+    by_gen: dict[tuple, list[dict]] = {}
     for r in rows:
-        by_day.setdefault(r["data_date"], []).append(r)
-    fps: dict[object, dict] = {}
-    for day, day_rows in by_day.items():
-        max_cap = max(_canon_captured_at(r["captured_at"]) for r in day_rows)
-        fps[day] = {
-            "count": len(day_rows),
+        by_gen.setdefault(_gen_key(r), []).append(r)
+    fps: dict[tuple, dict] = {}
+    for key, gen_rows in by_gen.items():
+        max_cap = max(_canon_captured_at(r["captured_at"]) for r in gen_rows)
+        fps[key] = {
+            "count": len(gen_rows),
             "max_cap": max_cap,
-            "checksum": _checksum(day_rows),
+            "checksum": _checksum(gen_rows),
         }
     return fps
 
@@ -288,52 +309,59 @@ def backup_money_flow(
     #    COPY (in-flight inserts past run_max are picked up next run).
     src_rows = [r for r in src_all if r["id"] <= run_max]
     dst_rows = _read_all(dst, dst_tbl)
-    src_fps = _day_fingerprints(src_rows)
-    dst_fps = _day_fingerprints(dst_rows)
+    src_fps = _gen_fingerprints(src_rows)
+    dst_fps = _gen_fingerprints(dst_rows)
 
-    # Decide which days to (re)copy and which to delete-then-recopy.
+    # Decide which generations to (re)copy and which to delete-then-recopy. The
+    # unit is the GENERATION key ``(data_date, ranking_type)`` — the exact unit
+    # the scraper rebuilds — so a partial source-side loss of one book never
+    # disturbs the other (Codex P1).
     #
     # NON-DESTRUCTIVE INVARIANT: the backup NEVER propagates a source-side DELETE
-    # of a whole day. A day present ONLY in the backup (gone from source) is LEFT
-    # INTACT — the off-site copy is disaster recovery, so a source that lost a
-    # historical day (bad restore, manual cleanup, partial corruption) must not
-    # erase the only recoverable copy on the next cron (Codex P1). We only ever
-    # DELETE a backup day to immediately RE-COPY it from source in the SAME txn
-    # (the same-day rebuild case: the day still exists in source with new ids /
-    # content, so its stale backup rows — including the rebuild's orphaned old
-    # ids — are replaced wholesale). Deletion is thus always paired with a recopy;
-    # a backup day is never left empty by this function.
-    days_to_delete: set = set()
-    days_to_copy: set = set()
-    for day in set(src_fps) | set(dst_fps):
-        in_src = day in src_fps
-        in_dst = day in dst_fps
+    # of a whole generation. A generation present ONLY in the backup (gone from
+    # source) is LEFT INTACT — the off-site copy is disaster recovery, so a source
+    # that lost a historical book (bad restore, manual cleanup, partial
+    # corruption) must not erase the only recoverable copy on the next cron
+    # (Codex P1). We only ever DELETE a backup generation to immediately RE-COPY it
+    # from source in the SAME txn (the same-day rebuild: the generation still
+    # exists in source with new ids / content, so its stale backup rows — including
+    # the rebuild's orphaned old ids — are replaced wholesale). Deletion is thus
+    # always paired with a recopy; a backup generation is never left empty here.
+    keys_to_delete: set = set()
+    keys_to_copy: set = set()
+    for key in set(src_fps) | set(dst_fps):
+        in_src = key in src_fps
+        in_dst = key in dst_fps
         if in_src and not in_dst:
-            days_to_copy.add(day)  # brand-new day -> append
+            keys_to_copy.add(key)  # brand-new generation -> append
         elif in_dst and not in_src:
-            continue  # backup-only day: retain (never propagate a source delete)
+            continue  # backup-only generation: retain (never propagate a delete)
         else:
-            s, d = src_fps[day], dst_fps[day]
+            s, d = src_fps[key], dst_fps[key]
             differs = (
                 s["count"] != d["count"]
                 or s["max_cap"] != d["max_cap"]
                 or s["checksum"] != d["checksum"]
             )
             if differs:
-                # Same-day rebuild: purge the day's stale backup rows and recopy
-                # the current source rows in one txn (delete is paired with copy).
-                days_to_delete.add(day)
-                days_to_copy.add(day)
+                # Same-day rebuild: purge this generation's stale backup rows and
+                # recopy the current source rows in one txn (delete paired w/ copy).
+                keys_to_delete.add(key)
+                keys_to_copy.add(key)
 
-    rows_to_copy = [r for r in src_rows if r["data_date"] in days_to_copy]
+    rows_to_copy = [r for r in src_rows if _gen_key(r) in keys_to_copy]
 
     copied = 0
-    # 4) One transaction on the destination: delete changed/dropped days, then
+    # 4) One transaction on the destination: delete changed generations, then
     #    re-insert. Commit once so a mid-run failure leaves the backup unchanged.
     with dst.begin() as dconn:
-        if days_to_delete:
+        if keys_to_delete:
             dconn.execute(
-                dst_tbl.delete().where(dst_tbl.c.data_date.in_(days_to_delete))
+                dst_tbl.delete().where(
+                    tuple_(dst_tbl.c.data_date, dst_tbl.c.ranking_type).in_(
+                        keys_to_delete
+                    )
+                )
             )
         for start in range(0, len(rows_to_copy), chunk_size):
             chunk = rows_to_copy[start : start + chunk_size]

--- a/src/rainier/db/money_flow_backup.py
+++ b/src/rainier/db/money_flow_backup.py
@@ -172,15 +172,20 @@ def _backup_schema_for(engine: Engine) -> str | None:
 class BackupResult:
     """Outcome of one ``backup_money_flow`` run.
 
-    ``copied`` — rows written this run (new days + recopied changed days).
+    ``copied`` — rows written this run (new gens + recopied changed gens).
     ``hwm_before`` — pre-run ``MAX(id)`` in the backup (reported for logging; the
-    reconcile keys on ``data_date``, not an id high-water mark).
+    reconcile keys on ``(data_date, ranking_type)``, not an id high-water mark).
     ``run_max`` — the stable ``MAX(id)`` upper bound the run reconciled up to.
+    ``source_empty`` — the source had ZERO rows, so the reconcile was skipped
+    (backup left intact). A configured backup whose source is empty is a
+    misconfiguration (mispointed ``LEGACY_DATABASE_URL`` / failed restore), so the
+    CLI turns this into a NON-ZERO exit — never a silent "0 rows" success.
     """
 
     copied: int
     hwm_before: int
     run_max: int
+    source_empty: bool = False
 
 
 @dataclass
@@ -303,7 +308,9 @@ def backup_money_flow(
             "left intact, hwm=%s). Check LEGACY_DATABASE_URL / local DB health.",
             hwm,
         )
-        return BackupResult(copied=0, hwm_before=hwm, run_max=run_max)
+        return BackupResult(
+            copied=0, hwm_before=hwm, run_max=run_max, source_empty=True
+        )
 
     # 3) Read the FULL backup. Source rows are restricted to id <= run_max for the
     #    COPY (in-flight inserts past run_max are picked up next run).

--- a/src/rainier/llm_thesis/signals/sector_momentum.py
+++ b/src/rainier/llm_thesis/signals/sector_momentum.py
@@ -14,6 +14,13 @@ from .base import SignalContext, SignalValue
 
 log = logging.getLogger(__name__)
 
+# QU100 sentiment is the two QU100 books only. The date probes below MUST be
+# scoped to these, matching analyze_sectors_at; otherwise a newer auxiliary board
+# (concept/etf) would advance latest_date/prior_date to a day with no QU100 data,
+# and analyze_sectors_at's "latest QU100 day <= as_of" fallback would silently
+# report a STALE day's sentiment as current.
+_QU100_RANKING_TYPES = ("top100", "bottom100")
+
 
 class SectorMomentumSignal:
     name = "sector_momentum"
@@ -43,12 +50,18 @@ class SectorMomentumSignal:
                 # global captured_at (which would read only one ranking type).
                 latest_date = (
                     session.query(func.max(MoneyFlowSnapshot.data_date))
-                    .filter(MoneyFlowSnapshot.data_date <= ctx.scan_date)
+                    .filter(
+                        MoneyFlowSnapshot.ranking_type.in_(_QU100_RANKING_TYPES),
+                        MoneyFlowSnapshot.data_date <= ctx.scan_date,
+                    )
                     .scalar()
                 )
                 prior_date = (
                     session.query(func.max(MoneyFlowSnapshot.data_date))
-                    .filter(MoneyFlowSnapshot.data_date <= prior_floor_date)
+                    .filter(
+                        MoneyFlowSnapshot.ranking_type.in_(_QU100_RANKING_TYPES),
+                        MoneyFlowSnapshot.data_date <= prior_floor_date,
+                    )
                     .scalar()
                 )
                 if latest_date is None:

--- a/src/rainier/llm_thesis/signals/sector_momentum.py
+++ b/src/rainier/llm_thesis/signals/sector_momentum.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, time, timedelta, timezone
+from datetime import timedelta
 
 from sqlalchemy import func
 
@@ -32,31 +32,37 @@ class SectorMomentumSignal:
             }
 
         days = int(ctx.params.get("days", 10))
-        scan_dt = datetime.combine(ctx.scan_date, time.max, tzinfo=timezone.utc)
-        prior_dt_floor = scan_dt - timedelta(days=days)
+        prior_floor_date = ctx.scan_date - timedelta(days=days)
 
         try:
             with get_session() as session:
-                latest_ts = (
-                    session.query(func.max(MoneyFlowSnapshot.captured_at))
-                    .filter(MoneyFlowSnapshot.captured_at <= scan_dt)
+                # Resolve the latest snapshot DATE on/before each as-of date. Under
+                # the rebuild-the-day fix a day holds one captured_at per
+                # (data_date, ranking_type); analyze_sectors_at picks each ranking
+                # type's latest generation, so we key on data_date, not a single
+                # global captured_at (which would read only one ranking type).
+                latest_date = (
+                    session.query(func.max(MoneyFlowSnapshot.data_date))
+                    .filter(MoneyFlowSnapshot.data_date <= ctx.scan_date)
                     .scalar()
                 )
-                prior_ts = (
-                    session.query(func.max(MoneyFlowSnapshot.captured_at))
-                    .filter(MoneyFlowSnapshot.captured_at <= prior_dt_floor)
+                prior_date = (
+                    session.query(func.max(MoneyFlowSnapshot.data_date))
+                    .filter(MoneyFlowSnapshot.data_date <= prior_floor_date)
                     .scalar()
                 )
-                if latest_ts is None:
+                if latest_date is None:
                     return None
 
                 # Defer expensive analysis to analyze_sectors_at (also explicit
                 # session injection so we don't open a second connection).
                 from rainier.analysis.sector_analyzer import analyze_sectors_at
 
-                today = analyze_sectors_at(latest_ts, session=session)
+                today = analyze_sectors_at(latest_date, session=session)
                 prior = (
-                    analyze_sectors_at(prior_ts, session=session) if prior_ts else []
+                    analyze_sectors_at(prior_date, session=session)
+                    if prior_date
+                    else []
                 )
         except Exception:
             log.exception("sector_momentum_db_error symbol=%s", ctx.symbol)

--- a/src/rainier/pipeline/post_scrape.py
+++ b/src/rainier/pipeline/post_scrape.py
@@ -35,7 +35,9 @@ from rainier.llm_thesis.service import compute_theses_and_persist
 log = structlog.get_logger()
 
 
-def run_post_scrape_pipeline(settings: Settings, session_name: str) -> None:
+def run_post_scrape_pipeline(
+    settings: Settings, session_name: str, scan_date: date | None = None,
+) -> None:
     """Execute the post-scrape pipeline for one session.
 
     Steps (mirrors the pre-extraction service.py block verbatim):
@@ -58,6 +60,12 @@ def run_post_scrape_pipeline(settings: Settings, session_name: str) -> None:
         settings: Already-loaded ``Settings``. Caller is responsible for
             calling ``load_settings_fresh()`` if it wants hot-reloaded YAML.
         session_name: ``"morning" | "midday" | "afternoon" | "close"``.
+        scan_date: the TRADING day these derived artifacts belong to. Defaults to
+            ``date.today()`` for the live scheduled/cron path (the scrape and the
+            pipeline run on the same trading day). ``recover`` passes the RECOVERED
+            day explicitly so a post-midnight or cross-timezone replay stamps
+            ``ScreenedStockRecord`` / thesis rows with the day the data is from,
+            not the wall-clock date the pipeline happened to run (Codex P1).
 
     Returns:
         None. Logs structured events at each step boundary.
@@ -74,7 +82,8 @@ def run_post_scrape_pipeline(settings: Settings, session_name: str) -> None:
     scan_candidates = all_candidates[:50]
     candidates = all_candidates[:20]
 
-    scan_date = date.today()
+    if scan_date is None:
+        scan_date = date.today()
     log.info(
         "post_scrape_screener_done",
         session=session_name,

--- a/src/rainier/scrapers/qu/scraper.py
+++ b/src/rainier/scrapers/qu/scraper.py
@@ -120,6 +120,10 @@ log = structlog.get_logger()
 # config knob only if a non-US market ever materializes.
 MARKET_TZ = ZoneInfo("America/New_York")
 
+# QU100 is exactly 100 ranked slots per (data_date, ranking_type). Ranks outside
+# 1..100 are a glitched API response and are dropped during canonicalization.
+QU100_MAX_RANK = 100
+
 
 def market_date(timestamp: datetime) -> date_type:
     """Return the US-market calendar date for a (UTC-or-other-tz) timestamp.
@@ -590,26 +594,51 @@ class QUScraper(BaseScraper):
         captured_at: datetime,
         data_date=None,
     ) -> int:
-        """Rebuild the day's ``(data_date, ranking_type)`` snapshot from this scrape.
+        """Rebuild the day's ``(data_date, ranking_type)`` snapshot by RANK slot.
 
-        Each later same-day scrape must OVERRIDE the symbols it returns and CARRY
-        FORWARD the rest, stamping the whole day with the latest ``captured_at`` —
-        one snapshot generation per ``(data_date, ranking_type)``. An empty scrape
-        (0 rows) is a no-op so a blank pull never wipes a good snapshot.
+        QU100 is 100 ranked SLOTS (rank 1..100) per ``(data_date, ranking_type)``.
+        Each later same-day scrape REBUILDS that day keyed on the rank slot, NOT
+        the symbol:
+
+            * the scrape batch is CANONICALIZED first — out-of-range ranks dropped,
+              a duplicate symbol or duplicate rank collapsed to one row (keep the
+              first occurrence). The cohort reader (``get_current_qu100_cohort``)
+              has NO dedup of its own, so this is the only guard against a glitched
+              API response double-counting a symbol/rank;
+            * every SCRAPED rank OVERRIDES its slot (fresh value, this session);
+            * every stored rank NOT in the scrape CARRIES FORWARD its prior
+              occupant (last data, ORIGINAL ``capture_session``, the new
+              ``captured_at``);
+            * a carried slot whose symbol was freshly scraped at ANOTHER rank is
+              DROPPED — fresh placement wins; that rank is left unfilled (dedup by
+              symbol);
+            * the whole day is stamped with the latest scrape's ``captured_at``
+              (ONE generation per ``(data_date, ranking_type)``);
+            * an empty scrape (0 rows, or a batch that canonicalizes to nothing) is
+              a no-op so a blank/fully-glitched pull never wipes a good snapshot.
+
+        Because carry-forward is RANK-keyed, a FULL scrape overrides every slot,
+        so a stock that fell out of the top 100 holds no rank and disappears — the
+        cohort stays <=100 with no fallen-out members (exactly 100 after a full
+        scrape). A partial/glitched scrape carries only the missing ranks, so the
+        contract readers see is "<=100, rank-ordered, current as of the latest
+        full scrape", NOT an unconditional exactly-100.
 
         Mechanics (one transaction):
 
-            read existing rows  ─►  carried = stored symbols NOT in this scrape
+            canonicalize batch ─► {rank: row}, each rank & symbol once
+            read existing rows ─► {rank: row}; carried = stored ranks NOT scraped,
+                                  minus any whose symbol was scraped elsewhere
             DELETE the day's rows
             INSERT  fresh rows  (this captured_at + this capture_session)
                   + carried rows (this captured_at, ORIGINAL capture_session,
                                   data copied into NEW instances — fresh ids)
 
-        We never UPDATE ``captured_at`` in place (it is the hypertable partition
-        key) and never re-``add`` the just-deleted ORM objects (identity-map
-        pitfall); carried field values are copied into fresh ``MoneyFlowSnapshot``
-        instances. ``captured_at`` advancing is itself the freshness signal.
-        Returns the count of rows that now make up the day's snapshot.
+        We never UPDATE ``captured_at``/``rank`` in place (``captured_at`` is the
+        hypertable partition key) and never re-``add`` the just-deleted ORM objects
+        (identity-map pitfall); carried field values are copied into fresh
+        ``MoneyFlowSnapshot`` instances. ``captured_at`` advancing is itself the
+        freshness signal. Returns the count of rows in the rebuilt snapshot.
 
         NOTE: delete-then-rebuild assumes scrapes for the same
         ``(data_date, ranking_type)`` are serial (cron / single-slot APScheduler).
@@ -624,24 +653,57 @@ class QUScraper(BaseScraper):
                           ranking_type=ranking_type, reason="empty_scrape")
             return 0
 
-        scraped_symbols = {row.symbol for row in rows}
+        # 0) Canonicalize the batch into {rank: row}: drop out-of-range ranks, and
+        #    keep the FIRST occurrence of any repeated rank OR symbol so neither
+        #    appears twice. This is the cohort reader's only defense against a
+        #    glitched API response.
+        canonical: dict[int, QU100Row] = {}
+        seen_symbols: set[str] = set()
+        dropped = 0
+        for row in rows:
+            if not (1 <= row.rank <= QU100_MAX_RANK):
+                dropped += 1
+                continue
+            if row.rank in canonical or row.symbol in seen_symbols:
+                dropped += 1
+                continue
+            canonical[row.rank] = row
+            seen_symbols.add(row.symbol)
+        if dropped:
+            self.log.warning("qu100_batch_canonicalized", date=str(effective_date),
+                             ranking_type=ranking_type, dropped=dropped,
+                             kept=len(canonical))
+        # A batch that canonicalizes to nothing (every row invalid) is treated like
+        # an empty scrape — never wipe a good snapshot with a fully-glitched pull.
+        if not canonical:
+            self.log.info("persist_skipped", date=str(effective_date),
+                          ranking_type=ranking_type, reason="no_valid_rows")
+            return 0
+
+        scraped_symbols = seen_symbols
 
         with get_session() as db:
-            # 1) Read the existing day's rows BEFORE deleting so we can carry
-            #    forward symbols this scrape did not return.
+            # 1) Read the existing day's rows BEFORE deleting, keyed by RANK (keep
+            #    the first occupant of a rank if legacy data has a duplicate).
             existing = db.execute(
                 select(MoneyFlowSnapshot).where(
                     MoneyFlowSnapshot.data_date == effective_date,
                     MoneyFlowSnapshot.ranking_type == ranking_type,
                 )
             ).scalars().all()
-            # Carry forward only symbols absent from this scrape. Copy the field
+            existing_by_rank: dict[int, MoneyFlowSnapshot] = {}
+            for row in existing:
+                existing_by_rank.setdefault(row.rank, row)
+
+            # Carry forward the prior occupant of any rank NOT in this scrape —
+            # UNLESS that symbol was freshly scraped at another rank (fresh wins;
+            # the carried slot is dropped, the rank left unfilled). Copy field
             # VALUES out now (the ORM objects get deleted next), keeping each
             # carried row's ORIGINAL capture_session truthful.
             carried = [
                 {
                     "symbol": row.symbol,
-                    "rank": row.rank,
+                    "rank": rank,
                     "daily_change": row.daily_change,
                     "sector": row.sector,
                     "industry": row.industry,
@@ -650,8 +712,8 @@ class QUScraper(BaseScraper):
                     "view_type": row.view_type,
                     "capture_session": row.capture_session,
                 }
-                for row in existing
-                if row.symbol not in scraped_symbols
+                for rank, row in existing_by_rank.items()
+                if rank not in canonical and row.symbol not in scraped_symbols
             ]
 
             # 2) Ensure stocks exist for the scraped symbols (carried symbols
@@ -664,7 +726,7 @@ class QUScraper(BaseScraper):
             }
             new_stocks = [
                 Stock(symbol=r.symbol, sector=r.sector, industry=r.industry)
-                for r in rows
+                for r in canonical.values()
                 if r.symbol not in existing_stocks
             ]
             if new_stocks:
@@ -698,7 +760,7 @@ class QUScraper(BaseScraper):
                     long_short=row.long_short,
                     raw_data=row.raw,
                 )
-                for row in rows
+                for row in canonical.values()
             ])
             db.add_all([
                 MoneyFlowSnapshot(
@@ -718,7 +780,7 @@ class QUScraper(BaseScraper):
                 for c in carried
             ])
 
-        return len(rows) + len(carried)
+        return len(canonical) + len(carried)
 
     # ------------------------------------------------------------------
     # Phase B: Detail pages

--- a/src/rainier/scrapers/qu/scraper.py
+++ b/src/rainier/scrapers/qu/scraper.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
 import structlog
-from sqlalchemy import func, select
+from sqlalchemy import delete, select
 
 from rainier.core.config import get_settings
 from rainier.core.database import get_session
@@ -590,28 +590,76 @@ class QUScraper(BaseScraper):
         captured_at: datetime,
         data_date=None,
     ) -> int:
-        """Save QU100 rows to the database using batch operations. Returns row count."""
+        """Rebuild the day's ``(data_date, ranking_type)`` snapshot from this scrape.
+
+        Each later same-day scrape must OVERRIDE the symbols it returns and CARRY
+        FORWARD the rest, stamping the whole day with the latest ``captured_at`` —
+        one snapshot generation per ``(data_date, ranking_type)``. An empty scrape
+        (0 rows) is a no-op so a blank pull never wipes a good snapshot.
+
+        Mechanics (one transaction):
+
+            read existing rows  ─►  carried = stored symbols NOT in this scrape
+            DELETE the day's rows
+            INSERT  fresh rows  (this captured_at + this capture_session)
+                  + carried rows (this captured_at, ORIGINAL capture_session,
+                                  data copied into NEW instances — fresh ids)
+
+        We never UPDATE ``captured_at`` in place (it is the hypertable partition
+        key) and never re-``add`` the just-deleted ORM objects (identity-map
+        pitfall); carried field values are copied into fresh ``MoneyFlowSnapshot``
+        instances. ``captured_at`` advancing is itself the freshness signal.
+        Returns the count of rows that now make up the day's snapshot.
+
+        NOTE: delete-then-rebuild assumes scrapes for the same
+        ``(data_date, ranking_type)`` are serial (cron / single-slot APScheduler).
+        Overlapping same-day scrapes could race the rebuild — accepted under the
+        serial scheduler; concurrency hardening is a tracked P2 follow-up.
+        """
         effective_date = data_date or captured_at.date()
 
+        # Empty scrape -> no-op. Never overwrite a good snapshot with a blank one.
+        if not rows:
+            self.log.info("persist_skipped", date=str(effective_date),
+                          ranking_type=ranking_type, reason="empty_scrape")
+            return 0
+
+        scraped_symbols = {row.symbol for row in rows}
+
         with get_session() as db:
-            # Check if this (date, ranking_type) already exists — skip if so
-            existing_count = db.execute(
-                select(func.count()).where(
+            # 1) Read the existing day's rows BEFORE deleting so we can carry
+            #    forward symbols this scrape did not return.
+            existing = db.execute(
+                select(MoneyFlowSnapshot).where(
                     MoneyFlowSnapshot.data_date == effective_date,
                     MoneyFlowSnapshot.ranking_type == ranking_type,
                 )
-            ).scalar()
-            if existing_count and existing_count >= len(rows):
-                self.log.info("persist_skipped", date=str(effective_date),
-                              ranking_type=ranking_type, reason="already_exists")
-                return len(rows)
+            ).scalars().all()
+            # Carry forward only symbols absent from this scrape. Copy the field
+            # VALUES out now (the ORM objects get deleted next), keeping each
+            # carried row's ORIGINAL capture_session truthful.
+            carried = [
+                {
+                    "symbol": row.symbol,
+                    "rank": row.rank,
+                    "daily_change": row.daily_change,
+                    "sector": row.sector,
+                    "industry": row.industry,
+                    "long_short": row.long_short,
+                    "raw_data": row.raw_data,
+                    "view_type": row.view_type,
+                    "capture_session": row.capture_session,
+                }
+                for row in existing
+                if row.symbol not in scraped_symbols
+            ]
 
-            # Ensure stocks exist
-            symbols = {row.symbol for row in rows}
+            # 2) Ensure stocks exist for the scraped symbols (carried symbols
+            #    already have a stock row from a prior scrape).
             existing_stocks = {
                 s.symbol
                 for s in db.execute(
-                    select(Stock.symbol).where(Stock.symbol.in_(symbols))
+                    select(Stock.symbol).where(Stock.symbol.in_(scraped_symbols))
                 ).all()
             }
             new_stocks = [
@@ -623,7 +671,19 @@ class QUScraper(BaseScraper):
                 db.add_all(new_stocks)
                 db.flush()
 
-            # Bulk insert all snapshots
+            # 3) Delete the day's existing rows, then rebuild. flush() so the
+            #    DELETE lands before the INSERTs in the same transaction.
+            db.execute(
+                delete(MoneyFlowSnapshot).where(
+                    MoneyFlowSnapshot.data_date == effective_date,
+                    MoneyFlowSnapshot.ranking_type == ranking_type,
+                )
+            )
+            db.flush()
+
+            # 4) Insert fresh rows (this session) + carried rows (this captured_at,
+            #    original capture_session). Carried rows are NEW instances (fresh
+            #    ids) — never the deleted ORM objects.
             db.add_all([
                 MoneyFlowSnapshot(
                     captured_at=captured_at,
@@ -640,8 +700,25 @@ class QUScraper(BaseScraper):
                 )
                 for row in rows
             ])
+            db.add_all([
+                MoneyFlowSnapshot(
+                    captured_at=captured_at,
+                    capture_session=c["capture_session"],
+                    data_date=effective_date,
+                    ranking_type=ranking_type,
+                    symbol=c["symbol"],
+                    rank=c["rank"],
+                    daily_change=c["daily_change"],
+                    sector=c["sector"],
+                    industry=c["industry"],
+                    long_short=c["long_short"],
+                    raw_data=c["raw_data"],
+                    view_type=c["view_type"],
+                )
+                for c in carried
+            ])
 
-        return len(rows)
+        return len(rows) + len(carried)
 
     # ------------------------------------------------------------------
     # Phase B: Detail pages

--- a/tests/test_cli_recover_freshness.py
+++ b/tests/test_cli_recover_freshness.py
@@ -38,7 +38,7 @@ from rainier.cli import (
     _latest_due_session,
     _latest_due_slot,
     _qu100_day_is_fresh,
-    _recover_market_today,
+    _recover_trading_day,
 )
 from rainier.core.models import MoneyFlowSnapshot
 
@@ -55,22 +55,24 @@ def _dt(h, m):
     return datetime(2026, 6, 1, h, m, tzinfo=TZ)
 
 
-# --- "today" anchored to the market trading date (Acceptance 7e) -----------
+# --- "today" anchored to the app-local schedule date -----------------------
 
 
-def test_recover_today_anchored_to_market_date():
-    """`recover` resolves "today" via the US market trading date, not the
-    app-tz/wall-clock date. A run at a late-PT instant that has already crossed
-    ET midnight must resolve to the NEXT ET trading date — matching the stored
-    `data_date = market_date(captured_at)` keying, so the freshness day filter
-    looks at the right day."""
+def test_recover_today_anchored_to_app_local_date():
+    """Codex P1 regression — `recover` resolves "today" via the APP-LOCAL calendar
+    date (the schedule's timezone), NOT the ET market date. A late-evening run that
+    has crossed ET midnight but is still the same app-local day must resolve to
+    that day, so a missed close is recovered against the day that just ended (using
+    the ET date would point at the next, not-yet-traded day and — on Friday night —
+    fall into the weekend fast-path and skip recovery entirely)."""
     pt = ZoneInfo("America/Los_Angeles")
-    # 2026-06-01 22:30 PT == 2026-06-02 01:30 ET (already the next ET day).
+    # 2026-06-01 22:30 PT == 2026-06-02 01:30 ET. App-local (PT) day is still
+    # Monday 2026-06-01 — recover must judge against Monday's close, not Tuesday.
     late_pt = datetime(2026, 6, 1, 22, 30, tzinfo=pt)
-    assert _recover_market_today(late_pt) == date(2026, 6, 2)
-    # mid-afternoon PT: ET date is the same calendar day.
+    assert _recover_trading_day(late_pt) == date(2026, 6, 1)
+    # mid-afternoon PT (during the scraping window): app-local == ET date anyway.
     afternoon_pt = datetime(2026, 6, 1, 13, 0, tzinfo=pt)
-    assert _recover_market_today(afternoon_pt) == date(2026, 6, 1)
+    assert _recover_trading_day(afternoon_pt) == date(2026, 6, 1)
 
 
 # --- per-book freshness primitive ------------------------------------------

--- a/tests/test_cli_recover_freshness.py
+++ b/tests/test_cli_recover_freshness.py
@@ -165,18 +165,22 @@ def db_factory():
     engine.dispose()
 
 
-def _insert(factory, ranking_type: str, captured_at: datetime, symbol: str = "X"):
+def _insert(factory, ranking_type: str, captured_at: datetime, symbol: str = "X",
+            count: int = 100):
+    """Seed ``count`` rows for a book (default 100 = a full scrape, above the
+    coverage floor). Pass a small ``count`` to simulate a glitched partial scrape."""
     with factory() as s:
-        s.add(
-            MoneyFlowSnapshot(
-                captured_at=captured_at,
-                capture_session="midday",
-                data_date=DAY,
-                ranking_type=ranking_type,
-                symbol=symbol,
-                rank=1,
+        for rank in range(1, count + 1):
+            s.add(
+                MoneyFlowSnapshot(
+                    captured_at=captured_at,
+                    capture_session="midday",
+                    data_date=DAY,
+                    ranking_type=ranking_type,
+                    symbol=f"{symbol}{rank}",
+                    rank=rank,
+                )
             )
-        )
         s.commit()
 
 
@@ -207,6 +211,30 @@ def test_day_stale_when_one_book_behind(db_factory):
     now = _dt(16, 0)  # latest due 15:30 ET == 19:30 UTC; bottom100 is 11:31 ET
     with db_factory() as db:
         assert _qu100_day_is_fresh(db, DAY, now, SCHEDULE, TZ) is False
+
+
+def test_day_stale_when_book_partial_despite_fresh_captured_at(db_factory):
+    """Codex P1 regression — a non-empty PARTIAL scrape (few ranks, nothing earlier
+    to carry forward) advances captured_at but leaves the book mostly empty. Rank
+    coverage below the floor must read STALE so recover re-fires, not run the
+    screener off a near-empty book."""
+    fresh = datetime(2026, 6, 1, 19, 31, tzinfo=timezone.utc)
+    _insert(db_factory, "top100", fresh, count=100)
+    _insert(db_factory, "bottom100", fresh, count=5)  # glitched partial book
+    now = _dt(16, 0)  # 15:30 ET due
+    with db_factory() as db:
+        assert _qu100_day_is_fresh(db, DAY, now, SCHEDULE, TZ) is False
+
+
+def test_day_fresh_with_minor_dedup_unfill(db_factory):
+    """A near-full book (a couple ranks unfilled by dedup) is still fresh — the
+    floor must not false-stale a legitimate full scrape."""
+    fresh = datetime(2026, 6, 1, 19, 31, tzinfo=timezone.utc)
+    _insert(db_factory, "top100", fresh, count=98)
+    _insert(db_factory, "bottom100", fresh, count=98)
+    now = _dt(16, 0)
+    with db_factory() as db:
+        assert _qu100_day_is_fresh(db, DAY, now, SCHEDULE, TZ) is True
 
 
 def test_day_fresh_before_any_slot_due_with_no_data(db_factory):

--- a/tests/test_cli_recover_freshness.py
+++ b/tests/test_cli_recover_freshness.py
@@ -1,6 +1,7 @@
 """WS D — `rainier recover` detects today's QU100 freshness via `captured_at`,
-not per-`capture_session` row counts; the Discord report is gated on the
-recovery scrape actually succeeding.
+not per-`capture_session` row counts; the Discord report is gated on freshness
+being RESTORED (re-read from the DB after the recovery scrape), not on the scrape
+coroutine merely returning.
 
 Under the rebuild-the-day fix a day holds ONE `captured_at` per
 `(data_date, ranking_type)` and the rows carry the LATEST scrape's
@@ -10,25 +11,37 @@ rebuild every row reads `capture_session="midday"`, so morning would show 0
 rows and recover would falsely re-scrape + re-report.
 
 The fix:
-  * `_is_qu100_fresh(latest_captured_at, now, schedule, tz)` — today's data is
-    fresh iff a snapshot exists for today AND its `captured_at` is at/after the
-    most-recent scheduled slot that is already due. Per-DAY, not per-slot.
-  * `_should_send_recovery_report(was_stale, scrape_succeeded)` — re-send the
-    daily outlook ONLY when the day was stale AND a recovery scrape this run
-    succeeded. A queued-but-failed scrape must NOT fire a report off a stale
-    snapshot (the exact frozen-data bug this PR fixes).
+  * `_is_qu100_fresh(latest_captured_at, now, schedule, tz)` — per-ranking_type
+    primitive: this book is fresh iff a snapshot exists AND its `captured_at` is
+    at/after the most-recent scheduled slot already due. Per-DAY, not per-slot.
+  * `_qu100_day_is_fresh(db, today, now, schedule, tz)` — the day is fresh only
+    when EVERY book (top100 AND bottom100) is fresh. A partial scrape (top100
+    lands, bottom100 empty no-op) must read STALE so recover re-fires — a single
+    global `max(captured_at)` would let fresh top100 mask stale bottom100.
+  * the report is sent only when the day was stale AND `_qu100_day_is_fresh` is
+    True again after the scrape — a scrape that returns without raising but lands
+    no fresh data (the documented empty-slot slip) must NOT fire a report off a
+    frozen snapshot (the exact bug this PR fixes).
 """
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime, timezone
 from zoneinfo import ZoneInfo
 
-from rainier.cli import _is_qu100_fresh, _should_send_recovery_report
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from rainier.cli import (
+    _is_qu100_fresh,
+    _latest_due_session,
+    _latest_due_slot,
+    _qu100_day_is_fresh,
+)
+from rainier.core.models import MoneyFlowSnapshot
 
 TZ = ZoneInfo("America/New_York")
-# Schedule mirrors settings.scraping.schedule (UTC clock strings the recover loop
-# reads). Use local-clock slot times for the helper under test.
 SCHEDULE = {
     "morning": "11:30",
     "midday": "13:30",
@@ -41,56 +54,142 @@ def _dt(h, m):
     return datetime(2026, 6, 1, h, m, tzinfo=TZ)
 
 
-# --- freshness detection ---------------------------------------------------
+# --- per-book freshness primitive ------------------------------------------
 
 
 def test_fresh_when_captured_at_after_latest_due_slot():
     """At 16:00 the latest due slot is 15:30; a snapshot captured 15:31 is fresh."""
-    now = _dt(16, 0)
-    latest = _dt(15, 31)
-    assert _is_qu100_fresh(latest, now, SCHEDULE, TZ) is True
+    assert _is_qu100_fresh(_dt(15, 31), _dt(16, 0), SCHEDULE, TZ) is True
+
+
+def test_fresh_when_captured_at_equals_latest_due_slot():
+    """A snapshot landing EXACTLY at the most-recent due slot is fresh (`>=`)."""
+    assert _is_qu100_fresh(_dt(15, 30), _dt(16, 0), SCHEDULE, TZ) is True
 
 
 def test_stale_when_captured_before_latest_due_slot():
-    """At 16:00 (15:30 due) a snapshot stuck at the 11:30 morning slot is STALE —
-    later slots never landed."""
-    now = _dt(16, 0)
-    latest = _dt(11, 31)  # only morning ran
-    assert _is_qu100_fresh(latest, now, SCHEDULE, TZ) is False
+    """At 16:00 (15:30 due) a snapshot stuck at the 11:30 morning slot is STALE."""
+    assert _is_qu100_fresh(_dt(11, 31), _dt(16, 0), SCHEDULE, TZ) is False
 
 
 def test_stale_when_no_snapshot_today():
-    now = _dt(16, 0)
-    assert _is_qu100_fresh(None, now, SCHEDULE, TZ) is False
+    assert _is_qu100_fresh(None, _dt(16, 0), SCHEDULE, TZ) is False
 
 
 def test_fresh_before_any_slot_due():
-    """Before the first slot (11:30) is due, having no data yet is not 'stale' —
-    nothing was due, so recover should not fire a scrape."""
-    now = _dt(9, 0)
-    assert _is_qu100_fresh(None, now, SCHEDULE, TZ) is True
+    """Before the first slot (11:30) is due, having no data yet is not 'stale'."""
+    assert _is_qu100_fresh(None, _dt(9, 0), SCHEDULE, TZ) is True
 
 
 def test_fresh_when_only_morning_due_and_morning_ran():
     """At 12:00 only the morning slot (11:30) is due; a morning snapshot is fresh."""
-    now = _dt(12, 0)
-    latest = _dt(11, 31)
-    assert _is_qu100_fresh(latest, now, SCHEDULE, TZ) is True
+    assert _is_qu100_fresh(_dt(11, 31), _dt(12, 0), SCHEDULE, TZ) is True
 
 
-# --- report gating ---------------------------------------------------------
+# --- latest-due-slot selection ---------------------------------------------
 
 
-def test_report_sent_when_stale_and_scrape_succeeds():
-    assert _should_send_recovery_report(was_stale=True, scrape_succeeded=True) is True
+def test_latest_due_slot_returns_most_recent_due():
+    name, slot_time = _latest_due_slot(SCHEDULE, _dt(16, 0))
+    assert name == "afternoon"  # 15:30, most recent <= 16:00
+    assert slot_time == _dt(15, 30)
 
 
-def test_report_not_sent_when_scrape_fails():
-    """A recovery scrape that FAILED must not fire a report off a stale snapshot."""
-    assert _should_send_recovery_report(was_stale=True, scrape_succeeded=False) is False
+def test_latest_due_slot_only_morning_due():
+    name, slot_time = _latest_due_slot(SCHEDULE, _dt(12, 0))
+    assert name == "morning"
+    assert slot_time == _dt(11, 30)
 
 
-def test_report_not_sent_when_already_fresh():
-    """Data already fresh -> treat the report as already sent (no duplicate)."""
-    assert _should_send_recovery_report(was_stale=False, scrape_succeeded=False) is False
-    assert _should_send_recovery_report(was_stale=False, scrape_succeeded=True) is False
+def test_latest_due_slot_none_due_yet():
+    name, slot_time = _latest_due_slot(SCHEDULE, _dt(9, 0))
+    assert name is None and slot_time is None
+
+
+def test_latest_due_session_falls_back_to_first_when_none_due():
+    """Defensive: when no slot is due, label with the first slot."""
+    assert _latest_due_session(SCHEDULE, _dt(9, 0)) == "morning"
+
+
+def test_latest_due_session_picks_most_recent_due():
+    assert _latest_due_session(SCHEDULE, _dt(16, 0)) == "afternoon"
+
+
+# --- per-ranking_type day freshness (DB-backed) ----------------------------
+
+_DDL = """
+CREATE TABLE money_flow_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  captured_at TIMESTAMP NOT NULL,
+  capture_session VARCHAR(20) NOT NULL,
+  data_date DATE NOT NULL,
+  view_type VARCHAR(10) NOT NULL DEFAULT 'daily',
+  ranking_type VARCHAR(10) NOT NULL,
+  symbol VARCHAR(10) NOT NULL,
+  rank INTEGER NOT NULL,
+  daily_change INTEGER, sector VARCHAR(100), industry VARCHAR(200),
+  long_short VARCHAR(50), raw_data JSON
+);
+"""
+
+DAY = date(2026, 6, 1)
+
+
+@pytest.fixture
+def db_factory():
+    engine = create_engine("sqlite://", future=True)
+    with engine.begin() as conn:
+        conn.execute(text(_DDL.strip()))
+    yield sessionmaker(bind=engine, expire_on_commit=False)
+    engine.dispose()
+
+
+def _insert(factory, ranking_type: str, captured_at: datetime, symbol: str = "X"):
+    with factory() as s:
+        s.add(
+            MoneyFlowSnapshot(
+                captured_at=captured_at,
+                capture_session="midday",
+                data_date=DAY,
+                ranking_type=ranking_type,
+                symbol=symbol,
+                rank=1,
+            )
+        )
+        s.commit()
+
+
+def test_day_fresh_when_both_books_fresh(db_factory):
+    """Both top100 and bottom100 at/after the latest due slot -> fresh."""
+    _insert(db_factory, "top100", datetime(2026, 6, 1, 19, 31, tzinfo=timezone.utc))
+    _insert(db_factory, "bottom100", datetime(2026, 6, 1, 19, 31, tzinfo=timezone.utc))
+    now = _dt(16, 0)  # 15:30 ET due == 19:30 UTC
+    with db_factory() as db:
+        assert _qu100_day_is_fresh(db, DAY, now, SCHEDULE, TZ) is True
+
+
+def test_day_stale_when_bottom100_missing(db_factory):
+    """REGRESSION: top100 fresh but bottom100 absent (empty no-op) -> STALE.
+
+    A single global max(captured_at) would read top100's fresh time and report the
+    whole day fresh, masking the missing book and skipping recovery."""
+    _insert(db_factory, "top100", datetime(2026, 6, 1, 19, 31, tzinfo=timezone.utc))
+    now = _dt(16, 0)
+    with db_factory() as db:
+        assert _qu100_day_is_fresh(db, DAY, now, SCHEDULE, TZ) is False
+
+
+def test_day_stale_when_one_book_behind(db_factory):
+    """REGRESSION: top100 fresh, bottom100 stuck at the morning slot -> STALE."""
+    _insert(db_factory, "top100", datetime(2026, 6, 1, 19, 31, tzinfo=timezone.utc))
+    _insert(db_factory, "bottom100", datetime(2026, 6, 1, 15, 31, tzinfo=timezone.utc))
+    now = _dt(16, 0)  # latest due 15:30 ET == 19:30 UTC; bottom100 is 11:31 ET
+    with db_factory() as db:
+        assert _qu100_day_is_fresh(db, DAY, now, SCHEDULE, TZ) is False
+
+
+def test_day_fresh_before_any_slot_due_with_no_data(db_factory):
+    """No slot due yet and no data -> fresh (nothing expected)."""
+    now = _dt(9, 0)
+    with db_factory() as db:
+        assert _qu100_day_is_fresh(db, DAY, now, SCHEDULE, TZ) is True

--- a/tests/test_cli_recover_freshness.py
+++ b/tests/test_cli_recover_freshness.py
@@ -1,0 +1,96 @@
+"""WS D — `rainier recover` detects today's QU100 freshness via `captured_at`,
+not per-`capture_session` row counts; the Discord report is gated on the
+recovery scrape actually succeeding.
+
+Under the rebuild-the-day fix a day holds ONE `captured_at` per
+`(data_date, ranking_type)` and the rows carry the LATEST scrape's
+`capture_session`. The old recover counted rows where
+`capture_session == <slot>` to decide a slot was "missed" — after a midday
+rebuild every row reads `capture_session="midday"`, so morning would show 0
+rows and recover would falsely re-scrape + re-report.
+
+The fix:
+  * `_is_qu100_fresh(latest_captured_at, now, schedule, tz)` — today's data is
+    fresh iff a snapshot exists for today AND its `captured_at` is at/after the
+    most-recent scheduled slot that is already due. Per-DAY, not per-slot.
+  * `_should_send_recovery_report(was_stale, scrape_succeeded)` — re-send the
+    daily outlook ONLY when the day was stale AND a recovery scrape this run
+    succeeded. A queued-but-failed scrape must NOT fire a report off a stale
+    snapshot (the exact frozen-data bug this PR fixes).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from rainier.cli import _is_qu100_fresh, _should_send_recovery_report
+
+TZ = ZoneInfo("America/New_York")
+# Schedule mirrors settings.scraping.schedule (UTC clock strings the recover loop
+# reads). Use local-clock slot times for the helper under test.
+SCHEDULE = {
+    "morning": "11:30",
+    "midday": "13:30",
+    "afternoon": "15:30",
+    "close": "18:00",
+}
+
+
+def _dt(h, m):
+    return datetime(2026, 6, 1, h, m, tzinfo=TZ)
+
+
+# --- freshness detection ---------------------------------------------------
+
+
+def test_fresh_when_captured_at_after_latest_due_slot():
+    """At 16:00 the latest due slot is 15:30; a snapshot captured 15:31 is fresh."""
+    now = _dt(16, 0)
+    latest = _dt(15, 31)
+    assert _is_qu100_fresh(latest, now, SCHEDULE, TZ) is True
+
+
+def test_stale_when_captured_before_latest_due_slot():
+    """At 16:00 (15:30 due) a snapshot stuck at the 11:30 morning slot is STALE —
+    later slots never landed."""
+    now = _dt(16, 0)
+    latest = _dt(11, 31)  # only morning ran
+    assert _is_qu100_fresh(latest, now, SCHEDULE, TZ) is False
+
+
+def test_stale_when_no_snapshot_today():
+    now = _dt(16, 0)
+    assert _is_qu100_fresh(None, now, SCHEDULE, TZ) is False
+
+
+def test_fresh_before_any_slot_due():
+    """Before the first slot (11:30) is due, having no data yet is not 'stale' —
+    nothing was due, so recover should not fire a scrape."""
+    now = _dt(9, 0)
+    assert _is_qu100_fresh(None, now, SCHEDULE, TZ) is True
+
+
+def test_fresh_when_only_morning_due_and_morning_ran():
+    """At 12:00 only the morning slot (11:30) is due; a morning snapshot is fresh."""
+    now = _dt(12, 0)
+    latest = _dt(11, 31)
+    assert _is_qu100_fresh(latest, now, SCHEDULE, TZ) is True
+
+
+# --- report gating ---------------------------------------------------------
+
+
+def test_report_sent_when_stale_and_scrape_succeeds():
+    assert _should_send_recovery_report(was_stale=True, scrape_succeeded=True) is True
+
+
+def test_report_not_sent_when_scrape_fails():
+    """A recovery scrape that FAILED must not fire a report off a stale snapshot."""
+    assert _should_send_recovery_report(was_stale=True, scrape_succeeded=False) is False
+
+
+def test_report_not_sent_when_already_fresh():
+    """Data already fresh -> treat the report as already sent (no duplicate)."""
+    assert _should_send_recovery_report(was_stale=False, scrape_succeeded=False) is False
+    assert _should_send_recovery_report(was_stale=False, scrape_succeeded=True) is False

--- a/tests/test_cli_recover_freshness.py
+++ b/tests/test_cli_recover_freshness.py
@@ -38,6 +38,7 @@ from rainier.cli import (
     _latest_due_session,
     _latest_due_slot,
     _qu100_day_is_fresh,
+    _recover_market_today,
 )
 from rainier.core.models import MoneyFlowSnapshot
 
@@ -52,6 +53,24 @@ SCHEDULE = {
 
 def _dt(h, m):
     return datetime(2026, 6, 1, h, m, tzinfo=TZ)
+
+
+# --- "today" anchored to the market trading date (Acceptance 7e) -----------
+
+
+def test_recover_today_anchored_to_market_date():
+    """`recover` resolves "today" via the US market trading date, not the
+    app-tz/wall-clock date. A run at a late-PT instant that has already crossed
+    ET midnight must resolve to the NEXT ET trading date — matching the stored
+    `data_date = market_date(captured_at)` keying, so the freshness day filter
+    looks at the right day."""
+    pt = ZoneInfo("America/Los_Angeles")
+    # 2026-06-01 22:30 PT == 2026-06-02 01:30 ET (already the next ET day).
+    late_pt = datetime(2026, 6, 1, 22, 30, tzinfo=pt)
+    assert _recover_market_today(late_pt) == date(2026, 6, 2)
+    # mid-afternoon PT: ET date is the same calendar day.
+    afternoon_pt = datetime(2026, 6, 1, 13, 0, tzinfo=pt)
+    assert _recover_market_today(afternoon_pt) == date(2026, 6, 1)
 
 
 # --- per-book freshness primitive ------------------------------------------

--- a/tests/test_cli_recover_freshness.py
+++ b/tests/test_cli_recover_freshness.py
@@ -193,3 +193,30 @@ def test_day_fresh_before_any_slot_due_with_no_data(db_factory):
     now = _dt(9, 0)
     with db_factory() as db:
         assert _qu100_day_is_fresh(db, DAY, now, SCHEDULE, TZ) is True
+
+
+def test_midnight_clamp_keeps_recovered_day_stale(db_factory):
+    """REGRESSION (Codex): a recovery that crosses local midnight must still judge
+    the recovered day against ITS OWN last slot, not a fresh next-day clock.
+
+    A snapshot stuck at the morning slot, evaluated with the clock clamped to
+    end-of-`DAY` (18:00 close is the last due slot), must read STALE. Without the
+    clamp the post-midnight clock would find no slot due on the new day and
+    falsely report fresh."""
+    _insert(db_factory, "top100", datetime(2026, 6, 1, 15, 31, tzinfo=timezone.utc))
+    _insert(db_factory, "bottom100", datetime(2026, 6, 1, 15, 31, tzinfo=timezone.utc))
+    # Clamp the clock to end-of-DAY (what _recover does when now crosses midnight).
+    clamped = datetime(2026, 6, 1, 23, 59, 59, tzinfo=TZ)
+    with db_factory() as db:
+        # 11:31 ET data vs the 18:00 close slot now due -> STALE.
+        assert _qu100_day_is_fresh(db, DAY, clamped, SCHEDULE, TZ) is False
+
+
+def test_midnight_clamp_fresh_when_close_slot_landed(db_factory):
+    """Clamped to end-of-day: a snapshot at/after the 18:00 close slot is fresh."""
+    _insert(db_factory, "top100", datetime(2026, 6, 1, 22, 1, tzinfo=timezone.utc))
+    _insert(db_factory, "bottom100", datetime(2026, 6, 1, 22, 1, tzinfo=timezone.utc))
+    clamped = datetime(2026, 6, 1, 23, 59, 59, tzinfo=TZ)
+    with db_factory() as db:
+        # 18:01 ET >= 18:00 close slot -> fresh.
+        assert _qu100_day_is_fresh(db, DAY, clamped, SCHEDULE, TZ) is True

--- a/tests/test_db_money_flow_backup.py
+++ b/tests/test_db_money_flow_backup.py
@@ -354,32 +354,56 @@ def test_verify_raw_data_value_divergence_fails(src_engine, dst_engine):
     assert any("checksum" in f.lower() for f in report.failures)
 
 
-def test_reconcile_self_heals_edited_old_row(src_engine, dst_engine):
-    """An edited OLD source row (same (id, captured_at), different value) is
-    detected by the per-day checksum and RE-COPIED by the reconcile.
+def test_reconcile_does_not_propagate_same_capture_edit(src_engine, dst_engine):
+    """Codex P1 — an in-place edit of a SOURCE row at the SAME captured_at is NOT
+    propagated to the backup; verify REPORTS it loudly instead.
 
-    Under the old HWM-by-id copy an in-place edit below the high-water mark was
-    never recopied — verify could only flag it. The data_date-aware reconcile
-    fingerprints each day and recopies any day whose checksum changed, so the
-    backup self-heals and verify is green.
+    A difference at the same captured_at is not a rebuild (a rebuild advances
+    captured_at). It is a source-side shrink / in-place edit / corruption, and the
+    reconcile cannot tell a genuine correction from corruption — so the
+    NON-DESTRUCTIVE invariant forbids overwriting the backup. The edit is detected
+    by verify_backup's content-faithful checksum (loud), never auto-destroyed.
     """
     mfb = _import()
     _seed_src(src_engine, [_row(i) for i in range(1, 4)])
     mfb.backup_money_flow(src_engine, dst_engine)  # backup now has 1,2,3
 
-    # Edit an OLD source row in place (id=2). Same data_date -> the day's checksum
-    # changes, so the reconcile recopies the whole day.
+    # Edit an OLD source row in place (id=2), SAME captured_at (no new rebuild).
     with src_engine.begin() as conn:
         conn.execute(_SRC.update().where(_SRC.c.id == 2).values(rank=777))
     mfb.backup_money_flow(src_engine, dst_engine)
 
-    # Backup now matches source — verify is green (self-healed).
-    report = mfb.verify_backup(src_engine, dst_engine, run_max=3)
-    assert report.ok, report.failures
+    # Backup row is NOT overwritten (non-destructive); verify FLAGS the drift.
     bt = mfb.backup_table()
     with dst_engine.connect() as conn:
         rank = conn.execute(select(bt.c.rank).where(bt.c.id == 2)).scalar_one()
-    assert rank == 777, "edited row must be recopied into the backup"
+    assert rank == 2, "same-captured_at edit must NOT be propagated to the backup"
+    report = mfb.verify_backup(src_engine, dst_engine, run_max=3)
+    assert not report.ok, "verify must loudly report the source/backup content drift"
+
+
+def test_reconcile_recopies_on_newer_capture_rebuild(src_engine, dst_engine):
+    """The flip side: a row changed under a NEWER captured_at IS a rebuild and the
+    backup DOES recopy it (orphans purged, content aligned)."""
+    mfb = _import()
+    _seed_src(src_engine, [_row(i) for i in range(1, 4)])
+    mfb.backup_money_flow(src_engine, dst_engine)
+
+    # Rebuild the day: drop the old generation, re-insert NEW ids under a NEWER
+    # captured_at with a corrected value (simulates WS A's rebuild generation).
+    newer = datetime(2026, 6, 1, 23, 30, tzinfo=timezone.utc)  # > _CAP (22:00)
+    with src_engine.begin() as conn:
+        conn.execute(_SRC.delete().where(_SRC.c.data_date == _row(1)["data_date"]))
+    _seed_src(
+        src_engine,
+        [_row(i, captured_at=newer, rank=777 if i == 5 else i) for i in (4, 5, 6)],
+    )
+    mfb.backup_money_flow(src_engine, dst_engine)
+
+    report = mfb.verify_backup(src_engine, dst_engine, run_max=6)
+    assert report.ok, report.failures
+    bt = mfb.backup_table()
+    assert _dst_ids(dst_engine, bt) == [4, 5, 6], "newer rebuild purges orphans 1,2,3"
 
 
 def test_verify_duplicate_source_id_fails(src_engine, dst_engine):

--- a/tests/test_db_money_flow_backup.py
+++ b/tests/test_db_money_flow_backup.py
@@ -455,6 +455,7 @@ def test_empty_source_no_op(src_engine, dst_engine):
     result = mfb.backup_money_flow(src_engine, dst_engine)
     assert result.copied == 0
     assert result.run_max == 0
+    assert result.source_empty is True
 
 
 # ===========================================================================
@@ -522,6 +523,36 @@ def test_cli_backup_copies_to_neon(monkeypatch, tmp_path, _local_src_path):
     check = create_engine(f"sqlite:///{dst_path}")
     assert _count(check, "backup_money_flow_snapshots") == 3
     check.dispose()
+    local_eng.dispose()
+
+
+def test_cli_empty_source_fails_loud(monkeypatch, tmp_path):
+    """Codex P1 regression — a configured backup whose local SOURCE is empty
+    (mispointed LEGACY_DATABASE_URL / failed restore) must FAIL the run (non-zero),
+    NOT print a silent '0 rows' success. The backup is left intact; the cron
+    alerts instead of masking a dead source."""
+    from rainier.cli import cli
+    from rainier.core import database
+    from rainier.db import engine as db_engine
+
+    # Empty local source (schema only, no rows).
+    local_path = tmp_path / "empty_local.db"
+    local_eng = create_engine(f"sqlite:///{local_path}")
+    _SRC_META.create_all(local_eng)
+    monkeypatch.setattr(database, "get_engine", lambda *a, **k: local_eng)
+
+    # A pre-seeded Neon-side backup that must NOT be wiped.
+    dst_path = tmp_path / "neon.db"
+    monkeypatch.setattr(
+        db_engine, "get_engine", lambda: create_engine(f"sqlite:///{dst_path}")
+    )
+
+    res = CliRunner().invoke(cli, ["db", "backup-money-flow"])
+    assert res.exit_code != 0, res.output
+    assert res.exception is None or isinstance(res.exception, SystemExit), (
+        f"expected a clean ClickException, got {res.exception!r}"
+    )
+    assert "empty" in res.output.lower()
     local_eng.dispose()
 
 

--- a/tests/test_db_money_flow_backup.py
+++ b/tests/test_db_money_flow_backup.py
@@ -474,12 +474,14 @@ def test_transaction_safety_rolls_back(src_engine, dst_engine):
 # ===========================================================================
 
 
-def test_empty_source_no_op(src_engine, dst_engine):
+def test_empty_source_bootstrap_no_op(src_engine, dst_engine):
+    """Source AND backup both empty -> legitimate bootstrap (fresh deploy / just
+    after db init, before the first scrape). No-op, NOT flagged as data loss."""
     mfb = _import()
     result = mfb.backup_money_flow(src_engine, dst_engine)
     assert result.copied == 0
     assert result.run_max == 0
-    assert result.source_empty is True
+    assert result.source_empty is False, "both-empty bootstrap must not be flagged"
 
 
 # ===========================================================================
@@ -550,33 +552,64 @@ def test_cli_backup_copies_to_neon(monkeypatch, tmp_path, _local_src_path):
     local_eng.dispose()
 
 
-def test_cli_empty_source_fails_loud(monkeypatch, tmp_path):
-    """Codex P1 regression — a configured backup whose local SOURCE is empty
-    (mispointed LEGACY_DATABASE_URL / failed restore) must FAIL the run (non-zero),
-    NOT print a silent '0 rows' success. The backup is left intact; the cron
-    alerts instead of masking a dead source."""
+def test_cli_empty_source_fails_loud_when_backup_has_rows(monkeypatch, tmp_path):
+    """Codex P1 regression — a SOURCE that LOST all its data while the backup
+    already has rows (mispointed LEGACY_DATABASE_URL / failed restore) must FAIL
+    the run (non-zero), NOT print a silent '0 rows' success. Backup left intact."""
     from rainier.cli import cli
     from rainier.core import database
     from rainier.db import engine as db_engine
 
-    # Empty local source (schema only, no rows).
-    local_path = tmp_path / "empty_local.db"
+    local_path = tmp_path / "local.db"
     local_eng = create_engine(f"sqlite:///{local_path}")
     _SRC_META.create_all(local_eng)
+    with local_eng.begin() as conn:
+        conn.execute(insert(_SRC), [_row(i) for i in range(1, 4)])
     monkeypatch.setattr(database, "get_engine", lambda *a, **k: local_eng)
 
-    # A pre-seeded Neon-side backup that must NOT be wiped.
+    dst_path = tmp_path / "neon.db"
+    monkeypatch.setattr(
+        db_engine, "get_engine", lambda: create_engine(f"sqlite:///{dst_path}")
+    )
+
+    # First run populates the backup.
+    res1 = CliRunner().invoke(cli, ["db", "backup-money-flow"])
+    assert res1.exit_code == 0, res1.output
+
+    # Source loses all its data (the dangerous misconfiguration) -> fail loud.
+    with local_eng.begin() as conn:
+        conn.execute(_SRC.delete())
+    res2 = CliRunner().invoke(cli, ["db", "backup-money-flow"])
+    assert res2.exit_code != 0, res2.output
+    assert res2.exception is None or isinstance(res2.exception, SystemExit), (
+        f"expected a clean ClickException, got {res2.exception!r}"
+    )
+    assert "empty" in res2.output.lower()
+    # Backup still holds the 3 rows (non-destructive).
+    assert _count(create_engine(f"sqlite:///{dst_path}"), "backup_money_flow_snapshots") == 3
+    local_eng.dispose()
+
+
+def test_cli_empty_source_bootstrap_exits_zero(monkeypatch, tmp_path):
+    """Codex P2 regression — a fresh deploy / just-after-db-init state (source AND
+    backup both empty, before the first scrape) is a legitimate no-op: the nightly
+    cron must exit 0, NOT page on the normal pre-bootstrap empty table."""
+    from rainier.cli import cli
+    from rainier.core import database
+    from rainier.db import engine as db_engine
+
+    local_path = tmp_path / "empty_local.db"
+    local_eng = create_engine(f"sqlite:///{local_path}")
+    _SRC_META.create_all(local_eng)  # schema only, no rows
+    monkeypatch.setattr(database, "get_engine", lambda *a, **k: local_eng)
+
     dst_path = tmp_path / "neon.db"
     monkeypatch.setattr(
         db_engine, "get_engine", lambda: create_engine(f"sqlite:///{dst_path}")
     )
 
     res = CliRunner().invoke(cli, ["db", "backup-money-flow"])
-    assert res.exit_code != 0, res.output
-    assert res.exception is None or isinstance(res.exception, SystemExit), (
-        f"expected a clean ClickException, got {res.exception!r}"
-    )
-    assert "empty" in res.output.lower()
+    assert res.exit_code == 0, res.output
     local_eng.dispose()
 
 

--- a/tests/test_db_money_flow_backup.py
+++ b/tests/test_db_money_flow_backup.py
@@ -151,22 +151,31 @@ def test_bootstrap_copies_all_rows(src_engine, dst_engine):
 
 
 # ===========================================================================
-# Test 2 — incremental: only new rows (> hwm) copied
+# Test 2 — incremental: a brand-new DAY appends; the unchanged old day is skipped
 # ===========================================================================
 
+_CAP_DAY2 = datetime(2026, 6, 2, 22, 0, tzinfo=timezone.utc)
 
-def test_incremental_only_new_rows(src_engine, dst_engine):
+
+def test_incremental_new_day_appends(src_engine, dst_engine):
+    """Under the data_date-aware reconcile, genuinely-new rows are a NEW trading
+    day; the unchanged prior day is not recopied."""
     mfb = _import()
-    _seed_src(src_engine, [_row(i) for i in range(1, 4)])
+    _seed_src(src_engine, [_row(i) for i in range(1, 4)])  # day 2026-06-01
     mfb.backup_money_flow(src_engine, dst_engine)
 
-    _seed_src(src_engine, [_row(i) for i in range(4, 7)])
+    # A new trading day (2026-06-02) — distinct data_date + captured_at.
+    _seed_src(
+        src_engine,
+        [_row(i, data_date=date(2026, 6, 2), captured_at=_CAP_DAY2) for i in range(4, 7)],
+    )
     result = mfb.backup_money_flow(src_engine, dst_engine)
 
-    assert result.copied == 3
+    assert result.copied == 3  # only the new day's 3 rows; old day skipped
     assert result.hwm_before == 3
     assert result.run_max == 6
     assert _dst_ids(dst_engine, mfb.backup_table()) == [1, 2, 3, 4, 5, 6]
+    assert mfb.verify_backup(src_engine, dst_engine, run_max=6).ok
 
 
 # ===========================================================================
@@ -214,17 +223,18 @@ def test_stable_upper_bound_race(src_engine, dst_engine):
     _seed_src(src_engine, [_row(i) for i in range(1, 4)])
 
     # Simulate a scrape landing mid-backup: a hook fires AFTER run_max is
-    # captured but BEFORE rows are read, inserting id=99.
+    # captured but BEFORE rows are read, inserting id=99 on a NEW trading day.
     def _mid(stage):
         if stage == "after_run_max":
-            _seed_src(src_engine, [_row(99)])
+            _seed_src(src_engine, [_row(99, data_date=date(2026, 6, 2), captured_at=_CAP_DAY2)])
 
     result = mfb.backup_money_flow(src_engine, dst_engine, _race_hook=_mid)
+    # id=99 > run_max(3) -> excluded this run (not a torn read).
     assert result.run_max == 3
     assert result.copied == 3
     assert _dst_ids(dst_engine, mfb.backup_table()) == [1, 2, 3]
 
-    # Next run picks up id=99.
+    # Next run reconciles the new day and picks up id=99.
     result2 = mfb.backup_money_flow(src_engine, dst_engine)
     assert result2.copied == 1
     assert _dst_ids(dst_engine, mfb.backup_table()) == [1, 2, 3, 99]
@@ -344,28 +354,32 @@ def test_verify_raw_data_value_divergence_fails(src_engine, dst_engine):
     assert any("checksum" in f.lower() for f in report.failures)
 
 
-def test_verify_edited_old_row_caught_by_full_window_checksum(src_engine, dst_engine):
-    """7(d) — an edited OLD source row with id <= hwm (same composite key,
-    different value) is caught by the FULL-window checksum.
+def test_reconcile_self_heals_edited_old_row(src_engine, dst_engine):
+    """An edited OLD source row (same (id, captured_at), different value) is
+    detected by the per-day checksum and RE-COPIED by the reconcile.
 
-    counts/max-id/missing-row all still pass because the (id, captured_at) key is
-    unchanged — only a full-window (id <= run_max, not just the incremental
-    window) checksum fires. This is the declared drift safety net.
+    Under the old HWM-by-id copy an in-place edit below the high-water mark was
+    never recopied — verify could only flag it. The data_date-aware reconcile
+    fingerprints each day and recopies any day whose checksum changed, so the
+    backup self-heals and verify is green.
     """
     mfb = _import()
     _seed_src(src_engine, [_row(i) for i in range(1, 4)])
-    mfb.backup_money_flow(src_engine, dst_engine)  # backup now has 1,2,3 (hwm=3)
+    mfb.backup_money_flow(src_engine, dst_engine)  # backup now has 1,2,3
 
-    # Edit an OLD source row in place (id=2, id <= hwm). The backup still holds
-    # the original value. New rows added so there IS an incremental window.
+    # Edit an OLD source row in place (id=2). Same data_date -> the day's checksum
+    # changes, so the reconcile recopies the whole day.
     with src_engine.begin() as conn:
         conn.execute(_SRC.update().where(_SRC.c.id == 2).values(rank=777))
-    _seed_src(src_engine, [_row(i) for i in range(4, 6)])
-    mfb.backup_money_flow(src_engine, dst_engine)  # copies 4,5; id=2 NOT recopied
+    mfb.backup_money_flow(src_engine, dst_engine)
 
-    report = mfb.verify_backup(src_engine, dst_engine, run_max=5)
-    assert not report.ok, "full-window checksum must catch an edited id<=hwm row"
-    assert any("checksum" in f.lower() for f in report.failures)
+    # Backup now matches source — verify is green (self-healed).
+    report = mfb.verify_backup(src_engine, dst_engine, run_max=3)
+    assert report.ok, report.failures
+    bt = mfb.backup_table()
+    with dst_engine.connect() as conn:
+        rank = conn.execute(select(bt.c.rank).where(bt.c.id == 2)).scalar_one()
+    assert rank == 777, "edited row must be recopied into the backup"
 
 
 def test_verify_duplicate_source_id_fails(src_engine, dst_engine):

--- a/tests/test_db_money_flow_backup_reconcile.py
+++ b/tests/test_db_money_flow_backup_reconcile.py
@@ -281,14 +281,14 @@ def test_concurrent_rebuild_does_not_purge_day_from_backup(src_engine, dst_engin
     assert mfb.verify_backup(src_engine, dst_engine, run_max=4).ok
 
 
-def test_deleted_latest_day_with_high_ids_is_retained(src_engine, dst_engine):
+def test_deleted_latest_day_with_high_ids_is_retained_and_alarmed(src_engine, dst_engine):
     """When the day the source lost held the HIGHEST ids, dropping it lowers
-    run_max below those ids. The backup retains that day (non-destructive
-    invariant); the retained ids sit ABOVE the lowered run_max so verify — bounded
-    to id<=run_max — stays green.
+    run_max below those ids. The backup RETAINS that day (non-destructive), and
+    the TRAILING-loss alarm (check f, uncapped) flags it even though it sits above
+    run_max where the id<=run_max checks can't see it.
 
     day1=id1, day2=id2 backed up. Delete day2 (the high-id day) from source ->
-    next run_max=1. day2 is backup-only -> retained, not purged."""
+    next run_max=1. day2 is backup-only -> retained, not purged; verify alarms."""
     mfb = _import()
     _seed(src_engine, [_row(1, data_date=DAY1), _row(2, data_date=DAY2, captured_at=T_DAY2)])
     mfb.backup_money_flow(src_engine, dst_engine)
@@ -301,7 +301,9 @@ def test_deleted_latest_day_with_high_ids_is_retained(src_engine, dst_engine):
     result = mfb.backup_money_flow(src_engine, dst_engine)
     assert result.run_max == 1, "run_max drops to the remaining max source id"
     assert _dst_ids(dst_engine, bt) == [1, 2], "lost high-id day must be retained in backup"
-    assert mfb.verify_backup(src_engine, dst_engine, run_max=1).ok
+    report = mfb.verify_backup(src_engine, dst_engine, run_max=1)
+    assert not report.ok, "trailing source-side loss must be alarmed"
+    assert any("exceeds source MAX(id)" in f for f in report.failures)
 
 
 def test_empty_source_does_not_wipe_backup(src_engine, dst_engine):
@@ -357,7 +359,12 @@ def test_lost_book_does_not_disturb_surviving_book(src_engine, dst_engine):
     result = mfb.backup_money_flow(src_engine, dst_engine)
     assert result.copied == 0, "top100 unchanged, bottom100 retained -> nothing recopied"
     assert _dst_ids(dst_engine, bt) == [1, 2, 3, 4], "surviving + lost book both kept"
-    assert mfb.verify_backup(src_engine, dst_engine, run_max=2).ok
+    # bottom100's ids (3,4) are the highest, so dropping them is a TRAILING loss
+    # the uncapped alarm (f) flags — the surviving book is untouched, the lost book
+    # retained, and verify surfaces the source-side loss.
+    report = mfb.verify_backup(src_engine, dst_engine, run_max=2)
+    assert not report.ok, "lost bottom100 (trailing ids) must be alarmed"
+    assert any("exceeds source MAX(id)" in f for f in report.failures)
 
 
 def test_one_book_rebuild_leaves_other_book_untouched(src_engine, dst_engine):

--- a/tests/test_db_money_flow_backup_reconcile.py
+++ b/tests/test_db_money_flow_backup_reconcile.py
@@ -275,3 +275,27 @@ def test_deleted_latest_day_with_high_ids_is_purged(src_engine, dst_engine):
     assert result.run_max == 1, "run_max drops to the remaining max source id"
     assert _dst_ids(dst_engine, bt) == [1], "deleted high-id day must be purged from backup"
     assert mfb.verify_backup(src_engine, dst_engine, run_max=1).ok
+
+
+def test_empty_source_does_not_wipe_backup(src_engine, dst_engine):
+    """Review regression — an EMPTY source must NOT purge the whole backup.
+
+    The reconcile deletes any backup day absent from the source. A source with NO
+    rows (fresh/rebuilt local DB, failed restore, or mis-pointed
+    LEGACY_DATABASE_URL) would otherwise flag EVERY backup day as
+    backup-only-and-gone and wipe the off-site copy of record on a routine cron.
+    The empty-source guard aborts as a no-op and leaves the backup intact."""
+    mfb = _import()
+    _seed(src_engine, [_row(1, data_date=DAY1), _row(2, data_date=DAY2, captured_at=T_DAY2)])
+    mfb.backup_money_flow(src_engine, dst_engine)
+    bt = mfb.backup_table()
+    assert _dst_ids(dst_engine, bt) == [1, 2]
+
+    # Source goes fully empty (every row gone — the dangerous misconfiguration).
+    with src_engine.begin() as conn:
+        conn.execute(delete(_SRC))
+
+    result = mfb.backup_money_flow(src_engine, dst_engine)
+    assert result.copied == 0
+    assert result.run_max == 0
+    assert _dst_ids(dst_engine, bt) == [1, 2], "empty source must NOT wipe the backup"

--- a/tests/test_db_money_flow_backup_reconcile.py
+++ b/tests/test_db_money_flow_backup_reconcile.py
@@ -304,3 +304,60 @@ def test_empty_source_does_not_wipe_backup(src_engine, dst_engine):
     assert result.copied == 0
     assert result.run_max == 0
     assert _dst_ids(dst_engine, bt) == [1, 2], "empty source must NOT wipe the backup"
+
+
+def test_lost_book_does_not_disturb_surviving_book(src_engine, dst_engine):
+    """Codex P1 regression — the reconcile keys on (data_date, ranking_type). A
+    partial source-side loss of ONE book (bottom100 dropped by a bad restore) must
+    NOT erase the surviving book from the backup, and the dropped book must be
+    RETAINED. Keying on data_date alone would treat the day as "changed", delete
+    BOTH books, and recopy only the survivor — silently losing bottom100."""
+    mfb = _import()
+    # Same day, two books: top100 (ids 1,2) and bottom100 (ids 3,4).
+    _seed(
+        src_engine,
+        [
+            _row(1, ranking_type="top100", rank=1),
+            _row(2, ranking_type="top100", rank=2),
+            _row(3, ranking_type="bottom100", rank=1),
+            _row(4, ranking_type="bottom100", rank=2),
+        ],
+    )
+    mfb.backup_money_flow(src_engine, dst_engine)
+    bt = mfb.backup_table()
+    assert _dst_ids(dst_engine, bt) == [1, 2, 3, 4]
+
+    # bottom100 vanishes from source (partial corruption); top100 untouched.
+    with src_engine.begin() as conn:
+        conn.execute(delete(_SRC).where(_SRC.c.ranking_type == "bottom100"))
+
+    result = mfb.backup_money_flow(src_engine, dst_engine)
+    assert result.copied == 0, "top100 unchanged, bottom100 retained -> nothing recopied"
+    assert _dst_ids(dst_engine, bt) == [1, 2, 3, 4], "surviving + lost book both kept"
+    assert mfb.verify_backup(src_engine, dst_engine, run_max=2).ok
+
+
+def test_one_book_rebuild_leaves_other_book_untouched(src_engine, dst_engine):
+    """A same-day rebuild of ONE book recopies only that book; the other book's
+    backup rows are not deleted or rewritten (per-generation delete key)."""
+    mfb = _import()
+    _seed(
+        src_engine,
+        [
+            _row(1, ranking_type="top100", rank=1),
+            _row(3, ranking_type="bottom100", rank=1),
+        ],
+    )
+    mfb.backup_money_flow(src_engine, dst_engine)
+    bt = mfb.backup_table()
+    assert _dst_ids(dst_engine, bt) == [1, 3]
+
+    # Rebuild top100 only: delete id1, insert id2 with a newer captured_at.
+    with src_engine.begin() as conn:
+        conn.execute(delete(_SRC).where(_SRC.c.id == 1))
+    _seed(src_engine, [_row(2, ranking_type="top100", rank=1, captured_at=T2)])
+
+    result = mfb.backup_money_flow(src_engine, dst_engine)
+    assert result.copied == 1, "only the rebuilt top100 row is recopied"
+    assert _dst_ids(dst_engine, bt) == [2, 3], "top100 -> {2}, bottom100 {3} untouched"
+    assert mfb.verify_backup(src_engine, dst_engine, run_max=3).ok

--- a/tests/test_db_money_flow_backup_reconcile.py
+++ b/tests/test_db_money_flow_backup_reconcile.py
@@ -1,0 +1,221 @@
+"""WS C — backup is a `data_date`-aware reconcile, not HWM-by-id append.
+
+The rebuild-the-day fix (WS A) makes a day's `money_flow_snapshots` rows change
+AFTER first write: a later same-day scrape DELETEs the day's rows and re-INSERTs
+fresh ones (new autoincrement ids). The old backup copy was high-water-mark by
+`id` (cursor = `MAX(id)`), insert-only — it structurally cannot:
+
+  * purge the orphaned OLD ids the rebuild deleted (they sit below the HWM), nor
+  * re-copy a changed day whose new rows it already passed.
+
+So `verify_backup`'s full-window checksum / missing-row checks would fail the
+nightly cron after any same-day rebuild. WS C replaces the cursor with a
+reconcile over the UNION of source+backup `data_date`s: a day that disagrees
+(newer `captured_at`, or a row-count / checksum mismatch — incl. a backup-only
+day the source shrank) is delete-by-day-then-recopied; new days still append; a
+day gone-to-zero in source is left deleted. `verify_backup` stays green and
+re-runnable after a rebuild.
+
+Both engines are SQLite in-memory (engine-agnostic core).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    Date,
+    DateTime,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    delete,
+    insert,
+    select,
+)
+from sqlalchemy.types import JSON
+
+_SRC_META = MetaData()
+_SRC = Table(
+    "money_flow_snapshots",
+    _SRC_META,
+    Column("id", BigInteger, nullable=False),
+    Column("captured_at", DateTime(timezone=True), nullable=False),
+    Column("capture_session", String(20), nullable=False),
+    Column("data_date", Date, nullable=False),
+    Column("view_type", String(10), nullable=False),
+    Column("ranking_type", String(10), nullable=False),
+    Column("symbol", String(10), nullable=False),
+    Column("rank", Integer, nullable=False),
+    Column("daily_change", Integer),
+    Column("sector", String(100)),
+    Column("industry", String(200)),
+    Column("long_short", String(50)),
+    Column("raw_data", JSON),
+)
+
+DAY1 = date(2026, 6, 1)
+DAY2 = date(2026, 6, 2)
+T1 = datetime(2026, 6, 1, 15, 45, tzinfo=timezone.utc)
+T2 = datetime(2026, 6, 1, 22, 0, tzinfo=timezone.utc)
+T_DAY2 = datetime(2026, 6, 2, 22, 0, tzinfo=timezone.utc)
+
+
+def _row(i: int, *, data_date: date = DAY1, captured_at: datetime = T1, **over) -> dict:
+    base = {
+        "id": i,
+        "captured_at": captured_at,
+        "capture_session": "morning",
+        "data_date": data_date,
+        "view_type": "daily",
+        "ranking_type": "top100",
+        "symbol": f"S{i:03d}",
+        "rank": i,
+        "daily_change": i,
+        "sector": "Tech",
+        "industry": "SW",
+        "long_short": "Long in",
+        "raw_data": {"id": i},
+    }
+    base.update(over)
+    return base
+
+
+@pytest.fixture
+def src_engine():
+    eng = create_engine("sqlite://")
+    _SRC_META.create_all(eng)
+    try:
+        yield eng
+    finally:
+        eng.dispose()
+
+
+@pytest.fixture
+def dst_engine():
+    eng = create_engine("sqlite://")
+    try:
+        yield eng
+    finally:
+        eng.dispose()
+
+
+def _import():
+    from rainier.db import money_flow_backup as mfb
+
+    return mfb
+
+
+def _seed(eng, rows):
+    with eng.begin() as conn:
+        conn.execute(insert(_SRC), rows)
+
+
+def _dst_ids(eng, bt) -> list[int]:
+    with eng.connect() as conn:
+        return sorted(conn.execute(select(bt.c.id)).scalars().all())
+
+
+def test_same_day_rebuild_purges_orphans_and_recopies(src_engine, dst_engine):
+    """Morning day1 (ids 1,2) backed up; a later same-day rebuild DELETEs 1,2 and
+    INSERTs fresh ids 3,4 with flipped data. The backup must end holding ONLY
+    {3,4} (orphans 1,2 purged) and verify must be green."""
+    mfb = _import()
+    _seed(src_engine, [_row(1), _row(2)])
+    mfb.backup_money_flow(src_engine, dst_engine)
+    bt = mfb.backup_table()
+    assert _dst_ids(dst_engine, bt) == [1, 2]
+
+    # Rebuild day1: delete the day's rows, insert fresh ones with a new captured_at
+    # and flipped dominance (simulates WS A).
+    with src_engine.begin() as conn:
+        conn.execute(delete(_SRC).where(_SRC.c.data_date == DAY1))
+    _seed(
+        src_engine,
+        [
+            _row(3, captured_at=T2, capture_session="midday", long_short="No dominance"),
+            _row(4, captured_at=T2, capture_session="midday", long_short="No dominance"),
+        ],
+    )
+
+    mfb.backup_money_flow(src_engine, dst_engine)
+
+    assert _dst_ids(dst_engine, bt) == [3, 4], "orphaned old ids 1,2 must be purged"
+
+    run_max = 4
+    report = mfb.verify_backup(src_engine, dst_engine, run_max=run_max)
+    assert report.ok, report.failures
+
+
+def test_reconcile_is_idempotent_after_rebuild(src_engine, dst_engine):
+    """A second reconcile run after a rebuild copies nothing new and stays green."""
+    mfb = _import()
+    _seed(src_engine, [_row(1, data_date=DAY1)])
+    mfb.backup_money_flow(src_engine, dst_engine)
+    with src_engine.begin() as conn:
+        conn.execute(delete(_SRC).where(_SRC.c.data_date == DAY1))
+    _seed(src_engine, [_row(2, data_date=DAY1, captured_at=T2)])
+    mfb.backup_money_flow(src_engine, dst_engine)
+
+    r2 = mfb.backup_money_flow(src_engine, dst_engine)  # second run, no changes
+    assert r2.copied == 0
+    bt = mfb.backup_table()
+    assert _dst_ids(dst_engine, bt) == [2]
+    assert mfb.verify_backup(src_engine, dst_engine, run_max=2).ok
+
+
+def test_new_day_still_appends(src_engine, dst_engine):
+    """An unchanged old day + a brand-new day: only the new day is copied."""
+    mfb = _import()
+    _seed(src_engine, [_row(1, data_date=DAY1)])
+    mfb.backup_money_flow(src_engine, dst_engine)
+
+    _seed(src_engine, [_row(2, data_date=DAY2, captured_at=T_DAY2)])
+    result = mfb.backup_money_flow(src_engine, dst_engine)
+
+    bt = mfb.backup_table()
+    assert _dst_ids(dst_engine, bt) == [1, 2]
+    assert result.copied >= 1
+    assert mfb.verify_backup(src_engine, dst_engine, run_max=2).ok
+
+
+def test_day_shrunk_in_source_recopies_smaller(src_engine, dst_engine):
+    """A day that SHRANK in source (3 rows -> 1 row, same/lower max-id) is a
+    backup-only-larger day MAX(id) can't detect — the reconcile must still purge
+    the dropped rows."""
+    mfb = _import()
+    _seed(src_engine, [_row(1), _row(2), _row(3)])
+    mfb.backup_money_flow(src_engine, dst_engine)
+    bt = mfb.backup_table()
+    assert _dst_ids(dst_engine, bt) == [1, 2, 3]
+
+    # Rebuild day1 smaller: keep only id=1 (delete 2,3), bump its captured_at.
+    with src_engine.begin() as conn:
+        conn.execute(delete(_SRC).where(_SRC.c.id.in_([2, 3])))
+        conn.execute(
+            _SRC.update().where(_SRC.c.id == 1).values(captured_at=T2)
+        )
+
+    mfb.backup_money_flow(src_engine, dst_engine)
+    assert _dst_ids(dst_engine, bt) == [1], "dropped rows 2,3 must be purged from backup"
+    assert mfb.verify_backup(src_engine, dst_engine, run_max=3).ok
+
+
+def test_day_gone_to_zero_left_deleted(src_engine, dst_engine):
+    """If a whole day disappears from source, the backup day is left deleted."""
+    mfb = _import()
+    _seed(src_engine, [_row(1, data_date=DAY1), _row(2, data_date=DAY2, captured_at=T_DAY2)])
+    mfb.backup_money_flow(src_engine, dst_engine)
+
+    with src_engine.begin() as conn:
+        conn.execute(delete(_SRC).where(_SRC.c.data_date == DAY1))
+
+    mfb.backup_money_flow(src_engine, dst_engine)
+    bt = mfb.backup_table()
+    assert _dst_ids(dst_engine, bt) == [2], "DAY1 rows must be purged from backup"
+    assert mfb.verify_backup(src_engine, dst_engine, run_max=2).ok

--- a/tests/test_db_money_flow_backup_reconcile.py
+++ b/tests/test_db_money_flow_backup_reconcile.py
@@ -219,3 +219,59 @@ def test_day_gone_to_zero_left_deleted(src_engine, dst_engine):
     bt = mfb.backup_table()
     assert _dst_ids(dst_engine, bt) == [2], "DAY1 rows must be purged from backup"
     assert mfb.verify_backup(src_engine, dst_engine, run_max=2).ok
+
+
+def test_concurrent_rebuild_does_not_purge_day_from_backup(src_engine, dst_engine):
+    """Codex P1 regression — a same-day rebuild landing AFTER the source snapshot
+    must NOT cause the day to be purged from the backup.
+
+    Day1 (ids 1,2) is backed up. Then, via the `after_run_max` race hook, we
+    simulate WS A rebuilding day1 (delete 1,2 -> insert 3,4) the instant after the
+    reconcile captured the source snapshot. The reconcile read run_max + src_rows
+    from one consistent snapshot, so it still sees {1,2}; the backup must keep the
+    day (NOT delete it and write nothing), and the rebuild is reconciled next run."""
+    mfb = _import()
+    _seed(src_engine, [_row(1), _row(2)])
+    mfb.backup_money_flow(src_engine, dst_engine)
+    bt = mfb.backup_table()
+    assert _dst_ids(dst_engine, bt) == [1, 2]
+
+    def _rebuild_after_snapshot(stage: str) -> None:
+        if stage == "after_run_max":
+            with src_engine.begin() as conn:
+                conn.execute(delete(_SRC).where(_SRC.c.data_date == DAY1))
+            _seed(
+                src_engine,
+                [_row(3, captured_at=T2, capture_session="midday"),
+                 _row(4, captured_at=T2, capture_session="midday")],
+            )
+
+    mfb.backup_money_flow(src_engine, dst_engine, _race_hook=_rebuild_after_snapshot)
+    assert _dst_ids(dst_engine, bt) == [1, 2], "day must not be purged on a torn read"
+
+    # Next run sees the rebuilt day whole and reconciles to {3,4}, still green.
+    mfb.backup_money_flow(src_engine, dst_engine)
+    assert _dst_ids(dst_engine, bt) == [3, 4]
+    assert mfb.verify_backup(src_engine, dst_engine, run_max=4).ok
+
+
+def test_deleted_latest_day_with_high_ids_is_purged(src_engine, dst_engine):
+    """Codex P2 regression — when the deleted day held the HIGHEST ids, dropping it
+    lowers run_max below those ids. The backup-only day must still be purged.
+
+    day1=id1, day2=id2 backed up. Delete day2 (the high-id day) from source ->
+    next run_max=1. The reconcile reads the FULL backup (uncapped), sees day2 only
+    in the backup, and purges it; verify at the lowered run_max is green."""
+    mfb = _import()
+    _seed(src_engine, [_row(1, data_date=DAY1), _row(2, data_date=DAY2, captured_at=T_DAY2)])
+    mfb.backup_money_flow(src_engine, dst_engine)
+    bt = mfb.backup_table()
+    assert _dst_ids(dst_engine, bt) == [1, 2]
+
+    with src_engine.begin() as conn:
+        conn.execute(delete(_SRC).where(_SRC.c.data_date == DAY2))  # drop the high-id day
+
+    result = mfb.backup_money_flow(src_engine, dst_engine)
+    assert result.run_max == 1, "run_max drops to the remaining max source id"
+    assert _dst_ids(dst_engine, bt) == [1], "deleted high-id day must be purged from backup"
+    assert mfb.verify_backup(src_engine, dst_engine, run_max=1).ok

--- a/tests/test_db_money_flow_backup_reconcile.py
+++ b/tests/test_db_money_flow_backup_reconcile.py
@@ -206,12 +206,11 @@ def test_day_shrunk_in_source_recopies_smaller(src_engine, dst_engine):
     assert mfb.verify_backup(src_engine, dst_engine, run_max=3).ok
 
 
-def test_day_lost_in_source_is_retained_in_backup(src_engine, dst_engine):
-    """Codex P1 regression — a historical day the SOURCE lost (bad restore, manual
-    cleanup, corruption) must be RETAINED in the backup, NOT purged. The off-site
-    copy is disaster recovery; it never propagates a source-side delete. verify
-    stays green because it asserts the backup is a content-faithful SUPERSET of the
-    source, not an exact mirror."""
+def test_day_lost_in_source_is_retained_but_verify_alarms(src_engine, dst_engine):
+    """Codex P1 — a historical day the SOURCE lost (bad restore, manual cleanup,
+    corruption) is RETAINED in the backup (never propagate a source-side delete),
+    AND verify ALARMS the source-side loss loudly (check e). The backup data is
+    safe; the alarm tells the operator the source diverged so they investigate."""
     mfb = _import()
     _seed(src_engine, [_row(1, data_date=DAY1), _row(2, data_date=DAY2, captured_at=T_DAY2)])
     mfb.backup_money_flow(src_engine, dst_engine)
@@ -222,7 +221,30 @@ def test_day_lost_in_source_is_retained_in_backup(src_engine, dst_engine):
     mfb.backup_money_flow(src_engine, dst_engine)
     bt = mfb.backup_table()
     assert _dst_ids(dst_engine, bt) == [1, 2], "lost DAY1 must be retained in the backup"
-    assert mfb.verify_backup(src_engine, dst_engine, run_max=2).ok
+    report = mfb.verify_backup(src_engine, dst_engine, run_max=2)
+    assert not report.ok, "verify must alarm the source-side data loss"
+    assert any("absent from the SOURCE" in f for f in report.failures)
+
+
+def test_partial_row_loss_in_source_retained_and_alarmed(src_engine, dst_engine):
+    """Codex P1 — the source loses SOME rows of a generation without a newer
+    captured_at (ids {1,3} survive, id 2 dropped). The backup retains all of
+    {1,2,3} (non-destructive) and verify ALARMS that the source dropped id 2."""
+    mfb = _import()
+    _seed(src_engine, [_row(1), _row(2), _row(3)])
+    mfb.backup_money_flow(src_engine, dst_engine)
+    bt = mfb.backup_table()
+    assert _dst_ids(dst_engine, bt) == [1, 2, 3]
+
+    # Source drops id 2 in place (same captured_at — not a rebuild).
+    with src_engine.begin() as conn:
+        conn.execute(delete(_SRC).where(_SRC.c.id == 2))
+
+    mfb.backup_money_flow(src_engine, dst_engine)
+    assert _dst_ids(dst_engine, bt) == [1, 2, 3], "dropped id 2 retained in backup"
+    report = mfb.verify_backup(src_engine, dst_engine, run_max=3)
+    assert not report.ok, "verify must alarm the partial source-side loss"
+    assert any("absent from the SOURCE" in f for f in report.failures)
 
 
 def test_concurrent_rebuild_does_not_purge_day_from_backup(src_engine, dst_engine):

--- a/tests/test_db_money_flow_backup_reconcile.py
+++ b/tests/test_db_money_flow_backup_reconcile.py
@@ -206,8 +206,12 @@ def test_day_shrunk_in_source_recopies_smaller(src_engine, dst_engine):
     assert mfb.verify_backup(src_engine, dst_engine, run_max=3).ok
 
 
-def test_day_gone_to_zero_left_deleted(src_engine, dst_engine):
-    """If a whole day disappears from source, the backup day is left deleted."""
+def test_day_lost_in_source_is_retained_in_backup(src_engine, dst_engine):
+    """Codex P1 regression — a historical day the SOURCE lost (bad restore, manual
+    cleanup, corruption) must be RETAINED in the backup, NOT purged. The off-site
+    copy is disaster recovery; it never propagates a source-side delete. verify
+    stays green because it asserts the backup is a content-faithful SUPERSET of the
+    source, not an exact mirror."""
     mfb = _import()
     _seed(src_engine, [_row(1, data_date=DAY1), _row(2, data_date=DAY2, captured_at=T_DAY2)])
     mfb.backup_money_flow(src_engine, dst_engine)
@@ -217,7 +221,7 @@ def test_day_gone_to_zero_left_deleted(src_engine, dst_engine):
 
     mfb.backup_money_flow(src_engine, dst_engine)
     bt = mfb.backup_table()
-    assert _dst_ids(dst_engine, bt) == [2], "DAY1 rows must be purged from backup"
+    assert _dst_ids(dst_engine, bt) == [1, 2], "lost DAY1 must be retained in the backup"
     assert mfb.verify_backup(src_engine, dst_engine, run_max=2).ok
 
 
@@ -255,13 +259,14 @@ def test_concurrent_rebuild_does_not_purge_day_from_backup(src_engine, dst_engin
     assert mfb.verify_backup(src_engine, dst_engine, run_max=4).ok
 
 
-def test_deleted_latest_day_with_high_ids_is_purged(src_engine, dst_engine):
-    """Codex P2 regression — when the deleted day held the HIGHEST ids, dropping it
-    lowers run_max below those ids. The backup-only day must still be purged.
+def test_deleted_latest_day_with_high_ids_is_retained(src_engine, dst_engine):
+    """When the day the source lost held the HIGHEST ids, dropping it lowers
+    run_max below those ids. The backup retains that day (non-destructive
+    invariant); the retained ids sit ABOVE the lowered run_max so verify — bounded
+    to id<=run_max — stays green.
 
     day1=id1, day2=id2 backed up. Delete day2 (the high-id day) from source ->
-    next run_max=1. The reconcile reads the FULL backup (uncapped), sees day2 only
-    in the backup, and purges it; verify at the lowered run_max is green."""
+    next run_max=1. day2 is backup-only -> retained, not purged."""
     mfb = _import()
     _seed(src_engine, [_row(1, data_date=DAY1), _row(2, data_date=DAY2, captured_at=T_DAY2)])
     mfb.backup_money_flow(src_engine, dst_engine)
@@ -273,7 +278,7 @@ def test_deleted_latest_day_with_high_ids_is_purged(src_engine, dst_engine):
 
     result = mfb.backup_money_flow(src_engine, dst_engine)
     assert result.run_max == 1, "run_max drops to the remaining max source id"
-    assert _dst_ids(dst_engine, bt) == [1], "deleted high-id day must be purged from backup"
+    assert _dst_ids(dst_engine, bt) == [1, 2], "lost high-id day must be retained in backup"
     assert mfb.verify_backup(src_engine, dst_engine, run_max=1).ok
 
 

--- a/tests/test_db_money_flow_backup_reconcile.py
+++ b/tests/test_db_money_flow_backup_reconcile.py
@@ -303,6 +303,7 @@ def test_empty_source_does_not_wipe_backup(src_engine, dst_engine):
     result = mfb.backup_money_flow(src_engine, dst_engine)
     assert result.copied == 0
     assert result.run_max == 0
+    assert result.source_empty is True, "empty source must be flagged for a loud CLI exit"
     assert _dst_ids(dst_engine, bt) == [1, 2], "empty source must NOT wipe the backup"
 
 

--- a/tests/test_llm_thesis/signals/test_sector_momentum.py
+++ b/tests/test_llm_thesis/signals/test_sector_momentum.py
@@ -90,3 +90,70 @@ def test_render_for_prompt():
     )
     assert "Technology" in out
     assert "+0.61" in out
+
+
+def test_date_probe_skips_later_non_qu100_board():
+    """Codex P2 regression — the max(data_date) probes are scoped to the QU100
+    books. A NEWER non-QU100 board (concept) on a later date must NOT advance
+    ``latest_date`` past the last QU100 day, or analyze_sectors_at's
+    "latest QU100 day <= as_of" fallback would serve a stale day's sentiment as
+    current. The probe must resolve to the QU100 day, not the concept day."""
+    from sqlalchemy import create_engine, text
+    from sqlalchemy.orm import sessionmaker
+
+    from rainier.core.models import MoneyFlowSnapshot
+
+    ddl = """
+    CREATE TABLE money_flow_snapshots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      captured_at TIMESTAMP NOT NULL, capture_session VARCHAR(20) NOT NULL,
+      data_date DATE NOT NULL, view_type VARCHAR(10) NOT NULL DEFAULT 'daily',
+      ranking_type VARCHAR(10) NOT NULL, symbol VARCHAR(10) NOT NULL,
+      rank INTEGER NOT NULL, daily_change INTEGER, sector VARCHAR(100),
+      industry VARCHAR(200), long_short VARCHAR(50), raw_data JSON
+    );
+    """
+    engine = create_engine("sqlite://", future=True)
+    with engine.begin() as conn:
+        conn.execute(text(ddl.strip()))
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    cap = datetime(2026, 5, 7, 20, 0, tzinfo=timezone.utc)
+    with factory() as s:
+        # Last QU100 day is May 6; a NEWER 'concept' board lands May 7 (== scan_date).
+        # WITHOUT the QU100 scope the probe would pick May 7 (concept) and
+        # analyze_sectors_at would serve the stale May 6 book as "today". With the
+        # scope the probe correctly resolves to May 6.
+        s.add_all([
+            MoneyFlowSnapshot(captured_at=cap, capture_session="afternoon",
+                              data_date=date(2026, 5, 6), ranking_type="top100",
+                              symbol="NVDA", rank=1, sector="Technology",
+                              long_short="Long in"),
+            MoneyFlowSnapshot(captured_at=cap, capture_session="afternoon",
+                              data_date=date(2026, 5, 7), ranking_type="concept",
+                              symbol="ZZZ", rank=1, sector="Materials",
+                              long_short="Long in"),
+        ])
+        s.commit()
+
+    captured_as_of: list = []
+
+    def _spy_analyze(as_of, session=None):
+        captured_as_of.append(as_of)
+        return [_trend("Technology", 0.5)]
+
+    cm = MagicMock()
+    cm.__enter__.return_value = factory()
+    cm.__exit__.return_value = False
+    sig = SectorMomentumSignal()
+    with patch(
+        "rainier.llm_thesis.signals.sector_momentum.get_session", return_value=cm,
+    ), patch(
+        "rainier.analysis.sector_analyzer.analyze_sectors_at", side_effect=_spy_analyze,
+    ):
+        sig.compute(_ctx())
+
+    # latest_date probe must resolve to the QU100 day (May 6), never the later
+    # concept row (May 7) — a non-QU100 board can't drive the as-of date.
+    assert captured_as_of, "analyze_sectors_at should have been called for today"
+    assert captured_as_of[0] == date(2026, 5, 6)
+    engine.dispose()

--- a/tests/test_pipeline/test_post_scrape.py
+++ b/tests/test_pipeline/test_post_scrape.py
@@ -560,6 +560,46 @@ class TestCliDelegation:
         mock_pipeline.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_cli_run_pipeline_forces_pipeline_for_single_day_recovery(self):
+        """Codex P1 regression — ``recover`` pins the scrape to the stale day
+        (dates=<today>) so it CANNOT pass dates=None, but must still restore the
+        derived outputs (screened_stocks / LLM theses / candidate alert). The
+        ``run_pipeline=True`` flag forces the post-scrape pipeline even with a
+        date_list set, so a recovered day is not left with only the raw snapshot."""
+        from unittest.mock import AsyncMock
+
+        mock_result = MagicMock(records_created=200, errors=[], duration_seconds=1.0)
+        mock_scraper = AsyncMock()
+        mock_scraper.execute = AsyncMock(return_value=mock_result)
+        settings = _make_settings()
+
+        with (
+            patch("rainier.scrapers.browser.BrowserManager") as MockBM,
+            patch("rainier.scrapers.get_scraper", return_value=mock_scraper),
+            patch("rainier.core.config.get_settings", return_value=settings),
+            patch("rainier.cli.run_post_scrape_pipeline") as mock_pipeline,
+        ):
+            MockBM.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+            MockBM.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            from rainier.cli import _run_qu_scrape
+
+            await _run_qu_scrape(
+                session="afternoon",
+                detail_top=0,
+                dates="2026-05-22",  # pinned single day (recover targets `today`)
+                days_back=0,
+                start_date=None,
+                delay=None,
+                headed=False,
+                cdp=None,
+                run_pipeline=True,
+            )
+
+        # Date pinned, but run_pipeline=True -> pipeline STILL runs for the day.
+        mock_pipeline.assert_called_once_with(settings, "afternoon")
+
+    @pytest.mark.asyncio
     async def test_cli_pipeline_runs_in_thread_so_inner_asyncio_run_is_safe(
         self,
     ):

--- a/tests/test_pipeline/test_post_scrape.py
+++ b/tests/test_pipeline/test_post_scrape.py
@@ -560,12 +560,11 @@ class TestCliDelegation:
         mock_pipeline.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_cli_run_pipeline_forces_pipeline_for_single_day_recovery(self):
-        """Codex P1 regression — ``recover`` pins the scrape to the stale day
-        (dates=<today>) so it CANNOT pass dates=None, but must still restore the
-        derived outputs (screened_stocks / LLM theses / candidate alert). The
-        ``run_pipeline=True`` flag forces the post-scrape pipeline even with a
-        date_list set, so a recovered day is not left with only the raw snapshot."""
+    async def test_cli_pinned_date_keeps_inline_pipeline_off(self):
+        """``recover`` pins the scrape to the stale day (dates=<today>), so
+        _run_qu_scrape's INLINE pipeline stays OFF — recover runs the pipeline
+        itself, gated on restored two-book freshness, so a stale half-book can't
+        fire screener/LLM/candidate output inline (Codex P1)."""
         from unittest.mock import AsyncMock
 
         mock_result = MagicMock(records_created=200, errors=[], duration_seconds=1.0)
@@ -593,11 +592,10 @@ class TestCliDelegation:
                 delay=None,
                 headed=False,
                 cdp=None,
-                run_pipeline=True,
             )
 
-        # Date pinned, but run_pipeline=True -> pipeline STILL runs for the day.
-        mock_pipeline.assert_called_once_with(settings, "afternoon")
+        # Date pinned -> inline pipeline must NOT run (recover gates it separately).
+        mock_pipeline.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_cli_pipeline_runs_in_thread_so_inner_asyncio_run_is_safe(

--- a/tests/test_pipeline/test_post_scrape.py
+++ b/tests/test_pipeline/test_post_scrape.py
@@ -327,6 +327,38 @@ class TestSlicing:
         assert len(mock_discord.call_args.args[0]) == 20
         assert len(mock_llm.call_args.args[0]) == 5
 
+    def test_explicit_scan_date_stamps_persisted_artifacts(self):
+        """Codex P1 regression — an explicit ``scan_date`` (recover passes the
+        RECOVERED trading day) is threaded to persist_screened_stocks AND
+        compute_theses_and_persist, so a post-midnight / cross-tz replay stamps
+        derived rows with the day the data is from, not date.today()."""
+        from datetime import date
+
+        recovered_day = date(2026, 5, 22)
+        cands = _candidates(10)
+        settings = _make_settings()
+
+        with (
+            patch(
+                "rainier.pipeline.post_scrape.screen_stocks",
+                return_value=(cands, {}),
+            ),
+            patch(
+                "rainier.pipeline.post_scrape.persist_screened_stocks"
+            ) as mock_persist,
+            patch(
+                "rainier.pipeline.post_scrape.compute_theses_and_persist",
+                return_value={},
+            ) as mock_llm,
+            patch("rainier.pipeline.post_scrape.send_stock_candidates"),
+        ):
+            from rainier.pipeline.post_scrape import run_post_scrape_pipeline
+
+            run_post_scrape_pipeline(settings, "afternoon", recovered_day)
+
+        assert mock_persist.call_args.kwargs["scan_date"] == recovered_day
+        assert mock_llm.call_args.kwargs["scan_date"] == recovered_day
+
     def test_fewer_than_5_candidates_llm_sees_all(self):
         cands = _candidates(3)
         settings = _make_settings()

--- a/tests/test_scrapers/test_persist_qu100_rebuild.py
+++ b/tests/test_scrapers/test_persist_qu100_rebuild.py
@@ -1,0 +1,236 @@
+"""WS A — `_persist_qu100` rebuilds the day's snapshot (override + carry-forward).
+
+Of the 4 daily QU100 scrapes only the first persisted: a skip-guard keyed on
+`(data_date, ranking_type)` (without `captured_at`) no-op'd every later scrape,
+so the screener re-posted frozen morning dominance all day. The fix makes every
+non-empty later scrape REBUILD that day's `(data_date, ranking_type)` snapshot:
+
+  * symbols the scrape returns are OVERRIDDEN with fresh values,
+  * symbols missing from the scrape are CARRIED FORWARD (last data, original
+    `capture_session`),
+  * the whole day's rows are re-stamped with the latest scrape's `captured_at`
+    (ONE generation per `(data_date, ranking_type)`),
+  * an empty scrape (0 rows) is a no-op (never wipes a good snapshot).
+
+Logic-lane harness: SQLite bound to the legacy `core.database` singleton. The
+real prod table is a TimescaleDB hypertable with a composite PK `(id,
+captured_at)`; here `id` is a single-column autoincrement PK (the composite is a
+hypertable artifact, irrelevant to the rebuild logic) so the ORM autoincrement
+that `_persist_qu100` relies on works on SQLite.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from rainier.core.models import MoneyFlowSnapshot
+from rainier.scrapers.qu.parsers import QU100Row
+from rainier.scrapers.qu.scraper import QUScraper
+
+# Hand-DDL so SQLite gets a rowid-alias autoincrement `id` (composite-PK
+# autoincrement is unsupported on SQLite and is a hypertable-only artifact).
+_DDL = """
+CREATE TABLE stocks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  symbol VARCHAR(10) NOT NULL UNIQUE,
+  name VARCHAR(255), sector VARCHAR(100), industry VARCHAR(200),
+  is_active BOOLEAN DEFAULT 1,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE money_flow_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  captured_at TIMESTAMP NOT NULL,
+  capture_session VARCHAR(20) NOT NULL,
+  data_date DATE NOT NULL,
+  view_type VARCHAR(10) NOT NULL DEFAULT 'daily',
+  ranking_type VARCHAR(10) NOT NULL,
+  symbol VARCHAR(10) NOT NULL REFERENCES stocks(symbol),
+  rank INTEGER NOT NULL,
+  daily_change INTEGER, sector VARCHAR(100), industry VARCHAR(200),
+  long_short VARCHAR(50), raw_data JSON
+);
+"""
+
+DAY = date(2026, 6, 1)
+T1 = datetime(2026, 6, 1, 15, 45, tzinfo=timezone.utc)  # morning
+T2 = datetime(2026, 6, 1, 17, 45, tzinfo=timezone.utc)  # midday
+T3 = datetime(2026, 6, 1, 22, 0, tzinfo=timezone.utc)  # close
+
+
+@pytest.fixture
+def sqlite_session_factory():
+    """SQLite engine + factory bound onto the legacy `core.database` singleton.
+
+    Never touches a provided URL / `public.*` (shared-DB-clobber learning): a
+    fresh in-memory DB per test.
+    """
+    from rainier.core import config, database
+
+    engine = create_engine("sqlite://", future=True)
+    with engine.begin() as conn:
+        for stmt in _DDL.strip().split(";"):
+            if stmt.strip():
+                conn.execute(text(stmt))
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+
+    prev_engine = database._engine
+    prev_factory = database._session_factory
+    prev_settings = config._settings
+    database._engine = engine
+    database._session_factory = factory
+    try:
+        yield factory
+    finally:
+        database._engine = prev_engine
+        database._session_factory = prev_factory
+        config._settings = prev_settings
+        engine.dispose()
+
+
+def _row(symbol: str, rank: int, long_short: str, sector: str = "Technology") -> QU100Row:
+    return QU100Row(
+        rank=rank,
+        symbol=symbol,
+        daily_change=rank,
+        sector=sector,
+        industry="Software",
+        long_short=long_short,
+        raw={"ticker": symbol, "rank": rank, "long_short": long_short},
+    )
+
+
+def _scraper() -> QUScraper:
+    """A QUScraper with just the logging attr `_persist_qu100` touches."""
+    import structlog
+
+    scraper = QUScraper.__new__(QUScraper)
+    scraper.log = structlog.get_logger().bind(scraper="qu")
+    return scraper
+
+
+def _snapshots(factory, ranking_type: str = "top100") -> list[MoneyFlowSnapshot]:
+    with factory() as s:
+        rows = (
+            s.query(MoneyFlowSnapshot)
+            .filter(MoneyFlowSnapshot.ranking_type == ranking_type)
+            .order_by(MoneyFlowSnapshot.symbol)
+            .all()
+        )
+        # detach so attribute access survives the closed session
+        for r in rows:
+            s.expunge(r)
+        return rows
+
+
+def _naive(dt: datetime) -> datetime:
+    """SQLite stores datetimes naive; compare on UTC wall-clock without tzinfo."""
+    return dt.replace(tzinfo=None)
+
+
+def test_override_full_flip(sqlite_session_factory):
+    """A→B full scrape where LLY flips Long-in→No-dominance keeps ONE LLY row."""
+    scraper = _scraper()
+    scraper._persist_qu100(
+        [_row("LLY", 1, "Long in"), _row("NVDA", 2, "Long in")],
+        "top100", "morning", T1, DAY,
+    )
+    scraper._persist_qu100(
+        [_row("LLY", 5, "No dominance"), _row("NVDA", 2, "Long in")],
+        "top100", "midday", T2, DAY,
+    )
+
+    rows = _snapshots(sqlite_session_factory)
+    by_symbol = {r.symbol: r for r in rows}
+    assert set(by_symbol) == {"LLY", "NVDA"}
+    # exactly one LLY row, holding the SECOND value
+    assert sum(1 for r in rows if r.symbol == "LLY") == 1
+    assert by_symbol["LLY"].long_short == "No dominance"
+    assert by_symbol["LLY"].rank == 5
+    # whole day re-stamped to the latest scrape's captured_at
+    assert all(_naive(r.captured_at) == _naive(T2) for r in rows)
+    assert by_symbol["LLY"].capture_session == "midday"
+
+
+def test_carry_forward_partial(sqlite_session_factory):
+    """A{X,Y}@T1 → B{X}@T2: X fresh@T2; Y carried (old data, captured_at=T2,
+    capture_session still Y's original); neither dropped."""
+    scraper = _scraper()
+    scraper._persist_qu100(
+        [_row("X", 1, "Long in"), _row("Y", 2, "Short in")],
+        "top100", "morning", T1, DAY,
+    )
+    scraper._persist_qu100(
+        [_row("X", 3, "No dominance")],
+        "top100", "midday", T2, DAY,
+    )
+
+    rows = _snapshots(sqlite_session_factory)
+    by_symbol = {r.symbol: r for r in rows}
+    assert set(by_symbol) == {"X", "Y"}, "carry-forward must not drop Y"
+
+    # X overridden with fresh data + this session
+    assert by_symbol["X"].long_short == "No dominance"
+    assert by_symbol["X"].rank == 3
+    assert by_symbol["X"].capture_session == "midday"
+
+    # Y carried: OLD data preserved, but re-stamped captured_at=T2 and KEEPS its
+    # original capture_session (truthful per row).
+    assert by_symbol["Y"].long_short == "Short in"
+    assert by_symbol["Y"].rank == 2
+    assert by_symbol["Y"].capture_session == "morning"
+
+    # one generation: the whole day shares the latest captured_at.
+    assert all(_naive(r.captured_at) == _naive(T2) for r in rows)
+
+
+def test_empty_scrape_is_noop(sqlite_session_factory):
+    """A(2 rows) → C(0 rows): C is a no-op; A snapshot intact."""
+    scraper = _scraper()
+    scraper._persist_qu100(
+        [_row("LLY", 1, "Long in"), _row("NVDA", 2, "Long in")],
+        "top100", "morning", T1, DAY,
+    )
+    returned = scraper._persist_qu100([], "top100", "close", T3, DAY)
+
+    assert returned == 0
+    rows = _snapshots(sqlite_session_factory)
+    by_symbol = {r.symbol: r for r in rows}
+    assert set(by_symbol) == {"LLY", "NVDA"}
+    # snapshot UNTOUCHED — still morning's captured_at, never re-stamped to T3.
+    assert all(_naive(r.captured_at) == _naive(T1) for r in rows)
+    assert by_symbol["LLY"].capture_session == "morning"
+
+
+def test_one_row_per_symbol_after_rebuild(sqlite_session_factory):
+    """Three consecutive scrapes never accumulate duplicate symbol rows."""
+    scraper = _scraper()
+    for ts, sess in ((T1, "morning"), (T2, "midday"), (T3, "close")):
+        scraper._persist_qu100(
+            [_row("LLY", 1, "Long in"), _row("NVDA", 2, "Long in")],
+            "top100", sess, ts, DAY,
+        )
+    rows = _snapshots(sqlite_session_factory)
+    assert len(rows) == 2  # one row per symbol, not 6
+    assert all(_naive(r.captured_at) == _naive(T3) for r in rows)
+
+
+def test_ranking_types_rebuilt_independently(sqlite_session_factory):
+    """top100 and bottom100 are merged independently; rebuilding one leaves the
+    other's snapshot at its own captured_at."""
+    scraper = _scraper()
+    scraper._persist_qu100([_row("AAA", 1, "Long in")], "top100", "morning", T1, DAY)
+    scraper._persist_qu100([_row("ZZZ", 1, "Short in")], "bottom100", "morning", T1, DAY)
+    # only top100 advances at T2
+    scraper._persist_qu100([_row("AAA", 2, "No dominance")], "top100", "midday", T2, DAY)
+
+    top = _snapshots(sqlite_session_factory, "top100")
+    bottom = _snapshots(sqlite_session_factory, "bottom100")
+    assert [_naive(r.captured_at) for r in top] == [_naive(T2)]
+    assert top[0].long_short == "No dominance"
+    assert [_naive(r.captured_at) for r in bottom] == [_naive(T1)]  # untouched
+    assert bottom[0].symbol == "ZZZ"

--- a/tests/test_scrapers/test_persist_qu100_rebuild.py
+++ b/tests/test_scrapers/test_persist_qu100_rebuild.py
@@ -1,16 +1,28 @@
-"""WS A — `_persist_qu100` rebuilds the day's snapshot (override + carry-forward).
+"""WS A — `_persist_qu100` rebuilds the day's snapshot by RANK slot.
 
 Of the 4 daily QU100 scrapes only the first persisted: a skip-guard keyed on
 `(data_date, ranking_type)` (without `captured_at`) no-op'd every later scrape,
 so the screener re-posted frozen morning dominance all day. The fix makes every
-non-empty later scrape REBUILD that day's `(data_date, ranking_type)` snapshot:
+non-empty later scrape REBUILD that day's `(data_date, ranking_type)` snapshot
+keyed on the RANK SLOT (1..100), NOT the symbol:
 
-  * symbols the scrape returns are OVERRIDDEN with fresh values,
-  * symbols missing from the scrape are CARRIED FORWARD (last data, original
-    `capture_session`),
+  * the batch is first CANONICALIZED — out-of-range ranks dropped, a duplicate
+    symbol or duplicate rank collapsed to one row (the cohort reader has no dedup
+    of its own, so this is the only guard against a glitched API response),
+  * ranks the scrape returns are OVERRIDDEN with fresh values,
+  * ranks MISSING from the scrape carry forward the prior occupant (last data,
+    original `capture_session`, the new `captured_at`),
+  * a carried slot whose symbol was freshly scraped at ANOTHER rank is DROPPED —
+    fresh wins; that rank is left unfilled (dedup by symbol),
   * the whole day's rows are re-stamped with the latest scrape's `captured_at`
     (ONE generation per `(data_date, ranking_type)`),
   * an empty scrape (0 rows) is a no-op (never wipes a good snapshot).
+
+Because carry-forward is rank-keyed, a FULL scrape overrides every slot, so a
+stock that fell out of the top 100 holds no rank and disappears — the cohort
+stays <=100 with no fallen-out members. The reader contract is therefore
+"<=100, rank-ordered, current as of the latest full scrape", NOT an
+unconditional exactly-100 (a legal partial/dedup-gap generation can be <100).
 
 Logic-lane harness: SQLite bound to the legacy `core.database` singleton. The
 real prod table is a TimescaleDB hypertable with a composite PK `(id,
@@ -92,7 +104,7 @@ def sqlite_session_factory():
         engine.dispose()
 
 
-def _row(symbol: str, rank: int, long_short: str, sector: str = "Technology") -> QU100Row:
+def _row(symbol: str, rank: int, long_short: str = "Long in", sector: str = "Technology") -> QU100Row:
     return QU100Row(
         rank=rank,
         symbol=symbol,
@@ -118,7 +130,7 @@ def _snapshots(factory, ranking_type: str = "top100") -> list[MoneyFlowSnapshot]
         rows = (
             s.query(MoneyFlowSnapshot)
             .filter(MoneyFlowSnapshot.ranking_type == ranking_type)
-            .order_by(MoneyFlowSnapshot.symbol)
+            .order_by(MoneyFlowSnapshot.rank)
             .all()
         )
         # detach so attribute access survives the closed session
@@ -132,6 +144,9 @@ def _naive(dt: datetime) -> datetime:
     return dt.replace(tzinfo=None)
 
 
+# --- Acceptance 1: flip override (full) ------------------------------------
+
+
 def test_override_full_flip(sqlite_session_factory):
     """A→B full scrape where LLY flips Long-in→No-dominance keeps ONE LLY row."""
     scraper = _scraper()
@@ -140,52 +155,203 @@ def test_override_full_flip(sqlite_session_factory):
         "top100", "morning", T1, DAY,
     )
     scraper._persist_qu100(
-        [_row("LLY", 5, "No dominance"), _row("NVDA", 2, "Long in")],
+        [_row("LLY", 1, "No dominance"), _row("NVDA", 2, "Long in")],
         "top100", "midday", T2, DAY,
     )
 
     rows = _snapshots(sqlite_session_factory)
     by_symbol = {r.symbol: r for r in rows}
     assert set(by_symbol) == {"LLY", "NVDA"}
-    # exactly one LLY row, holding the SECOND value
     assert sum(1 for r in rows if r.symbol == "LLY") == 1
     assert by_symbol["LLY"].long_short == "No dominance"
-    assert by_symbol["LLY"].rank == 5
+    assert by_symbol["LLY"].rank == 1
     # whole day re-stamped to the latest scrape's captured_at
     assert all(_naive(r.captured_at) == _naive(T2) for r in rows)
     assert by_symbol["LLY"].capture_session == "midday"
 
 
-def test_carry_forward_partial(sqlite_session_factory):
-    """A{X,Y}@T1 → B{X}@T2: X fresh@T2; Y carried (old data, captured_at=T2,
-    capture_session still Y's original); neither dropped."""
+# --- Acceptance 2a: dropout on a FULL scrape + cohort end-to-end ------------
+
+
+def test_dropout_on_full_scrape_cohort(sqlite_session_factory):
+    """A fallen-out stock holds no rank on a full scrape and disappears.
+
+    Load-bearing: `get_current_qu100_cohort` has NO dedup/LIMIT of its own — the
+    rank-keyed rebuild is the sole guarantor of <=100 / no fallen-out members.
+    """
+    from rainier.paper.ingest import get_current_qu100_cohort
+
     scraper = _scraper()
+    # A: ranks 1..3, Z occupies rank 3.
     scraper._persist_qu100(
-        [_row("X", 1, "Long in"), _row("Y", 2, "Short in")],
+        [_row("P", 1), _row("Q", 2), _row("Z", 3)],
         "top100", "morning", T1, DAY,
     )
+    # B full: rank 3 now W; Z fell out and holds no rank.
     scraper._persist_qu100(
-        [_row("X", 3, "No dominance")],
+        [_row("P", 1), _row("Q", 2), _row("W", 3)],
         "top100", "midday", T2, DAY,
     )
 
     rows = _snapshots(sqlite_session_factory)
-    by_symbol = {r.symbol: r for r in rows}
-    assert set(by_symbol) == {"X", "Y"}, "carry-forward must not drop Y"
+    symbols = {r.symbol for r in rows}
+    assert symbols == {"P", "Q", "W"}, "Z must NOT linger after a full scrape"
+    assert "Z" not in symbols
+    # one slot per rank, no fallen-out member; cohort = exactly the rebuilt set.
+    assert len(rows) == 3
+    assert all(_naive(r.captured_at) == _naive(T2) for r in rows)
 
-    # X overridden with fresh data + this session
-    assert by_symbol["X"].long_short == "No dominance"
-    assert by_symbol["X"].rank == 3
-    assert by_symbol["X"].capture_session == "midday"
+    cohort = get_current_qu100_cohort(DAY)
+    assert [c["symbol"] for c in cohort] == ["P", "Q", "W"]
+    assert len(cohort) == 3
+    assert "Z" not in {c["symbol"] for c in cohort}
 
-    # Y carried: OLD data preserved, but re-stamped captured_at=T2 and KEEPS its
+
+# --- Acceptance 2b: carry-forward across a partial gap ----------------------
+
+
+def test_carry_forward_partial_gap(sqlite_session_factory):
+    """B omits rank 2 (glitch) and changes rank 3: slot 2 carries A's stock
+    (old data, captured_at=T2, original capture_session); slots 1,3 override."""
+    scraper = _scraper()
+    scraper._persist_qu100(
+        [_row("X", 1, "Long in"), _row("Y", 2, "Short in"), _row("V", 3, "No dominance")],
+        "top100", "morning", T1, DAY,
+    )
+    # B: rank 1 overridden, rank 2 MISSING, rank 3 changed.
+    scraper._persist_qu100(
+        [_row("X", 1, "No dominance"), _row("V", 3, "Long in")],
+        "top100", "midday", T2, DAY,
+    )
+
+    rows = _snapshots(sqlite_session_factory)
+    by_rank = {r.rank: r for r in rows}
+    assert set(by_rank) == {1, 2, 3}
+
+    # slot 1 overridden with fresh data + this session
+    assert by_rank[1].symbol == "X"
+    assert by_rank[1].long_short == "No dominance"
+    assert by_rank[1].capture_session == "midday"
+
+    # slot 2 carried: OLD data preserved, re-stamped captured_at=T2, KEEPS its
     # original capture_session (truthful per row).
-    assert by_symbol["Y"].long_short == "Short in"
-    assert by_symbol["Y"].rank == 2
-    assert by_symbol["Y"].capture_session == "morning"
+    assert by_rank[2].symbol == "Y"
+    assert by_rank[2].long_short == "Short in"
+    assert by_rank[2].capture_session == "morning"
+
+    # slot 3 overridden
+    assert by_rank[3].symbol == "V"
+    assert by_rank[3].long_short == "Long in"
 
     # one generation: the whole day shares the latest captured_at.
     assert all(_naive(r.captured_at) == _naive(T2) for r in rows)
+
+
+# --- Acceptance 2c: symbol-moved dedup pins the "<100 acceptable" invariant --
+
+
+def test_symbol_moved_dedup_leaves_rank_unfilled(sqlite_session_factory):
+    """M moves rank 50→51 while rank 50 is omitted: M appears once (fresh at 51),
+    slot 50 is NOT a carried duplicate M, and the generation holds 99 rows."""
+    scraper = _scraper()
+    # A: full board ranks 1..100, M at rank 50.
+    a = [_row("M" if r == 50 else f"S{r}", r) for r in range(1, 101)]
+    scraper._persist_qu100(a, "top100", "morning", T1, DAY)
+
+    # B: ranks 1..49 + 51..100 (rank 50 omitted); M now at rank 51.
+    b = []
+    for r in range(1, 101):
+        if r == 50:
+            continue  # omitted gap
+        if r == 51:
+            b.append(_row("M", 51))  # M moved here (displaces original S51)
+        else:
+            b.append(_row(f"S{r}", r))
+    scraper._persist_qu100(b, "top100", "midday", T2, DAY)
+
+    rows = _snapshots(sqlite_session_factory)
+    by_rank = {r.rank: r for r in rows}
+    # 99 slots: rank 50 left unfilled (carried M dropped because fresh M wins @51).
+    assert len(rows) == 99
+    assert 50 not in by_rank
+    # M appears exactly once, at rank 51.
+    m_rows = [r for r in rows if r.symbol == "M"]
+    assert len(m_rows) == 1
+    assert m_rows[0].rank == 51
+    assert all(_naive(r.captured_at) == _naive(T2) for r in rows)
+
+
+# --- Acceptance 2d: first-ever scrape (no carry path) -----------------------
+
+
+def test_first_ever_scrape_plain_insert(sqlite_session_factory):
+    """No prior (data_date, ranking_type) rows -> plain insert, all fresh."""
+    scraper = _scraper()
+    n = scraper._persist_qu100(
+        [_row("A", 1), _row("B", 2), _row("C", 3)],
+        "top100", "morning", T1, DAY,
+    )
+    assert n == 3
+    rows = _snapshots(sqlite_session_factory)
+    assert {r.symbol for r in rows} == {"A", "B", "C"}
+    assert all(r.capture_session == "morning" for r in rows)
+    assert all(_naive(r.captured_at) == _naive(T1) for r in rows)
+
+
+# --- Acceptance 2e: degenerate prior (<100 ranks) carries without error -----
+
+
+def test_degenerate_prior_lt_100_carries(sqlite_session_factory):
+    """A prior generation with <100 ranks; a later partial scrape carries the
+    ranks that existed, with no error reading the short base."""
+    scraper = _scraper()
+    scraper._persist_qu100(
+        [_row("P", 1, "Long in"), _row("Q", 2, "Short in")],
+        "top100", "morning", T1, DAY,
+    )
+    # later partial scrape: rank 1 changed, rank 2 omitted.
+    scraper._persist_qu100(
+        [_row("P", 1, "No dominance")],
+        "top100", "midday", T2, DAY,
+    )
+    rows = _snapshots(sqlite_session_factory)
+    by_rank = {r.rank: r for r in rows}
+    assert set(by_rank) == {1, 2}
+    assert by_rank[1].long_short == "No dominance"
+    assert by_rank[2].symbol == "Q"  # carried
+    assert by_rank[2].capture_session == "morning"
+    assert all(_naive(r.captured_at) == _naive(T2) for r in rows)
+
+
+# --- Acceptance 2f: glitched batch is canonicalized -------------------------
+
+
+def test_glitched_batch_canonicalized(sqlite_session_factory):
+    """A batch with a duplicate symbol, a duplicate rank, and out-of-range ranks
+    is canonicalized so each symbol and each rank appears once and out-of-range
+    rows are dropped — the cohort cannot double-count."""
+    scraper = _scraper()
+    glitched = [
+        _row("DUP", 1),       # kept
+        _row("DUP", 2),       # dropped: symbol DUP already seen
+        _row("A3", 3),        # kept
+        _row("B3", 3),        # dropped: rank 3 already seen
+        _row("OOR0", 0),      # dropped: rank out of range (<1)
+        _row("OOR101", 101),  # dropped: rank out of range (>100)
+        _row("GOOD", 4),      # kept
+    ]
+    n = scraper._persist_qu100(glitched, "top100", "morning", T1, DAY)
+
+    rows = _snapshots(sqlite_session_factory)
+    ranks = sorted(r.rank for r in rows)
+    symbols = sorted(r.symbol for r in rows)
+    assert ranks == [1, 3, 4]  # no rank twice, no out-of-range rank
+    assert symbols == ["A3", "DUP", "GOOD"]  # DUP once, B3 dropped
+    assert len(rows) == 3
+    assert n == 3
+
+
+# --- Acceptance 3: empty scrape is a no-op ----------------------------------
 
 
 def test_empty_scrape_is_noop(sqlite_session_factory):
@@ -206,8 +372,25 @@ def test_empty_scrape_is_noop(sqlite_session_factory):
     assert by_symbol["LLY"].capture_session == "morning"
 
 
-def test_one_row_per_symbol_after_rebuild(sqlite_session_factory):
-    """Three consecutive scrapes never accumulate duplicate symbol rows."""
+def test_all_invalid_batch_is_noop(sqlite_session_factory):
+    """A batch whose every row is out-of-range canonicalizes to empty -> no-op
+    (never wipes a good snapshot with a fully-glitched pull)."""
+    scraper = _scraper()
+    scraper._persist_qu100([_row("LLY", 1, "Long in")], "top100", "morning", T1, DAY)
+    returned = scraper._persist_qu100(
+        [_row("BAD", 0), _row("WORSE", 200)], "top100", "close", T3, DAY
+    )
+    assert returned == 0
+    rows = _snapshots(sqlite_session_factory)
+    assert {r.symbol for r in rows} == {"LLY"}
+    assert all(_naive(r.captured_at) == _naive(T1) for r in rows)
+
+
+# --- Idempotence / independence --------------------------------------------
+
+
+def test_one_row_per_rank_after_rebuild(sqlite_session_factory):
+    """Three consecutive identical scrapes never accumulate duplicate rows."""
     scraper = _scraper()
     for ts, sess in ((T1, "morning"), (T2, "midday"), (T3, "close")):
         scraper._persist_qu100(
@@ -215,7 +398,7 @@ def test_one_row_per_symbol_after_rebuild(sqlite_session_factory):
             "top100", sess, ts, DAY,
         )
     rows = _snapshots(sqlite_session_factory)
-    assert len(rows) == 2  # one row per symbol, not 6
+    assert len(rows) == 2  # one row per rank, not 6
     assert all(_naive(r.captured_at) == _naive(T3) for r in rows)
 
 
@@ -225,8 +408,8 @@ def test_ranking_types_rebuilt_independently(sqlite_session_factory):
     scraper = _scraper()
     scraper._persist_qu100([_row("AAA", 1, "Long in")], "top100", "morning", T1, DAY)
     scraper._persist_qu100([_row("ZZZ", 1, "Short in")], "bottom100", "morning", T1, DAY)
-    # only top100 advances at T2
-    scraper._persist_qu100([_row("AAA", 2, "No dominance")], "top100", "midday", T2, DAY)
+    # only top100 advances at T2 (AAA stays at rank 1, value flips)
+    scraper._persist_qu100([_row("AAA", 1, "No dominance")], "top100", "midday", T2, DAY)
 
     top = _snapshots(sqlite_session_factory, "top100")
     bottom = _snapshots(sqlite_session_factory, "bottom100")

--- a/tests/test_sector_analyzer_as_of_date.py
+++ b/tests/test_sector_analyzer_as_of_date.py
@@ -1,0 +1,110 @@
+"""WS B — `analyze_sectors_at` keyed on an as-of DATE, per-ranking_type.
+
+`analyze_sectors_at` used to take a single global `captured_at` timestamp
+(`sector_momentum` passed `max(captured_at)`). Under the rebuild-the-day fix a
+day holds one `captured_at` per `(data_date, ranking_type)`, so a single global
+timestamp can only match ONE ranking type → half-book. The new contract takes an
+as-of `date` and resolves, independently per ranking type, the latest
+`(data_date <= as_of, captured_at)` generation, then unions.
+
+Logic-lane SQLite harness (rowid-alias `id`).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from rainier.analysis.sector_analyzer import analyze_sectors_at
+from rainier.core.models import MoneyFlowSnapshot, Stock
+
+_DDL = """
+CREATE TABLE stocks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  symbol VARCHAR(10) NOT NULL UNIQUE,
+  name VARCHAR(255), sector VARCHAR(100), industry VARCHAR(200),
+  is_active BOOLEAN DEFAULT 1,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE money_flow_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  captured_at TIMESTAMP NOT NULL,
+  capture_session VARCHAR(20) NOT NULL,
+  data_date DATE NOT NULL,
+  view_type VARCHAR(10) NOT NULL DEFAULT 'daily',
+  ranking_type VARCHAR(10) NOT NULL,
+  symbol VARCHAR(10) NOT NULL REFERENCES stocks(symbol),
+  rank INTEGER NOT NULL,
+  daily_change INTEGER, sector VARCHAR(100), industry VARCHAR(200),
+  long_short VARCHAR(50), raw_data JSON
+);
+"""
+
+DAY1 = date(2026, 6, 1)
+DAY2 = date(2026, 6, 2)
+T_EARLY = datetime(2026, 6, 1, 15, 45, tzinfo=timezone.utc)
+T_LATE = datetime(2026, 6, 1, 22, 0, tzinfo=timezone.utc)
+T_DAY2 = datetime(2026, 6, 2, 22, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite://", future=True)
+    with engine.begin() as conn:
+        for stmt in _DDL.strip().split(";"):
+            if stmt.strip():
+                conn.execute(text(stmt))
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    s = factory()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+def _snap(s, symbol, sector, long_short, rank, ranking_type, data_date, captured_at):
+    if not s.query(Stock).filter_by(symbol=symbol).first():
+        s.add(Stock(symbol=symbol, sector=sector))
+        s.flush()
+    s.add(
+        MoneyFlowSnapshot(
+            captured_at=captured_at, capture_session="x", data_date=data_date,
+            ranking_type=ranking_type, symbol=symbol, rank=rank,
+            sector=sector, long_short=long_short, raw_data={},
+        )
+    )
+
+
+def test_as_of_date_unions_both_ranking_types(session):
+    """top100 @T_LATE + bottom100 @T_EARLY on the same day: as-of DAY1 reads BOTH."""
+    _snap(session, "AAA", "Technology", "Long in", 1, "top100", DAY1, T_LATE)
+    _snap(session, "EEE", "Energy", "Short in", 1, "bottom100", DAY1, T_EARLY)
+    session.commit()
+
+    trends = analyze_sectors_at(DAY1, session=session)
+    sectors = {t.sector for t in trends}
+    assert sectors == {"Technology", "Energy"}
+
+
+def test_as_of_date_picks_latest_generation_on_or_before(session):
+    """Two generations on DAY1 for top100 (T_EARLY then T_LATE): the LATER wins;
+    DAY2 rows are excluded by an as-of of DAY1."""
+    _snap(session, "AAA", "Technology", "Short in", 1, "top100", DAY1, T_EARLY)
+    _snap(session, "AAA", "Technology", "Long in", 1, "top100", DAY1, T_LATE)
+    _snap(session, "AAA", "Technology", "Short in", 1, "top100", DAY2, T_DAY2)
+    session.commit()
+
+    trends = analyze_sectors_at(DAY1, session=session)
+    tech = next(t for t in trends if t.sector == "Technology")
+    # latest generation on/before DAY1 is T_LATE (Long in) — DAY2 excluded.
+    assert tech.long_in_count == 1
+    assert tech.short_in_count == 0
+
+
+def test_as_of_date_no_data_returns_empty(session):
+    assert analyze_sectors_at(date(2020, 1, 1), session=session) == []

--- a/tests/test_sector_analyzer_per_ranking_type.py
+++ b/tests/test_sector_analyzer_per_ranking_type.py
@@ -124,5 +124,23 @@ def test_ranking_type_on_different_data_date_not_dropped(session):
     assert "Energy" in sectors, "a ranking type stuck on an earlier data_date must survive"
 
 
+def test_non_qu100_ranking_type_excluded_from_sentiment(session):
+    """Codex P1 regression — only the QU100 books (top100 + bottom100) feed sector
+    sentiment. A stray auxiliary ranking type (e.g. 'concept') in the table must
+    NOT be unioned into the analysis, or it would silently skew the screener."""
+    # QU100 books: Technology bullish, Energy bearish.
+    _snap(session, "AAA", "Technology", "Long in", 1, "top100", DAY1, T2)
+    _snap(session, "EEE", "Energy", "Short in", 1, "bottom100", DAY1, T2)
+    # Auxiliary non-QU100 board for a sector that must NOT appear.
+    _snap(session, "CCC", "Materials", "Long in", 1, "concept", DAY1, T2)
+    session.commit()
+
+    trends = _analyze_sectors(session)
+    sectors = {t.sector for t in trends}
+    assert "Technology" in sectors
+    assert "Energy" in sectors
+    assert "Materials" not in sectors, "non-QU100 ranking_type must be excluded"
+
+
 def test_no_snapshots_returns_empty(session):
     assert _analyze_sectors(session) == []

--- a/tests/test_sector_analyzer_per_ranking_type.py
+++ b/tests/test_sector_analyzer_per_ranking_type.py
@@ -1,0 +1,128 @@
+"""WS B — sector reads resolve latest snapshot PER ranking_type, not globally.
+
+Under the rebuild-the-day fix a day holds ONE `captured_at` per
+`(data_date, ranking_type)`. On a partial-failure scrape one ranking type can
+advance (e.g. top100 rebuilt at T2) while the other stays at an earlier
+`captured_at` (bottom100 still at T1, or a different `data_date` entirely if it
+was never scraped today).
+
+`_analyze_sectors` used a GLOBAL `max(captured_at)` with no `ranking_type`
+scope. After the fix that reads only ONE ranking type's rows (the most recent
+one) and silently drops the other half-book. The fix resolves the latest
+`(data_date, captured_at)` INDEPENDENTLY per ranking type and unions the
+batches, so the analysis always sees the current full book.
+
+Logic-lane SQLite harness (rowid-alias `id`; composite PK is a hypertable
+artifact). Never touches a provided URL / `public.*`.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from rainier.analysis.sector_analyzer import _analyze_sectors
+from rainier.core.models import MoneyFlowSnapshot, Stock
+
+_DDL = """
+CREATE TABLE stocks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  symbol VARCHAR(10) NOT NULL UNIQUE,
+  name VARCHAR(255), sector VARCHAR(100), industry VARCHAR(200),
+  is_active BOOLEAN DEFAULT 1,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE money_flow_snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  captured_at TIMESTAMP NOT NULL,
+  capture_session VARCHAR(20) NOT NULL,
+  data_date DATE NOT NULL,
+  view_type VARCHAR(10) NOT NULL DEFAULT 'daily',
+  ranking_type VARCHAR(10) NOT NULL,
+  symbol VARCHAR(10) NOT NULL REFERENCES stocks(symbol),
+  rank INTEGER NOT NULL,
+  daily_change INTEGER, sector VARCHAR(100), industry VARCHAR(200),
+  long_short VARCHAR(50), raw_data JSON
+);
+"""
+
+DAY1 = date(2026, 6, 1)
+DAY2 = date(2026, 6, 2)
+T1 = datetime(2026, 6, 1, 15, 45, tzinfo=timezone.utc)
+T2 = datetime(2026, 6, 1, 22, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite://", future=True)
+    with engine.begin() as conn:
+        for stmt in _DDL.strip().split(";"):
+            if stmt.strip():
+                conn.execute(text(stmt))
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    s = factory()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+def _stock(s, symbol, sector):
+    if not s.query(Stock).filter_by(symbol=symbol).first():
+        s.add(Stock(symbol=symbol, sector=sector))
+        s.flush()
+
+
+def _snap(s, symbol, sector, long_short, rank, ranking_type, data_date, captured_at):
+    _stock(s, symbol, sector)
+    s.add(
+        MoneyFlowSnapshot(
+            captured_at=captured_at, capture_session="x", data_date=data_date,
+            ranking_type=ranking_type, symbol=symbol, rank=rank,
+            sector=sector, long_short=long_short, raw_data={},
+        )
+    )
+
+
+def test_partial_fail_reads_full_book_per_ranking_type(session):
+    """top100 rebuilt @T2, bottom100 still @T1 (same day). A global max(captured_at)
+    would read only top100; per-ranking_type reads BOTH books."""
+    # top100 @T2 — Technology bullish
+    _snap(session, "AAA", "Technology", "Long in", 1, "top100", DAY1, T2)
+    _snap(session, "BBB", "Technology", "Long in", 2, "top100", DAY1, T2)
+    # bottom100 @T1 — Energy bearish (earlier captured_at, same day)
+    _snap(session, "EEE", "Energy", "Short in", 1, "bottom100", DAY1, T1)
+    _snap(session, "FFF", "Energy", "Short in", 2, "bottom100", DAY1, T1)
+    session.commit()
+
+    trends = _analyze_sectors(session)
+    sectors = {t.sector for t in trends}
+    # Both ranking types' books are present — NOT just the latest captured_at half.
+    assert "Technology" in sectors
+    assert "Energy" in sectors, "bottom100 (@T1) must not be dropped by a global max"
+    energy = next(t for t in trends if t.sector == "Energy")
+    assert energy.short_in_count == 2
+
+
+def test_ranking_type_on_different_data_date_not_dropped(session):
+    """bottom100 was never scraped DAY2 (stuck on DAY1); top100 advanced to DAY2.
+    A globally-resolved latest data_date=DAY2 would drop bottom100 entirely."""
+    # top100 latest on DAY2
+    _snap(session, "AAA", "Technology", "Long in", 1, "top100", DAY2, T1)
+    # bottom100's last real rows are DAY1 only
+    _snap(session, "EEE", "Energy", "Short in", 1, "bottom100", DAY1, T1)
+    session.commit()
+
+    trends = _analyze_sectors(session)
+    sectors = {t.sector for t in trends}
+    assert "Technology" in sectors
+    assert "Energy" in sectors, "a ranking type stuck on an earlier data_date must survive"
+
+
+def test_no_snapshots_returns_empty(session):
+    assert _analyze_sectors(session) == []


### PR DESCRIPTION
## Summary
- WS A: `_persist_qu100` rebuilds the trading day with carry-forward so a partial re-scrape no longer drops prior rows.
- WS B: sector momentum resolves the latest snapshot generation per `ranking_type` (QU100-scoped).
- WS C: backup reconcile is `data_date`-aware (replaces HWM-by-id append); delete gated on newer `captured_at`.
- WS D: recover stamps derived artifacts with the recovered trading day; per-day `captured_at` freshness, report gated on scrape success with source-side loss verification.

## Review
- /review: passed (claude rounds: 3)
- codex review: passed (codex rounds: 15)

## Test plan
- [ ] CI green
- [ ] verify locally