### PR TITLE
feat: as-of money-flow selectors for A/B replay

### DIFF
--- a/src/rainier/analysis/sector_analyzer.py
+++ b/src/rainier/analysis/sector_analyzer.py
@@ -79,11 +79,21 @@ def _latest_generation_filter(session: Session, as_of: date_type | None):
 
 def _build_sector_trends(
     rows: list[tuple[str | None, str | None, int, str]],
+    *,
+    normalize_casing: bool = False,
 ) -> list[SectorTrend]:
-    """Group rows ``(sector, long_short, rank, symbol)`` into ranked SectorTrends."""
+    """Group rows ``(sector, long_short, rank, symbol)`` into ranked SectorTrends.
+
+    ``normalize_casing=True`` canonicalizes ``long_short`` at ingestion
+    ('Long In' -> 'Long in', 'Short In' -> 'Short in') so the exact-match
+    counts below admit the 406 historical title-cased days. Default ``False``
+    preserves live behavior byte-identically.
+    """
     sector_data: dict[str, list[tuple[str, str | None, int]]] = defaultdict(list)
     for sector, long_short, rank, symbol in rows:
         sector_key = sector or "Unknown"
+        if normalize_casing and long_short is not None:
+            long_short = long_short.capitalize()
         sector_data[sector_key].append((symbol, long_short, rank))
 
     sector_trends: list[SectorTrend] = []
@@ -176,7 +186,10 @@ def _analyze_sectors(session: Session) -> list[SectorTrend]:
 
 
 def analyze_sectors_at(
-    as_of: date_type, session: Session | None = None,
+    as_of: date_type,
+    session: Session | None = None,
+    *,
+    normalize_casing: bool = False,
 ) -> list[SectorTrend]:
     """Analyze sector trends as of a given data DATE (latest generation on or
     before ``as_of``, resolved INDEPENDENTLY per ranking_type).
@@ -187,14 +200,31 @@ def analyze_sectors_at(
     ``captured_at`` per ``(data_date, ranking_type)``, so a single timestamp
     could only match ONE ranking type. We pick each ranking type's latest
     generation with ``data_date <= as_of`` and union the books.
+
+    ``normalize_casing=True`` (A/B replay only) canonicalizes ``long_short``
+    casing before the sentiment counts, admitting the 406 historical
+    'Long In'/'Short In' days. The sector leg queries MoneyFlowSnapshot rows
+    itself, so it needs the flag directly — accessor-level normalization in
+    the screener cannot reach it.
+
+    The default ``False`` keeps live behavior byte-identical — including the
+    recorded design-§9.5 decision: `sector_momentum` live-consumes this
+    function over PRIOR data_dates, so historical 'Long In' days already go
+    uncounted in one live output today. That accepted exposure is resolved
+    later through the substrate's designated first experiment, not here.
     """
     if session is not None:
-        return _analyze_sectors_as_of(session, as_of)
+        return _analyze_sectors_as_of(session, as_of, normalize_casing=normalize_casing)
     with get_session() as s:
-        return _analyze_sectors_as_of(s, as_of)
+        return _analyze_sectors_as_of(s, as_of, normalize_casing=normalize_casing)
 
 
-def _analyze_sectors_as_of(session: Session, as_of: date_type) -> list[SectorTrend]:
+def _analyze_sectors_as_of(
+    session: Session,
+    as_of: date_type,
+    *,
+    normalize_casing: bool = False,
+) -> list[SectorTrend]:
     """Latest generation per ranking_type with ``data_date <= as_of``."""
     predicate = _latest_generation_filter(session, as_of=as_of)
     if predicate is None:
@@ -210,7 +240,7 @@ def _analyze_sectors_as_of(session: Session, as_of: date_type) -> list[SectorTre
         .filter(predicate)
         .all()
     )
-    return _build_sector_trends(rows)
+    return _build_sector_trends(rows, normalize_casing=normalize_casing)
 
 
 def get_sector_boost(sector: str, sector_trends: list[SectorTrend]) -> float:

