### PR TITLE
feat(db): legacy migrations/*.sql runner + drift guard chokepoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,13 @@ packages = ["src/rainier"]
 # CLI works from both editable installs (where the top-level db/ exists on disk)
 # and non-editable wheel installs (where it doesn't). Catches the codex iter-2
 # [P1]: without this, wheel installs would crash with "alembic config not found".
-force-include = { "db" = "rainier/_db_assets" }
+#
+# `migrations` ships the numbered legacy `migrations/*.sql` at
+# `rainier/_db_assets/migrations/` so `rainier db migrate-legacy` finds them in
+# a packaged install too — without it `discover_migrations()` returns [] and the
+# command falsely reports "up to date" (codex 43f3 [P1]). Resolved by
+# `legacy_migrate._resolve_migrations_dir()`, same two-path idiom as alembic.
+force-include = { "db" = "rainier/_db_assets", "migrations" = "rainier/_db_assets/migrations" }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2015,12 +2015,76 @@ def db():
 @db.command(name="init")
 @click.pass_context
 def db_init(ctx):
-    """Initialize database tables and hypertables."""
-    from rainier.core.database import init_db
+    """Initialize database tables and hypertables.
+
+    After ``create_all`` (additive only — it never ALTERs an existing table to
+    add a missing column), run ``check_schema_drift`` as a loud chokepoint. An
+    existing-but-drifted table (a stub ``stocks``, an unapplied
+    ``migrations/*.sql`` column) is invisible to ``create_all`` and otherwise
+    surfaces only as a silent zero-row scrape. If drift is found we print every
+    missing object and exit non-zero so it screams instead.
+    """
+    from rainier.core.database import get_engine, init_db
+    from rainier.core.schema_check import check_schema_drift
 
     click.echo("Initializing database...")
     init_db()
     click.echo("Database initialized successfully.")
+
+    findings = check_schema_drift(get_engine())
+    if findings:
+        click.echo("")
+        click.echo("SCHEMA DRIFT DETECTED — the live DB is behind the ORM:")
+        for finding in findings:
+            click.echo(f"  - {finding}")
+        click.echo("")
+        click.echo(
+            "Run 'rainier db migrate-legacy' to apply pending migrations/*.sql, "
+            "or repair the drifted table by hand."
+        )
+        raise click.ClickException(
+            f"{len(findings)} schema-drift finding(s); see above."
+        )
+    click.echo("Schema drift check: clean.")
+
+
+@db.command(name="migrate-legacy")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="List pending migrations/*.sql without applying anything.",
+)
+def db_migrate_legacy(dry_run: bool) -> None:
+    """Apply the numbered ``migrations/*.sql`` to the LEGACY ``core.database``.
+
+    This is the runner for the legacy local-TimescaleDB track (public.* tables),
+    NOT Alembic — ``rainier db migrate`` is Alembic against the separate Neon
+    canonical DB. Applies each forward (non-``_downgrade``) file in filename
+    order, recording it in ``schema_migrations``. Idempotent: already-recorded
+    files are skipped, so a second run is a no-op. ``--dry-run`` lists pending
+    files without touching the DB.
+    """
+    from rainier.core.database import get_engine
+    from rainier.core.legacy_migrate import run_migrations
+
+    engine = get_engine()
+    if dry_run:
+        pending = run_migrations(engine, dry_run=True)
+        if not pending:
+            click.echo("No pending legacy migrations.")
+            return
+        click.echo(f"{len(pending)} pending legacy migration(s):")
+        for name in pending:
+            click.echo(f"  - {name}")
+        return
+
+    applied = run_migrations(engine)
+    if not applied:
+        click.echo("Legacy migrations already up to date (no-op).")
+        return
+    click.echo(f"Applied {len(applied)} legacy migration(s):")
+    for name in applied:
+        click.echo(f"  - {name}")
 
 
 @db.command(name="gc-test-schemas")

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2067,16 +2067,28 @@ def db_init(ctx):
     # of implying full health.
     click.echo("Schema drift check (ORM-declared objects): clean.")
 
-    from rainier.core.legacy_migrate import pending_migrations
+    from rainier.core.legacy_migrate import applied_versions, pending_migrations
 
-    pending = pending_migrations(get_engine())
+    engine = get_engine()
+    pending = pending_migrations(engine)
     if pending:
+        if applied_versions(engine):
+            # Versioned DB: the pending files are new migrations — apply them.
+            hint = "Run 'rainier db migrate-legacy' to apply them."
+        else:
+            # Unversioned (incl. the fresh db-init bootstrap): a plain run
+            # refuses unversioned schemas, so lead with --baseline
+            # (codex 43f3 [P2]: the old wording pointed fresh installs at a
+            # command guaranteed to fail).
+            hint = (
+                "This DB is unversioned; adopt the file history with "
+                "'rainier db migrate-legacy --baseline' (a plain run refuses "
+                "unversioned schemas)."
+            )
         click.echo(
             f"NOTE: {len(pending)} legacy migration file(s) not recorded as applied "
             "in schema_migrations. `db init` (create_all) does NOT run "
-            "migration-only DDL such as indexes/constraints. Run "
-            "'rainier db migrate-legacy' to apply them ('--baseline' to adopt an "
-            "already-migrated schema)."
+            f"migration-only DDL such as indexes/constraints. {hint}"
         )
     click.echo("Database initialized successfully.")
 
@@ -2154,17 +2166,36 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
         return
 
     if baseline:
+        from rainier.core.legacy_migrate import applied_versions, pending_migrations
+        from rainier.core.schema_check import KNOWN_BENIGN_DRIFT, check_schema_drift
+
+        pending = pending_migrations(engine)
+
+        # Already-versioned takes precedence over the drift refusal
+        # (codex 43f3 [P2]): on an adopted DB with a new ORM-backed migration
+        # pending, the right guidance is a plain run — NOT the drift
+        # refusal's "hand-apply then re-run --baseline". Mirrors the guard
+        # inside baseline_migrations (kept there for non-CLI callers).
+        if pending and applied_versions(engine):
+            raise click.ClickException(
+                "schema_migrations already has recorded versions; the "
+                f"{len(pending)} pending file(s) are new migrations that must "
+                "be APPLIED, not stamped. Run 'rainier db migrate-legacy' "
+                "(without --baseline)."
+            )
+
         # Validate BEFORE stamping (codex 43f3 [P1]): baseline records files
         # as applied WITHOUT running them, so adopting a schema that is still
         # missing ORM-declared objects (the 0012/0013 incident state) would
         # permanently mask those migrations from the runner. Refuse with the
         # DB untouched — a stamp-then-fail would mutate bookkeeping into a
-        # harder-to-recover state.
-        from rainier.core.schema_check import KNOWN_BENIGN_DRIFT, check_schema_drift
-
-        missing = [
-            f for f in check_schema_drift(engine) if f not in KNOWN_BENIGN_DRIFT
-        ]
+        # harder-to-recover state. Skipped when nothing is pending (a no-op
+        # baseline stamps nothing, so there is nothing to mask).
+        missing = (
+            [f for f in check_schema_drift(engine) if f not in KNOWN_BENIGN_DRIFT]
+            if pending
+            else []
+        )
         if missing:
             click.echo(
                 "Refusing to baseline — the live schema is missing "

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2051,7 +2051,24 @@ def db_init(ctx):
             "or repair the drifted table by hand."
         )
         raise click.ClickException(f"{len(real)} schema-drift finding(s); see above.")
-    click.echo("Schema drift check: clean.")
+    # Honest scope: the drift check compares ORM tables/columns ONLY. It cannot
+    # see migration-only DDL (indexes/constraints, e.g. 0001's
+    # idx_llm_analysis_idempotent), and create_all never runs migrations/*.sql.
+    # So a "clean" fresh DB may still be missing that DDL — surface the
+    # unrecorded legacy-migration state instead of implying full health.
+    click.echo("Schema drift check (ORM tables/columns): clean.")
+
+    from rainier.core.legacy_migrate import pending_migrations
+
+    pending = pending_migrations(get_engine())
+    if pending:
+        click.echo(
+            f"NOTE: {len(pending)} legacy migration file(s) not recorded as applied "
+            "in schema_migrations. `db init` (create_all) does NOT run "
+            "migration-only DDL such as indexes/constraints. Run "
+            "'rainier db migrate-legacy' to apply them ('--baseline' to adopt an "
+            "already-migrated schema)."
+        )
 
 
 @db.command(name="migrate-legacy")
@@ -2129,9 +2146,17 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
             for finding in missing:
                 click.echo(f"  - {finding}")
             click.echo(
-                "A stamped migration's DDL may never have run. Hand-apply the "
-                "relevant migrations/*.sql to the legacy engine, then verify "
-                "with 'rainier db init'."
+                "A stamped migration's DDL may never have run — and because it "
+                "is now recorded as applied, a plain run will permanently skip "
+                "it. Hand-apply the relevant migrations/*.sql to the legacy "
+                "engine, then verify with 'rainier db init'."
+            )
+            # Exit non-zero (codex 43f3 review [P1]): the stamps are already
+            # committed, so automation must STOP here for manual repair instead
+            # of sailing past an incomplete adoption with exit 0.
+            raise click.ClickException(
+                f"baseline stamped {len(stamped)} file(s) but {len(missing)} "
+                "ORM object(s) are still missing; see above."
             )
         return
 

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2117,6 +2117,7 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
     from rainier.core.database import get_engine
     from rainier.core.legacy_migrate import (
         AlreadyVersionedError,
+        EmptyDatabaseError,
         UnversionedSchemaError,
         baseline_migrations,
         run_migrations,
@@ -2127,7 +2128,11 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
 
     engine = get_engine()
     if dry_run:
-        pending = run_migrations(engine, dry_run=True)
+        # The same guards as a real run apply, so the preview is truthful.
+        try:
+            pending = run_migrations(engine, dry_run=True)
+        except (UnversionedSchemaError, EmptyDatabaseError) as exc:
+            raise click.ClickException(str(exc)) from exc
         if not pending:
             click.echo("No pending legacy migrations.")
             return
@@ -2184,7 +2189,7 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
 
     try:
         applied = run_migrations(engine)
-    except UnversionedSchemaError as exc:
+    except (UnversionedSchemaError, EmptyDatabaseError) as exc:
         raise click.ClickException(str(exc)) from exc
     if not applied:
         click.echo("Legacy migrations already up to date (no-op).")

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2055,12 +2055,14 @@ def db_init(ctx):
             "unversioned schemas, and baseline refuses while drift remains)."
         )
         raise click.ClickException(f"{len(real)} schema-drift finding(s); see above.")
-    # Honest scope: the drift check compares ORM tables/columns ONLY. It cannot
-    # see migration-only DDL (indexes/constraints, e.g. 0001's
-    # idx_llm_analysis_idempotent), and create_all never runs migrations/*.sql.
-    # So a "clean" fresh DB may still be missing that DDL — surface the
-    # unrecorded legacy-migration state instead of implying full health.
-    click.echo("Schema drift check (ORM tables/columns): clean.")
+    # Honest scope: the drift check verifies ORM-DECLARED objects (tables,
+    # columns, named indexes/constraints by name). It cannot see DDL that
+    # exists only in migrations/*.sql without an ORM mirror (e.g. 0001's
+    # idx_llm_analysis_idempotent — absent on the live DB too: its expression
+    # is not runnable on modern Postgres), and create_all never runs
+    # migrations/*.sql. Surface the unrecorded legacy-migration state instead
+    # of implying full health.
+    click.echo("Schema drift check (ORM-declared objects): clean.")
 
     from rainier.core.legacy_migrate import pending_migrations
 
@@ -2089,8 +2091,9 @@ def db_init(ctx):
         "applied WITHOUT running their SQL (alembic 'stamp'). Use once on a DB "
         "that already has the schema but no schema_migrations table, then run "
         "without this flag for genuinely new files. Refuses (stamping nothing) "
-        "if ORM-declared tables/columns are missing; indexes/constraints that "
-        "exist only in migrations/*.sql are not verified."
+        "if ORM-declared objects (tables/columns/named indexes+constraints) "
+        "are missing, or if the DB is already versioned; DDL that exists only "
+        "in migrations/*.sql without an ORM mirror is not verified."
     ),
 )
 def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
@@ -2111,8 +2114,9 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
     expression is not runnable on modern Postgres at all (the live legacy DB
     lacks it too), so a from-0001 replay is not a supported path. ``db init``
     materializes every ORM-declared table/column/index/constraint; baseline
-    then adopts the file history. Migration-only DDL that the ORM does not
-    mirror is NOT verified by the baseline check (tables/columns scope).
+    then adopts the file history after verifying those ORM-declared objects
+    exist (by name). Migration-only DDL the ORM does not mirror is NOT
+    verifiable and is excluded — a documented limitation.
     """
     from rainier.core.database import get_engine
     from rainier.core.legacy_migrate import (
@@ -2181,9 +2185,10 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
         for name in stamped:
             click.echo(f"  - {name}")
         click.echo(
-            "Note: this validation covers ORM tables/columns only — "
-            "indexes/constraints that exist solely in migrations/*.sql are "
-            "not verified."
+            "Note: this validation covers ORM-declared objects (tables, "
+            "columns, named indexes/constraints) — DDL that exists solely in "
+            "migrations/*.sql without an ORM mirror, and same-name definition "
+            "drift, are not verified."
         )
         return
 

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2076,7 +2076,11 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
     without running them (to adopt an already-migrated DB).
     """
     from rainier.core.database import get_engine
-    from rainier.core.legacy_migrate import baseline_migrations, run_migrations
+    from rainier.core.legacy_migrate import (
+        UnversionedSchemaError,
+        baseline_migrations,
+        run_migrations,
+    )
 
     if dry_run and baseline:
         raise click.ClickException("--dry-run and --baseline are mutually exclusive.")
@@ -2102,7 +2106,10 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
             click.echo(f"  - {name}")
         return
 
-    applied = run_migrations(engine)
+    try:
+        applied = run_migrations(engine)
+    except UnversionedSchemaError as exc:
+        raise click.ClickException(str(exc)) from exc
     if not applied:
         click.echo("Legacy migrations already up to date (no-op).")
         return

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2054,7 +2054,17 @@ def db_init(ctx):
     is_flag=True,
     help="List pending migrations/*.sql without applying anything.",
 )
-def db_migrate_legacy(dry_run: bool) -> None:
+@click.option(
+    "--baseline",
+    is_flag=True,
+    help=(
+        "Adopt an existing pre-versioned DB: RECORD all pending migrations as "
+        "applied WITHOUT running their SQL (alembic 'stamp'). Use once on a DB "
+        "that already has the schema but no schema_migrations table, then run "
+        "without this flag for genuinely new files."
+    ),
+)
+def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
     """Apply the numbered ``migrations/*.sql`` to the LEGACY ``core.database``.
 
     This is the runner for the legacy local-TimescaleDB track (public.* tables),
@@ -2062,10 +2072,14 @@ def db_migrate_legacy(dry_run: bool) -> None:
     canonical DB. Applies each forward (non-``_downgrade``) file in filename
     order, recording it in ``schema_migrations``. Idempotent: already-recorded
     files are skipped, so a second run is a no-op. ``--dry-run`` lists pending
-    files without touching the DB.
+    files without touching the DB; ``--baseline`` stamps pending files as applied
+    without running them (to adopt an already-migrated DB).
     """
     from rainier.core.database import get_engine
-    from rainier.core.legacy_migrate import run_migrations
+    from rainier.core.legacy_migrate import baseline_migrations, run_migrations
+
+    if dry_run and baseline:
+        raise click.ClickException("--dry-run and --baseline are mutually exclusive.")
 
     engine = get_engine()
     if dry_run:
@@ -2075,6 +2089,16 @@ def db_migrate_legacy(dry_run: bool) -> None:
             return
         click.echo(f"{len(pending)} pending legacy migration(s):")
         for name in pending:
+            click.echo(f"  - {name}")
+        return
+
+    if baseline:
+        stamped = baseline_migrations(engine)
+        if not stamped:
+            click.echo("Nothing to baseline (all migrations already recorded).")
+            return
+        click.echo(f"Baselined {len(stamped)} migration(s) (recorded, NOT run):")
+        for name in stamped:
             click.echo(f"  - {name}")
         return
 

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2047,8 +2047,12 @@ def db_init(ctx):
             click.echo(f"  - {finding}")
         click.echo("")
         click.echo(
-            "Run 'rainier db migrate-legacy' to apply pending migrations/*.sql, "
-            "or repair the drifted table by hand."
+            "Recovery: if this DB is already versioned (schema_migrations "
+            "exists), run 'rainier db migrate-legacy' to apply the pending "
+            "files. If it is UNVERSIONED, hand-apply the missing "
+            "migrations/*.sql to the legacy engine first, then adopt with "
+            "'rainier db migrate-legacy --baseline' (a plain run refuses "
+            "unversioned schemas, and baseline refuses while drift remains)."
         )
         raise click.ClickException(f"{len(real)} schema-drift finding(s); see above.")
     # Honest scope: the drift check compares ORM tables/columns ONLY. It cannot
@@ -2112,6 +2116,7 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
     """
     from rainier.core.database import get_engine
     from rainier.core.legacy_migrate import (
+        AlreadyVersionedError,
         UnversionedSchemaError,
         baseline_migrations,
         run_migrations,
@@ -2160,7 +2165,10 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
                 f"{len(missing)} missing ORM object(s); nothing was stamped."
             )
 
-        stamped = baseline_migrations(engine)
+        try:
+            stamped = baseline_migrations(engine)
+        except AlreadyVersionedError as exc:
+            raise click.ClickException(str(exc)) from exc
         if not stamped:
             click.echo("Nothing to baseline (all migrations already recorded).")
             return

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2084,7 +2084,9 @@ def db_init(ctx):
         "Adopt an existing pre-versioned DB: RECORD all pending migrations as "
         "applied WITHOUT running their SQL (alembic 'stamp'). Use once on a DB "
         "that already has the schema but no schema_migrations table, then run "
-        "without this flag for genuinely new files."
+        "without this flag for genuinely new files. Refuses (stamping nothing) "
+        "if ORM-declared tables/columns are missing; indexes/constraints that "
+        "exist only in migrations/*.sql are not verified."
     ),
 )
 def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
@@ -2096,7 +2098,17 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
     order, recording it in ``schema_migrations``. Idempotent: already-recorded
     files are skipped, so a second run is a no-op. ``--dry-run`` lists pending
     files without touching the DB; ``--baseline`` stamps pending files as applied
-    without running them (to adopt an already-migrated DB).
+    without running them (to adopt an already-migrated DB) after validating that
+    no ORM-declared object is missing.
+
+    BOOTSTRAP (fresh legacy DB): ``rainier db init`` then ``rainier db
+    migrate-legacy --baseline``. The historical files assume an existing schema
+    (0001 ALTERs tables only ``db init`` creates) and 0001's idempotency-index
+    expression is not runnable on modern Postgres at all (the live legacy DB
+    lacks it too), so a from-0001 replay is not a supported path. ``db init``
+    materializes every ORM-declared table/column/index/constraint; baseline
+    then adopts the file history. Migration-only DDL that the ORM does not
+    mirror is NOT verified by the baseline check (tables/columns scope).
     """
     from rainier.core.database import get_engine
     from rainier.core.legacy_migrate import (
@@ -2120,6 +2132,34 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
         return
 
     if baseline:
+        # Validate BEFORE stamping (codex 43f3 [P1]): baseline records files
+        # as applied WITHOUT running them, so adopting a schema that is still
+        # missing ORM-declared objects (the 0012/0013 incident state) would
+        # permanently mask those migrations from the runner. Refuse with the
+        # DB untouched — a stamp-then-fail would mutate bookkeeping into a
+        # harder-to-recover state.
+        from rainier.core.schema_check import KNOWN_BENIGN_DRIFT, check_schema_drift
+
+        missing = [
+            f for f in check_schema_drift(engine) if f not in KNOWN_BENIGN_DRIFT
+        ]
+        if missing:
+            click.echo(
+                "Refusing to baseline — the live schema is missing "
+                "ORM-declared objects:"
+            )
+            for finding in missing:
+                click.echo(f"  - {finding}")
+            click.echo(
+                "Stamping now would record their migrations as applied and "
+                "permanently skip them. Create missing tables with 'rainier "
+                "db init', hand-apply the migrations for missing columns to "
+                "the legacy engine, then re-run --baseline."
+            )
+            raise click.ClickException(
+                f"{len(missing)} missing ORM object(s); nothing was stamped."
+            )
+
         stamped = baseline_migrations(engine)
         if not stamped:
             click.echo("Nothing to baseline (all migrations already recorded).")
@@ -2127,37 +2167,11 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
         click.echo(f"Baselined {len(stamped)} migration(s) (recorded, NOT run):")
         for name in stamped:
             click.echo(f"  - {name}")
-        # Baseline records files as applied WITHOUT running them, so it can
-        # paper over a migration whose DDL genuinely never ran (the 0012/0013
-        # incident state). Cross-check the ORM contract and scream if stamped
-        # bookkeeping now claims objects that the live schema doesn't have —
-        # a stamped-but-missing object can no longer be applied by this runner.
-        from rainier.core.schema_check import KNOWN_BENIGN_DRIFT, check_schema_drift
-
-        missing = [
-            f for f in check_schema_drift(engine) if f not in KNOWN_BENIGN_DRIFT
-        ]
-        if missing:
-            click.echo("")
-            click.echo(
-                "WARNING: baseline stamped the files above, but the live schema "
-                "is still missing ORM-declared objects:"
-            )
-            for finding in missing:
-                click.echo(f"  - {finding}")
-            click.echo(
-                "A stamped migration's DDL may never have run — and because it "
-                "is now recorded as applied, a plain run will permanently skip "
-                "it. Hand-apply the relevant migrations/*.sql to the legacy "
-                "engine, then verify with 'rainier db init'."
-            )
-            # Exit non-zero (codex 43f3 review [P1]): the stamps are already
-            # committed, so automation must STOP here for manual repair instead
-            # of sailing past an incomplete adoption with exit 0.
-            raise click.ClickException(
-                f"baseline stamped {len(stamped)} file(s) but {len(missing)} "
-                "ORM object(s) are still missing; see above."
-            )
+        click.echo(
+            "Note: this validation covers ORM tables/columns only — "
+            "indexes/constraints that exist solely in migrations/*.sql are "
+            "not verified."
+        )
         return
 
     try:

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2025,26 +2025,32 @@ def db_init(ctx):
     missing object and exit non-zero so it screams instead.
     """
     from rainier.core.database import get_engine, init_db
-    from rainier.core.schema_check import check_schema_drift
+    from rainier.core.schema_check import KNOWN_BENIGN_DRIFT, check_schema_drift
 
     click.echo("Initializing database...")
     init_db()
     click.echo("Database initialized successfully.")
 
+    # Split out the documented pre-existing benign drift (KNOWN_BENIGN_DRIFT):
+    # the operator runbook blocks only on findings BEYOND it. Hard-failing on
+    # the benign finding would make `db init` exit non-zero on the live legacy
+    # DB forever, with no migrations/*.sql able to clear it.
     findings = check_schema_drift(get_engine())
-    if findings:
+    benign = [f for f in findings if f in KNOWN_BENIGN_DRIFT]
+    real = [f for f in findings if f not in KNOWN_BENIGN_DRIFT]
+    for finding in benign:
+        click.echo(f"Known-benign drift (ignored): {finding}")
+    if real:
         click.echo("")
         click.echo("SCHEMA DRIFT DETECTED — the live DB is behind the ORM:")
-        for finding in findings:
+        for finding in real:
             click.echo(f"  - {finding}")
         click.echo("")
         click.echo(
             "Run 'rainier db migrate-legacy' to apply pending migrations/*.sql, "
             "or repair the drifted table by hand."
         )
-        raise click.ClickException(
-            f"{len(findings)} schema-drift finding(s); see above."
-        )
+        raise click.ClickException(f"{len(real)} schema-drift finding(s); see above.")
     click.echo("Schema drift check: clean.")
 
 
@@ -2104,6 +2110,29 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
         click.echo(f"Baselined {len(stamped)} migration(s) (recorded, NOT run):")
         for name in stamped:
             click.echo(f"  - {name}")
+        # Baseline records files as applied WITHOUT running them, so it can
+        # paper over a migration whose DDL genuinely never ran (the 0012/0013
+        # incident state). Cross-check the ORM contract and scream if stamped
+        # bookkeeping now claims objects that the live schema doesn't have —
+        # a stamped-but-missing object can no longer be applied by this runner.
+        from rainier.core.schema_check import KNOWN_BENIGN_DRIFT, check_schema_drift
+
+        missing = [
+            f for f in check_schema_drift(engine) if f not in KNOWN_BENIGN_DRIFT
+        ]
+        if missing:
+            click.echo("")
+            click.echo(
+                "WARNING: baseline stamped the files above, but the live schema "
+                "is still missing ORM-declared objects:"
+            )
+            for finding in missing:
+                click.echo(f"  - {finding}")
+            click.echo(
+                "A stamped migration's DDL may never have run. Hand-apply the "
+                "relevant migrations/*.sql to the legacy engine, then verify "
+                "with 'rainier db init'."
+            )
         return
 
     try:

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2029,7 +2029,10 @@ def db_init(ctx):
 
     click.echo("Initializing database...")
     init_db()
-    click.echo("Database initialized successfully.")
+    # Success banner is printed only AFTER the drift gate below passes —
+    # printing it here would tell operators/scripts "success" on the exact
+    # drifted state this chokepoint exists to catch (codex 43f3 [P2]).
+    click.echo("Tables created (create_all complete).")
 
     # Split out the documented pre-existing benign drift (KNOWN_BENIGN_DRIFT):
     # the operator runbook blocks only on findings BEYOND it. Hard-failing on
@@ -2075,6 +2078,7 @@ def db_init(ctx):
             "'rainier db migrate-legacy' to apply them ('--baseline' to adopt an "
             "already-migrated schema)."
         )
+    click.echo("Database initialized successfully.")
 
 
 @db.command(name="migrate-legacy")
@@ -2137,6 +2141,10 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
             pending = run_migrations(engine, dry_run=True)
         except (UnversionedSchemaError, EmptyDatabaseError) as exc:
             raise click.ClickException(str(exc)) from exc
+        except Exception as exc:  # unhealthy DB during the probe, etc.
+            raise click.ClickException(
+                f"legacy migration dry-run failed: {exc.__class__.__name__}: {exc}"
+            ) from exc
         if not pending:
             click.echo("No pending legacy migrations.")
             return

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -2178,6 +2178,10 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
             stamped = baseline_migrations(engine)
         except AlreadyVersionedError as exc:
             raise click.ClickException(str(exc)) from exc
+        except Exception as exc:  # mirror db_migrate's wrapping idiom
+            raise click.ClickException(
+                f"legacy baseline failed: {exc.__class__.__name__}: {exc}"
+            ) from exc
         if not stamped:
             click.echo("Nothing to baseline (all migrations already recorded).")
             return
@@ -2196,6 +2200,14 @@ def db_migrate_legacy(dry_run: bool, baseline: bool) -> None:
         applied = run_migrations(engine)
     except (UnversionedSchemaError, EmptyDatabaseError) as exc:
         raise click.ClickException(str(exc)) from exc
+    except Exception as exc:
+        # A real apply failure (bad future migration, permissions, dropped
+        # connection) surfaces as a clean `Error:` line, not a raw traceback —
+        # mirrors db_migrate's wrapping idiom. The failed file's transaction
+        # rolled back whole, so a re-run resumes at the same file.
+        raise click.ClickException(
+            f"legacy migration failed: {exc.__class__.__name__}: {exc}"
+        ) from exc
     if not applied:
         click.echo("Legacy migrations already up to date (no-op).")
         return

--- a/src/rainier/core/legacy_migrate.py
+++ b/src/rainier/core/legacy_migrate.py
@@ -169,11 +169,13 @@ def _pin_public(conn) -> None:
 
 
 class UnversionedSchemaError(RuntimeError):
-    """Raised when a non-empty legacy schema has no ``schema_migrations`` table.
+    """Raised when a non-empty legacy schema has no RECORDED versions.
 
-    Replaying ``0001..N`` from scratch on such a DB is unsafe — some historical
-    files don't re-run cleanly on an already-migrated schema. The caller must
-    first ``--baseline`` to adopt the existing prefix.
+    Covers both a missing ``schema_migrations`` table and an
+    existing-but-EMPTY one (a pre-created empty table must not disarm this
+    guard). Replaying ``0001..N`` from scratch on such a DB is unsafe — some
+    historical files don't re-run cleanly on an already-migrated schema. The
+    caller must first ``--baseline`` to adopt the existing prefix.
     """
 
 
@@ -196,15 +198,6 @@ class AlreadyVersionedError(RuntimeError):
     tables/columns drift check cannot see). Baseline exists for exactly one
     state: adopting an UNVERSIONED pre-existing schema.
     """
-
-
-def _version_table_exists(engine: Engine) -> bool:
-    sql = (
-        "SELECT 1 FROM information_schema.tables "
-        "WHERE table_schema = 'public' AND table_name = 'schema_migrations'"
-    )
-    with engine.connect() as conn:
-        return conn.execute(text(sql)).first() is not None
 
 
 def _legacy_schema_present(engine: Engine) -> bool:
@@ -360,10 +353,11 @@ def run_migrations(
     SAFETY GUARDS (both raise before any DB write):
 
     * ``UnversionedSchemaError`` — the legacy schema ALREADY has tables but no
-      ``schema_migrations`` table. Refuses to blindly replay ``0001..N``
-      (historical files don't re-run cleanly on an already-migrated schema).
-      Adopt with ``baseline_migrations`` / ``db migrate-legacy --baseline``,
-      then run for the new tail only.
+      RECORDED versions (``schema_migrations`` missing OR existing-but-empty;
+      an empty pre-created table must not disarm the guard). Refuses to
+      blindly replay ``0001..N`` (historical files don't re-run cleanly on an
+      already-migrated schema). Adopt with ``baseline_migrations`` /
+      ``db migrate-legacy --baseline``, then run for the new tail only.
     * ``EmptyDatabaseError`` — the DB is truly EMPTY and the DEFAULT (shipped)
       migration set is in use. The shipped files assume an existing schema
       (0001 ALTERs tables only ``db init`` creates), so a from-scratch replay
@@ -373,14 +367,18 @@ def run_migrations(
     Returns the list of filenames that were applied (dry-run: the filenames
     that WOULD be applied).
     """
-    if not _version_table_exists(engine):
+    # NO recorded versions (the table is missing OR exists but is empty — an
+    # empty pre-created table must not disarm the guard, codex 43f3 [P1]) means
+    # this DB has never been adopted by the runner.
+    if not applied_versions(engine):
         if _legacy_schema_present(engine):
             raise UnversionedSchemaError(
-                "Legacy schema already has tables but no schema_migrations "
-                "table. Refusing to replay 0001..N (some historical files "
-                "don't re-run cleanly on an existing schema). Run 'rainier db "
-                "migrate-legacy --baseline' once to adopt the current schema, "
-                "then re-run to apply any new migrations."
+                "Legacy schema already has tables but no recorded versions in "
+                "schema_migrations. Refusing to replay 0001..N (some "
+                "historical files don't re-run cleanly on an existing "
+                "schema). Run 'rainier db migrate-legacy --baseline' once to "
+                "adopt the current schema, then re-run to apply any new "
+                "migrations."
             )
         if migrations_dir is None:
             raise EmptyDatabaseError(

--- a/src/rainier/core/legacy_migrate.py
+++ b/src/rainier/core/legacy_migrate.py
@@ -170,6 +170,40 @@ def _ensure_version_table(engine: Engine) -> None:
         )
 
 
+class UnversionedSchemaError(RuntimeError):
+    """Raised when a non-empty legacy schema has no ``schema_migrations`` table.
+
+    Replaying ``0001..N`` from scratch on such a DB is unsafe — some historical
+    files don't re-run cleanly on an already-migrated schema. The caller must
+    first ``--baseline`` to adopt the existing prefix.
+    """
+
+
+def _version_table_exists(engine: Engine) -> bool:
+    sql = (
+        "SELECT 1 FROM information_schema.tables "
+        "WHERE table_schema = 'public' AND table_name = 'schema_migrations'"
+    )
+    with engine.connect() as conn:
+        return conn.execute(text(sql)).first() is not None
+
+
+def _legacy_schema_present(engine: Engine) -> bool:
+    """True if any non-bookkeeping table already exists in ``public``.
+
+    Used to distinguish a truly fresh DB (safe to run from 0001) from an
+    existing, hand-migrated DB (must be baselined first). ``schema_migrations``
+    itself is excluded so its presence/absence is judged separately.
+    """
+    sql = (
+        "SELECT 1 FROM information_schema.tables "
+        "WHERE table_schema = 'public' AND table_name <> 'schema_migrations' "
+        "LIMIT 1"
+    )
+    with engine.connect() as conn:
+        return conn.execute(text(sql)).first() is not None
+
+
 def applied_versions(engine: Engine) -> set[str]:
     """Return the set of already-applied migration filenames.
 
@@ -264,9 +298,12 @@ def run_migrations(
     ``dry_run=True`` lists the pending filenames WITHOUT creating the version
     table or applying anything.
 
-    For an existing schema with no version table, baseline first
-    (``baseline_migrations`` / ``db migrate-legacy --baseline``) so already-applied
-    files are stamped rather than replayed.
+    SAFETY GUARD: if the legacy schema ALREADY has tables but no
+    ``schema_migrations`` table, this raises ``UnversionedSchemaError`` instead
+    of blindly replaying ``0001..N`` (which can fail on an already-migrated
+    schema). Adopt such a DB with ``baseline_migrations`` /
+    ``db migrate-legacy --baseline`` first, then run for the new tail only. A
+    truly fresh DB (no tables) runs from 0001 normally.
 
     Returns the list of filenames that were applied (dry-run: the filenames
     that WOULD be applied).
@@ -274,6 +311,15 @@ def run_migrations(
     if dry_run:
         pending = pending_migrations(engine, migrations_dir)
         return [p.name for p in pending]
+
+    if not _version_table_exists(engine) and _legacy_schema_present(engine):
+        raise UnversionedSchemaError(
+            "Legacy schema already has tables but no schema_migrations table. "
+            "Refusing to replay 0001..N (some historical files don't re-run "
+            "cleanly on an existing schema). Run 'rainier db migrate-legacy "
+            "--baseline' once to adopt the current schema, then re-run to apply "
+            "any new migrations."
+        )
 
     _ensure_version_table(engine)
     pending = pending_migrations(engine, migrations_dir)

--- a/src/rainier/core/legacy_migrate.py
+++ b/src/rainier/core/legacy_migrate.py
@@ -141,6 +141,15 @@ def _strip_outer_transaction(sql: str) -> str:
 # tables all live in ``public``, so the version table belongs there too.
 _VERSION_TABLE = "public.schema_migrations"
 
+# Shared by _ensure_version_table (its own transaction) and baseline_migrations
+# (inside the single all-or-nothing stamp transaction).
+_CREATE_VERSION_TABLE_SQL = (
+    f"CREATE TABLE IF NOT EXISTS {_VERSION_TABLE} ("
+    "  version TEXT PRIMARY KEY,"
+    "  applied_at TIMESTAMPTZ NOT NULL DEFAULT now()"
+    ")"
+)
+
 
 def _pin_public(conn) -> None:
     """Pin this transaction's ``search_path`` to ``public``.
@@ -160,14 +169,7 @@ def _ensure_version_table(engine: Engine) -> None:
     """Create ``public.schema_migrations`` if absent (idempotent)."""
     with engine.begin() as conn:
         _pin_public(conn)
-        conn.execute(
-            text(
-                f"CREATE TABLE IF NOT EXISTS {_VERSION_TABLE} ("
-                "  version TEXT PRIMARY KEY,"
-                "  applied_at TIMESTAMPTZ NOT NULL DEFAULT now()"
-                ")"
-            )
-        )
+        conn.execute(text(_CREATE_VERSION_TABLE_SQL))
 
 
 class UnversionedSchemaError(RuntimeError):
@@ -266,20 +268,29 @@ def baseline_migrations(
     file as applied, executing NONE of their SQL. After baselining, the operator
     runs ``run_migrations`` for any genuinely new files only.
 
+    ATOMIC: the table creation and ALL stamps run in ONE transaction. A
+    per-file (or ensure-then-stamp) split would let an interrupt leave a
+    partial/empty ``schema_migrations`` behind — which defeats
+    ``run_migrations``'s ``UnversionedSchemaError`` guard (the table now
+    exists), so the next plain run would replay the un-stamped historical SQL
+    onto the already-migrated live schema. All-or-nothing means an interrupted
+    baseline leaves the DB exactly as it was, and the guard still fires.
+
     Returns the filenames that were stamped (recorded without running).
     """
-    _ensure_version_table(engine)
     pending = pending_migrations(engine, migrations_dir)
     stamped: list[str] = []
-    for path in pending:
-        with engine.begin() as conn:
-            _pin_public(conn)
+    with engine.begin() as conn:
+        _pin_public(conn)
+        conn.execute(text(_CREATE_VERSION_TABLE_SQL))
+        for path in pending:
             conn.execute(
                 text(f"INSERT INTO {_VERSION_TABLE} (version) VALUES (:v)"),
                 {"v": path.name},
             )
-        log.info("legacy_migration_baselined", version=path.name)
-        stamped.append(path.name)
+            stamped.append(path.name)
+    for name in stamped:
+        log.info("legacy_migration_baselined", version=name)
     return stamped
 
 

--- a/src/rainier/core/legacy_migrate.py
+++ b/src/rainier/core/legacy_migrate.py
@@ -142,9 +142,24 @@ def _strip_outer_transaction(sql: str) -> str:
 _VERSION_TABLE = "public.schema_migrations"
 
 
+def _pin_public(conn) -> None:
+    """Pin this transaction's ``search_path`` to ``public``.
+
+    The migration SQL bodies reference tables UNQUALIFIED (they were written to
+    target the legacy public schema). If the engine was created with a custom
+    ``search_path`` (e.g. test isolation uses ``search_path=<schema>,public``),
+    that unqualified DDL would land in the wrong schema while the bookkeeping
+    table is hardcoded to ``public`` — a split that desyncs the two. Pinning
+    both to ``public`` for the duration of the apply keeps DDL and bookkeeping in
+    the same schema. ``SET LOCAL`` is transaction-scoped, so it reverts on commit.
+    """
+    conn.exec_driver_sql("SET LOCAL search_path TO public")
+
+
 def _ensure_version_table(engine: Engine) -> None:
     """Create ``public.schema_migrations`` if absent (idempotent)."""
     with engine.begin() as conn:
+        _pin_public(conn)
         conn.execute(
             text(
                 f"CREATE TABLE IF NOT EXISTS {_VERSION_TABLE} ("
@@ -191,12 +206,47 @@ def _apply_one(engine: Engine, path: Path) -> None:
     """
     body = _strip_outer_transaction(path.read_text())
     with engine.begin() as conn:
+        _pin_public(conn)
         if body.strip():
             conn.exec_driver_sql(body)
         conn.execute(
             text(f"INSERT INTO {_VERSION_TABLE} (version) VALUES (:v)"),
             {"v": path.name},
         )
+
+
+def baseline_migrations(
+    engine: Engine, *, migrations_dir: Path | None = None
+) -> list[str]:
+    """Adopt an existing pre-versioned DB: RECORD pending files WITHOUT running.
+
+    Some legacy DBs already carry the schema (created by ``db init`` or by hand
+    via ``psql -f``) but have no ``schema_migrations`` table. Running
+    ``run_migrations`` against them would replay 0001..N from scratch; a few
+    historical files are not guaranteed to re-run cleanly on an already-migrated
+    schema (e.g. 0001's non-IMMUTABLE index expression), so the first real run
+    could crash before establishing a head.
+
+    Baseline is the adoption escape hatch (alembic's ``stamp``): it creates
+    ``public.schema_migrations`` and records every NOT-yet-recorded discovered
+    file as applied, executing NONE of their SQL. After baselining, the operator
+    runs ``run_migrations`` for any genuinely new files only.
+
+    Returns the filenames that were stamped (recorded without running).
+    """
+    _ensure_version_table(engine)
+    pending = pending_migrations(engine, migrations_dir)
+    stamped: list[str] = []
+    for path in pending:
+        with engine.begin() as conn:
+            _pin_public(conn)
+            conn.execute(
+                text(f"INSERT INTO {_VERSION_TABLE} (version) VALUES (:v)"),
+                {"v": path.name},
+            )
+        log.info("legacy_migration_baselined", version=path.name)
+        stamped.append(path.name)
+    return stamped
 
 
 def run_migrations(
@@ -213,6 +263,10 @@ def run_migrations(
 
     ``dry_run=True`` lists the pending filenames WITHOUT creating the version
     table or applying anything.
+
+    For an existing schema with no version table, baseline first
+    (``baseline_migrations`` / ``db migrate-legacy --baseline``) so already-applied
+    files are stamped rather than replayed.
 
     Returns the list of filenames that were applied (dry-run: the filenames
     that WOULD be applied).

--- a/src/rainier/core/legacy_migrate.py
+++ b/src/rainier/core/legacy_migrate.py
@@ -177,6 +177,17 @@ class UnversionedSchemaError(RuntimeError):
     """
 
 
+class AlreadyVersionedError(RuntimeError):
+    """Raised when baseline is invoked on a DB that already has recorded versions.
+
+    Pending files on an already-versioned DB are genuinely NEW migrations that
+    must be APPLIED (``run_migrations``), not stamped — stamping would record
+    them as done and permanently skip their DDL (e.g. a constraint rebuild the
+    tables/columns drift check cannot see). Baseline exists for exactly one
+    state: adopting an UNVERSIONED pre-existing schema.
+    """
+
+
 def _version_table_exists(engine: Engine) -> bool:
     sql = (
         "SELECT 1 FROM information_schema.tables "
@@ -283,9 +294,23 @@ def baseline_migrations(
     onto the already-migrated live schema. All-or-nothing means an interrupted
     baseline leaves the DB exactly as it was, and the guard still fires.
 
+    REFUSES on an already-versioned DB (codex 43f3 [P1]): when
+    ``schema_migrations`` already has recorded versions, any pending file is a
+    genuinely NEW migration that must be applied by ``run_migrations`` — a
+    baseline there would stamp it as done without ever executing its DDL, and
+    the tables/columns drift check cannot catch index/constraint-only files
+    (e.g. 0008's ``ck_paper_skip_reason`` rebuild).
+
     Returns the filenames that were stamped (recorded without running).
     """
     pending = pending_migrations(engine, migrations_dir)
+    if pending and applied_versions(engine):
+        raise AlreadyVersionedError(
+            "schema_migrations already has recorded versions; the "
+            f"{len(pending)} pending file(s) are new migrations that must be "
+            "APPLIED, not stamped. Run 'rainier db migrate-legacy' (without "
+            "--baseline). Baseline only adopts an unversioned existing schema."
+        )
     stamped: list[str] = []
     with engine.begin() as conn:
         _pin_public(conn)

--- a/src/rainier/core/legacy_migrate.py
+++ b/src/rainier/core/legacy_migrate.py
@@ -1,0 +1,193 @@
+"""Runner for the numbered ``migrations/*.sql`` files (the LEGACY DB track).
+
+Why this exists
+---------------
+rainier has TWO migration tracks against TWO databases (see memory
+``project_two_database_url_engines``):
+
+  * Alembic (``db/alembic/``, ``rainier db migrate``) → the *Neon* canonical
+    DB (``db.engine``, ``market.*``). NOT this module.
+  * Numbered ``migrations/0001..NNNN.sql`` → the LEGACY local TimescaleDB
+    (``core.database``, ``public.*``). THIS module.
+
+The numbered files were applied **by hand** (``psql "$LEGACY_DATABASE_URL"
+-f ...``) with no runner and no version table. The result: 0012/0013 silently
+never ran on the local DB and the reclaim feature broke. This runner gives the
+legacy track a real, idempotent apply mechanism with a ``schema_migrations``
+version table, so "what's applied" is recorded instead of guessed.
+
+How it applies a file
+---------------------
+Every up-migration file wraps its own ``BEGIN; ... COMMIT;``. To make the
+file's DDL and the bookkeeping INSERT atomic (record a version ONLY if its DDL
+committed) the runner strips that outer ``BEGIN;``/``COMMIT;`` and runs the
+file body + the version INSERT inside ONE transaction it controls:
+
+    ┌─ engine.begin() (one transaction per file) ─────────────┐
+    │  <stripped file body, e.g. CREATE TABLE IF NOT EXISTS …> │
+    │  INSERT INTO schema_migrations (version) VALUES (<file>) │
+    └─────────────────────────────────────────────────────────┘
+
+If the DDL raises, the whole transaction rolls back and nothing is recorded —
+the next run retries the same file. Already-recorded files are skipped, so a
+second run is a no-op (idempotent).
+
+``*_downgrade.sql`` files are NEVER applied by this runner; only the forward
+(up) migrations are.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+log = structlog.get_logger()
+
+# Repo-root-relative migrations directory. legacy_migrate.py lives at
+# src/rainier/core/legacy_migrate.py → parents[3] is the repo root.
+MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "migrations"
+
+# Forward migrations are ``NNNN_<name>.sql``; downgrades are
+# ``NNNN_<name>_downgrade.sql`` and must be excluded.
+_UP_MIGRATION_RE = re.compile(r"^\d+_.*(?<!_downgrade)\.sql$")
+
+# A line that is exactly ``BEGIN;`` / ``COMMIT;`` (optionally ``BEGIN``),
+# case-insensitive, ignoring surrounding whitespace. Used to strip the file's
+# own transaction wrapper so the runner can control the transaction.
+_TXN_LINE_RE = re.compile(r"^\s*(BEGIN|COMMIT)\s*;?\s*$", re.IGNORECASE)
+
+
+def discover_migrations(migrations_dir: Path | None = None) -> list[Path]:
+    """Return the forward migration files, sorted by filename.
+
+    Filename order is the apply order (zero-padded numeric prefixes sort
+    lexicographically). ``*_downgrade.sql`` files are excluded.
+    """
+    directory = migrations_dir or MIGRATIONS_DIR
+    if not directory.is_dir():
+        return []
+    return sorted(
+        p for p in directory.iterdir() if p.is_file() and _UP_MIGRATION_RE.match(p.name)
+    )
+
+
+def _strip_outer_transaction(sql: str) -> str:
+    """Remove a leading ``BEGIN;`` and a trailing ``COMMIT;`` line.
+
+    The runner wraps each file in its own transaction, so the file's own outer
+    wrapper must be removed to avoid a nested-transaction warning/abort. Only
+    standalone ``BEGIN;``/``COMMIT;`` *lines* are stripped — DDL that merely
+    contains those words inline is untouched.
+    """
+    lines = sql.splitlines()
+
+    # Drop a leading standalone BEGIN; (skipping blank/comment lines before it).
+    start = 0
+    while start < len(lines) and (
+        not lines[start].strip() or lines[start].lstrip().startswith("--")
+    ):
+        start += 1
+    if start < len(lines) and _TXN_LINE_RE.match(lines[start]) and \
+            lines[start].strip().upper().startswith("BEGIN"):
+        lines = lines[:start] + lines[start + 1 :]
+
+    # Drop a trailing standalone COMMIT; (skipping blank/comment lines after it).
+    end = len(lines) - 1
+    while end >= 0 and (not lines[end].strip() or lines[end].lstrip().startswith("--")):
+        end -= 1
+    if end >= 0 and _TXN_LINE_RE.match(lines[end]) and \
+            lines[end].strip().upper().startswith("COMMIT"):
+        lines = lines[:end] + lines[end + 1 :]
+
+    return "\n".join(lines)
+
+
+def _ensure_version_table(engine: Engine) -> None:
+    """Create ``schema_migrations`` if absent (idempotent)."""
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS schema_migrations ("
+                "  version TEXT PRIMARY KEY,"
+                "  applied_at TIMESTAMPTZ NOT NULL DEFAULT now()"
+                ")"
+            )
+        )
+
+
+def applied_versions(engine: Engine) -> set[str]:
+    """Return the set of already-applied migration filenames.
+
+    Returns an empty set when ``schema_migrations`` does not exist yet (a
+    fresh DB), so callers can compute "pending" without first creating it.
+    """
+    insp_sql = (
+        "SELECT 1 FROM information_schema.tables "
+        "WHERE table_schema = 'public' AND table_name = 'schema_migrations'"
+    )
+    with engine.connect() as conn:
+        if conn.execute(text(insp_sql)).first() is None:
+            return set()
+        rows = conn.execute(text("SELECT version FROM schema_migrations")).scalars().all()
+    return set(rows)
+
+
+def pending_migrations(
+    engine: Engine, migrations_dir: Path | None = None
+) -> list[Path]:
+    """Return discovered migrations not yet recorded in ``schema_migrations``."""
+    done = applied_versions(engine)
+    return [p for p in discover_migrations(migrations_dir) if p.name not in done]
+
+
+def _apply_one(engine: Engine, path: Path) -> None:
+    """Apply a single migration file and record it, atomically.
+
+    The file body (minus its own ``BEGIN;``/``COMMIT;``) and the bookkeeping
+    INSERT run in ONE ``engine.begin()`` transaction. ``exec_driver_sql`` runs
+    the multi-statement body as a single script via the DBAPI driver.
+    """
+    body = _strip_outer_transaction(path.read_text())
+    with engine.begin() as conn:
+        if body.strip():
+            conn.exec_driver_sql(body)
+        conn.execute(
+            text("INSERT INTO schema_migrations (version) VALUES (:v)"),
+            {"v": path.name},
+        )
+
+
+def run_migrations(
+    engine: Engine,
+    *,
+    dry_run: bool = False,
+    migrations_dir: Path | None = None,
+) -> list[str]:
+    """Apply all pending legacy migrations in filename order.
+
+    Creates ``schema_migrations`` if absent, then applies each not-yet-recorded
+    forward migration in its own transaction, recording the filename on success.
+    Already-applied files are skipped, so a second run is a no-op.
+
+    ``dry_run=True`` lists the pending filenames WITHOUT creating the version
+    table or applying anything.
+
+    Returns the list of filenames that were applied (dry-run: the filenames
+    that WOULD be applied).
+    """
+    if dry_run:
+        pending = pending_migrations(engine, migrations_dir)
+        return [p.name for p in pending]
+
+    _ensure_version_table(engine)
+    pending = pending_migrations(engine, migrations_dir)
+    applied: list[str] = []
+    for path in pending:
+        _apply_one(engine, path)
+        log.info("legacy_migration_applied", version=path.name)
+        applied.append(path.name)
+    return applied

--- a/src/rainier/core/legacy_migrate.py
+++ b/src/rainier/core/legacy_migrate.py
@@ -177,6 +177,16 @@ class UnversionedSchemaError(RuntimeError):
     """
 
 
+class EmptyDatabaseError(RuntimeError):
+    """Raised when a plain run targets a truly EMPTY DB with the shipped files.
+
+    The shipped ``migrations/*.sql`` assume an existing schema (0001 starts
+    with ``ALTER TABLE analysis_results``, a table only ``db init`` creates),
+    so a from-scratch replay dies at file 1 with a raw SQL error. The
+    supported bootstrap is ``db init`` then ``--baseline``.
+    """
+
+
 class AlreadyVersionedError(RuntimeError):
     """Raised when baseline is invoked on a DB that already has recorded versions.
 
@@ -342,30 +352,48 @@ def run_migrations(
     table survives to disarm the safety guard below.
 
     ``dry_run=True`` lists the pending filenames WITHOUT creating the version
-    table or applying anything.
+    table or applying anything. The safety guards below run for dry-run too,
+    so a dry-run is a TRUTHFUL preview of what a real run would do (codex 43f3
+    [P2]: listing "13 pending" on a DB the real run refuses was misleading in
+    the exact recovery scenario this runner targets).
 
-    SAFETY GUARD: if the legacy schema ALREADY has tables but no
-    ``schema_migrations`` table, this raises ``UnversionedSchemaError`` instead
-    of blindly replaying ``0001..N`` (which can fail on an already-migrated
-    schema). Adopt such a DB with ``baseline_migrations`` /
-    ``db migrate-legacy --baseline`` first, then run for the new tail only. A
-    truly fresh DB (no tables) runs from 0001 normally.
+    SAFETY GUARDS (both raise before any DB write):
+
+    * ``UnversionedSchemaError`` — the legacy schema ALREADY has tables but no
+      ``schema_migrations`` table. Refuses to blindly replay ``0001..N``
+      (historical files don't re-run cleanly on an already-migrated schema).
+      Adopt with ``baseline_migrations`` / ``db migrate-legacy --baseline``,
+      then run for the new tail only.
+    * ``EmptyDatabaseError`` — the DB is truly EMPTY and the DEFAULT (shipped)
+      migration set is in use. The shipped files assume an existing schema
+      (0001 ALTERs tables only ``db init`` creates), so a from-scratch replay
+      dies at file 1; steer to ``db init`` + ``--baseline`` instead. A custom
+      ``migrations_dir`` skips this guard (self-contained sets bootstrap fine).
 
     Returns the list of filenames that were applied (dry-run: the filenames
     that WOULD be applied).
     """
+    if not _version_table_exists(engine):
+        if _legacy_schema_present(engine):
+            raise UnversionedSchemaError(
+                "Legacy schema already has tables but no schema_migrations "
+                "table. Refusing to replay 0001..N (some historical files "
+                "don't re-run cleanly on an existing schema). Run 'rainier db "
+                "migrate-legacy --baseline' once to adopt the current schema, "
+                "then re-run to apply any new migrations."
+            )
+        if migrations_dir is None:
+            raise EmptyDatabaseError(
+                "Empty legacy database: the shipped migrations/*.sql assume an "
+                "existing schema (0001 ALTERs tables only 'rainier db init' "
+                "creates) and cannot bootstrap from scratch. Run 'rainier db "
+                "init' first, then 'rainier db migrate-legacy --baseline' to "
+                "adopt the file history."
+            )
+
     if dry_run:
         pending = pending_migrations(engine, migrations_dir)
         return [p.name for p in pending]
-
-    if not _version_table_exists(engine) and _legacy_schema_present(engine):
-        raise UnversionedSchemaError(
-            "Legacy schema already has tables but no schema_migrations table. "
-            "Refusing to replay 0001..N (some historical files don't re-run "
-            "cleanly on an existing schema). Run 'rainier db migrate-legacy "
-            "--baseline' once to adopt the current schema, then re-run to apply "
-            "any new migrations."
-        )
 
     pending = pending_migrations(engine, migrations_dir)
     applied: list[str] = []

--- a/src/rainier/core/legacy_migrate.py
+++ b/src/rainier/core/legacy_migrate.py
@@ -24,6 +24,7 @@ committed) the runner strips that outer ``BEGIN;``/``COMMIT;`` and runs the
 file body + the version INSERT inside ONE transaction it controls:
 
     ┌─ engine.begin() (one transaction per file) ─────────────┐
+    │  CREATE TABLE IF NOT EXISTS schema_migrations …          │
     │  <stripped file body, e.g. CREATE TABLE IF NOT EXISTS …> │
     │  INSERT INTO schema_migrations (version) VALUES (<file>) │
     └─────────────────────────────────────────────────────────┘
@@ -141,8 +142,10 @@ def _strip_outer_transaction(sql: str) -> str:
 # tables all live in ``public``, so the version table belongs there too.
 _VERSION_TABLE = "public.schema_migrations"
 
-# Shared by _ensure_version_table (its own transaction) and baseline_migrations
-# (inside the single all-or-nothing stamp transaction).
+# Executed by _apply_one (inside each per-file apply transaction) and
+# baseline_migrations (inside the single all-or-nothing stamp transaction).
+# NEVER in its own up-front transaction: a pre-committed empty version table
+# surviving a failed first apply would disarm the UnversionedSchemaError guard.
 _CREATE_VERSION_TABLE_SQL = (
     f"CREATE TABLE IF NOT EXISTS {_VERSION_TABLE} ("
     "  version TEXT PRIMARY KEY,"
@@ -163,13 +166,6 @@ def _pin_public(conn) -> None:
     the same schema. ``SET LOCAL`` is transaction-scoped, so it reverts on commit.
     """
     conn.exec_driver_sql("SET LOCAL search_path TO public")
-
-
-def _ensure_version_table(engine: Engine) -> None:
-    """Create ``public.schema_migrations`` if absent (idempotent)."""
-    with engine.begin() as conn:
-        _pin_public(conn)
-        conn.execute(text(_CREATE_VERSION_TABLE_SQL))
 
 
 class UnversionedSchemaError(RuntimeError):
@@ -236,13 +232,24 @@ def pending_migrations(
 def _apply_one(engine: Engine, path: Path) -> None:
     """Apply a single migration file and record it, atomically.
 
-    The file body (minus its own ``BEGIN;``/``COMMIT;``) and the bookkeeping
-    INSERT run in ONE ``engine.begin()`` transaction. ``exec_driver_sql`` runs
-    the multi-statement body as a single script via the DBAPI driver.
+    The version-table CREATE IF NOT EXISTS, the file body (minus its own
+    ``BEGIN;``/``COMMIT;``) and the bookkeeping INSERT run in ONE
+    ``engine.begin()`` transaction. ``exec_driver_sql`` runs the
+    multi-statement body as a single script via the DBAPI driver.
+
+    Creating the version table HERE (not in a separate up-front transaction)
+    is load-bearing (review 43f3 iter-2): if the very first apply on a fresh
+    DB fails, a pre-committed empty ``schema_migrations`` would survive the
+    rollback and permanently disarm ``run_migrations``'s
+    ``UnversionedSchemaError`` guard — the operator's natural recovery
+    (``db init``, retry) would then replay non-rerunnable historical SQL
+    instead of being routed to ``--baseline``. In-transaction, a failed first
+    apply leaves the DB exactly as it was.
     """
     body = _strip_outer_transaction(path.read_text())
     with engine.begin() as conn:
         _pin_public(conn)
+        conn.execute(text(_CREATE_VERSION_TABLE_SQL))
         if body.strip():
             conn.exec_driver_sql(body)
         conn.execute(
@@ -302,9 +309,12 @@ def run_migrations(
 ) -> list[str]:
     """Apply all pending legacy migrations in filename order.
 
-    Creates ``schema_migrations`` if absent, then applies each not-yet-recorded
-    forward migration in its own transaction, recording the filename on success.
-    Already-applied files are skipped, so a second run is a no-op.
+    Applies each not-yet-recorded forward migration in its own transaction
+    (which also creates ``schema_migrations`` if absent — inside that same
+    transaction, see ``_apply_one``), recording the filename on success.
+    Already-applied files are skipped, so a second run is a no-op. A run that
+    fails on its FIRST file leaves the DB untouched — no half-created version
+    table survives to disarm the safety guard below.
 
     ``dry_run=True`` lists the pending filenames WITHOUT creating the version
     table or applying anything.
@@ -332,7 +342,6 @@ def run_migrations(
             "any new migrations."
         )
 
-    _ensure_version_table(engine)
     pending = pending_migrations(engine, migrations_dir)
     applied: list[str] = []
     for path in pending:

--- a/src/rainier/core/legacy_migrate.py
+++ b/src/rainier/core/legacy_migrate.py
@@ -47,9 +47,37 @@ from sqlalchemy.engine import Engine
 
 log = structlog.get_logger()
 
-# Repo-root-relative migrations directory. legacy_migrate.py lives at
-# src/rainier/core/legacy_migrate.py → parents[3] is the repo root.
-MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "migrations"
+
+def _resolve_migrations_dir() -> Path:
+    """Locate the numbered ``migrations/*.sql`` directory.
+
+    Resolved in two ways, in priority order — mirrors ``_resolve_alembic_config``
+    in cli.py so the command works from both install shapes:
+
+    1. **Wheel install** — ``importlib.resources.files("rainier") / "_db_assets"
+       / "migrations"``. Hatchling's ``force-include`` ships the top-level
+       ``migrations/`` tree into the wheel there, so a packaged CLI (no source
+       checkout) still finds the files instead of returning ``[]`` and falsely
+       reporting "up to date".
+    2. **Editable / source checkout** — ``<repo>/migrations`` via ``__file__``
+       (this module at ``src/rainier/core/legacy_migrate.py`` → ``parents[3]``
+       is the repo root).
+    """
+    from importlib import resources
+
+    try:
+        anchor = resources.files("rainier") / "_db_assets" / "migrations"
+        with resources.as_file(anchor) as path_obj:
+            packaged = Path(path_obj)
+        if packaged.is_dir():
+            return packaged
+    except (ModuleNotFoundError, FileNotFoundError):
+        pass  # fall through to source-checkout path
+
+    return Path(__file__).resolve().parents[3] / "migrations"
+
+
+MIGRATIONS_DIR = _resolve_migrations_dir()
 
 # Forward migrations are ``NNNN_<name>.sql``; downgrades are
 # ``NNNN_<name>_downgrade.sql`` and must be excluded.
@@ -106,12 +134,20 @@ def _strip_outer_transaction(sql: str) -> str:
     return "\n".join(lines)
 
 
+# The version table is ALWAYS schema-qualified ``public.schema_migrations``.
+# Unqualified DDL/DML would resolve through the role's ``search_path``, which can
+# put the CREATE in one schema and a later existence-check in another — then the
+# runner thinks nothing is applied and replays every migration. The legacy ORM
+# tables all live in ``public``, so the version table belongs there too.
+_VERSION_TABLE = "public.schema_migrations"
+
+
 def _ensure_version_table(engine: Engine) -> None:
-    """Create ``schema_migrations`` if absent (idempotent)."""
+    """Create ``public.schema_migrations`` if absent (idempotent)."""
     with engine.begin() as conn:
         conn.execute(
             text(
-                "CREATE TABLE IF NOT EXISTS schema_migrations ("
+                f"CREATE TABLE IF NOT EXISTS {_VERSION_TABLE} ("
                 "  version TEXT PRIMARY KEY,"
                 "  applied_at TIMESTAMPTZ NOT NULL DEFAULT now()"
                 ")"
@@ -122,7 +158,7 @@ def _ensure_version_table(engine: Engine) -> None:
 def applied_versions(engine: Engine) -> set[str]:
     """Return the set of already-applied migration filenames.
 
-    Returns an empty set when ``schema_migrations`` does not exist yet (a
+    Returns an empty set when ``public.schema_migrations`` does not exist yet (a
     fresh DB), so callers can compute "pending" without first creating it.
     """
     insp_sql = (
@@ -132,7 +168,9 @@ def applied_versions(engine: Engine) -> set[str]:
     with engine.connect() as conn:
         if conn.execute(text(insp_sql)).first() is None:
             return set()
-        rows = conn.execute(text("SELECT version FROM schema_migrations")).scalars().all()
+        rows = (
+            conn.execute(text(f"SELECT version FROM {_VERSION_TABLE}")).scalars().all()
+        )
     return set(rows)
 
 
@@ -156,7 +194,7 @@ def _apply_one(engine: Engine, path: Path) -> None:
         if body.strip():
             conn.exec_driver_sql(body)
         conn.execute(
-            text("INSERT INTO schema_migrations (version) VALUES (:v)"),
+            text(f"INSERT INTO {_VERSION_TABLE} (version) VALUES (:v)"),
             {"v": path.name},
         )
 

--- a/src/rainier/core/schema_check.py
+++ b/src/rainier/core/schema_check.py
@@ -20,6 +20,19 @@ from sqlalchemy.engine import Engine
 
 from rainier.core.models import Base
 
+# Documented PRE-EXISTING benign drift the loud chokepoints must not block on.
+# ``capital_flow_bars`` on the live legacy DB is an empty (0-row) table orphaned
+# by the old stock_id-FK -> symbol refactor: no ``migrations/*.sql`` adds the
+# column, the QU100 pipeline never reads the table, and the operator's runbook
+# (memory ``project_prod_checkout_staleness``) says to block only on findings
+# BEYOND it. Without this allowlist ``rainier db init`` would exit non-zero on
+# the live DB forever, with ``db migrate-legacy`` unable to clear it.
+KNOWN_BENIGN_DRIFT: frozenset[str] = frozenset(
+    {
+        "missing column: capital_flow_bars.symbol",
+    }
+)
+
 
 def check_schema_drift(engine: Engine) -> list[str]:
     """Compare the legacy ORM to ``engine``'s live schema.

--- a/src/rainier/core/schema_check.py
+++ b/src/rainier/core/schema_check.py
@@ -21,29 +21,31 @@ from sqlalchemy.engine import Engine
 from rainier.core.models import Base
 
 # Documented PRE-EXISTING benign drift the loud chokepoints must not block on
-# (every entry verified against the live legacy DB, 2026-07-03):
-#
-# * ``capital_flow_bars.symbol`` (+ its index): the table is an empty (0-row)
-#   orphan of the old stock_id-FK -> symbol refactor. No ``migrations/*.sql``
-#   adds the column, the QU100 pipeline never reads the table, and the
-#   operator's runbook (memory ``project_prod_checkout_staleness``) says to
-#   block only on findings BEYOND it. Without this allowlist ``rainier db
-#   init`` would exit non-zero on the live DB forever, with ``db
-#   migrate-legacy`` unable to clear it.
-# * ``paper_reclaim_queue.ix_paper_reclaim_queue_*``: NAME aliasing, not
-#   missing DDL — migrations/0012_reclaim_queue.sql created these indexes as
-#   ``ix_paper_reclaim_status`` / ``ix_paper_reclaim_symbol`` (verified
-#   present live), while the ORM's ``index=True`` auto-names expect
-#   ``ix_paper_reclaim_queue_<col>``. Same columns, same semantics; a fresh
-#   ``db init`` DB carries the ORM names instead.
+# (verified against the live legacy DB, 2026-07-03): ``capital_flow_bars``
+# (+ its ``symbol`` index) is an empty (0-row) orphan of the old
+# stock_id-FK -> symbol refactor. No ``migrations/*.sql`` adds the column, the
+# QU100 pipeline never reads the table, and the operator's runbook (memory
+# ``project_prod_checkout_staleness``) says to block only on findings BEYOND
+# it. Without this allowlist ``rainier db init`` would exit non-zero on the
+# live DB forever, with ``db migrate-legacy`` unable to clear it.
 KNOWN_BENIGN_DRIFT: frozenset[str] = frozenset(
     {
         "missing column: capital_flow_bars.symbol",
         "missing index: capital_flow_bars.ix_capital_flow_bars_symbol",
-        "missing index: paper_reclaim_queue.ix_paper_reclaim_queue_status",
-        "missing index: paper_reclaim_queue.ix_paper_reclaim_queue_symbol",
     }
 )
+
+# NAME aliasing between the ORM's auto-names and migration-created names
+# (verified live 2026-07-03): migrations/0012_reclaim_queue.sql created its
+# indexes as ``ix_paper_reclaim_status`` / ``ix_paper_reclaim_symbol``, while
+# the ORM's ``index=True`` auto-names expect ``ix_paper_reclaim_queue_<col>``.
+# Same columns, same semantics — EITHER name satisfies the contract. This is
+# deliberately NOT an allowlist entry (codex 43f3 [P2]): a DB where NEITHER
+# name exists (partial/manual 0012 apply) is real drift and must be flagged.
+INDEX_NAME_ALIASES: dict[str, tuple[str, ...]] = {
+    "ix_paper_reclaim_queue_status": ("ix_paper_reclaim_status",),
+    "ix_paper_reclaim_queue_symbol": ("ix_paper_reclaim_symbol",),
+}
 
 
 def check_schema_drift(engine: Engine) -> list[str]:
@@ -118,8 +120,13 @@ def check_schema_drift(engine: Engine) -> list[str]:
             live_names.add(pk["name"])
 
         for index in sorted(table.indexes, key=lambda ix: str(ix.name)):
-            if index.name and str(index.name) not in live_names:
-                findings.append(f"missing index: {table_name}.{index.name}")
+            if not index.name:
+                continue
+            name = str(index.name)
+            aliases = INDEX_NAME_ALIASES.get(name, ())
+            if name in live_names or any(a in live_names for a in aliases):
+                continue
+            findings.append(f"missing index: {table_name}.{name}")
         # table.constraints is a set — sort for stable finding order. Unnamed
         # constraints (None / SQLAlchemy's anonymous-name sentinel, which is
         # not a plain str) can't be checked by name and are skipped.

--- a/src/rainier/core/schema_check.py
+++ b/src/rainier/core/schema_check.py
@@ -20,16 +20,28 @@ from sqlalchemy.engine import Engine
 
 from rainier.core.models import Base
 
-# Documented PRE-EXISTING benign drift the loud chokepoints must not block on.
-# ``capital_flow_bars`` on the live legacy DB is an empty (0-row) table orphaned
-# by the old stock_id-FK -> symbol refactor: no ``migrations/*.sql`` adds the
-# column, the QU100 pipeline never reads the table, and the operator's runbook
-# (memory ``project_prod_checkout_staleness``) says to block only on findings
-# BEYOND it. Without this allowlist ``rainier db init`` would exit non-zero on
-# the live DB forever, with ``db migrate-legacy`` unable to clear it.
+# Documented PRE-EXISTING benign drift the loud chokepoints must not block on
+# (every entry verified against the live legacy DB, 2026-07-03):
+#
+# * ``capital_flow_bars.symbol`` (+ its index): the table is an empty (0-row)
+#   orphan of the old stock_id-FK -> symbol refactor. No ``migrations/*.sql``
+#   adds the column, the QU100 pipeline never reads the table, and the
+#   operator's runbook (memory ``project_prod_checkout_staleness``) says to
+#   block only on findings BEYOND it. Without this allowlist ``rainier db
+#   init`` would exit non-zero on the live DB forever, with ``db
+#   migrate-legacy`` unable to clear it.
+# * ``paper_reclaim_queue.ix_paper_reclaim_queue_*``: NAME aliasing, not
+#   missing DDL — migrations/0012_reclaim_queue.sql created these indexes as
+#   ``ix_paper_reclaim_status`` / ``ix_paper_reclaim_symbol`` (verified
+#   present live), while the ORM's ``index=True`` auto-names expect
+#   ``ix_paper_reclaim_queue_<col>``. Same columns, same semantics; a fresh
+#   ``db init`` DB carries the ORM names instead.
 KNOWN_BENIGN_DRIFT: frozenset[str] = frozenset(
     {
         "missing column: capital_flow_bars.symbol",
+        "missing index: capital_flow_bars.ix_capital_flow_bars_symbol",
+        "missing index: paper_reclaim_queue.ix_paper_reclaim_queue_status",
+        "missing index: paper_reclaim_queue.ix_paper_reclaim_queue_symbol",
     }
 )
 
@@ -41,12 +53,22 @@ def check_schema_drift(engine: Engine) -> list[str]:
 
       * ``"missing table: <name>"``
       * ``"missing column: <table>.<column>"``
+      * ``"missing index: <table>.<name>"``
+      * ``"missing constraint: <table>.<name>"``
 
-    An empty list means the live schema satisfies every ORM-declared table and
-    column. Extra (DB-only) tables/columns are intentionally NOT reported: the
-    ORM is the contract, and a shared instance may legitimately carry tables the
-    legacy models don't declare. Findings are ordered by ORM table-definition
-    order (tables before their columns) for stable output.
+    An empty list means the live schema satisfies every ORM-declared table,
+    column, and NAMED index/constraint. Index/constraint checking is by NAME
+    presence only (codex 43f3 review: an index/constraint-only
+    ``migrations/*.sql`` that never ran was invisible to a tables/columns
+    check, so ``--baseline`` could stamp it as applied) — a live object whose
+    name matches but whose definition drifted is NOT detected, and DDL that
+    exists only in migration files (never mirrored in the ORM) cannot be
+    checked at all. Unnamed ORM constraints (auto-named PKs/FKs) are skipped.
+
+    Extra (DB-only) tables/columns/indexes are intentionally NOT reported: the
+    ORM is the contract, and a shared instance may legitimately carry objects
+    the legacy models don't declare. Findings are ordered by ORM
+    table-definition order for stable output.
     """
     insp = inspect(engine)
     existing_tables = set(insp.get_table_names())
@@ -59,4 +81,40 @@ def check_schema_drift(engine: Engine) -> list[str]:
         for column in table.columns:
             if column.name not in live_cols:
                 findings.append(f"missing column: {table_name}.{column.name}")
+
+        # Postgres exposes a UNIQUE declared as a constraint via
+        # get_unique_constraints and one declared as an index via get_indexes
+        # (and backs the former with a same-named index), so membership is
+        # checked against the UNION of all live names to avoid classification
+        # false-positives.
+        live_names: set[str] = set()
+        live_names.update(
+            ix["name"] for ix in insp.get_indexes(table_name) if ix.get("name")
+        )
+        live_names.update(
+            c["name"] for c in insp.get_unique_constraints(table_name) if c.get("name")
+        )
+        live_names.update(
+            c["name"] for c in insp.get_check_constraints(table_name) if c.get("name")
+        )
+        pk = insp.get_pk_constraint(table_name)
+        if pk and pk.get("name"):
+            live_names.add(pk["name"])
+
+        for index in sorted(table.indexes, key=lambda ix: str(ix.name)):
+            if index.name and str(index.name) not in live_names:
+                findings.append(f"missing index: {table_name}.{index.name}")
+        # table.constraints is a set — sort for stable finding order. Unnamed
+        # constraints (None / SQLAlchemy's anonymous-name sentinel, which is
+        # not a plain str) can't be checked by name and are skipped.
+        declared_constraints = sorted(
+            (
+                str(c.name)
+                for c in table.constraints
+                if isinstance(c.name, str) and c.name
+            ),
+        )
+        for name in declared_constraints:
+            if name not in live_names:
+                findings.append(f"missing constraint: {table_name}.{name}")
     return findings

--- a/src/rainier/core/schema_check.py
+++ b/src/rainier/core/schema_check.py
@@ -47,7 +47,11 @@ KNOWN_BENIGN_DRIFT: frozenset[str] = frozenset(
 
 
 def check_schema_drift(engine: Engine) -> list[str]:
-    """Compare the legacy ORM to ``engine``'s live schema.
+    """Compare the legacy ORM to ``engine``'s live ``public`` schema.
+
+    Inspection targets ``public`` explicitly, independent of the engine's
+    ``search_path`` — matching the migration runner, which pins its DDL and
+    ``schema_migrations`` bookkeeping to ``public``.
 
     Returns a list of human-readable findings, each one of:
 
@@ -70,14 +74,20 @@ def check_schema_drift(engine: Engine) -> list[str]:
     the legacy models don't declare. Findings are ordered by ORM
     table-definition order for stable output.
     """
+    # Inspect ``public`` EXPLICITLY (codex 43f3 [P1]): the legacy ORM tables
+    # and the migration runner's bookkeeping/DDL all live in (and are pinned
+    # to) ``public``. Unqualified inspector calls would follow the engine's
+    # ``search_path`` and could validate a DIFFERENT front schema — reporting
+    # "clean" for a schema the runner never stamps.
+    schema = "public"
     insp = inspect(engine)
-    existing_tables = set(insp.get_table_names())
+    existing_tables = set(insp.get_table_names(schema=schema))
     findings: list[str] = []
     for table_name, table in Base.metadata.tables.items():
         if table_name not in existing_tables:
             findings.append(f"missing table: {table_name}")
             continue
-        live_cols = {col["name"] for col in insp.get_columns(table_name)}
+        live_cols = {col["name"] for col in insp.get_columns(table_name, schema=schema)}
         for column in table.columns:
             if column.name not in live_cols:
                 findings.append(f"missing column: {table_name}.{column.name}")
@@ -89,15 +99,21 @@ def check_schema_drift(engine: Engine) -> list[str]:
         # false-positives.
         live_names: set[str] = set()
         live_names.update(
-            ix["name"] for ix in insp.get_indexes(table_name) if ix.get("name")
+            ix["name"]
+            for ix in insp.get_indexes(table_name, schema=schema)
+            if ix.get("name")
         )
         live_names.update(
-            c["name"] for c in insp.get_unique_constraints(table_name) if c.get("name")
+            c["name"]
+            for c in insp.get_unique_constraints(table_name, schema=schema)
+            if c.get("name")
         )
         live_names.update(
-            c["name"] for c in insp.get_check_constraints(table_name) if c.get("name")
+            c["name"]
+            for c in insp.get_check_constraints(table_name, schema=schema)
+            if c.get("name")
         )
-        pk = insp.get_pk_constraint(table_name)
+        pk = insp.get_pk_constraint(table_name, schema=schema)
         if pk and pk.get("name"):
             live_names.add(pk["name"])
 

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -239,12 +239,13 @@ def test_db_migrate_legacy_baseline_stamps(monkeypatch):
     assert "WARNING" not in result.output, "clean drift must not warn"
 
 
-def test_db_migrate_legacy_baseline_warns_on_missing_objects(monkeypatch):
-    """`--baseline` warns loudly when the ORM contract says stamped bookkeeping
-    now covers objects the live schema doesn't have (review 43f3 iter-1: a
-    blanket baseline over the '0012/0013 never ran' state would otherwise
-    silently mark the missing migrations as applied). Known-benign drift is
-    excluded from the warning."""
+def test_db_migrate_legacy_baseline_fails_loud_on_missing_objects(monkeypatch):
+    """`--baseline` exits NON-ZERO when the ORM contract says stamped
+    bookkeeping now covers objects the live schema doesn't have (review 43f3
+    iter-1 + codex [P1]: a blanket baseline over the '0012/0013 never ran'
+    state would otherwise silently mark the missing migrations as applied, and
+    an exit-0 warning would let automation sail past the partial-adoption
+    state). Known-benign drift is excluded from the warning."""
     import rainier.core.database as db_mod
     import rainier.core.legacy_migrate as lm_mod
     import rainier.core.schema_check as sc_mod
@@ -267,13 +268,15 @@ def test_db_migrate_legacy_baseline_warns_on_missing_objects(monkeypatch):
 
     runner = CliRunner()
     result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy", "--baseline"])
-    assert result.exit_code == 0, result.output
+    assert result.exit_code != 0, result.output
     assert "WARNING" in result.output
     assert "paper_reclaim_queue" in result.output
     assert "capital_flow_bars.symbol" not in result.output, (
         "known-benign drift must not appear in the baseline warning"
     )
     assert "Hand-apply" in result.output
+    # The stamps happened and are reported before the loud failure.
+    assert "Baselined 1" in result.output
 
 
 def test_db_migrate_legacy_dry_run_and_baseline_conflict(monkeypatch):
@@ -365,19 +368,49 @@ def test_db_init_exits_loud_on_drift(monkeypatch):
 
 def test_db_init_clean_when_no_drift(monkeypatch):
     """`db init` succeeds and reports a clean drift check when there are no
-    findings."""
+    findings and no pending legacy migrations."""
     import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
     import rainier.core.schema_check as sc_mod
     from rainier import cli as cli_mod
 
     monkeypatch.setattr(db_mod, "init_db", lambda: None)
     monkeypatch.setattr(db_mod, "get_engine", lambda: object())
     monkeypatch.setattr(sc_mod, "check_schema_drift", lambda engine: [])
+    monkeypatch.setattr(lm_mod, "pending_migrations", lambda engine: [])
 
     runner = CliRunner()
     result = runner.invoke(cli_mod.cli, ["db", "init"])
     assert result.exit_code == 0, result.output
     assert "clean" in result.output.lower()
+    assert "NOTE:" not in result.output, "no pending files must mean no note"
+
+
+def test_db_init_notes_pending_legacy_migrations(monkeypatch):
+    """`db init` must not imply full health when legacy migration files are
+    unrecorded (codex 43f3 review [P1]): create_all never runs migration-only
+    DDL (indexes/constraints), so a fresh DB that passes the tables/columns
+    drift check still needs `db migrate-legacy`. The success path prints a
+    NOTE pointing there."""
+    import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
+    import rainier.core.schema_check as sc_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "init_db", lambda: None)
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+    monkeypatch.setattr(sc_mod, "check_schema_drift", lambda engine: [])
+    monkeypatch.setattr(
+        lm_mod,
+        "pending_migrations",
+        lambda engine: ["0012_reclaim_queue.sql", "0013_paper_trade_shadow.sql"],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "init"])
+    assert result.exit_code == 0, result.output
+    assert "NOTE: 2 legacy migration file(s)" in result.output
+    assert "migrate-legacy" in result.output
 
 
 def test_db_init_ignores_known_benign_drift(monkeypatch):
@@ -387,6 +420,7 @@ def test_db_init_ignores_known_benign_drift(monkeypatch):
     runbook blocks only on findings beyond it. Hard-failing would make
     `db init` exit non-zero on the live DB forever."""
     import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
     import rainier.core.schema_check as sc_mod
     from rainier import cli as cli_mod
 
@@ -397,6 +431,7 @@ def test_db_init_ignores_known_benign_drift(monkeypatch):
         "check_schema_drift",
         lambda engine: ["missing column: capital_flow_bars.symbol"],
     )
+    monkeypatch.setattr(lm_mod, "pending_migrations", lambda engine: [])
 
     runner = CliRunner()
     result = runner.invoke(cli_mod.cli, ["db", "init"])

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -374,6 +374,30 @@ def test_db_migrate_legacy_unversioned_schema_fails_clean(monkeypatch):
     assert "--baseline" in (result.output or "")
 
 
+def test_db_migrate_legacy_dry_run_failure_fails_clean(monkeypatch):
+    """An unexpected probe failure during --dry-run (unhealthy DB) surfaces
+    as a clean `Error:` line, not a raw traceback (codex 43f3 [P2])."""
+    import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+
+    def _raise(engine, *, dry_run=False):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(lm_mod, "run_migrations", _raise)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy", "--dry-run"])
+    assert result.exit_code != 0
+    assert "Traceback" not in (result.output or "")
+    assert not isinstance(result.exception, RuntimeError), (
+        "dry-run probe failures must be wrapped in a ClickException, not leaked"
+    )
+    assert "dry-run failed" in result.output
+
+
 def test_db_migrate_legacy_apply_failure_fails_clean(monkeypatch):
     """A real apply failure (bad migration SQL, dropped connection) surfaces
     as a clean `Error:` line, never a raw traceback (codex 43f3 [P2] —
@@ -443,6 +467,9 @@ def test_db_init_exits_loud_on_drift(monkeypatch):
     assert "screened_stocks.bearish_invalidation_level" in result.output
     assert "paper_reclaim_queue" in result.output
     assert "migrate-legacy" in result.output
+    # The success banner must NOT be printed on the drift-failure path
+    # (codex 43f3 [P2]: scripts reading stdout saw "success" then non-zero).
+    assert "Database initialized successfully" not in result.output
 
 
 def test_db_init_clean_when_no_drift(monkeypatch):
@@ -463,6 +490,8 @@ def test_db_init_clean_when_no_drift(monkeypatch):
     assert result.exit_code == 0, result.output
     assert "clean" in result.output.lower()
     assert "NOTE:" not in result.output, "no pending files must mean no note"
+    # Success banner prints only after all checks pass.
+    assert "Database initialized successfully" in result.output
 
 
 def test_db_init_notes_pending_legacy_migrations(monkeypatch):

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -239,24 +239,23 @@ def test_db_migrate_legacy_baseline_stamps(monkeypatch):
     assert "WARNING" not in result.output, "clean drift must not warn"
 
 
-def test_db_migrate_legacy_baseline_fails_loud_on_missing_objects(monkeypatch):
-    """`--baseline` exits NON-ZERO when the ORM contract says stamped
-    bookkeeping now covers objects the live schema doesn't have (review 43f3
-    iter-1 + codex [P1]: a blanket baseline over the '0012/0013 never ran'
-    state would otherwise silently mark the missing migrations as applied, and
-    an exit-0 warning would let automation sail past the partial-adoption
-    state). Known-benign drift is excluded from the warning."""
+def test_db_migrate_legacy_baseline_refuses_on_missing_objects(monkeypatch):
+    """`--baseline` refuses BEFORE stamping when the live schema is missing
+    ORM-declared objects (codex 43f3 [P1]: stamping first would record the
+    missing migrations as applied, so a stamp-then-fail mutates bookkeeping
+    into a harder-to-recover state — the runner would permanently skip them).
+    Nothing is stamped, exit non-zero. Known-benign drift is excluded."""
     import rainier.core.database as db_mod
     import rainier.core.legacy_migrate as lm_mod
     import rainier.core.schema_check as sc_mod
     from rainier import cli as cli_mod
 
     monkeypatch.setattr(db_mod, "get_engine", lambda: object())
-    monkeypatch.setattr(
-        lm_mod,
-        "baseline_migrations",
-        lambda engine, *, migrations_dir=None: ["0012_reclaim_queue.sql"],
-    )
+
+    def _boom_baseline(*_a, **_k):
+        raise AssertionError("baseline_migrations must NOT be called on refusal")
+
+    monkeypatch.setattr(lm_mod, "baseline_migrations", _boom_baseline)
     monkeypatch.setattr(
         sc_mod,
         "check_schema_drift",
@@ -269,14 +268,37 @@ def test_db_migrate_legacy_baseline_fails_loud_on_missing_objects(monkeypatch):
     runner = CliRunner()
     result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy", "--baseline"])
     assert result.exit_code != 0, result.output
-    assert "WARNING" in result.output
+    assert "Refusing to baseline" in result.output
     assert "paper_reclaim_queue" in result.output
     assert "capital_flow_bars.symbol" not in result.output, (
-        "known-benign drift must not appear in the baseline warning"
+        "known-benign drift must not trigger the baseline refusal"
     )
-    assert "Hand-apply" in result.output
-    # The stamps happened and are reported before the loud failure.
+    assert "nothing was stamped" in result.output
+    assert "Baselined" not in result.output
+
+
+def test_db_migrate_legacy_baseline_notes_verification_scope(monkeypatch):
+    """A successful `--baseline` prints the honest verification-scope note
+    (codex 43f3 [P2 deferred]: the check covers ORM tables/columns only —
+    migration-only indexes/constraints are not verified)."""
+    import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
+    import rainier.core.schema_check as sc_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+    monkeypatch.setattr(sc_mod, "check_schema_drift", lambda engine: [])
+    monkeypatch.setattr(
+        lm_mod,
+        "baseline_migrations",
+        lambda engine, *, migrations_dir=None: ["0012_reclaim_queue.sql"],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy", "--baseline"])
+    assert result.exit_code == 0, result.output
     assert "Baselined 1" in result.output
+    assert "tables/columns only" in result.output
 
 
 def test_db_migrate_legacy_dry_run_and_baseline_conflict(monkeypatch):

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -374,6 +374,32 @@ def test_db_migrate_legacy_unversioned_schema_fails_clean(monkeypatch):
     assert "--baseline" in (result.output or "")
 
 
+def test_db_migrate_legacy_apply_failure_fails_clean(monkeypatch):
+    """A real apply failure (bad migration SQL, dropped connection) surfaces
+    as a clean `Error:` line, never a raw traceback (codex 43f3 [P2] —
+    mirrors db_migrate's wrapping idiom)."""
+    import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+
+    def _raise(engine, *, dry_run=False):
+        raise RuntimeError("relation \"boom\" does not exist")
+
+    monkeypatch.setattr(lm_mod, "run_migrations", _raise)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy"])
+    assert result.exit_code != 0
+    assert "Traceback" not in (result.output or "")
+    assert not isinstance(result.exception, RuntimeError), (
+        "apply failures must be wrapped in a ClickException, not leaked"
+    )
+    assert "legacy migration failed" in result.output
+    assert "boom" in result.output
+
+
 def test_db_migrate_legacy_noop_when_up_to_date(monkeypatch):
     """`db migrate-legacy` reports a no-op when nothing is pending."""
     import rainier.core.database as db_mod

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -218,6 +218,12 @@ def test_db_migrate_legacy_baseline_stamps(monkeypatch):
 
     monkeypatch.setattr(db_mod, "get_engine", lambda: object())
     monkeypatch.setattr(sc_mod, "check_schema_drift", lambda engine: [])
+    monkeypatch.setattr(
+        lm_mod,
+        "pending_migrations",
+        lambda engine: ["0001_llm_thesis_pr1.sql", "0002_llm_thesis_pr2.sql"],
+    )
+    monkeypatch.setattr(lm_mod, "applied_versions", lambda engine: set())
 
     def _fake_baseline(engine, *, migrations_dir=None):
         calls["baseline"] = True
@@ -251,6 +257,10 @@ def test_db_migrate_legacy_baseline_refuses_on_missing_objects(monkeypatch):
     from rainier import cli as cli_mod
 
     monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        lm_mod, "pending_migrations", lambda engine: ["0012_reclaim_queue.sql"]
+    )
+    monkeypatch.setattr(lm_mod, "applied_versions", lambda engine: set())
 
     def _boom_baseline(*_a, **_k):
         raise AssertionError("baseline_migrations must NOT be called on refusal")
@@ -278,33 +288,43 @@ def test_db_migrate_legacy_baseline_refuses_on_missing_objects(monkeypatch):
 
 
 def test_db_migrate_legacy_baseline_already_versioned_fails_clean(monkeypatch):
-    """When baseline_migrations refuses an already-versioned DB, the CLI
-    surfaces a clean error (non-zero, no traceback) pointing at a plain run."""
+    """`--baseline` on an already-versioned DB with pending files fails clean
+    with plain-run guidance BEFORE the drift refusal (codex 43f3 [P2]: the
+    drift refusal's hand-apply-then-baseline recovery is wrong there), and
+    stamps nothing."""
     import rainier.core.database as db_mod
     import rainier.core.legacy_migrate as lm_mod
     import rainier.core.schema_check as sc_mod
     from rainier import cli as cli_mod
 
     monkeypatch.setattr(db_mod, "get_engine", lambda: object())
-    monkeypatch.setattr(sc_mod, "check_schema_drift", lambda engine: [])
+    monkeypatch.setattr(
+        lm_mod, "pending_migrations", lambda engine: ["0014_future.sql"]
+    )
+    monkeypatch.setattr(
+        lm_mod, "applied_versions", lambda engine: {"0001_llm_thesis_pr1.sql"}
+    )
+    # Drift ALSO present (the new ORM-backed migration's column) — the
+    # already-versioned guidance must still win over the drift refusal.
+    monkeypatch.setattr(
+        sc_mod,
+        "check_schema_drift",
+        lambda engine: ["missing column: paper_trade.shadow"],
+    )
 
-    def _raise(engine, *, migrations_dir=None):
-        raise lm_mod.AlreadyVersionedError(
-            "schema_migrations already has recorded versions; the 1 pending "
-            "file(s) are new migrations that must be APPLIED, not stamped. "
-            "Run 'rainier db migrate-legacy' (without --baseline)."
-        )
+    def _boom_baseline(*_a, **_k):
+        raise AssertionError("baseline_migrations must NOT be called")
 
-    monkeypatch.setattr(lm_mod, "baseline_migrations", _raise)
+    monkeypatch.setattr(lm_mod, "baseline_migrations", _boom_baseline)
 
     runner = CliRunner()
     result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy", "--baseline"])
     assert result.exit_code != 0
     assert "Traceback" not in (result.output or "")
-    assert not isinstance(result.exception, lm_mod.AlreadyVersionedError), (
-        "AlreadyVersionedError must be wrapped in a ClickException, not leaked"
-    )
     assert "must be APPLIED" in result.output
+    assert "Refusing to baseline" not in result.output, (
+        "already-versioned guidance must take precedence over the drift refusal"
+    )
 
 
 def test_db_migrate_legacy_baseline_notes_verification_scope(monkeypatch):
@@ -318,6 +338,10 @@ def test_db_migrate_legacy_baseline_notes_verification_scope(monkeypatch):
 
     monkeypatch.setattr(db_mod, "get_engine", lambda: object())
     monkeypatch.setattr(sc_mod, "check_schema_drift", lambda engine: [])
+    monkeypatch.setattr(
+        lm_mod, "pending_migrations", lambda engine: ["0012_reclaim_queue.sql"]
+    )
+    monkeypatch.setattr(lm_mod, "applied_versions", lambda engine: set())
     monkeypatch.setattr(
         lm_mod,
         "baseline_migrations",
@@ -513,12 +537,41 @@ def test_db_init_notes_pending_legacy_migrations(monkeypatch):
         "pending_migrations",
         lambda engine: ["0012_reclaim_queue.sql", "0013_paper_trade_shadow.sql"],
     )
+    # Fresh-bootstrap state: nothing recorded yet -> the note must lead with
+    # --baseline (a plain run refuses unversioned schemas, codex 43f3 [P2]).
+    monkeypatch.setattr(lm_mod, "applied_versions", lambda engine: set())
 
     runner = CliRunner()
     result = runner.invoke(cli_mod.cli, ["db", "init"])
     assert result.exit_code == 0, result.output
     assert "NOTE: 2 legacy migration file(s)" in result.output
-    assert "migrate-legacy" in result.output
+    assert "--baseline" in result.output
+
+
+def test_db_init_notes_pending_on_versioned_db_points_at_plain_run(monkeypatch):
+    """On an already-versioned DB with pending files, the db init note points
+    at a plain `migrate-legacy` run (the files are new migrations to apply)."""
+    import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
+    import rainier.core.schema_check as sc_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "init_db", lambda: None)
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+    monkeypatch.setattr(sc_mod, "check_schema_drift", lambda engine: [])
+    monkeypatch.setattr(
+        lm_mod, "pending_migrations", lambda engine: ["0014_future.sql"]
+    )
+    monkeypatch.setattr(
+        lm_mod, "applied_versions", lambda engine: {"0001_llm_thesis_pr1.sql"}
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "init"])
+    assert result.exit_code == 0, result.output
+    assert "NOTE: 1 legacy migration file(s)" in result.output
+    assert "Run 'rainier db migrate-legacy' to apply them." in result.output
+    assert "--baseline" not in result.output
 
 
 def test_db_init_ignores_known_benign_drift(monkeypatch):

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -251,6 +251,33 @@ def test_db_migrate_legacy_dry_run_and_baseline_conflict(monkeypatch):
     assert "mutually exclusive" in result.output
 
 
+def test_db_migrate_legacy_unversioned_schema_fails_clean(monkeypatch):
+    """When run_migrations raises UnversionedSchemaError, the CLI surfaces a
+    clean error (non-zero, no traceback) pointing at --baseline."""
+    import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+
+    def _raise(engine):
+        raise lm_mod.UnversionedSchemaError(
+            "Legacy schema already has tables but no schema_migrations table. "
+            "Run 'rainier db migrate-legacy --baseline' once ..."
+        )
+
+    monkeypatch.setattr(lm_mod, "run_migrations", _raise)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy"])
+    assert result.exit_code != 0
+    assert "Traceback" not in (result.output or "")
+    assert not isinstance(result.exception, lm_mod.UnversionedSchemaError), (
+        "UnversionedSchemaError must be wrapped in a ClickException, not leaked"
+    )
+    assert "--baseline" in (result.output or "")
+
+
 def test_db_migrate_legacy_noop_when_up_to_date(monkeypatch):
     """`db migrate-legacy` reports a no-op when nothing is pending."""
     import rainier.core.database as db_mod

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -277,6 +277,36 @@ def test_db_migrate_legacy_baseline_refuses_on_missing_objects(monkeypatch):
     assert "Baselined" not in result.output
 
 
+def test_db_migrate_legacy_baseline_already_versioned_fails_clean(monkeypatch):
+    """When baseline_migrations refuses an already-versioned DB, the CLI
+    surfaces a clean error (non-zero, no traceback) pointing at a plain run."""
+    import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
+    import rainier.core.schema_check as sc_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+    monkeypatch.setattr(sc_mod, "check_schema_drift", lambda engine: [])
+
+    def _raise(engine, *, migrations_dir=None):
+        raise lm_mod.AlreadyVersionedError(
+            "schema_migrations already has recorded versions; the 1 pending "
+            "file(s) are new migrations that must be APPLIED, not stamped. "
+            "Run 'rainier db migrate-legacy' (without --baseline)."
+        )
+
+    monkeypatch.setattr(lm_mod, "baseline_migrations", _raise)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy", "--baseline"])
+    assert result.exit_code != 0
+    assert "Traceback" not in (result.output or "")
+    assert not isinstance(result.exception, lm_mod.AlreadyVersionedError), (
+        "AlreadyVersionedError must be wrapped in a ClickException, not leaked"
+    )
+    assert "must be APPLIED" in result.output
+
+
 def test_db_migrate_legacy_baseline_notes_verification_scope(monkeypatch):
     """A successful `--baseline` prints the honest verification-scope note
     (codex 43f3 [P2 deferred]: the check covers ORM tables/columns only —

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -40,7 +40,14 @@ def test_db_group_does_not_shadow_legacy_subcommands():
     result = runner.invoke(cli, ["db", "--help"])
     assert result.exit_code == 0, result.output
 
-    for subcmd in ("init", "backfill-prices", "ping", "migrate", "gc-test-schemas"):
+    for subcmd in (
+        "init",
+        "backfill-prices",
+        "ping",
+        "migrate",
+        "migrate-legacy",
+        "gc-test-schemas",
+    ):
         assert subcmd in result.output, (
             f"`rainier db --help` is missing `{subcmd}` — likely caused by a "
             f"duplicate `@cli.group() def db()` shadowing the original. "
@@ -142,6 +149,123 @@ def test_db_gc_test_schemas_apply_surfaces_failures(monkeypatch):
     result = runner.invoke(cli_mod.cli, ["db", "gc-test-schemas", "--apply"])
     assert result.exit_code != 0
     assert "FAILED" in result.output
+
+
+def test_db_migrate_legacy_dry_run_lists_pending(monkeypatch):
+    """`db migrate-legacy --dry-run` lists pending files and applies nothing.
+
+    Stubs the legacy engine + the runner so no live DB is needed. The command
+    must call ``run_migrations(engine, dry_run=True)`` and echo each pending file.
+    """
+    from rainier import cli as cli_mod
+
+    calls = {}
+
+    import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+
+    def _fake_run(engine, *, dry_run=False):
+        calls["dry_run"] = dry_run
+        return ["0012_reclaim_queue.sql", "0013_paper_trade_shadow.sql"]
+
+    monkeypatch.setattr(lm_mod, "run_migrations", _fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert calls["dry_run"] is True
+    assert "0012_reclaim_queue.sql" in result.output
+    assert "0013_paper_trade_shadow.sql" in result.output
+    assert "pending" in result.output.lower()
+
+
+def test_db_migrate_legacy_applies_and_reports(monkeypatch):
+    """`db migrate-legacy` (no flag) applies pending files and lists them."""
+    from rainier import cli as cli_mod
+
+    calls = {}
+
+    import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+
+    def _fake_run(engine, *, dry_run=False):
+        calls["dry_run"] = dry_run
+        return ["0012_reclaim_queue.sql"]
+
+    monkeypatch.setattr(lm_mod, "run_migrations", _fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy"])
+    assert result.exit_code == 0, result.output
+    assert calls["dry_run"] is False
+    assert "Applied 1" in result.output
+    assert "0012_reclaim_queue.sql" in result.output
+
+
+def test_db_migrate_legacy_noop_when_up_to_date(monkeypatch):
+    """`db migrate-legacy` reports a no-op when nothing is pending."""
+    import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+    monkeypatch.setattr(lm_mod, "run_migrations", lambda engine, *, dry_run=False: [])
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy"])
+    assert result.exit_code == 0, result.output
+    assert "up to date" in result.output.lower()
+
+
+def test_db_init_exits_loud_on_drift(monkeypatch):
+    """`db init` exits non-zero and prints every missing object when the drift
+    checker reports findings (the loud chokepoint).
+
+    Stubs ``init_db`` (no live DB) + ``check_schema_drift`` to return findings.
+    """
+    import rainier.core.database as db_mod
+    import rainier.core.schema_check as sc_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "init_db", lambda: None)
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        sc_mod,
+        "check_schema_drift",
+        lambda engine: [
+            "missing column: screened_stocks.bearish_invalidation_level",
+            "missing table: paper_reclaim_queue",
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "init"])
+    assert result.exit_code != 0, result.output
+    assert "SCHEMA DRIFT DETECTED" in result.output
+    assert "screened_stocks.bearish_invalidation_level" in result.output
+    assert "paper_reclaim_queue" in result.output
+    assert "migrate-legacy" in result.output
+
+
+def test_db_init_clean_when_no_drift(monkeypatch):
+    """`db init` succeeds and reports a clean drift check when there are no
+    findings."""
+    import rainier.core.database as db_mod
+    import rainier.core.schema_check as sc_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "init_db", lambda: None)
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+    monkeypatch.setattr(sc_mod, "check_schema_drift", lambda engine: [])
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "init"])
+    assert result.exit_code == 0, result.output
+    assert "clean" in result.output.lower()
 
 
 def test_db_migrate_help_exposes_downgrade_flag():

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -214,8 +214,10 @@ def test_db_migrate_legacy_baseline_stamps(monkeypatch):
 
     import rainier.core.database as db_mod
     import rainier.core.legacy_migrate as lm_mod
+    import rainier.core.schema_check as sc_mod
 
     monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+    monkeypatch.setattr(sc_mod, "check_schema_drift", lambda engine: [])
 
     def _fake_baseline(engine, *, migrations_dir=None):
         calls["baseline"] = True
@@ -234,6 +236,44 @@ def test_db_migrate_legacy_baseline_stamps(monkeypatch):
     assert calls.get("baseline") is True
     assert "Baselined 2" in result.output
     assert "NOT run" in result.output
+    assert "WARNING" not in result.output, "clean drift must not warn"
+
+
+def test_db_migrate_legacy_baseline_warns_on_missing_objects(monkeypatch):
+    """`--baseline` warns loudly when the ORM contract says stamped bookkeeping
+    now covers objects the live schema doesn't have (review 43f3 iter-1: a
+    blanket baseline over the '0012/0013 never ran' state would otherwise
+    silently mark the missing migrations as applied). Known-benign drift is
+    excluded from the warning."""
+    import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
+    import rainier.core.schema_check as sc_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        lm_mod,
+        "baseline_migrations",
+        lambda engine, *, migrations_dir=None: ["0012_reclaim_queue.sql"],
+    )
+    monkeypatch.setattr(
+        sc_mod,
+        "check_schema_drift",
+        lambda engine: [
+            "missing column: capital_flow_bars.symbol",  # known-benign: excluded
+            "missing table: paper_reclaim_queue",
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy", "--baseline"])
+    assert result.exit_code == 0, result.output
+    assert "WARNING" in result.output
+    assert "paper_reclaim_queue" in result.output
+    assert "capital_flow_bars.symbol" not in result.output, (
+        "known-benign drift must not appear in the baseline warning"
+    )
+    assert "Hand-apply" in result.output
 
 
 def test_db_migrate_legacy_dry_run_and_baseline_conflict(monkeypatch):
@@ -338,6 +378,60 @@ def test_db_init_clean_when_no_drift(monkeypatch):
     result = runner.invoke(cli_mod.cli, ["db", "init"])
     assert result.exit_code == 0, result.output
     assert "clean" in result.output.lower()
+
+
+def test_db_init_ignores_known_benign_drift(monkeypatch):
+    """`db init` must NOT fail on the documented pre-existing benign drift
+    (review 43f3 iter-1): the live legacy DB's `capital_flow_bars` lacks
+    `symbol` (orphaned 0-row table, no migration adds it), and the operator
+    runbook blocks only on findings beyond it. Hard-failing would make
+    `db init` exit non-zero on the live DB forever."""
+    import rainier.core.database as db_mod
+    import rainier.core.schema_check as sc_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "init_db", lambda: None)
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        sc_mod,
+        "check_schema_drift",
+        lambda engine: ["missing column: capital_flow_bars.symbol"],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "init"])
+    assert result.exit_code == 0, result.output
+    assert "Known-benign drift (ignored)" in result.output
+    assert "capital_flow_bars.symbol" in result.output
+    assert "SCHEMA DRIFT DETECTED" not in result.output
+
+
+def test_db_init_fails_on_drift_beyond_benign(monkeypatch):
+    """`db init` still fails loud when real drift exists alongside the benign
+    finding — only the real findings are counted and listed in the failure."""
+    import rainier.core.database as db_mod
+    import rainier.core.schema_check as sc_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "init_db", lambda: None)
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        sc_mod,
+        "check_schema_drift",
+        lambda engine: [
+            "missing column: capital_flow_bars.symbol",
+            "missing table: paper_reclaim_queue",
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "init"])
+    assert result.exit_code != 0, result.output
+    assert "SCHEMA DRIFT DETECTED" in result.output
+    assert "paper_reclaim_queue" in result.output
+    assert "1 schema-drift finding(s)" in result.output, (
+        "the benign finding must not be counted in the failure total"
+    )
 
 
 def test_db_migrate_help_exposes_downgrade_flag():

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -308,9 +308,9 @@ def test_db_migrate_legacy_baseline_already_versioned_fails_clean(monkeypatch):
 
 
 def test_db_migrate_legacy_baseline_notes_verification_scope(monkeypatch):
-    """A successful `--baseline` prints the honest verification-scope note
-    (codex 43f3 [P2 deferred]: the check covers ORM tables/columns only —
-    migration-only indexes/constraints are not verified)."""
+    """A successful `--baseline` prints the honest verification-scope note:
+    the check covers ORM-declared objects (incl. named indexes/constraints);
+    migration-only DDL without an ORM mirror is not verified."""
     import rainier.core.database as db_mod
     import rainier.core.legacy_migrate as lm_mod
     import rainier.core.schema_check as sc_mod
@@ -328,7 +328,8 @@ def test_db_migrate_legacy_baseline_notes_verification_scope(monkeypatch):
     result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy", "--baseline"])
     assert result.exit_code == 0, result.output
     assert "Baselined 1" in result.output
-    assert "tables/columns only" in result.output
+    assert "ORM-declared objects" in result.output
+    assert "not verified" in result.output
 
 
 def test_db_migrate_legacy_dry_run_and_baseline_conflict(monkeypatch):

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -394,6 +394,46 @@ def test_wheel_packages_db_assets_under_rainier_db_assets():
     assert (repo_root / "db" / "alembic").is_dir()
 
 
+def test_wheel_packages_legacy_migrations_under_db_assets():
+    """Regression (codex 43f3 [P1]): pyproject must force-include the top-level
+    `migrations/` tree at `rainier/_db_assets/migrations/` so a packaged
+    (non-editable) install of `rainier db migrate-legacy` finds the numbered
+    SQL files. Without it, `discover_migrations()` returns [] in a wheel and the
+    command falsely reports "up to date", never applying 0001..N.
+
+    Asserts the static config (no wheel build) — same approach as the db-assets
+    test above. The matching resolver is
+    `legacy_migrate._resolve_migrations_dir()`.
+    """
+    from pathlib import Path
+
+    try:
+        import tomllib  # py311+
+    except ImportError:  # pragma: no cover
+        import tomli as tomllib
+
+    repo_root = Path(__file__).resolve().parents[2]
+    with (repo_root / "pyproject.toml").open("rb") as fh:
+        pyproject = tomllib.load(fh)
+
+    force_include = (
+        pyproject.get("tool", {})
+        .get("hatch", {})
+        .get("build", {})
+        .get("targets", {})
+        .get("wheel", {})
+        .get("force-include", {})
+    )
+    assert force_include.get("migrations") == "rainier/_db_assets/migrations", (
+        "pyproject.toml's [tool.hatch.build.targets.wheel] must force-include "
+        '`"migrations" = "rainier/_db_assets/migrations"` so wheels ship the '
+        "legacy migrations/*.sql. Got: " + repr(force_include)
+    )
+
+    # Sanity: the source dir referenced by force-include actually exists.
+    assert (repo_root / "migrations").is_dir()
+
+
 def test_alembic_ini_script_location_is_config_relative(tmp_path, monkeypatch):
     """Regression: alembic.ini's `script_location` must resolve relative to
     the ini file (via `%(here)s`), NOT relative to cwd. Without this, running

--- a/tests/test_cli/test_db.py
+++ b/tests/test_cli/test_db.py
@@ -206,6 +206,51 @@ def test_db_migrate_legacy_applies_and_reports(monkeypatch):
     assert "0012_reclaim_queue.sql" in result.output
 
 
+def test_db_migrate_legacy_baseline_stamps(monkeypatch):
+    """`db migrate-legacy --baseline` records pending files without running them."""
+    from rainier import cli as cli_mod
+
+    calls = {}
+
+    import rainier.core.database as db_mod
+    import rainier.core.legacy_migrate as lm_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+
+    def _fake_baseline(engine, *, migrations_dir=None):
+        calls["baseline"] = True
+        return ["0001_llm_thesis_pr1.sql", "0002_llm_thesis_pr2.sql"]
+
+    # run_migrations must NOT be called on the baseline path.
+    def _boom_run(*_a, **_k):
+        raise AssertionError("run_migrations must not run on --baseline")
+
+    monkeypatch.setattr(lm_mod, "baseline_migrations", _fake_baseline)
+    monkeypatch.setattr(lm_mod, "run_migrations", _boom_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["db", "migrate-legacy", "--baseline"])
+    assert result.exit_code == 0, result.output
+    assert calls.get("baseline") is True
+    assert "Baselined 2" in result.output
+    assert "NOT run" in result.output
+
+
+def test_db_migrate_legacy_dry_run_and_baseline_conflict(monkeypatch):
+    """`--dry-run --baseline` together is rejected (mutually exclusive)."""
+    import rainier.core.database as db_mod
+    from rainier import cli as cli_mod
+
+    monkeypatch.setattr(db_mod, "get_engine", lambda: object())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli, ["db", "migrate-legacy", "--dry-run", "--baseline"]
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
 def test_db_migrate_legacy_noop_when_up_to_date(monkeypatch):
     """`db migrate-legacy` reports a no-op when nothing is pending."""
     import rainier.core.database as db_mod

--- a/tests/test_legacy_migrate.py
+++ b/tests/test_legacy_migrate.py
@@ -254,6 +254,50 @@ def test_failed_migration_records_nothing(throwaway_engine, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Baseline: adopt an existing schema WITHOUT replaying SQL (codex 43f3 [P1])
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_records_without_running(throwaway_engine, tmp_path):
+    from rainier.core.legacy_migrate import (
+        applied_versions,
+        baseline_migrations,
+        run_migrations,
+    )
+
+    _make_synthetic_migrations(tmp_path)
+    stamped = baseline_migrations(throwaway_engine, migrations_dir=tmp_path)
+    assert stamped == ["0001_create_a.sql", "0002_create_b.sql", "0003_add_col.sql"]
+
+    # All recorded, but NONE of the SQL ran — the tables don't exist.
+    insp = inspect(throwaway_engine)
+    assert applied_versions(throwaway_engine) == set(stamped)
+    assert "mig_a" not in insp.get_table_names()
+    assert "mig_b" not in insp.get_table_names()
+
+    # After baseline, a normal run is a no-op (everything already stamped).
+    assert run_migrations(throwaway_engine, migrations_dir=tmp_path) == []
+
+
+def test_baseline_then_run_applies_only_new(throwaway_engine, tmp_path):
+    """Baseline the existing set, add a NEW file, then run applies only the new
+    one — the realistic adoption flow."""
+    from rainier.core.legacy_migrate import baseline_migrations, run_migrations
+
+    _make_synthetic_migrations(tmp_path)
+    baseline_migrations(throwaway_engine, migrations_dir=tmp_path)
+
+    _write_migration(
+        tmp_path,
+        "0004_new.sql",
+        "BEGIN;\nCREATE TABLE IF NOT EXISTS mig_new (id int PRIMARY KEY);\nCOMMIT;\n",
+    )
+    applied = run_migrations(throwaway_engine, migrations_dir=tmp_path)
+    assert applied == ["0004_new.sql"]
+    assert "mig_new" in inspect(throwaway_engine).get_table_names()
+
+
+# ---------------------------------------------------------------------------
 # search_path independence — version table is always public.schema_migrations
 # (codex 43f3 [P2]): an unqualified table under a non-public search_path would
 # put the CREATE in one schema and the existence-check in another → replay loop.
@@ -285,10 +329,13 @@ def test_idempotent_under_non_public_search_path(throwaway_engine, tmp_path):
     assert second == [], "re-run under a non-public search_path must be a no-op"
     assert applied_versions(throwaway_engine) == set(first)
 
-    # The version table landed in public, not the shadow schema.
+    # Both the version table AND the migration DDL landed in public, not the
+    # shadow schema — _pin_public keeps bookkeeping and DDL in the same schema.
     insp = inspect(throwaway_engine)
     assert "schema_migrations" in insp.get_table_names(schema="public")
     assert "schema_migrations" not in insp.get_table_names(schema="shadow")
+    assert {"mig_a", "mig_b"} <= set(insp.get_table_names(schema="public"))
+    assert "mig_a" not in insp.get_table_names(schema="shadow")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_legacy_migrate.py
+++ b/tests/test_legacy_migrate.py
@@ -1,0 +1,344 @@
+"""Tests for the legacy ``migrations/*.sql`` runner (``core/legacy_migrate``).
+
+Guards the 2026-06-22 legacy-drift fix: the numbered migrations were applied by
+hand with no runner and no version table, so 0012/0013 silently never ran. This
+runner records what's applied in ``schema_migrations`` and is idempotent.
+
+Two flavors:
+  * SYNTHETIC migrations dir (``tmp_path``) — deterministic ordering /
+    idempotency / missing-middle / dry-run, independent of real file contents.
+  * REAL ``migrations/*.sql`` — the runner applies the shipped files end to end
+    and reports zero schema drift afterwards (the chokepoint stays green).
+
+Gated on ``requires_postgres``. Uses an ISOLATED per-process throwaway database
+(CREATE DATABASE alongside the provided URL) so it never touches a live DB even
+if ``RAINIER_TEST_DATABASE_URL`` points at one — same guard as
+``tests/test_schema_check.py``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+
+pytestmark = pytest.mark.requires_postgres
+
+try:
+    from pytest_postgresql import factories as _pg_factories
+
+    _HAS_PYTEST_POSTGRESQL = True
+except ImportError:  # pragma: no cover
+    _HAS_PYTEST_POSTGRESQL = False
+
+
+def _local_pg_binary_available() -> bool:
+    import shutil
+
+    return shutil.which("pg_config") is not None and shutil.which("initdb") is not None
+
+
+if _HAS_PYTEST_POSTGRESQL and _local_pg_binary_available():
+    postgresql_proc = _pg_factories.postgresql_proc(port=None, unixsocketdir="/tmp")
+    postgresql = _pg_factories.postgresql("postgresql_proc")
+
+
+@pytest.fixture
+def base_db_url(request):
+    """Clean Postgres URL. RAINIER_TEST_DATABASE_URL -> pytest-postgresql -> skip."""
+    env_url = os.environ.get("RAINIER_TEST_DATABASE_URL")
+    if env_url:
+        return env_url
+    if not _HAS_PYTEST_POSTGRESQL:
+        pytest.skip("pytest-postgresql not installed")
+    if not _local_pg_binary_available():
+        pytest.skip("pg_config / initdb not on PATH; set RAINIER_TEST_DATABASE_URL")
+    pg = request.getfixturevalue("postgresql")
+    return (
+        f"postgresql+psycopg://{pg.info.user}@{pg.info.host}:{pg.info.port}"
+        f"/{pg.info.dbname}"
+    )
+
+
+@pytest.fixture
+def throwaway_engine(base_db_url):
+    """An empty engine on an ISOLATED per-process throwaway database.
+
+    Never ``drop_all``s / mutates the provided URL: CREATE DATABASE a per-pid
+    throwaway alongside it, yield an engine on it, DROP DATABASE on teardown.
+    Mirrors tests/test_schema_check.py so even a live RAINIER_TEST_DATABASE_URL
+    is safe.
+    """
+    from sqlalchemy.engine import make_url
+
+    base = make_url(base_db_url)
+    throwaway = f"legacymigrate_test_{os.getpid()}"
+    admin = create_engine(base_db_url, isolation_level="AUTOCOMMIT")
+    with admin.connect() as conn:
+        can_create = conn.exec_driver_sql(
+            "SELECT rolcreatedb OR rolsuper FROM pg_roles WHERE rolname = current_user"
+        ).scalar()
+        if not can_create:
+            admin.dispose()
+            pytest.skip("test role lacks CREATEDB; cannot isolate a throwaway database")
+        conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{throwaway}"')
+        conn.exec_driver_sql(f'CREATE DATABASE "{throwaway}"')
+
+    engine = None
+    try:
+        engine = create_engine(base.set(database=throwaway))
+        yield engine
+    finally:
+        if engine is not None:
+            engine.dispose()
+        with admin.connect() as conn:
+            conn.exec_driver_sql(f'DROP DATABASE IF EXISTS "{throwaway}"')
+        admin.dispose()
+
+
+def _write_migration(directory, name: str, sql: str) -> None:
+    (directory / name).write_text(sql)
+
+
+def _make_synthetic_migrations(directory) -> None:
+    """Three forward migrations + a downgrade decoy the runner must ignore."""
+    _write_migration(
+        directory,
+        "0001_create_a.sql",
+        "BEGIN;\nCREATE TABLE IF NOT EXISTS mig_a (id int PRIMARY KEY);\nCOMMIT;\n",
+    )
+    _write_migration(
+        directory,
+        "0002_create_b.sql",
+        "BEGIN;\nCREATE TABLE IF NOT EXISTS mig_b (id int PRIMARY KEY);\nCOMMIT;\n",
+    )
+    _write_migration(
+        directory,
+        "0003_add_col.sql",
+        "BEGIN;\nALTER TABLE mig_a ADD COLUMN IF NOT EXISTS extra text;\nCOMMIT;\n",
+    )
+    # Decoy: a downgrade file must NEVER be applied by the runner.
+    _write_migration(
+        directory,
+        "0003_add_col_downgrade.sql",
+        "BEGIN;\nDROP TABLE IF EXISTS mig_a;\nCOMMIT;\n",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def test_discover_excludes_downgrades_and_sorts(tmp_path):
+    from rainier.core.legacy_migrate import discover_migrations
+
+    _make_synthetic_migrations(tmp_path)
+    names = [p.name for p in discover_migrations(tmp_path)]
+    assert names == ["0001_create_a.sql", "0002_create_b.sql", "0003_add_col.sql"], names
+    assert not any("downgrade" in n for n in names)
+
+
+# ---------------------------------------------------------------------------
+# Fresh DB: creates schema_migrations + applies in order
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_db_applies_all_in_order(throwaway_engine, tmp_path):
+    from rainier.core.legacy_migrate import applied_versions, run_migrations
+
+    _make_synthetic_migrations(tmp_path)
+    applied = run_migrations(throwaway_engine, migrations_dir=tmp_path)
+    assert applied == ["0001_create_a.sql", "0002_create_b.sql", "0003_add_col.sql"]
+
+    insp = inspect(throwaway_engine)
+    assert "schema_migrations" in insp.get_table_names()
+    assert {"mig_a", "mig_b"} <= set(insp.get_table_names())
+    # 0003's ALTER ran (proves order: 0001 created mig_a before 0003 altered it).
+    assert "extra" in {c["name"] for c in insp.get_columns("mig_a")}
+    assert applied_versions(throwaway_engine) == set(applied)
+
+
+def test_second_run_is_noop(throwaway_engine, tmp_path):
+    from rainier.core.legacy_migrate import run_migrations
+
+    _make_synthetic_migrations(tmp_path)
+    run_migrations(throwaway_engine, migrations_dir=tmp_path)
+    second = run_migrations(throwaway_engine, migrations_dir=tmp_path)
+    assert second == [], "re-run must apply nothing (idempotent)"
+
+
+# ---------------------------------------------------------------------------
+# DB missing a later migration: only the missing one is applied + recorded
+# (the 0012 scenario, generalized — applies whatever is not yet recorded).
+# ---------------------------------------------------------------------------
+
+
+def test_db_missing_latest_applies_only_that_one(throwaway_engine, tmp_path):
+    from rainier.core.legacy_migrate import run_migrations
+
+    _make_synthetic_migrations(tmp_path)
+    # Simulate a DB that has 0001+0002 applied but is MISSING 0003 (the "0012
+    # never ran" state): create the version table + record the first two, and
+    # create their tables so the world matches the bookkeeping.
+    with throwaway_engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE schema_migrations ("
+                " version TEXT PRIMARY KEY, applied_at TIMESTAMPTZ DEFAULT now())"
+            )
+        )
+        conn.execute(text("CREATE TABLE mig_a (id int PRIMARY KEY)"))
+        conn.execute(text("CREATE TABLE mig_b (id int PRIMARY KEY)"))
+        conn.execute(
+            text(
+                "INSERT INTO schema_migrations (version) VALUES "
+                "('0001_create_a.sql'), ('0002_create_b.sql')"
+            )
+        )
+
+    applied = run_migrations(throwaway_engine, migrations_dir=tmp_path)
+    assert applied == ["0003_add_col.sql"], "only the missing migration applies"
+
+    insp = inspect(throwaway_engine)
+    assert "extra" in {c["name"] for c in insp.get_columns("mig_a")}
+
+    # Re-run records nothing new.
+    assert run_migrations(throwaway_engine, migrations_dir=tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# --dry-run lists pending, applies nothing
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_lists_pending_and_applies_nothing(throwaway_engine, tmp_path):
+    from rainier.core.legacy_migrate import run_migrations
+
+    _make_synthetic_migrations(tmp_path)
+    pending = run_migrations(throwaway_engine, dry_run=True, migrations_dir=tmp_path)
+    assert pending == ["0001_create_a.sql", "0002_create_b.sql", "0003_add_col.sql"]
+
+    insp = inspect(throwaway_engine)
+    # Nothing applied: no schema_migrations table, no migration tables.
+    assert "schema_migrations" not in insp.get_table_names()
+    assert "mig_a" not in insp.get_table_names()
+
+
+# ---------------------------------------------------------------------------
+# Failure mid-file rolls back the version record (atomicity)
+# ---------------------------------------------------------------------------
+
+
+def test_failed_migration_records_nothing(throwaway_engine, tmp_path):
+    from rainier.core.legacy_migrate import applied_versions, run_migrations
+
+    _write_migration(
+        tmp_path,
+        "0001_ok.sql",
+        "BEGIN;\nCREATE TABLE IF NOT EXISTS mig_ok (id int PRIMARY KEY);\nCOMMIT;\n",
+    )
+    _write_migration(
+        tmp_path,
+        "0002_boom.sql",
+        "BEGIN;\nCREATE TABLE mig_boom (id int);\nSELECT 1/0;\nCOMMIT;\n",
+    )
+    with pytest.raises(Exception):
+        run_migrations(throwaway_engine, migrations_dir=tmp_path)
+
+    insp = inspect(throwaway_engine)
+    # 0001 committed + recorded; 0002 rolled back entirely — not recorded, table absent.
+    assert applied_versions(throwaway_engine) == {"0001_ok.sql"}
+    assert "mig_boom" not in insp.get_table_names()
+
+
+# ---------------------------------------------------------------------------
+# REAL shipped migrations are discovered + driven by the runner
+# ---------------------------------------------------------------------------
+# These use the real migrations/*.sql (no temp dir) but do NOT depend on every
+# file's DDL executing on a bare engine — a migration's *content* (e.g. 0001's
+# non-IMMUTABLE index expression) is out of scope for the runner task, which
+# may not even rewrite those files. They prove the runner sees the shipped
+# files in order and records what it drives.
+
+
+def test_real_migrations_discovered_in_order():
+    """``discover_migrations`` finds the shipped numbered files, sorted, with
+    the ``*_downgrade.sql`` files excluded."""
+    from rainier.core.legacy_migrate import MIGRATIONS_DIR, discover_migrations
+
+    names = [p.name for p in discover_migrations()]
+    assert names, "expected shipped migrations/*.sql to be discovered"
+    assert names == sorted(names), "shipped migrations must be filename-sorted"
+    assert all(p.parent == MIGRATIONS_DIR for p in discover_migrations())
+    assert not any("downgrade" in n for n in names), (
+        f"downgrade files must never be discovered as forward migrations: {names}"
+    )
+    # Every discovered file has a zero-padded numeric prefix.
+    assert all(n.split("_", 1)[0].isdigit() for n in names), names
+
+
+def test_real_migrations_all_pending_on_fresh_db(throwaway_engine):
+    """On a fresh DB, ``pending_migrations`` returns every shipped forward file
+    (nothing recorded yet), and ``--dry-run`` lists them without applying."""
+    from rainier.core.legacy_migrate import (
+        discover_migrations,
+        pending_migrations,
+        run_migrations,
+    )
+
+    all_names = [p.name for p in discover_migrations()]
+    pending = [p.name for p in pending_migrations(throwaway_engine)]
+    assert pending == all_names
+
+    dry = run_migrations(throwaway_engine, dry_run=True)
+    assert dry == all_names
+
+    # Dry-run created nothing.
+    insp = inspect(throwaway_engine)
+    assert "schema_migrations" not in insp.get_table_names()
+
+
+def test_real_migration_recorded_when_driven(throwaway_engine):
+    """The runner records a shipped file in ``schema_migrations`` after it
+    applies — proven on the first file the runner can drive on a bare engine.
+
+    Records all files that come BEFORE any content-failure as applied, then
+    asserts the recorded set is a contiguous prefix of the shipped order and
+    that a re-run never re-applies a recorded file. (Migration *content* that
+    can't run on a bare engine is the migration author's concern, not the
+    runner's; the runner's job is order + bookkeeping + atomic rollback.)"""
+    from rainier.core.legacy_migrate import (
+        applied_versions,
+        discover_migrations,
+        run_migrations,
+    )
+    from rainier.core.models import Base
+
+    # Seed the ORM tables the ALTERs target, so a file fails (if at all) on its
+    # own content, not on a missing base table.
+    Base.metadata.create_all(throwaway_engine)
+
+    all_names = [p.name for p in discover_migrations()]
+    try:
+        run_migrations(throwaway_engine)
+    except Exception:
+        pass  # a file's content may not run on this bare engine — that's fine.
+
+    recorded = applied_versions(throwaway_engine)
+    # Whatever got recorded is a contiguous prefix of the shipped order: the
+    # runner stops at the first failure and records nothing past it.
+    expected_prefix = all_names[: len(recorded)]
+    assert recorded == set(expected_prefix), (
+        f"recorded set {recorded} is not the shipped-order prefix {expected_prefix}"
+    )
+
+    # A re-run never re-applies an already-recorded file (idempotent prefix).
+    try:
+        applied_again = run_migrations(throwaway_engine)
+    except Exception:
+        applied_again = []
+    assert not (set(applied_again) & recorded), (
+        "re-run must not re-apply an already-recorded migration"
+    )

--- a/tests/test_legacy_migrate.py
+++ b/tests/test_legacy_migrate.py
@@ -387,43 +387,63 @@ def test_real_migrations_all_pending_on_fresh_db(throwaway_engine):
 
 def test_real_migration_recorded_when_driven(throwaway_engine):
     """The runner records a shipped file in ``schema_migrations`` after it
-    applies — proven on the first file the runner can drive on a bare engine.
+    records the shipped files via the baseline adoption flow.
 
-    Records all files that come BEFORE any content-failure as applied, then
-    asserts the recorded set is a contiguous prefix of the shipped order and
-    that a re-run never re-applies a recorded file. (Migration *content* that
-    can't run on a bare engine is the migration author's concern, not the
-    runner's; the runner's job is order + bookkeeping + atomic rollback.)"""
+    The realistic state for the shipped files is "schema already exists" (db
+    init / hand psql), so the correct way to record them is baseline — which
+    stamps every discovered file WITHOUT running its (possibly non-rerunnable)
+    SQL. This proves the runner sees and records the real shipped set, then is a
+    no-op."""
     from rainier.core.legacy_migrate import (
         applied_versions,
+        baseline_migrations,
         discover_migrations,
         run_migrations,
     )
     from rainier.core.models import Base
 
-    # Seed the ORM tables the ALTERs target, so a file fails (if at all) on its
-    # own content, not on a missing base table.
+    # Seed the ORM tables (the realistic "already migrated by db init" state).
     Base.metadata.create_all(throwaway_engine)
 
     all_names = [p.name for p in discover_migrations()]
-    try:
+    stamped = baseline_migrations(throwaway_engine)
+    assert stamped == all_names, "baseline must record every shipped file in order"
+    assert applied_versions(throwaway_engine) == set(all_names)
+
+    # After baseline, a normal run is a no-op (everything recorded).
+    assert run_migrations(throwaway_engine) == []
+
+
+def test_run_refuses_unversioned_existing_schema(throwaway_engine):
+    """run_migrations raises on an existing schema with no schema_migrations
+    table — it must NOT replay 0001..N (codex 43f3 round-3 [P1])."""
+    from rainier.core.legacy_migrate import (
+        UnversionedSchemaError,
+        applied_versions,
+        run_migrations,
+    )
+    from rainier.core.models import Base
+
+    Base.metadata.create_all(throwaway_engine)  # tables present, no version table
+    with pytest.raises(UnversionedSchemaError):
         run_migrations(throwaway_engine)
-    except Exception:
-        pass  # a file's content may not run on this bare engine — that's fine.
 
-    recorded = applied_versions(throwaway_engine)
-    # Whatever got recorded is a contiguous prefix of the shipped order: the
-    # runner stops at the first failure and records nothing past it.
-    expected_prefix = all_names[: len(recorded)]
-    assert recorded == set(expected_prefix), (
-        f"recorded set {recorded} is not the shipped-order prefix {expected_prefix}"
-    )
+    # Nothing was created or recorded — the guard fired before any work.
+    assert applied_versions(throwaway_engine) == set()
+    assert "schema_migrations" not in inspect(throwaway_engine).get_table_names()
 
-    # A re-run never re-applies an already-recorded file (idempotent prefix).
-    try:
-        applied_again = run_migrations(throwaway_engine)
-    except Exception:
-        applied_again = []
-    assert not (set(applied_again) & recorded), (
-        "re-run must not re-apply an already-recorded migration"
-    )
+    # Baseline adopts it; then a run is a clean no-op.
+    from rainier.core.legacy_migrate import baseline_migrations
+
+    baseline_migrations(throwaway_engine)
+    assert run_migrations(throwaway_engine) == []
+
+
+def test_fresh_empty_db_runs_from_0001_despite_guard(throwaway_engine, tmp_path):
+    """The guard only blocks a NON-EMPTY unversioned schema; a truly fresh
+    (empty) DB still runs from the first migration normally."""
+    from rainier.core.legacy_migrate import run_migrations
+
+    _make_synthetic_migrations(tmp_path)
+    applied = run_migrations(throwaway_engine, migrations_dir=tmp_path)
+    assert applied == ["0001_create_a.sql", "0002_create_b.sql", "0003_add_col.sql"]

--- a/tests/test_legacy_migrate.py
+++ b/tests/test_legacy_migrate.py
@@ -335,6 +335,41 @@ def test_baseline_then_run_applies_only_new(throwaway_engine, tmp_path):
     assert "mig_new" in inspect(throwaway_engine).get_table_names()
 
 
+def test_baseline_refuses_already_versioned_db(throwaway_engine, tmp_path):
+    """Baseline on a DB that already has recorded versions must refuse
+    (codex 43f3 [P1]): pending files there are genuinely NEW migrations that
+    must be APPLIED — stamping would permanently skip their DDL (the
+    tables/columns drift check can't see an index/constraint-only file)."""
+    from rainier.core.legacy_migrate import (
+        AlreadyVersionedError,
+        applied_versions,
+        baseline_migrations,
+        run_migrations,
+    )
+
+    _make_synthetic_migrations(tmp_path)
+    first = baseline_migrations(throwaway_engine, migrations_dir=tmp_path)
+    assert len(first) == 3
+
+    # A genuinely new migration lands after adoption.
+    _write_migration(
+        tmp_path,
+        "0004_new.sql",
+        "BEGIN;\nCREATE TABLE IF NOT EXISTS mig_new (id int PRIMARY KEY);\nCOMMIT;\n",
+    )
+
+    with pytest.raises(AlreadyVersionedError):
+        baseline_migrations(throwaway_engine, migrations_dir=tmp_path)
+    assert applied_versions(throwaway_engine) == set(first), (
+        "the refused baseline must not stamp the new file"
+    )
+
+    # The correct path still works: a plain run APPLIES the new file.
+    assert run_migrations(throwaway_engine, migrations_dir=tmp_path) == [
+        "0004_new.sql"
+    ]
+
+
 def test_baseline_is_all_or_nothing(throwaway_engine, tmp_path):
     """A failed/interrupted baseline must stamp NOTHING (review 43f3 iter-1).
 

--- a/tests/test_legacy_migrate.py
+++ b/tests/test_legacy_migrate.py
@@ -565,6 +565,31 @@ def test_run_refuses_unversioned_existing_schema(throwaway_engine):
     assert run_migrations(throwaway_engine) == []
 
 
+def test_run_refuses_empty_version_table_on_existing_schema(throwaway_engine, tmp_path):
+    """An existing-but-EMPTY schema_migrations table must not disarm the
+    guard (codex 43f3 [P1]): a manually pre-created (or historically leaked)
+    empty version table alongside real legacy tables is still an unversioned
+    schema — replaying 0001..N onto it is the exact unsafe path the guard
+    blocks. Applies to dry-run too."""
+    from rainier.core.legacy_migrate import UnversionedSchemaError, run_migrations
+
+    _make_synthetic_migrations(tmp_path)
+    with throwaway_engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE public.schema_migrations ("
+                " version TEXT PRIMARY KEY,"
+                " applied_at TIMESTAMPTZ NOT NULL DEFAULT now())"
+            )
+        )
+        conn.execute(text("CREATE TABLE legacy_table (id int PRIMARY KEY)"))
+
+    with pytest.raises(UnversionedSchemaError):
+        run_migrations(throwaway_engine, migrations_dir=tmp_path)
+    with pytest.raises(UnversionedSchemaError):
+        run_migrations(throwaway_engine, dry_run=True, migrations_dir=tmp_path)
+
+
 def test_fresh_empty_db_runs_from_0001_despite_guard(throwaway_engine, tmp_path):
     """The guard only blocks a NON-EMPTY unversioned schema; a truly fresh
     (empty) DB still runs from the first migration normally."""

--- a/tests/test_legacy_migrate.py
+++ b/tests/test_legacy_migrate.py
@@ -254,6 +254,44 @@ def test_failed_migration_records_nothing(throwaway_engine, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# search_path independence — version table is always public.schema_migrations
+# (codex 43f3 [P2]): an unqualified table under a non-public search_path would
+# put the CREATE in one schema and the existence-check in another → replay loop.
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_under_non_public_search_path(throwaway_engine, tmp_path):
+    from sqlalchemy import event
+
+    from rainier.core.legacy_migrate import applied_versions, run_migrations
+
+    # Create a user schema that shadows public in the search_path. If the runner
+    # wrote/read schema_migrations unqualified, the second run would not see the
+    # first run's records and would replay everything.
+    with throwaway_engine.begin() as conn:
+        conn.execute(text("CREATE SCHEMA IF NOT EXISTS shadow"))
+
+    @event.listens_for(throwaway_engine, "connect")
+    def _set_search_path(dbapi_conn, _record):  # pragma: no cover - tiny hook
+        cur = dbapi_conn.cursor()
+        cur.execute("SET search_path TO shadow, public")
+        cur.close()
+
+    _make_synthetic_migrations(tmp_path)
+    first = run_migrations(throwaway_engine, migrations_dir=tmp_path)
+    assert first == ["0001_create_a.sql", "0002_create_b.sql", "0003_add_col.sql"]
+
+    second = run_migrations(throwaway_engine, migrations_dir=tmp_path)
+    assert second == [], "re-run under a non-public search_path must be a no-op"
+    assert applied_versions(throwaway_engine) == set(first)
+
+    # The version table landed in public, not the shadow schema.
+    insp = inspect(throwaway_engine)
+    assert "schema_migrations" in insp.get_table_names(schema="public")
+    assert "schema_migrations" not in insp.get_table_names(schema="shadow")
+
+
+# ---------------------------------------------------------------------------
 # REAL shipped migrations are discovered + driven by the runner
 # ---------------------------------------------------------------------------
 # These use the real migrations/*.sql (no temp dir) but do NOT depend on every

--- a/tests/test_legacy_migrate.py
+++ b/tests/test_legacy_migrate.py
@@ -244,7 +244,9 @@ def test_failed_migration_records_nothing(throwaway_engine, tmp_path):
         "0002_boom.sql",
         "BEGIN;\nCREATE TABLE mig_boom (id int);\nSELECT 1/0;\nCOMMIT;\n",
     )
-    with pytest.raises(Exception):
+    from sqlalchemy.exc import DBAPIError
+
+    with pytest.raises(DBAPIError):
         run_migrations(throwaway_engine, migrations_dir=tmp_path)
 
     insp = inspect(throwaway_engine)
@@ -297,6 +299,38 @@ def test_baseline_then_run_applies_only_new(throwaway_engine, tmp_path):
     assert "mig_new" in inspect(throwaway_engine).get_table_names()
 
 
+def test_baseline_is_all_or_nothing(throwaway_engine, tmp_path):
+    """A failed/interrupted baseline must stamp NOTHING (review 43f3 iter-1).
+
+    A partially-stamped ``schema_migrations`` defeats the
+    ``UnversionedSchemaError`` guard (the table now exists), so the next plain
+    run would replay the un-stamped tail's SQL onto the already-migrated
+    schema. Force a mid-stamp failure via a CHECK that rejects the LAST pending
+    file and assert no prefix was recorded.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    from rainier.core.legacy_migrate import applied_versions, baseline_migrations
+
+    _make_synthetic_migrations(tmp_path)
+    with throwaway_engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE public.schema_migrations ("
+                " version TEXT PRIMARY KEY,"
+                " applied_at TIMESTAMPTZ NOT NULL DEFAULT now(),"
+                " CHECK (version <> '0003_add_col.sql'))"
+            )
+        )
+
+    with pytest.raises(IntegrityError):
+        baseline_migrations(throwaway_engine, migrations_dir=tmp_path)
+
+    assert applied_versions(throwaway_engine) == set(), (
+        "a failed baseline must roll back every stamp, not leave a prefix"
+    )
+
+
 # ---------------------------------------------------------------------------
 # search_path independence — version table is always public.schema_migrations
 # (codex 43f3 [P2]): an unqualified table under a non-public search_path would
@@ -316,10 +350,22 @@ def test_idempotent_under_non_public_search_path(throwaway_engine, tmp_path):
         conn.execute(text("CREATE SCHEMA IF NOT EXISTS shadow"))
 
     @event.listens_for(throwaway_engine, "connect")
-    def _set_search_path(dbapi_conn, _record):  # pragma: no cover - tiny hook
+    def _set_search_path(dbapi_conn, _record):
         cur = dbapi_conn.cursor()
         cur.execute("SET search_path TO shadow, public")
         cur.close()
+
+    # The pool already holds the DBAPI connection that ran CREATE SCHEMA above,
+    # and the "connect" hook fires only on NEW connections — without a dispose,
+    # every later checkout reuses the un-hooked pooled connection and this test
+    # passes vacuously even with _pin_public removed. Dispose so run_migrations
+    # checks out fresh, shadow-first connections, and sanity-check the hook took.
+    throwaway_engine.dispose()
+    with throwaway_engine.connect() as conn:
+        search_path = conn.exec_driver_sql("SHOW search_path").scalar()
+    assert "shadow" in search_path, (
+        f"test-harness bug: search_path hook did not apply ({search_path!r})"
+    )
 
     _make_synthetic_migrations(tmp_path)
     first = run_migrations(throwaway_engine, migrations_dir=tmp_path)

--- a/tests/test_legacy_migrate.py
+++ b/tests/test_legacy_migrate.py
@@ -255,6 +255,42 @@ def test_failed_migration_records_nothing(throwaway_engine, tmp_path):
     assert "mig_boom" not in insp.get_table_names()
 
 
+def test_failed_first_migration_leaves_guard_armed(throwaway_engine, tmp_path):
+    """A run that fails on its FIRST file must leave the DB untouched
+    (review 43f3 iter-2).
+
+    The version table used to be committed in its own up-front transaction; a
+    first-apply failure (the real 0001 does an ALTER on a table only ``db
+    init`` creates, so this is the guaranteed fresh-DB outcome) left an EMPTY
+    ``schema_migrations`` behind. That permanently disarmed the
+    ``UnversionedSchemaError`` guard: after the operator's natural recovery
+    (``db init``, retry) the runner would replay non-rerunnable historical SQL
+    instead of routing to ``--baseline``.
+    """
+    from sqlalchemy.exc import ProgrammingError
+
+    from rainier.core.legacy_migrate import UnversionedSchemaError, run_migrations
+
+    # Mirrors real 0001 on an empty DB: ALTER on a table no migration creates.
+    _write_migration(
+        tmp_path,
+        "0001_alter_missing.sql",
+        "BEGIN;\nALTER TABLE not_there ADD COLUMN x int;\nCOMMIT;\n",
+    )
+    with pytest.raises(ProgrammingError):
+        run_migrations(throwaway_engine, migrations_dir=tmp_path)
+
+    # The failed run left NOTHING behind — especially no empty version table.
+    assert "schema_migrations" not in inspect(throwaway_engine).get_table_names()
+
+    # Operator recovery: schema gets created out-of-band (db init). The guard
+    # must still fire and route to --baseline instead of replaying.
+    with throwaway_engine.begin() as conn:
+        conn.execute(text("CREATE TABLE not_there (id int)"))
+    with pytest.raises(UnversionedSchemaError):
+        run_migrations(throwaway_engine, migrations_dir=tmp_path)
+
+
 # ---------------------------------------------------------------------------
 # Baseline: adopt an existing schema WITHOUT replaying SQL (codex 43f3 [P1])
 # ---------------------------------------------------------------------------

--- a/tests/test_legacy_migrate.py
+++ b/tests/test_legacy_migrate.py
@@ -483,8 +483,12 @@ def test_real_migrations_discovered_in_order():
 
 def test_real_migrations_all_pending_on_fresh_db(throwaway_engine):
     """On a fresh DB, ``pending_migrations`` returns every shipped forward file
-    (nothing recorded yet), and ``--dry-run`` lists them without applying."""
+    (nothing recorded yet) — but a run/dry-run with the DEFAULT (shipped) set
+    raises ``EmptyDatabaseError`` steering to ``db init`` + ``--baseline``
+    (codex 43f3 [P2]: 0001 ALTERs tables only ``db init`` creates, so a
+    from-scratch replay would die at file 1 with a raw SQL error)."""
     from rainier.core.legacy_migrate import (
+        EmptyDatabaseError,
         discover_migrations,
         pending_migrations,
         run_migrations,
@@ -494,10 +498,12 @@ def test_real_migrations_all_pending_on_fresh_db(throwaway_engine):
     pending = [p.name for p in pending_migrations(throwaway_engine)]
     assert pending == all_names
 
-    dry = run_migrations(throwaway_engine, dry_run=True)
-    assert dry == all_names
+    with pytest.raises(EmptyDatabaseError):
+        run_migrations(throwaway_engine, dry_run=True)
+    with pytest.raises(EmptyDatabaseError):
+        run_migrations(throwaway_engine)
 
-    # Dry-run created nothing.
+    # Neither attempt created anything.
     insp = inspect(throwaway_engine)
     assert "schema_migrations" not in insp.get_table_names()
 
@@ -533,7 +539,8 @@ def test_real_migration_recorded_when_driven(throwaway_engine):
 
 def test_run_refuses_unversioned_existing_schema(throwaway_engine):
     """run_migrations raises on an existing schema with no schema_migrations
-    table — it must NOT replay 0001..N (codex 43f3 round-3 [P1])."""
+    table — it must NOT replay 0001..N (codex 43f3 round-3 [P1]). The same
+    guard fires for --dry-run so the preview is truthful (codex [P2])."""
     from rainier.core.legacy_migrate import (
         UnversionedSchemaError,
         applied_versions,
@@ -544,6 +551,8 @@ def test_run_refuses_unversioned_existing_schema(throwaway_engine):
     Base.metadata.create_all(throwaway_engine)  # tables present, no version table
     with pytest.raises(UnversionedSchemaError):
         run_migrations(throwaway_engine)
+    with pytest.raises(UnversionedSchemaError):
+        run_migrations(throwaway_engine, dry_run=True)
 
     # Nothing was created or recorded — the guard fired before any work.
     assert applied_versions(throwaway_engine) == set()

--- a/tests/test_schema_check.py
+++ b/tests/test_schema_check.py
@@ -170,6 +170,34 @@ def test_detects_dropped_constraint(legacy_engine):
     )
 
 
+def test_index_alias_satisfies_but_both_missing_flags(legacy_engine):
+    """The 0012 name-aliased reclaim-queue indexes: EITHER name satisfies the
+    contract, but a DB where NEITHER exists is real drift (codex 43f3 [P2] —
+    a static allowlist would have masked the both-missing state)."""
+    from rainier.core.schema_check import check_schema_drift
+
+    # Live-DB shape: migration name instead of the ORM auto-name -> clean.
+    with legacy_engine.begin() as conn:
+        conn.execute(
+            text(
+                "ALTER INDEX ix_paper_reclaim_queue_status "
+                "RENAME TO ix_paper_reclaim_status"
+            )
+        )
+    assert check_schema_drift(legacy_engine) == [], (
+        "the migration-created alias name must satisfy the ORM index contract"
+    )
+
+    # Partial-apply shape: NEITHER name exists -> must be flagged.
+    with legacy_engine.begin() as conn:
+        conn.execute(text("DROP INDEX ix_paper_reclaim_status"))
+    findings = check_schema_drift(legacy_engine)
+    assert (
+        "missing index: paper_reclaim_queue.ix_paper_reclaim_queue_status"
+        in findings
+    )
+
+
 def test_checks_public_regardless_of_search_path(legacy_engine):
     """The drift check must inspect ``public`` explicitly (codex 43f3 [P1]):
     with a non-public-first ``search_path``, unqualified inspection would

--- a/tests/test_schema_check.py
+++ b/tests/test_schema_check.py
@@ -137,6 +137,39 @@ def test_detects_dropped_table(legacy_engine):
     assert "missing table: stock_prices" in findings
 
 
+def test_detects_dropped_index(legacy_engine):
+    """An ORM-declared named index that is absent live must be flagged
+    (codex 43f3 review: an index-only migration that never ran was invisible
+    to the tables/columns check, so --baseline could stamp it as applied)."""
+    from rainier.core.schema_check import check_schema_drift
+
+    with legacy_engine.begin() as conn:
+        conn.execute(text("DROP INDEX ix_signals_symbol_ts"))
+
+    findings = check_schema_drift(legacy_engine)
+    assert "missing index: signals.ix_signals_symbol_ts" in findings
+
+
+def test_detects_dropped_constraint(legacy_engine):
+    """An ORM-declared named constraint that is absent live must be flagged
+    (e.g. a constraint-only migration like 0008's ck_paper_skip_reason rebuild
+    that never ran)."""
+    from rainier.core.schema_check import check_schema_drift
+
+    with legacy_engine.begin() as conn:
+        conn.execute(
+            text(
+                "ALTER TABLE paper_reclaim_queue "
+                "DROP CONSTRAINT ck_paper_reclaim_status"
+            )
+        )
+
+    findings = check_schema_drift(legacy_engine)
+    assert (
+        "missing constraint: paper_reclaim_queue.ck_paper_reclaim_status" in findings
+    )
+
+
 def test_multiple_stub_columns_all_reported(legacy_engine):
     """The full stub (all 6 non-id/symbol columns dropped) reports each one,
     so an operator sees the complete repair list, not just the first miss."""

--- a/tests/test_schema_check.py
+++ b/tests/test_schema_check.py
@@ -170,6 +170,40 @@ def test_detects_dropped_constraint(legacy_engine):
     )
 
 
+def test_checks_public_regardless_of_search_path(legacy_engine):
+    """The drift check must inspect ``public`` explicitly (codex 43f3 [P1]):
+    with a non-public-first ``search_path``, unqualified inspection would
+    validate the FRONT schema instead of the one the migration runner stamps
+    and pins DDL to. Here public holds the full schema and the front (shadow)
+    schema is empty — the check must still be clean."""
+    from sqlalchemy import event
+
+    from rainier.core.schema_check import check_schema_drift
+
+    with legacy_engine.begin() as conn:
+        conn.execute(text("CREATE SCHEMA IF NOT EXISTS shadow"))
+
+    @event.listens_for(legacy_engine, "connect")
+    def _set_search_path(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("SET search_path TO shadow, public")
+        cur.close()
+
+    # The pool still holds the un-hooked connection that ran CREATE SCHEMA;
+    # dispose so inspection checks out fresh, shadow-first connections.
+    legacy_engine.dispose()
+    with legacy_engine.connect() as conn:
+        search_path = conn.exec_driver_sql("SHOW search_path").scalar()
+    assert "shadow" in search_path, (
+        f"test-harness bug: search_path hook did not apply ({search_path!r})"
+    )
+
+    assert check_schema_drift(legacy_engine) == [], (
+        "public holds the full ORM schema; a shadow-first search_path must "
+        "not make the check inspect (and fail against) the empty front schema"
+    )
+
+
 def test_multiple_stub_columns_all_reported(legacy_engine):
     """The full stub (all 6 non-id/symbol columns dropped) reports each one,
     so an operator sees the complete repair list, not just the first miss."""


### PR DESCRIPTION
## Summary
- Adds a legacy `migrations/*.sql` runner with a `schema_migrations` version table pinned to the `public` schema, packaged in the wheel
- Guards `db init`/`run` against unversioned existing schemas via a drift-check chokepoint, with baseline adoption path (`--baseline`), benign-drift allowlist, and alias-aware index checks
- Hardens failure paths: apply/baseline errors wrapped in ClickException, dry-run probe failures wrapped, success banner only after the drift gate passes

## Review
- /review: passed (claude rounds: 6)
- codex review: passed (codex rounds: 12)

## Test plan
- [ ] CI green
- [ ] verify locally