--- a/src/rainier/analysis/stock_screener.py
+++ b/src/rainier/analysis/stock_screener.py
@@ -453,6 +453,9 @@ def capital_flow_as_of(
 
     Returns entries newest-first.
     """
+    # The LIMIT lives on the per-day subquery (newest `limit` DISTINCT days),
+    # not on the joined rows — exact (flow_date, captured_at) duplicate rows
+    # must never consume window slots and compress the day count below limit.
     latest_per_day = (
         session.query(
             StockCapitalFlow.flow_date.label("flow_date"),
@@ -464,6 +467,8 @@ def capital_flow_as_of(
             StockCapitalFlow.flow_date <= as_of_date,
         )
         .group_by(StockCapitalFlow.flow_date)
+        .order_by(StockCapitalFlow.flow_date.desc())
+        .limit(limit)
         .subquery()
     )
     rows = (
@@ -485,7 +490,6 @@ def capital_flow_as_of(
         # id tiebreak: exact (flow_date, captured_at) dupes would otherwise
         # come back in DB-dependent order and break replay reproducibility.
         .order_by(StockCapitalFlow.flow_date.desc(), StockCapitalFlow.id.desc())
-        .limit(limit)
         .all()
     )
     # Belt over the join: if one scrape run somehow wrote the same

--- a/src/rainier/analysis/stock_screener.py
+++ b/src/rainier/analysis/stock_screener.py
@@ -229,10 +229,16 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
     """LIVE money-flow screen: staleness-guarded delegation to the as-of
     selector at today's date.
 
-    Behavior is byte-identical to the pre-extraction selector: same generation
-    resolution, same exact-match 'Long in' casing (``normalize_casing=False``),
-    same 24h staleness guard. The guard lives HERE (live only) — the as-of
-    path replays history and must not care about wall-clock age.
+    Behavior matches the pre-extraction selector: same generation resolution,
+    same exact-match 'Long in' casing (``normalize_casing=False``), same 24h
+    staleness guard. The guard lives HERE (live only) — the as-of path replays
+    history and must not care about wall-clock age. The resolved generation is
+    PINNED and passed through, so the rows screened are exactly the rows the
+    guard vetted (no re-resolution race, no double query).
+
+    One intentional divergence from the old unbounded ``max(data_date)``: the
+    resolution is now bounded ``data_date <= today`` (UTC), so a pathologically
+    future-stamped row is ignored instead of hijacking the "latest" day.
     """
     today = datetime.now(timezone.utc).date()
     generation = _resolve_top100_generation(session, today)
@@ -256,7 +262,9 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
         )
         return []
 
-    return _screen_money_flow_as_of(session, today, normalize_casing=False)
+    return _screen_money_flow_as_of(
+        session, today, normalize_casing=False, _generation=generation
+    )
 
 
 def _screen_money_flow_as_of(
@@ -264,6 +272,7 @@ def _screen_money_flow_as_of(
     as_of_date: date_type,
     *,
     normalize_casing: bool = False,
+    _generation: tuple[date_type, datetime] | None = None,
 ) -> list[MoneyFlowSignal]:
     """Screen stocks as they would have been screened on ``as_of_date``.
 
@@ -285,9 +294,14 @@ def _screen_money_flow_as_of(
     No staleness guard: replay reads arbitrarily old history. The live 24h
     guard belongs to `_screen_money_flow`.
 
+    ``_generation`` (internal): a pre-resolved ``(data_date, captured_at)``
+    pair. The live path passes the generation its staleness guard just vetted
+    so the vetted rows are exactly the screened rows — re-resolving here could
+    race a concurrent delete/rebuild onto an unvetted older generation.
+
     Returns list of MoneyFlowSignal sorted by signal_strength descending.
     """
-    generation = _resolve_top100_generation(session, as_of_date)
+    generation = _generation or _resolve_top100_generation(session, as_of_date)
     if generation is None:
         log.warning("No money flow snapshots on or before %s", as_of_date)
         return []
@@ -313,7 +327,9 @@ def _screen_money_flow_as_of(
             MoneyFlowSnapshot.data_date == latest_date,
             MoneyFlowSnapshot.captured_at == latest_ts,
         )
-        .order_by(MoneyFlowSnapshot.rank.asc())
+        # Secondary symbol sort: equal ranks otherwise come back in
+        # DB-dependent order, and the replay corpus must be reproducible.
+        .order_by(MoneyFlowSnapshot.rank.asc(), MoneyFlowSnapshot.symbol.asc())
         .all()
     )
 
@@ -406,15 +422,37 @@ def capital_flow_as_of(
     *,
     normalize_casing: bool = False,
 ) -> list[CapitalFlowEntry]:
-    """Latest ``limit`` daily capital-flow rows with ``flow_date <= as_of_date``.
+    """Latest ``limit`` daily capital-flow DAYS with ``flow_date <= as_of_date``.
 
     The date bound closes the replay look-ahead (the pre-extraction live query
     had no date filter — harmless live where no future-dated rows exist, a
     leak when replaying a past day). ``normalize_casing=True`` canonicalizes
     ``long_short`` ('Long In' -> 'Long in'), same convention as the selector.
 
-    Returns rows newest-first.
+    One entry per ``flow_date`` — the row from the NEWEST ``captured_at`` for
+    that day. `stock_capital_flow` has no unique key on (symbol, flow_date,
+    period_type) and the qu-detail scraper blind-inserts the page's trailing
+    multi-day window on every run, so any symbol scraped twice accumulates
+    duplicate daily rows. Without the dedup those duplicates compress the
+    ``limit`` window, inflate the consecutive-"+" streak count (rows != days),
+    and make ``cf_rows[0]`` — hence `capital_flow_direction` and its +0.2
+    score — nondeterministic across identical replays.
+
+    Returns entries newest-first.
     """
+    latest_per_day = (
+        session.query(
+            StockCapitalFlow.flow_date.label("flow_date"),
+            func.max(StockCapitalFlow.captured_at).label("captured_at"),
+        )
+        .filter(
+            StockCapitalFlow.symbol == symbol,
+            StockCapitalFlow.period_type == "daily",
+            StockCapitalFlow.flow_date <= as_of_date,
+        )
+        .group_by(StockCapitalFlow.flow_date)
+        .subquery()
+    )
     rows = (
         session.query(
             StockCapitalFlow.flow_date,
@@ -422,28 +460,40 @@ def capital_flow_as_of(
             StockCapitalFlow.long_short,
             StockCapitalFlow.rank,
         )
+        .join(
+            latest_per_day,
+            (StockCapitalFlow.flow_date == latest_per_day.c.flow_date)
+            & (StockCapitalFlow.captured_at == latest_per_day.c.captured_at),
+        )
         .filter(
             StockCapitalFlow.symbol == symbol,
             StockCapitalFlow.period_type == "daily",
-            StockCapitalFlow.flow_date <= as_of_date,
         )
         .order_by(StockCapitalFlow.flow_date.desc())
         .limit(limit)
         .all()
     )
-    return [
-        CapitalFlowEntry(
-            flow_date=r.flow_date,
-            capital_flow_direction=r.capital_flow_direction,
-            long_short=(
-                r.long_short.capitalize()
-                if normalize_casing and r.long_short is not None
-                else r.long_short
-            ),
-            rank=r.rank,
+    # Belt over the join: if one scrape run somehow wrote the same
+    # (flow_date, captured_at) twice, keep the first row per day.
+    seen_days: set[date_type] = set()
+    entries: list[CapitalFlowEntry] = []
+    for r in rows:
+        if r.flow_date in seen_days:
+            continue
+        seen_days.add(r.flow_date)
+        entries.append(
+            CapitalFlowEntry(
+                flow_date=r.flow_date,
+                capital_flow_direction=r.capital_flow_direction,
+                long_short=(
+                    r.long_short.capitalize()
+                    if normalize_casing and r.long_short is not None
+                    else r.long_short
+                ),
+                rank=r.rank,
+            )
         )
-        for r in rows
-    ]
+    return entries
 
 
 def _compute_money_flow_score(

--- a/src/rainier/analysis/stock_screener.py
+++ b/src/rainier/analysis/stock_screener.py
@@ -8,7 +8,9 @@ Layer 3: Technical pattern detection (Caisen methodology)
 from __future__ import annotations
 
 import logging
+from datetime import date as date_type
 from datetime import datetime, timezone
+from typing import NamedTuple
 
 import pandas as pd
 import yfinance as yf
@@ -177,36 +179,40 @@ def screen_stocks(
 # ---------------------------------------------------------------------------
 
 
-def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
-    """Screen stocks from latest QU100 snapshot + capital flow history.
+def _resolve_top100_generation(
+    session: Session, as_of_date: date_type
+) -> tuple[date_type, datetime] | None:
+    """Resolve the latest top100 snapshot generation on or before ``as_of_date``.
 
-    Step 1: Get latest 'Long in' stocks from MoneyFlowSnapshot.
-    Step 2: Enrich with capital flow direction from StockCapitalFlow.
+    Mirrors the #148 per-(data_date, ranking_type) convention
+    (``sector_analyzer._latest_generation_filter``), scoped to top100:
 
-    Returns list of MoneyFlowSignal sorted by signal_strength descending.
+        as_of = max(data_date) where data_date <= t and ranking_type='top100'
+        ts    = max(captured_at) within that (data_date, 'top100') generation
+
+    Scope "latest" by trading DAY, not insert time. The 2026-06-04 backfill
+    stamped all 1,373 historical days with one shared `captured_at`, so a
+    global `captured_at == max(captured_at)` selected every backfilled day at
+    once (duplicate symbols across days -> CardinalityViolation downstream).
+
+    Both the date and the timestamp are scoped to ranking_type == "top100"
+    (the same scope as the selector's row query). A day whose newest scrape
+    held only bottom100 (or another non-top100 partial) must NOT become the
+    "latest" date — otherwise the top100 row filter returns nothing and the
+    report blanks even though a fresh top100 snapshot exists on a prior day.
+
+    Returns ``(data_date, captured_at)`` or ``None`` when nothing matches.
     """
-    # Step 1: Latest QU100 snapshot — "Long in" stocks only.
-    #
-    # Scope "latest" by trading DAY, not insert time. The 2026-06-04 backfill
-    # stamped all 1,373 historical days with one shared `captured_at`, so the
-    # old `captured_at == max(captured_at)` selected every backfilled day at
-    # once (duplicate symbols across days -> CardinalityViolation downstream).
-    # Pick the most recent `data_date`, then the latest `captured_at` WITHIN
-    # that date — one clean trading-day snapshot regardless of insert collisions.
-    #
-    # Both the date and the timestamp are scoped to ranking_type == "top100"
-    # (the same scope as the row query below). A day whose newest scrape held
-    # only bottom100 (or another non-top100 partial) must NOT become the
-    # "latest" date — otherwise the top100 row filter returns nothing and the
-    # report blanks even though a fresh top100 snapshot exists on a prior day.
     latest_date = (
         session.query(func.max(MoneyFlowSnapshot.data_date))
-        .filter(MoneyFlowSnapshot.ranking_type == "top100")
+        .filter(
+            MoneyFlowSnapshot.ranking_type == "top100",
+            MoneyFlowSnapshot.data_date <= as_of_date,
+        )
         .scalar()
     )
     if latest_date is None:
-        log.warning("No money flow snapshots in database")
-        return []
+        return None
 
     latest_ts = (
         session.query(func.max(MoneyFlowSnapshot.captured_at))
@@ -216,6 +222,24 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
         )
         .scalar()
     )
+    return latest_date, latest_ts
+
+
+def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
+    """LIVE money-flow screen: staleness-guarded delegation to the as-of
+    selector at today's date.
+
+    Behavior is byte-identical to the pre-extraction selector: same generation
+    resolution, same exact-match 'Long in' casing (``normalize_casing=False``),
+    same 24h staleness guard. The guard lives HERE (live only) — the as-of
+    path replays history and must not care about wall-clock age.
+    """
+    today = datetime.now(timezone.utc).date()
+    generation = _resolve_top100_generation(session, today)
+    if generation is None:
+        log.warning("No money flow snapshots in database")
+        return []
+    latest_date, latest_ts = generation
 
     # Staleness check: reject data older than 24 hours. Age is judged on the
     # latest trading day's captured_at (when that day's snapshot was scraped).
@@ -232,6 +256,48 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
         )
         return []
 
+    return _screen_money_flow_as_of(session, today, normalize_casing=False)
+
+
+def _screen_money_flow_as_of(
+    session: Session,
+    as_of_date: date_type,
+    *,
+    normalize_casing: bool = False,
+) -> list[MoneyFlowSignal]:
+    """Screen stocks as they would have been screened on ``as_of_date``.
+
+    Step 1: 'Long in' stocks from the latest top100 generation with
+            data_date <= as_of_date (#148 convention, `_resolve_top100_generation`).
+    Step 2: Enrich with capital flow history via `capital_flow_as_of`
+            (flow_date <= as_of_date — no look-ahead).
+
+    ``normalize_casing`` is the live/replay split for the `long_short` casing
+    trap ('Long in' 1,011 historical days vs 'Long In' 406):
+      * False (default, live): exact-match 'Long in' — byte-identical to the
+        pre-extraction live behavior.
+      * True (replay): case-insensitive admission, and the emitted signals
+        carry the canonical 'Long in' spelling so the downstream scorer's
+        exact match (`_compute_money_flow_score`) prices the row correctly.
+        Admitting without canonicalizing would silently mis-score every
+        'Long In' day — the corpus-corruption trap this flag exists to close.
+
+    No staleness guard: replay reads arbitrarily old history. The live 24h
+    guard belongs to `_screen_money_flow`.
+
+    Returns list of MoneyFlowSignal sorted by signal_strength descending.
+    """
+    generation = _resolve_top100_generation(session, as_of_date)
+    if generation is None:
+        log.warning("No money flow snapshots on or before %s", as_of_date)
+        return []
+    latest_date, latest_ts = generation
+
+    if normalize_casing:
+        long_in_filter = func.lower(MoneyFlowSnapshot.long_short) == "long in"
+    else:
+        long_in_filter = MoneyFlowSnapshot.long_short == "Long in"
+
     rows = (
         session.query(
             MoneyFlowSnapshot.symbol,
@@ -243,7 +309,7 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
         )
         .filter(
             MoneyFlowSnapshot.ranking_type == "top100",
-            MoneyFlowSnapshot.long_short == "Long in",
+            long_in_filter,
             MoneyFlowSnapshot.data_date == latest_date,
             MoneyFlowSnapshot.captured_at == latest_ts,
         )
@@ -261,35 +327,26 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
 
     # Defensive dedup by symbol: even within one (data_date, captured_at) a
     # symbol must appear once. Rows are rank-ascending, so the first occurrence
-    # is the best-ranked — keep it.
+    # is the best-ranked — keep it. (Mirrors the live guard.)
     seen: set[str] = set()
     rows = [r for r in rows if not (r.symbol in seen or seen.add(r.symbol))]
 
-    # Step 2: Enrich each stock with capital flow data
+    # Step 2: Enrich each stock with capital flow data (as-of bounded)
     signals: list[MoneyFlowSignal] = []
     for row in rows:
         symbol = row.symbol
         rank = row.rank
         daily_change = row.daily_change or 0
         long_short = row.long_short or "Long in"
+        if normalize_casing:
+            # Canonicalize ('Long In' -> 'Long in') so the exact-match scorer
+            # and every downstream consumer see one consistent spelling.
+            long_short = long_short.capitalize()
         sector = row.sector or "Unknown"
         industry = row.industry or "Unknown"
 
-        # Get recent capital flow history
-        cf_rows = (
-            session.query(
-                StockCapitalFlow.flow_date,
-                StockCapitalFlow.capital_flow_direction,
-                StockCapitalFlow.long_short,
-                StockCapitalFlow.rank,
-            )
-            .filter(
-                StockCapitalFlow.symbol == symbol,
-                StockCapitalFlow.period_type == "daily",
-            )
-            .order_by(StockCapitalFlow.flow_date.desc())
-            .limit(5)
-            .all()
+        cf_rows = capital_flow_as_of(
+            session, symbol, as_of_date, limit=5, normalize_casing=normalize_casing
         )
 
         # Determine capital flow direction from most recent entry
@@ -330,6 +387,63 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
 
     signals.sort(key=lambda s: s.signal_strength, reverse=True)
     return signals
+
+
+class CapitalFlowEntry(NamedTuple):
+    """One daily `stock_capital_flow` row as seen by the screener."""
+
+    flow_date: date_type
+    capital_flow_direction: str | None
+    long_short: str | None
+    rank: int | None
+
+
+def capital_flow_as_of(
+    session: Session,
+    symbol: str,
+    as_of_date: date_type,
+    limit: int = 5,
+    *,
+    normalize_casing: bool = False,
+) -> list[CapitalFlowEntry]:
+    """Latest ``limit`` daily capital-flow rows with ``flow_date <= as_of_date``.
+
+    The date bound closes the replay look-ahead (the pre-extraction live query
+    had no date filter — harmless live where no future-dated rows exist, a
+    leak when replaying a past day). ``normalize_casing=True`` canonicalizes
+    ``long_short`` ('Long In' -> 'Long in'), same convention as the selector.
+
+    Returns rows newest-first.
+    """
+    rows = (
+        session.query(
+            StockCapitalFlow.flow_date,
+            StockCapitalFlow.capital_flow_direction,
+            StockCapitalFlow.long_short,
+            StockCapitalFlow.rank,
+        )
+        .filter(
+            StockCapitalFlow.symbol == symbol,
+            StockCapitalFlow.period_type == "daily",
+            StockCapitalFlow.flow_date <= as_of_date,
+        )
+        .order_by(StockCapitalFlow.flow_date.desc())
+        .limit(limit)
+        .all()
+    )
+    return [
+        CapitalFlowEntry(
+            flow_date=r.flow_date,
+            capital_flow_direction=r.capital_flow_direction,
+            long_short=(
+                r.long_short.capitalize()
+                if normalize_casing and r.long_short is not None
+                else r.long_short
+            ),
+            rank=r.rank,
+        )
+        for r in rows
+    ]
 
 
 def _compute_money_flow_score(

--- a/src/rainier/analysis/stock_screener.py
+++ b/src/rainier/analysis/stock_screener.py
@@ -11,6 +11,7 @@ import logging
 from datetime import date as date_type
 from datetime import datetime, timezone
 from typing import NamedTuple
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 import yfinance as yf
@@ -31,6 +32,11 @@ from rainier.core.types import (
 )
 
 log = logging.getLogger(__name__)
+
+# `data_date` is stored as the US-market calendar day (see
+# scrapers.qu.scraper.MARKET_TZ / market_date()); mirrored here rather than
+# imported because analysis/ must not pull the scrapers/ (Playwright) stack.
+_MARKET_TZ = ZoneInfo("America/New_York")
 
 
 # ---------------------------------------------------------------------------
@@ -237,9 +243,12 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
     guard vetted (no re-resolution race, no double query).
 
     Two intentional divergences from the pre-extraction selector:
-      1. Resolution is bounded ``data_date <= today`` (UTC) instead of the old
+      1. Resolution is bounded ``data_date <= today`` instead of the old
          unbounded ``max(data_date)`` — a pathologically future-stamped row is
-         ignored instead of hijacking the "latest" day.
+         ignored instead of hijacking the "latest" day. "Today" is the ET
+         market day (the calendar ``data_date`` is stored in), not the UTC
+         date: between 00:00 UTC and ET midnight the UTC date is one day
+         ahead, which would let a next-market-day stamp slip under the bound.
       2. Capital-flow enrichment goes through `capital_flow_as_of`, which
          dedups duplicate ``(symbol, flow_date)`` rows (newest ``captured_at``
          wins) — the old query counted raw rows. Vacuous live as of
@@ -248,7 +257,7 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
          Once qu-detail populates the table this is a correctness guard
          (streaks count days, not re-scraped duplicates), not a scoring flip.
     """
-    today = datetime.now(timezone.utc).date()
+    today = datetime.now(timezone.utc).astimezone(_MARKET_TZ).date()
     generation = _resolve_top100_generation(session, today)
     if generation is None:
         log.warning("No money flow snapshots in database")

--- a/src/rainier/analysis/stock_screener.py
+++ b/src/rainier/analysis/stock_screener.py
@@ -236,9 +236,17 @@ def _screen_money_flow(session: Session) -> list[MoneyFlowSignal]:
     PINNED and passed through, so the rows screened are exactly the rows the
     guard vetted (no re-resolution race, no double query).
 
-    One intentional divergence from the old unbounded ``max(data_date)``: the
-    resolution is now bounded ``data_date <= today`` (UTC), so a pathologically
-    future-stamped row is ignored instead of hijacking the "latest" day.
+    Two intentional divergences from the pre-extraction selector:
+      1. Resolution is bounded ``data_date <= today`` (UTC) instead of the old
+         unbounded ``max(data_date)`` — a pathologically future-stamped row is
+         ignored instead of hijacking the "latest" day.
+      2. Capital-flow enrichment goes through `capital_flow_as_of`, which
+         dedups duplicate ``(symbol, flow_date)`` rows (newest ``captured_at``
+         wins) — the old query counted raw rows. Vacuous live as of
+         2026-07-04: prod ``stock_capital_flow`` holds ZERO daily rows
+         (verified against the live DB), so live output is unchanged today.
+         Once qu-detail populates the table this is a correctness guard
+         (streaks count days, not re-scraped duplicates), not a scoring flip.
     """
     today = datetime.now(timezone.utc).date()
     generation = _resolve_top100_generation(session, today)
@@ -438,6 +446,11 @@ def capital_flow_as_of(
     and make ``cf_rows[0]`` — hence `capital_flow_direction` and its +0.2
     score — nondeterministic across identical replays.
 
+    Event-time, not point-in-time: max(``captured_at``) per day means a replay
+    of day t uses the newest restatement of day-t rows even if it was scraped
+    after t. Rows still describe days <= t (no market look-ahead); a
+    ``captured_at <= t`` bound is impossible for backfill-stamped history.
+
     Returns entries newest-first.
     """
     latest_per_day = (
@@ -469,7 +482,9 @@ def capital_flow_as_of(
             StockCapitalFlow.symbol == symbol,
             StockCapitalFlow.period_type == "daily",
         )
-        .order_by(StockCapitalFlow.flow_date.desc())
+        # id tiebreak: exact (flow_date, captured_at) dupes would otherwise
+        # come back in DB-dependent order and break replay reproducibility.
+        .order_by(StockCapitalFlow.flow_date.desc(), StockCapitalFlow.id.desc())
         .limit(limit)
         .all()
     )

--- a/tests/test_asof_money_flow_selectors.py
+++ b/tests/test_asof_money_flow_selectors.py
@@ -1,0 +1,455 @@
+"""As-of money-flow selectors for A/B replay (task ab-asof-selectors-8f6f).
+
+The replay must answer "which stocks would the screener have picked on day t?"
+without leaking future data. This covers:
+
+* `_screen_money_flow_as_of(session, t, *, normalize_casing=False)` — mirrors
+  the #148 per-(data_date, ranking_type) generation convention (max data_date
+  <= t for top100, then max captured_at within that generation) plus the live
+  per-symbol dedup. NO 24h staleness guard (replay reads history).
+* `capital_flow_as_of(session, symbol, t, limit=5, *, normalize_casing=False)`
+  — closes the look-ahead in the capital-flow enrichment (live grabs the
+  latest 5 rows with no date filter; as-of filters flow_date <= t).
+* `normalize_casing` — the live/replay split for the `long_short` casing trap
+  ('Long in' 1,011 days vs 'Long In' 406 days). `True` admits both spellings
+  and canonicalizes so scorer + sector leg agree; `False` (default, live)
+  keeps exact-match byte-identical.
+* `analyze_sectors_at(..., normalize_casing=...)` — the sector leg queries
+  MoneyFlowSnapshot rows itself, so it needs the flag directly.
+
+Raw-DDL SQLite harness mirroring `money_flow_snapshots` / `stock_capital_flow`
+(the ORM models can't create on SQLite — composite PK + JSONB); the ORM-class
+queries run unmodified against these tables. Timestamps are stored tz-naive
+UTC (SQLite TIMESTAMP-affinity artifact, see
+tests/test_stock_screener_latest_snapshot.py).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from rainier.analysis.sector_analyzer import analyze_sectors_at, get_sector_boost
+from rainier.analysis.stock_screener import (
+    _screen_money_flow,
+    _screen_money_flow_as_of,
+    capital_flow_as_of,
+)
+
+_DDL_SNAPSHOTS = """
+CREATE TABLE money_flow_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    captured_at TIMESTAMP NOT NULL,
+    capture_session TEXT,
+    data_date DATE NOT NULL,
+    view_type TEXT,
+    ranking_type TEXT NOT NULL,
+    symbol TEXT NOT NULL,
+    rank INTEGER NOT NULL,
+    daily_change INTEGER,
+    sector TEXT,
+    industry TEXT,
+    long_short TEXT,
+    raw_data TEXT
+)
+"""
+
+_DDL_CAPITAL_FLOW = """
+CREATE TABLE stock_capital_flow (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    symbol TEXT NOT NULL,
+    captured_at TIMESTAMP NOT NULL,
+    flow_date DATE NOT NULL,
+    period_type TEXT NOT NULL,
+    week_start DATE,
+    week_end DATE,
+    capital_flow_direction TEXT,
+    long_short TEXT,
+    rank INTEGER,
+    rank_total INTEGER,
+    raw_data TEXT
+)
+"""
+
+# Fixed historical day t and generation timestamps — all far outside the 24h
+# staleness window on purpose: the as-of path must not care.
+T = date(2026, 6, 4)
+TS_EARLY = datetime(2026, 6, 4, 15, 45)
+TS_LATE = datetime(2026, 6, 4, 22, 0)
+
+
+@pytest.fixture
+def db_session():
+    eng = create_engine("sqlite://")
+    with eng.begin() as conn:
+        conn.execute(text(_DDL_SNAPSHOTS))
+        conn.execute(text(_DDL_CAPITAL_FLOW))
+    sess = Session(eng)
+    try:
+        yield sess
+    finally:
+        sess.close()
+        eng.dispose()
+
+
+def _insert_snapshot(
+    session: Session,
+    *,
+    symbol: str,
+    rank: int,
+    data_date: str,
+    captured_at: datetime,
+    ranking_type: str = "top100",
+    long_short: str = "Long in",
+    sector: str = "Technology",
+    daily_change: int = 0,
+):
+    session.execute(
+        text(
+            "INSERT INTO money_flow_snapshots "
+            "(captured_at, capture_session, data_date, view_type, ranking_type, "
+            " symbol, rank, daily_change, sector, industry, long_short) "
+            "VALUES (:captured_at, 'afternoon', :data_date, 'daily', :ranking_type, "
+            " :symbol, :rank, :daily_change, :sector, 'X', :long_short)"
+        ),
+        {
+            "captured_at": captured_at,
+            "data_date": data_date,
+            "ranking_type": ranking_type,
+            "symbol": symbol,
+            "rank": rank,
+            "daily_change": daily_change,
+            "sector": sector,
+            "long_short": long_short,
+        },
+    )
+    session.commit()
+
+
+def _insert_capital_flow(
+    session: Session,
+    *,
+    symbol: str,
+    flow_date: str,
+    direction: str = "+",
+    long_short: str = "Long in",
+    rank: int = 1,
+    period_type: str = "daily",
+):
+    session.execute(
+        text(
+            "INSERT INTO stock_capital_flow "
+            "(symbol, captured_at, flow_date, period_type, capital_flow_direction, "
+            " long_short, rank, rank_total) "
+            "VALUES (:symbol, :captured_at, :flow_date, :period_type, :direction, "
+            " :long_short, :rank, 100)"
+        ),
+        {
+            "symbol": symbol,
+            "captured_at": datetime(2026, 6, 4, 22, 0),
+            "flow_date": flow_date,
+            "period_type": period_type,
+            "direction": direction,
+            "long_short": long_short,
+            "rank": rank,
+        },
+    )
+    session.commit()
+
+
+def _recent_ts() -> datetime:
+    """A captured_at within the live 24h staleness window (tz-naive UTC)."""
+    return (datetime.now(timezone.utc) - timedelta(hours=1)).replace(tzinfo=None)
+
+
+# ---------------------------------------------------------------------------
+# As-of resolution (#148 generation convention)
+# ---------------------------------------------------------------------------
+
+
+def test_as_of_trading_day_selects_that_day(db_session):
+    """t is a trading day with data -> exactly that day's generation."""
+    _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date="2026-06-04", captured_at=TS_LATE)
+    _insert_snapshot(db_session, symbol="TSLA", rank=2, data_date="2026-06-04", captured_at=TS_LATE)
+    # Future day must never leak into an as-of t read.
+    _insert_snapshot(
+        db_session, symbol="AMD", rank=1, data_date="2026-06-05",
+        captured_at=datetime(2026, 6, 5, 22, 0),
+    )
+
+    signals = _screen_money_flow_as_of(db_session, T)
+    assert sorted(s.symbol for s in signals) == ["NVDA", "TSLA"]
+
+
+def test_as_of_non_trading_day_falls_back_to_nearest(db_session):
+    """t is a non-trading day (weekend) -> nearest data_date <= t."""
+    _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date="2026-06-04", captured_at=TS_LATE)
+    _insert_snapshot(db_session, symbol="TSLA", rank=2, data_date="2026-06-04", captured_at=TS_LATE)
+
+    signals = _screen_money_flow_as_of(db_session, date(2026, 6, 7))  # Sunday
+    assert sorted(s.symbol for s in signals) == ["NVDA", "TSLA"]
+
+
+def test_as_of_picks_latest_generation_within_day(db_session):
+    """Two captured_at batches for one (data_date, top100) -> latest generation only."""
+    _insert_snapshot(db_session, symbol="NVDA", rank=9, data_date="2026-06-04", captured_at=TS_EARLY)
+    _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date="2026-06-04", captured_at=TS_LATE)
+    _insert_snapshot(db_session, symbol="AMD", rank=2, data_date="2026-06-04", captured_at=TS_LATE)
+
+    signals = _screen_money_flow_as_of(db_session, T)
+    by_symbol = {s.symbol: s for s in signals}
+    assert set(by_symbol) == {"NVDA", "AMD"}
+    assert by_symbol["NVDA"].rank == 1  # late generation wins
+
+
+def test_as_of_generation_scoped_to_top100(db_session):
+    """A newer data_date holding only bottom100 must not blank the as-of read
+    (same scope rule as the live selector)."""
+    _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date="2026-06-03", captured_at=TS_EARLY)
+    _insert_snapshot(
+        db_session, symbol="META", rank=1, data_date="2026-06-04",
+        captured_at=TS_LATE, ranking_type="bottom100",
+    )
+
+    signals = _screen_money_flow_as_of(db_session, T)
+    assert [s.symbol for s in signals] == ["NVDA"]
+
+
+def test_as_of_dedup_per_symbol_mirrors_live(db_session):
+    """Duplicate symbol rows within one generation -> one signal, best rank kept."""
+    _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date="2026-06-04", captured_at=TS_LATE)
+    _insert_snapshot(db_session, symbol="NVDA", rank=5, data_date="2026-06-04", captured_at=TS_LATE)
+
+    signals = _screen_money_flow_as_of(db_session, T)
+    assert [s.symbol for s in signals] == ["NVDA"]
+    assert signals[0].rank == 1
+
+
+def test_as_of_has_no_staleness_guard(db_session):
+    """Replay reads history: a generation weeks/months old must still return.
+    (TS_LATE is 2026-06-04 — far beyond the live 24h window.)"""
+    _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date="2026-06-04", captured_at=TS_LATE)
+
+    signals = _screen_money_flow_as_of(db_session, T)
+    assert [s.symbol for s in signals] == ["NVDA"]
+
+
+def test_as_of_empty_db_returns_empty(db_session):
+    assert _screen_money_flow_as_of(db_session, T) == []
+
+
+# ---------------------------------------------------------------------------
+# Casing normalization (the live/replay split)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_true_admits_and_scores_title_cased_day(db_session):
+    """'Long In' (406 historical days) admitted AND scored under the flag.
+
+    Canonicalized long_short means _compute_money_flow_score's exact
+    'Long in' match awards the 0.5 base — an admitted-but-mis-scored row
+    (0.15 only) is exactly the silent-corruption trap this flag closes.
+    """
+    _insert_snapshot(
+        db_session, symbol="NVDA", rank=1, data_date="2026-06-04",
+        captured_at=TS_LATE, long_short="Long In",
+    )
+
+    signals = _screen_money_flow_as_of(db_session, T, normalize_casing=True)
+    assert [s.symbol for s in signals] == ["NVDA"]
+    assert signals[0].long_short == "Long in"  # canonical casing out
+    # 0.5 (Long in base) + 0.15 (rank <= 30); no capital flow rows.
+    assert signals[0].signal_strength == pytest.approx(0.65)
+
+
+def test_normalize_false_keeps_exact_match(db_session):
+    """Default (live) path: 'Long In' rows are NOT admitted — regression on
+    byte-identical live behavior."""
+    _insert_snapshot(
+        db_session, symbol="NVDA", rank=1, data_date="2026-06-04",
+        captured_at=TS_LATE, long_short="Long In",
+    )
+
+    assert _screen_money_flow_as_of(db_session, T) == []
+    assert _screen_money_flow_as_of(db_session, T, normalize_casing=False) == []
+
+
+def test_sector_leg_normalize_true_counts_title_cased(db_session):
+    """analyze_sectors_at(normalize_casing=True): a 'Long In' day is counted
+    long, turns the sector bullish, and yields the 0.1 boost."""
+    _insert_snapshot(
+        db_session, symbol="NVDA", rank=1, data_date="2026-06-04",
+        captured_at=TS_LATE, long_short="Long In", sector="Technology",
+    )
+
+    trends = analyze_sectors_at(T, session=db_session, normalize_casing=True)
+    tech = next(t for t in trends if t.sector == "Technology")
+    assert tech.long_in_count == 1
+    assert tech.short_in_count == 0
+    assert tech.trend_direction == "bullish"
+    assert tech.top_stocks == ["NVDA"]
+    assert get_sector_boost("Technology", trends) == pytest.approx(0.1)
+
+
+def test_sector_leg_normalize_true_counts_title_cased_short(db_session):
+    """'Short In' normalizes into the short count too."""
+    _insert_snapshot(
+        db_session, symbol="XOM", rank=1, data_date="2026-06-04",
+        captured_at=TS_LATE, long_short="Short In", sector="Energy",
+        ranking_type="bottom100",
+    )
+
+    trends = analyze_sectors_at(T, session=db_session, normalize_casing=True)
+    energy = next(t for t in trends if t.sector == "Energy")
+    assert energy.short_in_count == 1
+    assert energy.trend_direction == "bearish"
+
+
+def test_recorded_decision_sector_momentum_live_exposure(db_session):
+    """Recorded decision (design §9.5, accepted): the live default path of
+    analyze_sectors_at — as consumed by llm_thesis sector_momentum over PRIOR
+    data_dates — keeps exact-match casing. Historical 'Long In' days stay
+    uncounted live; that exposure is resolved later through the substrate's
+    designated first experiment, NOT by this task."""
+    _insert_snapshot(
+        db_session, symbol="NVDA", rank=1, data_date="2026-06-04",
+        captured_at=TS_LATE, long_short="Long In", sector="Technology",
+    )
+
+    trends = analyze_sectors_at(T, session=db_session)  # default: no normalization
+    tech = next(t for t in trends if t.sector == "Technology")
+    assert tech.long_in_count == 0
+    assert tech.trend_direction == "neutral"
+
+
+# ---------------------------------------------------------------------------
+# As-of capital flow (look-ahead close)
+# ---------------------------------------------------------------------------
+
+
+def test_capital_flow_as_of_excludes_future_rows(db_session):
+    """Rows with flow_date > t never returned; results newest-first."""
+    for d in ["2026-06-01", "2026-06-02", "2026-06-03", "2026-06-04", "2026-06-05"]:
+        _insert_capital_flow(db_session, symbol="NVDA", flow_date=d)
+
+    rows = capital_flow_as_of(db_session, "NVDA", date(2026, 6, 3))
+    assert [r.flow_date for r in rows] == [
+        date(2026, 6, 3), date(2026, 6, 2), date(2026, 6, 1),
+    ]
+
+
+def test_capital_flow_as_of_limit_and_period_type(db_session):
+    """limit caps to the newest N on-or-before t; non-daily rows excluded."""
+    for i in range(1, 8):
+        _insert_capital_flow(db_session, symbol="NVDA", flow_date=f"2026-06-0{i}")
+    _insert_capital_flow(
+        db_session, symbol="NVDA", flow_date="2026-06-07", period_type="weekly",
+    )
+
+    rows = capital_flow_as_of(db_session, "NVDA", date(2026, 6, 7), limit=5)
+    assert len(rows) == 5
+    assert rows[0].flow_date == date(2026, 6, 7)
+    assert rows[-1].flow_date == date(2026, 6, 3)
+
+
+def test_capital_flow_as_of_normalize_casing(db_session):
+    """normalize_casing=True canonicalizes long_short; False returns raw."""
+    _insert_capital_flow(
+        db_session, symbol="NVDA", flow_date="2026-06-04", long_short="Long In",
+    )
+
+    raw = capital_flow_as_of(db_session, "NVDA", T)
+    assert raw[0].long_short == "Long In"
+
+    normalized = capital_flow_as_of(db_session, "NVDA", T, normalize_casing=True)
+    assert normalized[0].long_short == "Long in"
+
+
+# ---------------------------------------------------------------------------
+# No look-ahead through the composed selector
+# ---------------------------------------------------------------------------
+
+
+def test_no_lookahead_capital_flow_in_selector(db_session):
+    """Future capital-flow rows must not affect direction / streak / score.
+
+    A '+' row dated after t would flip direction to '+' (+0.2) and extend the
+    streak if the enrichment leg leaked — the exact live bug (no date filter).
+    """
+    _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date="2026-06-04", captured_at=TS_LATE)
+    _insert_capital_flow(db_session, symbol="NVDA", flow_date="2026-06-05", direction="+")
+    _insert_capital_flow(db_session, symbol="NVDA", flow_date="2026-06-04", direction="-")
+    _insert_capital_flow(db_session, symbol="NVDA", flow_date="2026-06-03", direction="+")
+
+    signals = _screen_money_flow_as_of(db_session, T)
+    assert [s.symbol for s in signals] == ["NVDA"]
+    sig = signals[0]
+    assert sig.capital_flow_direction == "-"  # 2026-06-04 row, not the future '+'
+    assert sig.days_in_top100 == 0
+    # 0.5 base + 0.15 rank; no '+' direction bonus, no streak bonus.
+    assert sig.signal_strength == pytest.approx(0.65)
+
+
+def test_no_lookahead_money_flow_snapshots(db_session):
+    """Snapshot days after t never affect the as-of basket."""
+    _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date="2026-06-04", captured_at=TS_LATE)
+    _insert_snapshot(
+        db_session, symbol="TSLA", rank=1, data_date="2026-06-08",
+        captured_at=datetime(2026, 6, 8, 22, 0),
+    )
+
+    signals = _screen_money_flow_as_of(db_session, T)
+    assert [s.symbol for s in signals] == ["NVDA"]
+
+
+# ---------------------------------------------------------------------------
+# Live parity (byte-identical delegation)
+# ---------------------------------------------------------------------------
+
+
+def test_live_delegates_to_as_of_identically(db_session):
+    """_screen_money_flow == _screen_money_flow_as_of(today, normalize=False)
+    on a fresh fixture — the extraction changes nothing live."""
+    ts = _recent_ts()
+    today = datetime.now(timezone.utc).date().isoformat()
+    for i, sym in enumerate(["NVDA", "TSLA", "AMD"], start=1):
+        _insert_snapshot(
+            db_session, symbol=sym, rank=i, data_date=today,
+            captured_at=ts, daily_change=1,
+        )
+    _insert_snapshot(
+        db_session, symbol="META", rank=4, data_date=today,
+        captured_at=ts, long_short="Short in",
+    )
+    # 'Long In' rows stay excluded on BOTH live paths (exact match).
+    _insert_snapshot(
+        db_session, symbol="ORCL", rank=5, data_date=today,
+        captured_at=ts, long_short="Long In",
+    )
+    for d_off in range(4):
+        d = (datetime.now(timezone.utc).date() - timedelta(days=d_off)).isoformat()
+        _insert_capital_flow(db_session, symbol="NVDA", flow_date=d, direction="+")
+
+    live = _screen_money_flow(db_session)
+    as_of = _screen_money_flow_as_of(
+        db_session, datetime.now(timezone.utc).date(), normalize_casing=False
+    )
+    assert live  # non-vacuous
+    assert live == as_of
+    assert sorted(s.symbol for s in live) == ["AMD", "NVDA", "TSLA"]
+
+
+def test_live_staleness_guard_retained(db_session):
+    """The 24h guard still protects the LIVE path only."""
+    stale_ts = (datetime.now(timezone.utc) - timedelta(hours=30)).replace(tzinfo=None)
+    d = (datetime.now(timezone.utc) - timedelta(hours=30)).date()
+    _insert_snapshot(
+        db_session, symbol="NVDA", rank=1, data_date=d.isoformat(), captured_at=stale_ts,
+    )
+
+    assert _screen_money_flow(db_session) == []
+    # Same data via the as-of path (replay) still returns.
+    assert [s.symbol for s in _screen_money_flow_as_of(db_session, date.today())] == ["NVDA"]

--- a/tests/test_asof_money_flow_selectors.py
+++ b/tests/test_asof_money_flow_selectors.py
@@ -114,7 +114,7 @@ def _insert_snapshot(
     data_date: str,
     captured_at: datetime,
     ranking_type: str = "top100",
-    long_short: str = "Long in",
+    long_short: str | None = "Long in",
     sector: str = "Technology",
     daily_change: int = 0,
 ):
@@ -146,9 +146,10 @@ def _insert_capital_flow(
     symbol: str,
     flow_date: str,
     direction: str = "+",
-    long_short: str = "Long in",
+    long_short: str | None = "Long in",
     rank: int = 1,
     period_type: str = "daily",
+    captured_at: datetime = datetime(2026, 6, 4, 22, 0),
 ):
     session.execute(
         text(
@@ -160,7 +161,7 @@ def _insert_capital_flow(
         ),
         {
             "symbol": symbol,
-            "captured_at": _ts_param(datetime(2026, 6, 4, 22, 0)),
+            "captured_at": _ts_param(captured_at),
             "flow_date": flow_date,
             "period_type": period_type,
             "direction": direction,
@@ -465,3 +466,168 @@ def test_live_staleness_guard_retained(db_session):
     # Same data via the as-of path (replay) still returns.
     today_utc = datetime.now(timezone.utc).date()
     assert [s.symbol for s in _screen_money_flow_as_of(db_session, today_utc)] == ["NVDA"]
+
+
+def test_live_resolves_generation_once(db_session, monkeypatch):
+    """The live path pins the staleness-vetted generation into the as-of
+    selector — exactly ONE resolution per call. A second resolution could race
+    a concurrent delete/rebuild onto an unvetted older generation (and doubles
+    the aggregate queries for nothing)."""
+    import rainier.analysis.stock_screener as ss
+
+    _insert_snapshot(
+        db_session, symbol="NVDA", rank=1,
+        data_date=datetime.now(timezone.utc).date().isoformat(),
+        captured_at=_recent_ts(),
+    )
+
+    calls: list[date] = []
+    real = ss._resolve_top100_generation
+
+    def counting(session, as_of_date):
+        calls.append(as_of_date)
+        return real(session, as_of_date)
+
+    monkeypatch.setattr(ss, "_resolve_top100_generation", counting)
+    signals = ss._screen_money_flow(db_session)
+    assert [s.symbol for s in signals] == ["NVDA"]
+    assert len(calls) == 1
+
+
+def test_live_ignores_future_data_date(db_session):
+    """A pathologically future-stamped data_date must not hijack the live
+    'latest' day (intentional divergence from the old unbounded max)."""
+    today = datetime.now(timezone.utc).date()
+    _insert_snapshot(
+        db_session, symbol="NVDA", rank=1, data_date=today.isoformat(),
+        captured_at=_recent_ts(),
+    )
+    _insert_snapshot(
+        db_session, symbol="HACK", rank=1,
+        data_date=(today + timedelta(days=30)).isoformat(),
+        captured_at=_recent_ts(),
+    )
+
+    assert [s.symbol for s in _screen_money_flow(db_session)] == ["NVDA"]
+
+
+# ---------------------------------------------------------------------------
+# Duplicate capital-flow rows (no unique key on symbol/flow_date/period_type;
+# the qu-detail scraper blind-inserts a trailing window every run)
+# ---------------------------------------------------------------------------
+
+
+def test_capital_flow_as_of_dedups_rescraped_days(db_session):
+    """One entry per flow_date; the newest captured_at wins deterministically."""
+    _insert_capital_flow(
+        db_session, symbol="NVDA", flow_date="2026-06-04", direction="-",
+        captured_at=datetime(2026, 6, 4, 15, 45),
+    )
+    _insert_capital_flow(
+        db_session, symbol="NVDA", flow_date="2026-06-04", direction="+",
+        captured_at=datetime(2026, 6, 4, 22, 0),
+    )
+
+    rows = capital_flow_as_of(db_session, "NVDA", T)
+    assert [r.flow_date for r in rows] == [date(2026, 6, 4)]
+    assert rows[0].capital_flow_direction == "+"  # newest scrape wins
+
+
+def test_capital_flow_as_of_limit_counts_days_not_rows(db_session):
+    """Duplicated days must not compress the limit window below `limit`
+    distinct days."""
+    for i in range(1, 7):  # 6 days, each inserted twice (re-scrape)
+        for ts in (datetime(2026, 6, 6, 15, 45), datetime(2026, 6, 6, 22, 0)):
+            _insert_capital_flow(
+                db_session, symbol="NVDA", flow_date=f"2026-06-0{i}", captured_at=ts,
+            )
+
+    rows = capital_flow_as_of(db_session, "NVDA", date(2026, 6, 6), limit=5)
+    assert [r.flow_date for r in rows] == [
+        date(2026, 6, 6), date(2026, 6, 5), date(2026, 6, 4),
+        date(2026, 6, 3), date(2026, 6, 2),
+    ]
+
+
+def test_dup_capital_flow_rows_do_not_inflate_streak(db_session):
+    """days_in_top100 counts consecutive '+' DAYS, not raw duplicate rows.
+
+    Two '+' days duplicated into four rows must NOT fire the >= 3-day streak
+    bonus (+0.05)."""
+    _insert_snapshot(db_session, symbol="NVDA", rank=1, data_date="2026-06-04", captured_at=TS_LATE)
+    for d in ("2026-06-04", "2026-06-03"):
+        for ts in (datetime(2026, 6, 4, 15, 45), datetime(2026, 6, 4, 22, 0)):
+            _insert_capital_flow(
+                db_session, symbol="NVDA", flow_date=d, direction="+", captured_at=ts,
+            )
+
+    signals = _screen_money_flow_as_of(db_session, T)
+    assert [s.symbol for s in signals] == ["NVDA"]
+    sig = signals[0]
+    assert sig.days_in_top100 == 2
+    # 0.5 base + 0.2 '+' direction + 0.15 rank; NO 0.05 streak bonus.
+    assert sig.signal_strength == pytest.approx(0.85)
+
+
+# ---------------------------------------------------------------------------
+# normalize_casing hardening
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_true_excludes_short_rows(db_session):
+    """Case-insensitive admission stays scoped to 'long in' — shorts of either
+    casing must not leak into the replay basket."""
+    _insert_snapshot(
+        db_session, symbol="NVDA", rank=1, data_date="2026-06-04",
+        captured_at=TS_LATE, long_short="Long In",
+    )
+    _insert_snapshot(
+        db_session, symbol="META", rank=2, data_date="2026-06-04",
+        captured_at=TS_LATE, long_short="Short in",
+    )
+    _insert_snapshot(
+        db_session, symbol="XOM", rank=3, data_date="2026-06-04",
+        captured_at=TS_LATE, long_short="Short In",
+    )
+
+    signals = _screen_money_flow_as_of(db_session, T, normalize_casing=True)
+    assert [s.symbol for s in signals] == ["NVDA"]
+
+
+def test_sector_leg_normalize_null_long_short_safe(db_session):
+    """NULL long_short rows must not crash the normalize branch and count
+    neither long nor short."""
+    _insert_snapshot(
+        db_session, symbol="NVDA", rank=1, data_date="2026-06-04",
+        captured_at=TS_LATE, long_short=None, sector="Technology",
+    )
+
+    trends = analyze_sectors_at(T, session=db_session, normalize_casing=True)
+    tech = next(t for t in trends if t.sector == "Technology")
+    assert tech.long_in_count == 0
+    assert tech.short_in_count == 0
+
+
+def test_capital_flow_as_of_normalize_null_long_short(db_session):
+    """NULL long_short passes through the normalize branch as None."""
+    _insert_capital_flow(
+        db_session, symbol="NVDA", flow_date="2026-06-04", long_short=None,
+    )
+
+    rows = capital_flow_as_of(db_session, "NVDA", T, normalize_casing=True)
+    assert rows[0].long_short is None
+
+
+# ---------------------------------------------------------------------------
+# Replay determinism
+# ---------------------------------------------------------------------------
+
+
+def test_equal_rank_ties_order_by_symbol(db_session):
+    """Equal-rank, equal-score rows come back symbol-ascending — the corpus
+    must be byte-reproducible across runs."""
+    _insert_snapshot(db_session, symbol="ZZZ", rank=1, data_date="2026-06-04", captured_at=TS_LATE)
+    _insert_snapshot(db_session, symbol="AAA", rank=1, data_date="2026-06-04", captured_at=TS_LATE)
+
+    signals = _screen_money_flow_as_of(db_session, T)
+    assert [s.symbol for s in signals] == ["AAA", "ZZZ"]

--- a/tests/test_asof_money_flow_selectors.py
+++ b/tests/test_asof_money_flow_selectors.py
@@ -81,6 +81,17 @@ TS_EARLY = datetime(2026, 6, 4, 15, 45)
 TS_LATE = datetime(2026, 6, 4, 22, 0)
 
 
+def _ts_param(ts: datetime) -> str:
+    """Bind-format a captured_at for raw INSERT (SQLite harness artifact).
+
+    sqlite3's default datetime adapter omits a zero microsecond field
+    ('... 22:00:00') while SQLAlchemy's DateTime equality bind always emits
+    it ('... 22:00:00.000000') — a raw-inserted whole-second timestamp would
+    never equality-match. Store the SQLAlchemy spelling.
+    """
+    return ts.isoformat(sep=" ", timespec="microseconds")
+
+
 @pytest.fixture
 def db_session():
     eng = create_engine("sqlite://")
@@ -116,7 +127,7 @@ def _insert_snapshot(
             " :symbol, :rank, :daily_change, :sector, 'X', :long_short)"
         ),
         {
-            "captured_at": captured_at,
+            "captured_at": _ts_param(captured_at),
             "data_date": data_date,
             "ranking_type": ranking_type,
             "symbol": symbol,
@@ -149,7 +160,7 @@ def _insert_capital_flow(
         ),
         {
             "symbol": symbol,
-            "captured_at": datetime(2026, 6, 4, 22, 0),
+            "captured_at": _ts_param(datetime(2026, 6, 4, 22, 0)),
             "flow_date": flow_date,
             "period_type": period_type,
             "direction": direction,

--- a/tests/test_asof_money_flow_selectors.py
+++ b/tests/test_asof_money_flow_selectors.py
@@ -463,4 +463,5 @@ def test_live_staleness_guard_retained(db_session):
 
     assert _screen_money_flow(db_session) == []
     # Same data via the as-of path (replay) still returns.
-    assert [s.symbol for s in _screen_money_flow_as_of(db_session, date.today())] == ["NVDA"]
+    today_utc = datetime.now(timezone.utc).date()
+    assert [s.symbol for s in _screen_money_flow_as_of(db_session, today_utc)] == ["NVDA"]

--- a/tests/test_asof_money_flow_selectors.py
+++ b/tests/test_asof_money_flow_selectors.py
@@ -27,6 +27,7 @@ tests/test_stock_screener_latest_snapshot.py).
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 from sqlalchemy import create_engine, text
@@ -175,6 +176,12 @@ def _insert_capital_flow(
 def _recent_ts() -> datetime:
     """A captured_at within the live 24h staleness window (tz-naive UTC)."""
     return (datetime.now(timezone.utc) - timedelta(hours=1)).replace(tzinfo=None)
+
+
+def _market_today() -> date:
+    """The ET market day — the calendar `data_date` is stored in and the
+    live path bounds by (see stock_screener._MARKET_TZ)."""
+    return datetime.now(timezone.utc).astimezone(ZoneInfo("America/New_York")).date()
 
 
 # ---------------------------------------------------------------------------
@@ -426,7 +433,7 @@ def test_live_delegates_to_as_of_identically(db_session):
     """_screen_money_flow == _screen_money_flow_as_of(today, normalize=False)
     on a fresh fixture — the extraction changes nothing live."""
     ts = _recent_ts()
-    today = datetime.now(timezone.utc).date().isoformat()
+    today = _market_today().isoformat()
     for i, sym in enumerate(["NVDA", "TSLA", "AMD"], start=1):
         _insert_snapshot(
             db_session, symbol=sym, rank=i, data_date=today,
@@ -442,12 +449,12 @@ def test_live_delegates_to_as_of_identically(db_session):
         captured_at=ts, long_short="Long In",
     )
     for d_off in range(4):
-        d = (datetime.now(timezone.utc).date() - timedelta(days=d_off)).isoformat()
+        d = (_market_today() - timedelta(days=d_off)).isoformat()
         _insert_capital_flow(db_session, symbol="NVDA", flow_date=d, direction="+")
 
     live = _screen_money_flow(db_session)
     as_of = _screen_money_flow_as_of(
-        db_session, datetime.now(timezone.utc).date(), normalize_casing=False
+        db_session, _market_today(), normalize_casing=False
     )
     assert live  # non-vacuous
     assert live == as_of
@@ -477,7 +484,7 @@ def test_live_resolves_generation_once(db_session, monkeypatch):
 
     _insert_snapshot(
         db_session, symbol="NVDA", rank=1,
-        data_date=datetime.now(timezone.utc).date().isoformat(),
+        data_date=_market_today().isoformat(),
         captured_at=_recent_ts(),
     )
 
@@ -497,13 +504,21 @@ def test_live_resolves_generation_once(db_session, monkeypatch):
 def test_live_ignores_future_data_date(db_session):
     """A pathologically future-stamped data_date must not hijack the live
     'latest' day (intentional divergence from the old unbounded max)."""
-    today = datetime.now(timezone.utc).date()
+    today = _market_today()
     _insert_snapshot(
         db_session, symbol="NVDA", rank=1, data_date=today.isoformat(),
         captured_at=_recent_ts(),
     )
+    # +1 day is the sharpest case: after 00:00 UTC the UTC date already
+    # equals market-today+1, so a UTC-date bound would admit this row —
+    # the ET market-day bound must not.
     _insert_snapshot(
         db_session, symbol="HACK", rank=1,
+        data_date=(today + timedelta(days=1)).isoformat(),
+        captured_at=_recent_ts(),
+    )
+    _insert_snapshot(
+        db_session, symbol="HACK2", rank=1,
         data_date=(today + timedelta(days=30)).isoformat(),
         captured_at=_recent_ts(),
     )

--- a/tests/test_asof_money_flow_selectors.py
+++ b/tests/test_asof_money_flow_selectors.py
@@ -549,6 +549,27 @@ def test_capital_flow_as_of_limit_counts_days_not_rows(db_session):
     ]
 
 
+def test_capital_flow_as_of_exact_dupes_do_not_compress_window(db_session):
+    """EXACT (flow_date, captured_at) duplicate rows must not consume limit
+    slots: the limit selects distinct DAYS, so 6 days with the newest day
+    written twice still yield 5 distinct days."""
+    ts = datetime(2026, 6, 6, 22, 0)
+    for i in range(1, 7):
+        _insert_capital_flow(
+            db_session, symbol="NVDA", flow_date=f"2026-06-0{i}", captured_at=ts,
+        )
+    # Newest day again — same captured_at, an exact duplicate row.
+    _insert_capital_flow(
+        db_session, symbol="NVDA", flow_date="2026-06-06", captured_at=ts,
+    )
+
+    rows = capital_flow_as_of(db_session, "NVDA", date(2026, 6, 6), limit=5)
+    assert [r.flow_date for r in rows] == [
+        date(2026, 6, 6), date(2026, 6, 5), date(2026, 6, 4),
+        date(2026, 6, 3), date(2026, 6, 2),
+    ]
+
+
 def test_dup_capital_flow_rows_do_not_inflate_streak(db_session):
     """days_in_top100 counts consecutive '+' DAYS, not raw duplicate rows.
 


### PR DESCRIPTION
## Summary
- Add as-of money-flow selectors for A/B replay (TDD red/green), with staleness-retention handling
- Pin vetted generation live; dedup duplicate capital-flow days with symbol + id tiebreaks for determinism
- Live bound uses the ET market day (not UTC date); per-day subquery limits distinct days, not joined rows

## Review
- /review: passed (claude rounds: 4)
- codex review: passed (codex rounds: 4)

## Test plan
- [ ] CI green
- [ ] verify locally

https://claude.ai/code/session_01Pfoeo7Z8fU4XdfztdS7NLZ