### PR TITLE
feat: experiment spec interpreter + scorecard contracts

### DIFF
--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -371,9 +371,15 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
     layer = _require_str(raw, "layer", source)
     primary = _require_str(raw, "primary", source)
 
-    guardrails_raw = raw.get("guardrails")
-    if guardrails_raw is None:
-        guardrails_raw = []
+    if "guardrails" in raw and raw["guardrails"] is None:
+        # A bare `guardrails:` line parses as null — silently loading it as
+        # "no guardrails" would quietly drop the experiment's risk checks.
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: `guardrails:` with no value "
+            f"parses as null — write `guardrails: []` to explicitly declare "
+            f"none, or list the reward keys"
+        )
+    guardrails_raw = raw.get("guardrails", [])
     if not isinstance(guardrails_raw, list) or not all(
         isinstance(g, str) and g for g in guardrails_raw
     ):

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -1,0 +1,302 @@
+"""Experiment-spec interpreter for the A/B substrate (design §10.4).
+
+An experiment is a YAML file, not engine code: champion + challengers +
+the one contended ``layer`` + reward keys + window. Specs live in
+``config/experiments/*.yaml``; each carries ``status: active | retired``
+and :func:`load_active_specs` is the single discovery entry point (cron
+shadow arm, evaluator CLI).
+
+    experiment.yaml ──► interpreter ──► validate override keys ──► deep-merge
+                            │             (model_fields +            (existing
+                            │              pattern names;             merge_stock_
+                            │              reject unknown)            screener_config)
+                            └──► layer = declared field set → mutual exclusion
+
+The override-key validation is load-bearing and CANNOT be delegated
+downstream: ``merge_stock_screener_config`` performs no key validation,
+and ``StockScreenerConfig(**merged)`` silently drops unknown kwargs
+(``core/champion.py:86-88``) — an unvalidated typo'd key would yield a
+challenger identical to the champion, a silent no-op A/B that "finds" no
+difference. The interpreter never invents config paths: a knob must exist
+as a ``StockScreenerConfig`` field before it can be experimented on.
+
+Reward keys (``primary`` / ``guardrails``) are opaque strings here,
+resolved at run time by the reward registry — no import of the rewards
+module (keeps this contract independent of the registry task).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Spec home (pinned in the task plan; consumed by the shadow arm + evaluator).
+DEFAULT_EXPERIMENTS_DIR = Path("config/experiments")
+
+# Default purge/embargo gap for walk-forward validation = the max
+# forward-return horizon H (20 trading days), per §10.4.
+DEFAULT_EMBARGO_DAYS = 20
+
+_VALID_STATUSES = ("active", "retired")
+
+
+class ExperimentSpecError(ValueError):
+    """Raised when an experiment spec fails parse or validation."""
+
+
+@dataclass(frozen=True)
+class ExperimentWindow:
+    """Train/holdout ranges (``start..end`` strings) + embargo gap."""
+
+    train: str
+    holdout: str
+    embargo_days: int = DEFAULT_EMBARGO_DAYS
+
+
+@dataclass(frozen=True)
+class Challenger:
+    """One challenger arm: id + validated override (dotted paths translated)."""
+
+    id: str
+    override: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ExperimentSpec:
+    """A parsed, validated experiment spec (design §10.4)."""
+
+    id: str
+    status: str
+    champion: str
+    layer: str
+    challengers: tuple[Challenger, ...]
+    primary: str
+    guardrails: tuple[str, ...]
+    window: ExperimentWindow
+    source: str = "<memory>"
+
+    @property
+    def is_active(self) -> bool:
+        return self.status == "active"
+
+
+def _validate_override(
+    override: Any, *, spec_id: str, challenger_id: str, source: str
+) -> dict[str, Any]:
+    """Validate every override key; translate ``pattern_weights.<p>`` dotted paths.
+
+    Reuses the check pattern from ``load_champion_overrides``
+    (``core/champion.py:91-110``): flat keys against
+    ``StockScreenerConfig.model_fields``, nested/dotted pattern keys against
+    the known pattern names. Rejects the spec on ANY unknown key — see the
+    module docstring for why this is interpreter-side.
+    """
+    from rainier.core.config import StockScreenerConfig
+
+    ctx = f"{source}: experiment {spec_id!r} challenger {challenger_id!r}"
+    if not isinstance(override, dict) or not override:
+        raise ExperimentSpecError(
+            f"{ctx}: override must be a non-empty mapping — an empty override "
+            f"yields a challenger identical to the champion (silent no-op A/B)"
+        )
+
+    known_fields = set(StockScreenerConfig.model_fields)
+    known_patterns = set(StockScreenerConfig().pattern_weights)
+    out: dict[str, Any] = {}
+    for key, value in override.items():
+        if key.startswith("pattern_weights."):
+            pattern = key.split(".", 1)[1]
+            if pattern not in known_patterns:
+                raise ExperimentSpecError(
+                    f"{ctx}: unknown pattern_weights key {pattern!r} "
+                    f"(typo? known: {sorted(known_patterns)})"
+                )
+            out.setdefault("pattern_weights", {})[pattern] = value
+        elif key == "pattern_weights":
+            if not isinstance(value, dict):
+                raise ExperimentSpecError(
+                    f"{ctx}: pattern_weights override must be a mapping, "
+                    f"got {type(value).__name__}"
+                )
+            unknown_pw = sorted(set(value) - known_patterns)
+            if unknown_pw:
+                raise ExperimentSpecError(
+                    f"{ctx}: unknown pattern_weights key(s): "
+                    f"{', '.join(unknown_pw)} (typo? known: {sorted(known_patterns)})"
+                )
+            out.setdefault("pattern_weights", {}).update(value)
+        elif key in known_fields:
+            out[key] = value
+        else:
+            raise ExperimentSpecError(
+                f"{ctx}: unknown override key {key!r} — override keys must be "
+                f"real StockScreenerConfig fields (or pattern_weights.<pattern> "
+                f"dotted paths); the interpreter never invents config paths"
+            )
+    return out
+
+
+def _require(raw: dict[str, Any], key: str, typ: type, source: str) -> Any:
+    val = raw.get(key)
+    if not isinstance(val, typ) or (typ is str and not val):
+        raise ExperimentSpecError(
+            f"{source}: spec field {key!r} must be a non-empty {typ.__name__}, "
+            f"got {val!r}"
+        )
+    return val
+
+
+def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
+    """Parse + validate one raw spec mapping into an :class:`ExperimentSpec`."""
+    if not isinstance(raw, dict):
+        raise ExperimentSpecError(
+            f"{source}: spec must be a YAML mapping, got {type(raw).__name__}"
+        )
+    spec_id = _require(raw, "id", str, source)
+    status = _require(raw, "status", str, source)
+    if status not in _VALID_STATUSES:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r} has invalid status {status!r} "
+            f"(must be one of {list(_VALID_STATUSES)})"
+        )
+    champion = _require(raw, "champion", str, source)
+    layer = _require(raw, "layer", str, source)
+    primary = _require(raw, "primary", str, source)
+
+    guardrails_raw = raw.get("guardrails") or []
+    if not isinstance(guardrails_raw, list) or not all(
+        isinstance(g, str) for g in guardrails_raw
+    ):
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: guardrails must be a list of strings"
+        )
+
+    window_raw = raw.get("window")
+    if not isinstance(window_raw, dict):
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: window must be a mapping with "
+            f"train/holdout (got {window_raw!r})"
+        )
+    train = window_raw.get("train")
+    holdout = window_raw.get("holdout")
+    if not isinstance(train, str) or not isinstance(holdout, str):
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: window.train and window.holdout "
+            f"are required strings (start..end)"
+        )
+    embargo_days = window_raw.get("embargo_days", DEFAULT_EMBARGO_DAYS)
+    if not isinstance(embargo_days, int) or isinstance(embargo_days, bool) or embargo_days < 0:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: embargo_days must be a "
+            f"non-negative int, got {embargo_days!r}"
+        )
+
+    challengers_raw = raw.get("challengers")
+    if not isinstance(challengers_raw, list) or not challengers_raw:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: challengers must be a non-empty list"
+        )
+    challengers: list[Challenger] = []
+    seen_ids: set[str] = set()
+    for entry in challengers_raw:
+        if not isinstance(entry, dict) or not isinstance(entry.get("id"), str):
+            raise ExperimentSpecError(
+                f"{source}: experiment {spec_id!r}: each challenger needs an "
+                f"`id` and an `override` mapping (got {entry!r})"
+            )
+        cid = entry["id"]
+        if cid in seen_ids:
+            raise ExperimentSpecError(
+                f"{source}: experiment {spec_id!r}: duplicate challenger id {cid!r}"
+            )
+        seen_ids.add(cid)
+        override = _validate_override(
+            entry.get("override"), spec_id=spec_id, challenger_id=cid, source=source
+        )
+        challengers.append(Challenger(id=cid, override=override))
+
+    return ExperimentSpec(
+        id=spec_id,
+        status=status,
+        champion=champion,
+        layer=layer,
+        challengers=tuple(challengers),
+        primary=primary,
+        guardrails=tuple(guardrails_raw),
+        window=ExperimentWindow(train=train, holdout=holdout, embargo_days=embargo_days),
+        source=source,
+    )
+
+
+def load_spec(path: str | Path) -> ExperimentSpec:
+    """Load + validate one experiment spec YAML file."""
+    p = Path(path)
+    with p.open("r") as fh:
+        raw = yaml.safe_load(fh)
+    return parse_spec(raw, source=str(p))
+
+
+def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpec]:
+    """Discover specs in ``config/experiments/*.yaml``; return ACTIVE ones only.
+
+    The single discovery entry point for every consumer. Every spec in the
+    directory must parse (a malformed spec — bad status, unknown override
+    key — fails the whole load loudly; retired-but-broken specs don't get to
+    rot silently). Mutual exclusion is evaluated across the ACTIVE set:
+    two active specs claiming the same ``layer`` is an error, and so are
+    duplicate active experiment ids. Retired specs never conflict.
+    """
+    base = Path(directory) if directory is not None else DEFAULT_EXPERIMENTS_DIR
+    active: list[ExperimentSpec] = []
+    layer_owner: dict[str, str] = {}
+    seen_ids: dict[str, str] = {}
+    for path in sorted(base.glob("*.yaml")):
+        spec = load_spec(path)
+        if not spec.is_active:
+            continue
+        if spec.id in seen_ids:
+            raise ExperimentSpecError(
+                f"duplicate active experiment id {spec.id!r}: "
+                f"{seen_ids[spec.id]} and {path}"
+            )
+        seen_ids[spec.id] = str(path)
+        if spec.layer in layer_owner:
+            raise ExperimentSpecError(
+                f"mutual exclusion: layer {spec.layer!r} claimed by two active "
+                f"experiments: {layer_owner[spec.layer]!r} and {spec.id!r} — "
+                f"retire one before activating the other"
+            )
+        layer_owner[spec.layer] = spec.id
+        active.append(spec)
+    return active
+
+
+def materialize_challengers(
+    spec: ExperimentSpec,
+    base_overrides: dict[str, Any] | None = None,
+) -> tuple[Any, dict[str, Any]]:
+    """Materialize (champion_config, {challenger_id: config}) for a spec.
+
+    ``base_overrides`` is the champion-effective override layer (e.g.
+    ``settings.yaml:stock_screener`` already merged with ``champion.yaml``
+    via the existing loaders). Each challenger = that layer deep-merged with
+    its validated override via the existing ``merge_stock_screener_config``
+    — so a challenger differs from the champion ONLY in the overridden keys,
+    and a partial ``pattern_weights`` override keeps every other pattern's
+    weight. Deep-merge happens only AFTER override-key validation (done at
+    parse time); this function never sees unvalidated keys.
+    """
+    from rainier.core.champion import merge_stock_screener_config
+    from rainier.core.config import StockScreenerConfig
+
+    champion_cfg = StockScreenerConfig(
+        **merge_stock_screener_config(base_overrides, None)
+    )
+    challenger_cfgs: dict[str, Any] = {}
+    for challenger in spec.challengers:
+        merged = merge_stock_screener_config(base_overrides, challenger.override)
+        challenger_cfgs[challenger.id] = StockScreenerConfig(**merged)
+    return champion_cfg, challenger_cfgs

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -50,6 +50,10 @@ if TYPE_CHECKING:  # runtime imports stay local (config load cost, cycle safety)
     from rainier.core.config import StockScreenerConfig
 
 # Spec home (pinned in the task plan; consumed by the shadow arm + evaluator).
+# CWD-relative by project convention — matches DEFAULT_MODEL_DIR in
+# core/champion.py; cron jobs run from the repo root (scripts/cron-wrapper.sh).
+# A wrong CWD fails LOUD (load_active_specs raises on a missing directory),
+# never as a silently empty experiment queue.
 DEFAULT_EXPERIMENTS_DIR = Path("config/experiments")
 
 # Default purge/embargo gap for walk-forward validation = the max
@@ -602,13 +606,17 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
 
 def materialize_challengers(
     spec: ExperimentSpec,
-    base_overrides: dict[str, Any] | None = None,
+    base_overrides: dict[str, Any] | None,
 ) -> tuple["StockScreenerConfig", dict[str, "StockScreenerConfig"]]:
     """Materialize (champion_config, {challenger_id: config}) for a spec.
 
     ``base_overrides`` is the champion-effective override layer (e.g.
     ``settings.yaml:stock_screener`` already merged with ``champion.yaml``
-    via the existing loaders). Each challenger = that layer deep-merged with
+    via the existing loaders). It is deliberately REQUIRED — no default —
+    so a production caller cannot forget it and silently baseline every
+    challenger on pydantic code defaults instead of the live champion.
+    Passing ``None`` explicitly means "code-defaults baseline" and is for
+    synthetic/test replays only. Each challenger = that layer deep-merged with
     its validated override via the existing ``merge_stock_screener_config``
     — so a challenger differs from the champion ONLY in the overridden keys,
     and a partial ``pattern_weights`` override keeps every other pattern's

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -364,8 +364,9 @@ def load_spec(path: str | Path) -> ExperimentSpec:
             raw = yaml.safe_load(fh)
     except yaml.YAMLError as exc:
         raise ExperimentSpecError(f"{p}: invalid YAML — {exc}") from exc
-    except OSError as exc:
-        # PermissionError, IsADirectoryError, … — same contract exception.
+    except (OSError, UnicodeDecodeError) as exc:
+        # PermissionError, IsADirectoryError, non-UTF8 bytes, … — same
+        # contract exception.
         raise ExperimentSpecError(f"{p}: unreadable — {exc}") from exc
     return parse_spec(raw, source=str(p))
 

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -257,10 +257,11 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
     if guardrails_raw is None:
         guardrails_raw = []
     if not isinstance(guardrails_raw, list) or not all(
-        isinstance(g, str) for g in guardrails_raw
+        isinstance(g, str) and g for g in guardrails_raw
     ):
         raise ExperimentSpecError(
-            f"{source}: experiment {spec_id!r}: guardrails must be a list of strings"
+            f"{source}: experiment {spec_id!r}: guardrails must be a list of "
+            f"non-empty strings"
         )
 
     window_raw = raw.get("window")
@@ -358,11 +359,14 @@ def load_spec(path: str | Path) -> ExperimentSpec:
     exception can't miss a broken file.
     """
     p = Path(path)
-    with p.open("r") as fh:
-        try:
+    try:
+        with p.open("r") as fh:
             raw = yaml.safe_load(fh)
-        except yaml.YAMLError as exc:
-            raise ExperimentSpecError(f"{p}: invalid YAML — {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise ExperimentSpecError(f"{p}: invalid YAML — {exc}") from exc
+    except OSError as exc:
+        # PermissionError, IsADirectoryError, … — same contract exception.
+        raise ExperimentSpecError(f"{p}: unreadable — {exc}") from exc
     return parse_spec(raw, source=str(p))
 
 

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -62,6 +62,31 @@ class ExperimentSpecError(ValueError):
     """Raised when an experiment spec fails parse or validation."""
 
 
+class _NoDuplicateKeysLoader(yaml.SafeLoader):
+    """SafeLoader that rejects duplicate mapping keys.
+
+    Plain ``yaml.safe_load`` silently last-write-wins on duplicate keys —
+    a spec with two ``buy_threshold:`` lines (or two ``window:`` blocks)
+    would load the second and drop the first without a sound, defeating
+    the interpreter's declare-it-once stance.
+    """
+
+    def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> dict:
+        seen: list[Any] = []
+        for key_node, _value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if key in seen:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key!r} — last-write-wins would be "
+                    f"silent; declare it once",
+                    key_node.start_mark,
+                )
+            seen.append(key)
+        return super().construct_mapping(node, deep)
+
+
 @dataclass(frozen=True)
 class ExperimentWindow:
     """Train/holdout ranges (``start..end`` strings) + embargo gap."""
@@ -218,6 +243,25 @@ def _validate_override(
         raise ExperimentSpecError(
             f"{ctx}: override value(s) rejected by StockScreenerConfig — {exc}"
         ) from exc
+
+    # Strict mode still admits `.nan` / `.inf` YAML floats: a NaN threshold
+    # makes every score comparison False and a NaN weight poisons composite
+    # scores — the same silent-corruption class, so reject non-finite here.
+    import math
+
+    def _reject_non_finite(label: str, value: Any) -> None:
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ExperimentSpecError(
+                f"{ctx}: override {label!r} is {value!r} — non-finite values "
+                f"(nan/inf) poison score comparisons silently"
+            )
+
+    for key, value in out.items():
+        if key == "pattern_weights" and isinstance(value, dict):
+            for pattern, weight in value.items():
+                _reject_non_finite(f"pattern_weights.{pattern}", weight)
+        else:
+            _reject_non_finite(key, value)
     return out
 
 
@@ -425,7 +469,7 @@ def load_spec(path: str | Path) -> ExperimentSpec:
     p = Path(path)
     try:
         with p.open("r") as fh:
-            raw = yaml.safe_load(fh)
+            raw = yaml.load(fh, Loader=_NoDuplicateKeysLoader)  # noqa: S506 — SafeLoader subclass
     except yaml.YAMLError as exc:
         raise ExperimentSpecError(f"{p}: invalid YAML — {exc}") from exc
     except (OSError, UnicodeDecodeError) as exc:
@@ -462,18 +506,32 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
             f"(indistinguishable from an empty queue); create it or pass "
             f"the right path"
         )
-    stray_yml = sorted(base.glob("*.yml"))
-    if stray_yml:
+    # Any yaml-ish file that `*.yaml` won't match (.yml, .YAML, .YML, …) is
+    # rejected loudly instead of silently skipped. Dotfiles (editor lockfiles
+    # like `.#spec.yaml`, backups) are not specs and are ignored entirely —
+    # an operator merely having a spec open in an editor at cron time must
+    # not fail the run.
+    stray = sorted(
+        p.name
+        for p in base.iterdir()
+        if not p.name.startswith(".")
+        and p.suffix.lower() in {".yml", ".yaml"}
+        and p.suffix != ".yaml"
+    )
+    if stray:
         raise ExperimentSpecError(
-            f"stray .yml spec file(s) in {base}: "
-            f"{', '.join(p.name for p in stray_yml)} — discovery only reads "
-            f"*.yaml; rename to .yaml so the spec isn't silently ignored"
+            f"stray spec file(s) in {base}: {', '.join(stray)} — discovery "
+            f"only reads *.yaml (lowercase); rename so the spec isn't "
+            f"silently ignored"
         )
     active: list[ExperimentSpec] = []
     layer_owner: dict[str, str] = {}
     key_owner: dict[str, str] = {}
+    challenger_owner: dict[str, str] = {}
     seen_ids: dict[str, str] = {}
     for path in sorted(base.glob("*.yaml")):
+        if path.name.startswith("."):
+            continue  # editor lockfiles / backups, not specs
         spec = load_spec(path)
         if not spec.is_active:
             continue
@@ -501,6 +559,17 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
             )
         for k in spec.override_keys:
             key_owner[k] = spec.id
+        for challenger in spec.challengers:
+            if challenger.id in challenger_owner:
+                # Scorecards key on candidate_id (base_scorecard carries no
+                # experiment_id), so two live arms sharing an id would emit
+                # indistinguishable scorecards — misattribution, silently.
+                raise ExperimentSpecError(
+                    f"challenger id {challenger.id!r} used by two active "
+                    f"experiments: {challenger_owner[challenger.id]!r} and "
+                    f"{spec.id!r} — arm ids must be unique across the active set"
+                )
+            challenger_owner[challenger.id] = spec.id
         active.append(spec)
     return active
 
@@ -531,6 +600,31 @@ def materialize_challengers(
 
     from rainier.core.champion import merge_stock_screener_config
     from rainier.core.config import StockScreenerConfig
+
+    if base_overrides:
+        # Key-check the caller's layer too: StockScreenerConfig silently
+        # drops unknown kwargs, so a typo'd base key would materialize a
+        # "champion" that doesn't match the live config — the silent-no-op
+        # class this module never delegates downstream.
+        known = set(StockScreenerConfig.model_fields)
+        unknown = sorted(
+            repr(k) for k in base_overrides if not isinstance(k, str) or k not in known
+        )
+        if unknown:
+            raise ExperimentSpecError(
+                f"experiment {spec.id!r}: unknown base_overrides key(s): "
+                f"{', '.join(unknown)} — StockScreenerConfig would silently "
+                f"drop them (materialized champion would not match the live config)"
+            )
+        base_pw = base_overrides.get("pattern_weights")
+        if isinstance(base_pw, dict):
+            known_patterns = set(StockScreenerConfig().pattern_weights)
+            unknown_pw = sorted(repr(p) for p in set(base_pw) - known_patterns)
+            if unknown_pw:
+                raise ExperimentSpecError(
+                    f"experiment {spec.id!r}: unknown base_overrides "
+                    f"pattern_weights key(s): {', '.join(unknown_pw)}"
+                )
 
     try:
         champion_cfg = StockScreenerConfig(

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -649,9 +649,14 @@ def materialize_challengers(
         )
 
     try:
-        champion_cfg = StockScreenerConfig(
-            **merge_stock_screener_config(base_overrides, None)
-        )
+        merged_champion = merge_stock_screener_config(base_overrides, None)
+        # Value smoke-check the base layer STRICTLY, mirroring the parse-time
+        # check on spec-authored overrides: lax construction would silently
+        # coerce `buy_threshold: true` → 1.0 or "0.35" → 0.35 in the champion
+        # (and every challenger inheriting the field). A malformed base
+        # config fails loudly here instead of skewing the A/B comparison.
+        StockScreenerConfig.model_validate(merged_champion, strict=True)
+        champion_cfg = StockScreenerConfig(**merged_champion)
     except ValidationError as exc:
         raise ExperimentSpecError(
             f"experiment {spec.id!r}: champion base overrides rejected by "

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -24,6 +24,17 @@ as a ``StockScreenerConfig`` field before it can be experimented on.
 Reward keys (``primary`` / ``guardrails``) are opaque strings here,
 resolved at run time by the reward registry — no import of the rewards
 module (keeps this contract independent of the registry task).
+
+``champion:`` names the champion model file the experiment was authored
+against (``champion.yaml`` — a file reference, not a version pin; §10.4
+has no version field). Champion-drift attribution across promotions is
+NOT this layer's job: the evaluator replays champion + challengers from
+ONE :func:`materialize_challengers` call over one corpus (so within any
+evaluation they share the exact base), and every result row is stamped
+with the champion ``version`` + ``corpus_hash`` in the results registry
+(§10.5) — a promotion mid-experiment changes future rows' recorded
+baseline, never silently mixes baselines within one comparison. The
+operator-gated promote flow is a separate task and does not exist yet.
 """
 
 from __future__ import annotations
@@ -610,6 +621,14 @@ def materialize_challengers(
     unattended cron shadow arm. Construction stays lax (parity with the live
     config loaders); spec-authored values were already strict-checked at
     parse time.
+
+    CONSUMER CONTRACT (champion-drift attribution, §10.5): every evaluation
+    must take champion AND challengers from ONE call to this function over
+    one corpus — never mix configs materialized before and after a champion
+    promotion — and must stamp the champion ``version`` + ``corpus_hash``
+    into the results registry row. ``spec.champion`` is a file reference,
+    not a version pin (§10.4 defines no version field); baseline identity is
+    recorded per-result by the registry, not frozen at parse time.
     """
     from pydantic import ValidationError
 

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -29,9 +29,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
+
+if TYPE_CHECKING:  # runtime imports stay local (config load cost, cycle safety)
+    from rainier.core.config import StockScreenerConfig
 
 # Spec home (pinned in the task plan; consumed by the shadow arm + evaluator).
 DEFAULT_EXPERIMENTS_DIR = Path("config/experiments")
@@ -139,12 +142,11 @@ def _validate_override(
     return out
 
 
-def _require(raw: dict[str, Any], key: str, typ: type, source: str) -> Any:
+def _require_str(raw: dict[str, Any], key: str, source: str) -> str:
     val = raw.get(key)
-    if not isinstance(val, typ) or (typ is str and not val):
+    if not isinstance(val, str) or not val:
         raise ExperimentSpecError(
-            f"{source}: spec field {key!r} must be a non-empty {typ.__name__}, "
-            f"got {val!r}"
+            f"{source}: spec field {key!r} must be a non-empty str, got {val!r}"
         )
     return val
 
@@ -155,16 +157,16 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
         raise ExperimentSpecError(
             f"{source}: spec must be a YAML mapping, got {type(raw).__name__}"
         )
-    spec_id = _require(raw, "id", str, source)
-    status = _require(raw, "status", str, source)
+    spec_id = _require_str(raw, "id", source)
+    status = _require_str(raw, "status", source)
     if status not in _VALID_STATUSES:
         raise ExperimentSpecError(
             f"{source}: experiment {spec_id!r} has invalid status {status!r} "
             f"(must be one of {list(_VALID_STATUSES)})"
         )
-    champion = _require(raw, "champion", str, source)
-    layer = _require(raw, "layer", str, source)
-    primary = _require(raw, "primary", str, source)
+    champion = _require_str(raw, "champion", source)
+    layer = _require_str(raw, "layer", source)
+    primary = _require_str(raw, "primary", source)
 
     guardrails_raw = raw.get("guardrails") or []
     if not isinstance(guardrails_raw, list) or not all(
@@ -277,7 +279,7 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
 def materialize_challengers(
     spec: ExperimentSpec,
     base_overrides: dict[str, Any] | None = None,
-) -> tuple[Any, dict[str, Any]]:
+) -> tuple["StockScreenerConfig", dict[str, "StockScreenerConfig"]]:
     """Materialize (champion_config, {challenger_id: config}) for a spec.
 
     ``base_overrides`` is the champion-effective override layer (e.g.
@@ -295,7 +297,7 @@ def materialize_challengers(
     champion_cfg = StockScreenerConfig(
         **merge_stock_screener_config(base_overrides, None)
     )
-    challenger_cfgs: dict[str, Any] = {}
+    challenger_cfgs: dict[str, StockScreenerConfig] = {}
     for challenger in spec.challengers:
         merged = merge_stock_screener_config(base_overrides, challenger.override)
         challenger_cfgs[challenger.id] = StockScreenerConfig(**merged)

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -138,6 +138,13 @@ def _validate_override(
     known_patterns = set(StockScreenerConfig().pattern_weights)
     out: dict[str, Any] = {}
     for key, value in override.items():
+        if not isinstance(key, str):
+            # YAML 1.1 quirks (`on:` → True, bare ints) must surface as the
+            # spec-contract exception, not a downstream TypeError.
+            raise ExperimentSpecError(
+                f"{ctx}: override keys must be str, got {key!r} "
+                f"({type(key).__name__})"
+            )
         if key.startswith("pattern_weights."):
             pattern = key.split(".", 1)[1]
             if pattern not in known_patterns:
@@ -154,10 +161,18 @@ def _validate_override(
                 )
             pw[pattern] = value
         elif key == "pattern_weights":
-            if not isinstance(value, dict):
+            if not isinstance(value, dict) or not value:
+                # An EMPTY mapping would translate to an empty override —
+                # a challenger identical to the champion (silent no-op A/B)
+                # that would also escape cross-spec mutual exclusion.
                 raise ExperimentSpecError(
-                    f"{ctx}: pattern_weights override must be a mapping, "
-                    f"got {type(value).__name__}"
+                    f"{ctx}: pattern_weights override must be a non-empty "
+                    f"mapping, got {value!r}"
+                )
+            non_str_pw = [p for p in value if not isinstance(p, str)]
+            if non_str_pw:
+                raise ExperimentSpecError(
+                    f"{ctx}: pattern_weights keys must be str, got {non_str_pw!r}"
                 )
             unknown_pw = sorted(set(value) - known_patterns)
             if unknown_pw:
@@ -214,6 +229,12 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
         raise ExperimentSpecError(
             f"{source}: spec must be a YAML mapping, got {type(raw).__name__}"
         )
+    non_str = [k for k in raw if not isinstance(k, str)]
+    if non_str:
+        raise ExperimentSpecError(
+            f"{source}: spec keys must be str, got {non_str!r} "
+            f"(YAML 1.1 parses bare `on`/`yes` as booleans — quote them)"
+        )
     unknown_keys = sorted(set(raw) - _ALLOWED_SPEC_KEYS)
     if unknown_keys:
         raise ExperimentSpecError(
@@ -232,7 +253,9 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
     layer = _require_str(raw, "layer", source)
     primary = _require_str(raw, "primary", source)
 
-    guardrails_raw = raw.get("guardrails") or []
+    guardrails_raw = raw.get("guardrails")
+    if guardrails_raw is None:
+        guardrails_raw = []
     if not isinstance(guardrails_raw, list) or not all(
         isinstance(g, str) for g in guardrails_raw
     ):
@@ -245,6 +268,12 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
         raise ExperimentSpecError(
             f"{source}: experiment {spec_id!r}: window must be a mapping with "
             f"train/holdout (got {window_raw!r})"
+        )
+    non_str_w = [k for k in window_raw if not isinstance(k, str)]
+    if non_str_w:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: window keys must be str, "
+            f"got {non_str_w!r}"
         )
     unknown_window = sorted(set(window_raw) - _ALLOWED_WINDOW_KEYS)
     if unknown_window:
@@ -279,6 +308,12 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
             raise ExperimentSpecError(
                 f"{source}: experiment {spec_id!r}: each challenger needs an "
                 f"`id` and an `override` mapping (got {entry!r})"
+            )
+        non_str_c = [k for k in entry if not isinstance(k, str)]
+        if non_str_c:
+            raise ExperimentSpecError(
+                f"{source}: experiment {spec_id!r}: challenger keys must be "
+                f"str, got {non_str_c!r}"
             )
         unknown_c = sorted(set(entry) - _ALLOWED_CHALLENGER_KEYS)
         if unknown_c:

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -29,6 +29,7 @@ module (keeps this contract independent of the registry task).
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -201,12 +202,18 @@ def _validate_override(
     # Value smoke-check at parse time: a bad value (e.g. a non-numeric weight)
     # must fail at spec-authoring/load time as ExperimentSpecError, not at
     # 8am inside the cron shadow arm as a raw pydantic ValidationError.
+    # STRICT validation: lax construction would coerce `buy_threshold: true`
+    # to 1.0 (a plausible-looking losing challenger — silent corruption of
+    # the A/B result) and accept numeric strings like "0.35". Strict mode
+    # still accepts int where a float is declared, so `weight: 1` stays valid.
     from pydantic import ValidationError
 
     from rainier.core.champion import merge_stock_screener_config
 
     try:
-        StockScreenerConfig(**merge_stock_screener_config(None, out))
+        StockScreenerConfig.model_validate(
+            merge_stock_screener_config(None, out), strict=True
+        )
     except ValidationError as exc:
         raise ExperimentSpecError(
             f"{ctx}: override value(s) rejected by StockScreenerConfig — {exc}"
@@ -221,6 +228,43 @@ def _require_str(raw: dict[str, Any], key: str, source: str) -> str:
             f"{source}: spec field {key!r} must be a non-empty str, got {val!r}"
         )
     return val
+
+
+_WINDOW_RANGE_HINT = "YYYY-MM-DD..YYYY-MM-DD"
+
+
+def _parse_date_range(value: Any, *, field: str, ctx: str) -> tuple[date, date]:
+    """Parse one ``start..end`` window string into (start, end) dates.
+
+    A garbage/empty/reversed range would otherwise parse cleanly here and
+    detonate (or worse, silently mis-slice) downstream in the evaluator at
+    cron time — the exact failure class the parse-time value smoke-check
+    exists to prevent for override values.
+    """
+    if not isinstance(value, str) or not value:
+        raise ExperimentSpecError(
+            f"{ctx}: window.{field} is a required non-empty string "
+            f"({_WINDOW_RANGE_HINT}), got {value!r}"
+        )
+    parts = value.split("..")
+    if len(parts) != 2:
+        raise ExperimentSpecError(
+            f"{ctx}: window.{field} must be {_WINDOW_RANGE_HINT!r} "
+            f"(exactly one `..` separator), got {value!r}"
+        )
+    try:
+        start, end = date.fromisoformat(parts[0]), date.fromisoformat(parts[1])
+    except ValueError as exc:
+        raise ExperimentSpecError(
+            f"{ctx}: window.{field} must be {_WINDOW_RANGE_HINT!r}, "
+            f"got {value!r} — {exc}"
+        ) from exc
+    if start > end:
+        raise ExperimentSpecError(
+            f"{ctx}: window.{field} start {parts[0]} is after end {parts[1]} "
+            f"— reversed range"
+        )
+    return start, end
 
 
 def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
@@ -263,6 +307,18 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
             f"{source}: experiment {spec_id!r}: guardrails must be a list of "
             f"non-empty strings"
         )
+    dup_guardrails = sorted({g for g in guardrails_raw if guardrails_raw.count(g) > 1})
+    if dup_guardrails:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: duplicate guardrail(s): "
+            f"{', '.join(dup_guardrails)}"
+        )
+    if primary in guardrails_raw:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: primary reward {primary!r} is "
+            f"also listed in guardrails — a reward key is either the "
+            f"optimization target or a guardrail, not both"
+        )
 
     window_raw = raw.get("window")
     if not isinstance(window_raw, dict):
@@ -283,12 +339,20 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
             f"{', '.join(unknown_window)} (allowed: {sorted(_ALLOWED_WINDOW_KEYS)}; "
             f"a typo'd `embargo_dayz:` would otherwise silently keep the default)"
         )
+    ctx = f"{source}: experiment {spec_id!r}"
     train = window_raw.get("train")
     holdout = window_raw.get("holdout")
-    if not isinstance(train, str) or not isinstance(holdout, str):
+    _, train_end = _parse_date_range(train, field="train", ctx=ctx)
+    holdout_start, _ = _parse_date_range(holdout, field="holdout", ctx=ctx)
+    if holdout_start <= train_end:
+        # Overlapping (or reversed) train/holdout leaks training data into
+        # the holdout. The embargo gap in TRADING days is enforced by the
+        # evaluator, which owns the trading calendar — here we can only pin
+        # the calendar-level ordering invariant.
         raise ExperimentSpecError(
-            f"{source}: experiment {spec_id!r}: window.train and window.holdout "
-            f"are required strings (start..end)"
+            f"{ctx}: window.holdout ({holdout}) must start after window.train "
+            f"ends ({train}) — overlapping windows leak train data into the "
+            f"holdout"
         )
     embargo_days = window_raw.get("embargo_days", DEFAULT_EMBARGO_DAYS)
     if not isinstance(embargo_days, int) or isinstance(embargo_days, bool) or embargo_days < 0:
@@ -383,8 +447,28 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
     name — two active specs overriding the SAME config knob under different
     labels is ALSO an error (entangled experiments would contaminate
     attribution silently). Retired specs never conflict.
+
+    Discovery itself fails loudly too: a MISSING directory raises (a wrong
+    CWD or a deploy that lost ``config/experiments`` would otherwise be
+    indistinguishable from a legitimately empty queue — the same silent-no-op
+    class the interpreter exists to kill), and stray ``*.yml`` files are
+    rejected rather than silently skipped.
     """
     base = Path(directory) if directory is not None else DEFAULT_EXPERIMENTS_DIR
+    if not base.is_dir():
+        raise ExperimentSpecError(
+            f"experiments directory {base} does not exist — a missing "
+            f"directory would silently disable every experiment "
+            f"(indistinguishable from an empty queue); create it or pass "
+            f"the right path"
+        )
+    stray_yml = sorted(base.glob("*.yml"))
+    if stray_yml:
+        raise ExperimentSpecError(
+            f"stray .yml spec file(s) in {base}: "
+            f"{', '.join(p.name for p in stray_yml)} — discovery only reads "
+            f"*.yaml; rename to .yaml so the spec isn't silently ignored"
+        )
     active: list[ExperimentSpec] = []
     layer_owner: dict[str, str] = {}
     key_owner: dict[str, str] = {}
@@ -435,15 +519,36 @@ def materialize_challengers(
     and a partial ``pattern_weights`` override keeps every other pattern's
     weight. Deep-merge happens only AFTER override-key validation (done at
     parse time); this function never sees unvalidated keys.
+
+    ``base_overrides`` come from the CALLER (settings/champion layer), not
+    the spec, so they are validated here — a bad value must still surface as
+    the contract exception, not a raw pydantic ``ValidationError`` inside the
+    unattended cron shadow arm. Construction stays lax (parity with the live
+    config loaders); spec-authored values were already strict-checked at
+    parse time.
     """
+    from pydantic import ValidationError
+
     from rainier.core.champion import merge_stock_screener_config
     from rainier.core.config import StockScreenerConfig
 
-    champion_cfg = StockScreenerConfig(
-        **merge_stock_screener_config(base_overrides, None)
-    )
+    try:
+        champion_cfg = StockScreenerConfig(
+            **merge_stock_screener_config(base_overrides, None)
+        )
+    except ValidationError as exc:
+        raise ExperimentSpecError(
+            f"experiment {spec.id!r}: champion base overrides rejected by "
+            f"StockScreenerConfig — {exc}"
+        ) from exc
     challenger_cfgs: dict[str, StockScreenerConfig] = {}
     for challenger in spec.challengers:
         merged = merge_stock_screener_config(base_overrides, challenger.override)
-        challenger_cfgs[challenger.id] = StockScreenerConfig(**merged)
+        try:
+            challenger_cfgs[challenger.id] = StockScreenerConfig(**merged)
+        except ValidationError as exc:
+            raise ExperimentSpecError(
+                f"experiment {spec.id!r} challenger {challenger.id!r}: merged "
+                f"config rejected by StockScreenerConfig — {exc}"
+            ) from exc
     return champion_cfg, challenger_cfgs

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -10,7 +10,8 @@ shadow arm, evaluator CLI).
                             │             (model_fields +            (existing
                             │              pattern names;             merge_stock_
                             │              reject unknown)            screener_config)
-                            └──► layer = declared field set → mutual exclusion
+                            └──► mutual exclusion across ACTIVE specs:
+                                 layer label unique AND override-key sets disjoint
 
 The override-key validation is load-bearing and CANNOT be delegated
 downstream: ``merge_stock_screener_config`` performs no key validation,
@@ -44,6 +45,16 @@ DEFAULT_EXPERIMENTS_DIR = Path("config/experiments")
 DEFAULT_EMBARGO_DAYS = 20
 
 _VALID_STATUSES = ("active", "retired")
+
+# Design §10.4 pins the exact spec shape — unknown keys are rejected loudly.
+# Without this, a typo'd `guardrail:` (singular) would parse cleanly into a
+# guardrail-free experiment, and `embargo_dayz:` would silently keep the
+# default embargo — the same silent-no-op class the override-key check kills.
+_ALLOWED_SPEC_KEYS = frozenset(
+    {"id", "status", "champion", "layer", "challengers", "primary", "guardrails", "window"}
+)
+_ALLOWED_WINDOW_KEYS = frozenset({"train", "holdout", "embargo_days"})
+_ALLOWED_CHALLENGER_KEYS = frozenset({"id", "override"})
 
 
 class ExperimentSpecError(ValueError):
@@ -85,6 +96,23 @@ class ExperimentSpec:
     def is_active(self) -> bool:
         return self.status == "active"
 
+    @property
+    def override_keys(self) -> frozenset[str]:
+        """Granular knob set this experiment contends, across all challengers.
+
+        ``pattern_weights`` is expanded to per-pattern ``pattern_weights.<p>``
+        keys so two experiments touching DIFFERENT patterns don't conflict.
+        Used by :func:`load_active_specs` for cross-spec mutual exclusion.
+        """
+        keys: set[str] = set()
+        for challenger in self.challengers:
+            for key, value in challenger.override.items():
+                if key == "pattern_weights" and isinstance(value, dict):
+                    keys.update(f"pattern_weights.{p}" for p in value)
+                else:
+                    keys.add(key)
+        return frozenset(keys)
+
 
 def _validate_override(
     override: Any, *, spec_id: str, challenger_id: str, source: str
@@ -117,7 +145,14 @@ def _validate_override(
                     f"{ctx}: unknown pattern_weights key {pattern!r} "
                     f"(typo? known: {sorted(known_patterns)})"
                 )
-            out.setdefault("pattern_weights", {})[pattern] = value
+            pw = out.setdefault("pattern_weights", {})
+            if pattern in pw:
+                raise ExperimentSpecError(
+                    f"{ctx}: pattern {pattern!r} assigned twice (dotted "
+                    f"`pattern_weights.{pattern}` AND nested `pattern_weights:`) "
+                    f"— last-write-wins would be silent; declare it once"
+                )
+            pw[pattern] = value
         elif key == "pattern_weights":
             if not isinstance(value, dict):
                 raise ExperimentSpecError(
@@ -130,7 +165,15 @@ def _validate_override(
                     f"{ctx}: unknown pattern_weights key(s): "
                     f"{', '.join(unknown_pw)} (typo? known: {sorted(known_patterns)})"
                 )
-            out.setdefault("pattern_weights", {}).update(value)
+            pw = out.setdefault("pattern_weights", {})
+            dup = sorted(set(value) & set(pw))
+            if dup:
+                raise ExperimentSpecError(
+                    f"{ctx}: pattern(s) {', '.join(dup)} assigned twice (dotted "
+                    f"`pattern_weights.<p>` AND nested `pattern_weights:`) "
+                    f"— last-write-wins would be silent; declare each once"
+                )
+            pw.update(value)
         elif key in known_fields:
             out[key] = value
         else:
@@ -139,6 +182,20 @@ def _validate_override(
                 f"real StockScreenerConfig fields (or pattern_weights.<pattern> "
                 f"dotted paths); the interpreter never invents config paths"
             )
+
+    # Value smoke-check at parse time: a bad value (e.g. a non-numeric weight)
+    # must fail at spec-authoring/load time as ExperimentSpecError, not at
+    # 8am inside the cron shadow arm as a raw pydantic ValidationError.
+    from pydantic import ValidationError
+
+    from rainier.core.champion import merge_stock_screener_config
+
+    try:
+        StockScreenerConfig(**merge_stock_screener_config(None, out))
+    except ValidationError as exc:
+        raise ExperimentSpecError(
+            f"{ctx}: override value(s) rejected by StockScreenerConfig — {exc}"
+        ) from exc
     return out
 
 
@@ -156,6 +213,13 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
     if not isinstance(raw, dict):
         raise ExperimentSpecError(
             f"{source}: spec must be a YAML mapping, got {type(raw).__name__}"
+        )
+    unknown_keys = sorted(set(raw) - _ALLOWED_SPEC_KEYS)
+    if unknown_keys:
+        raise ExperimentSpecError(
+            f"{source}: unknown spec key(s): {', '.join(unknown_keys)} — the "
+            f"§10.4 spec shape is exact (allowed: {sorted(_ALLOWED_SPEC_KEYS)}); "
+            f"a typo'd key (e.g. `guardrail:`) would otherwise be silently ignored"
         )
     spec_id = _require_str(raw, "id", source)
     status = _require_str(raw, "status", source)
@@ -181,6 +245,13 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
         raise ExperimentSpecError(
             f"{source}: experiment {spec_id!r}: window must be a mapping with "
             f"train/holdout (got {window_raw!r})"
+        )
+    unknown_window = sorted(set(window_raw) - _ALLOWED_WINDOW_KEYS)
+    if unknown_window:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: unknown window key(s): "
+            f"{', '.join(unknown_window)} (allowed: {sorted(_ALLOWED_WINDOW_KEYS)}; "
+            f"a typo'd `embargo_dayz:` would otherwise silently keep the default)"
         )
     train = window_raw.get("train")
     holdout = window_raw.get("holdout")
@@ -209,7 +280,18 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
                 f"{source}: experiment {spec_id!r}: each challenger needs an "
                 f"`id` and an `override` mapping (got {entry!r})"
             )
+        unknown_c = sorted(set(entry) - _ALLOWED_CHALLENGER_KEYS)
+        if unknown_c:
+            raise ExperimentSpecError(
+                f"{source}: experiment {spec_id!r}: unknown challenger key(s): "
+                f"{', '.join(unknown_c)} (allowed: id, override)"
+            )
         cid = entry["id"]
+        if not cid:
+            raise ExperimentSpecError(
+                f"{source}: experiment {spec_id!r}: challenger id must be a "
+                f"non-empty str"
+            )
         if cid in seen_ids:
             raise ExperimentSpecError(
                 f"{source}: experiment {spec_id!r}: duplicate challenger id {cid!r}"
@@ -234,10 +316,18 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
 
 
 def load_spec(path: str | Path) -> ExperimentSpec:
-    """Load + validate one experiment spec YAML file."""
+    """Load + validate one experiment spec YAML file.
+
+    Every failure — including a YAML syntax error — surfaces as
+    :class:`ExperimentSpecError`, so consumers catching the spec-contract
+    exception can't miss a broken file.
+    """
     p = Path(path)
     with p.open("r") as fh:
-        raw = yaml.safe_load(fh)
+        try:
+            raw = yaml.safe_load(fh)
+        except yaml.YAMLError as exc:
+            raise ExperimentSpecError(f"{p}: invalid YAML — {exc}") from exc
     return parse_spec(raw, source=str(p))
 
 
@@ -248,12 +338,16 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
     directory must parse (a malformed spec — bad status, unknown override
     key — fails the whole load loudly; retired-but-broken specs don't get to
     rot silently). Mutual exclusion is evaluated across the ACTIVE set:
-    two active specs claiming the same ``layer`` is an error, and so are
-    duplicate active experiment ids. Retired specs never conflict.
+    two active specs claiming the same ``layer`` label is an error, duplicate
+    active experiment ids are an error, and — because a layer label is just a
+    name — two active specs overriding the SAME config knob under different
+    labels is ALSO an error (entangled experiments would contaminate
+    attribution silently). Retired specs never conflict.
     """
     base = Path(directory) if directory is not None else DEFAULT_EXPERIMENTS_DIR
     active: list[ExperimentSpec] = []
     layer_owner: dict[str, str] = {}
+    key_owner: dict[str, str] = {}
     seen_ids: dict[str, str] = {}
     for path in sorted(base.glob("*.yaml")):
         spec = load_spec(path)
@@ -272,6 +366,17 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
                 f"retire one before activating the other"
             )
         layer_owner[spec.layer] = spec.id
+        overlap = sorted(k for k in spec.override_keys if k in key_owner)
+        if overlap:
+            raise ExperimentSpecError(
+                f"mutual exclusion: override key(s) {', '.join(overlap)} "
+                f"contended by two active experiments: "
+                f"{key_owner[overlap[0]]!r} and {spec.id!r} — a knob belongs "
+                f"to at most one active experiment (layer labels don't "
+                f"substitute for disjoint key sets)"
+            )
+        for k in spec.override_keys:
+            key_owner[k] = spec.id
         active.append(spec)
     return active
 

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -74,6 +74,10 @@ class _NoDuplicateKeysLoader(yaml.SafeLoader):
     def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> dict:
         seen: list[Any] = []
         for key_node, _value_node in node.value:
+            if key_node.tag == "tag:yaml.org,2002:merge":
+                # `<<:` merge keys are flattened by SafeLoader with documented
+                # override semantics (explicit keys win) — not author duplicates.
+                continue
             key = self.construct_object(key_node, deep=deep)
             if key in seen:
                 raise yaml.constructor.ConstructorError(
@@ -247,22 +251,33 @@ def _validate_override(
     # Strict mode still admits `.nan` / `.inf` YAML floats: a NaN threshold
     # makes every score comparison False and a NaN weight poisons composite
     # scores — the same silent-corruption class, so reject non-finite here.
+    _require_finite_values(out, ctx)
+    return out
+
+
+def _require_finite_values(overrides: dict[str, Any], ctx: str) -> None:
+    """Reject nan/inf floats in an override layer (incl. nested pattern_weights).
+
+    pydantic strict mode admits ``.nan`` / ``.inf`` floats; non-finite
+    thresholds/weights poison score comparisons silently instead of failing.
+    Used for spec-authored overrides at parse time AND caller-supplied
+    ``base_overrides`` at materialization time.
+    """
     import math
 
-    def _reject_non_finite(label: str, value: Any) -> None:
+    def _check(label: str, value: Any) -> None:
         if isinstance(value, float) and not math.isfinite(value):
             raise ExperimentSpecError(
-                f"{ctx}: override {label!r} is {value!r} — non-finite values "
+                f"{ctx}: {label!r} is {value!r} — non-finite values "
                 f"(nan/inf) poison score comparisons silently"
             )
 
-    for key, value in out.items():
+    for key, value in overrides.items():
         if key == "pattern_weights" and isinstance(value, dict):
             for pattern, weight in value.items():
-                _reject_non_finite(f"pattern_weights.{pattern}", weight)
+                _check(f"pattern_weights.{pattern}", weight)
         else:
-            _reject_non_finite(key, value)
-    return out
+            _check(key, value)
 
 
 def _require_str(raw: dict[str, Any], key: str, source: str) -> str:
@@ -625,6 +640,13 @@ def materialize_challengers(
                     f"experiment {spec.id!r}: unknown base_overrides "
                     f"pattern_weights key(s): {', '.join(unknown_pw)}"
                 )
+        # A nan/inf in the base layer would materialize a champion (and every
+        # challenger inheriting the field) with non-finite thresholds/weights
+        # — the same silent-poisoning _validate_override guards against for
+        # spec-authored values.
+        _require_finite_values(
+            base_overrides, f"experiment {spec.id!r}: base_overrides"
+        )
 
     try:
         champion_cfg = StockScreenerConfig(

--- a/src/rainier/research/output_schema.py
+++ b/src/rainier/research/output_schema.py
@@ -43,8 +43,13 @@ class _FieldSpec:
 def load(path: str | Path | None = None) -> dict[str, Any]:
     """Read the schema YAML; returned dict is the raw shape (schemas: {...})."""
     p = Path(path) if path is not None else SCHEMA_PATH
-    with p.open("r") as fh:
-        data = yaml.safe_load(fh)
+    try:
+        with p.open("r") as fh:
+            data = yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        # Consumers catch SchemaError (the module contract) — a raw
+        # ParserError from a broken schema file must not bypass them.
+        raise SchemaError(f"{p}: invalid YAML — {exc}") from exc
     if not isinstance(data, dict) or "schemas" not in data:
         raise SchemaError(f"{p} has no top-level `schemas:` key")
     return data
@@ -200,7 +205,12 @@ def parse_block(text: str) -> dict[str, Any]:
         raise SchemaError("block is not `---` fenced")
     # Drop the fences.
     inner = stripped[3:-3].strip()
-    parsed = yaml.safe_load(inner)
+    try:
+        parsed = yaml.safe_load(inner)
+    except yaml.YAMLError as exc:
+        # A truncated block (process killed mid-write) must surface as the
+        # module contract exception, not a raw yaml ParserError.
+        raise SchemaError(f"block is not valid YAML — {exc}") from exc
     if not isinstance(parsed, dict):
         raise SchemaError(f"block must parse to a dict; got {type(parsed).__name__}")
     return parsed

--- a/src/rainier/research/output_schema.py
+++ b/src/rainier/research/output_schema.py
@@ -8,6 +8,7 @@ new verb adds a block (not by inventing fields ad-hoc in CLI code).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -69,18 +70,8 @@ def _coerce_fields(schema: dict[str, Any]) -> list[_FieldSpec]:
     return out
 
 
-def validate(name: str, payload: dict[str, Any], strict: bool = True) -> None:
-    """Validate ``payload`` against the schema named ``name``.
-
-    Strict mode (default) rejects any extra field not declared in the schema.
-    Non-strict mode tolerates forward-compatible extras — used at runtime so
-    a new field added in a future commit doesn't blow up an older CLI.
-    """
-    data = load()
-    schemas = data["schemas"]
-    if name not in schemas:
-        raise SchemaError(f"unknown schema {name!r}; known: {sorted(schemas)}")
-    specs = _coerce_fields(schemas[name])
+def _check_payload(specs: list[_FieldSpec], payload: dict[str, Any], strict: bool) -> None:
+    """Shared field checks: presence, strict extras, types, enums."""
     declared = {spec.name for spec in specs}
 
     missing = declared - payload.keys()
@@ -105,6 +96,53 @@ def validate(name: str, payload: dict[str, Any], strict: bool = True) -> None:
             raise SchemaError(
                 f"field {spec.name!r}: value {val!r} not in enum {spec.enum}"
             )
+
+
+def validate(name: str, payload: dict[str, Any], strict: bool = True) -> None:
+    """Validate ``payload`` against the schema named ``name``.
+
+    Strict mode (default) rejects any extra field not declared in the schema.
+    Non-strict mode tolerates forward-compatible extras — used at runtime so
+    a new field added in a future commit doesn't blow up an older CLI.
+    """
+    data = load()
+    schemas = data["schemas"]
+    if name not in schemas:
+        raise SchemaError(f"unknown schema {name!r}; known: {sorted(schemas)}")
+    _check_payload(_coerce_fields(schemas[name]), payload, strict)
+
+
+def validate_composed(
+    base: str,
+    payload: dict[str, Any],
+    extensions: Sequence[str] = (),
+    strict: bool = True,
+) -> None:
+    """Validate ``payload`` against a base schema plus optional extensions.
+
+    A/B-substrate scorecards (design §10.5) compose a candidate-agnostic
+    ``base_scorecard`` with optional per-candidate-type extensions (e.g.
+    ``llm_extension``). The composed field set is the union of the named
+    schemas: every field of the base AND every named extension is required;
+    extras beyond the union fail strict mode. An extension payload alone
+    fails on the missing base fields — the extension is never standalone.
+    """
+    data = load()
+    schemas = data["schemas"]
+    specs: list[_FieldSpec] = []
+    seen: set[str] = set()
+    for name in (base, *extensions):
+        if name not in schemas:
+            raise SchemaError(f"unknown schema {name!r}; known: {sorted(schemas)}")
+        for spec in _coerce_fields(schemas[name]):
+            if spec.name in seen:
+                raise SchemaError(
+                    f"field {spec.name!r} declared by more than one of "
+                    f"{[base, *extensions]}"
+                )
+            seen.add(spec.name)
+            specs.append(spec)
+    _check_payload(specs, payload, strict)
 
 
 def format_block(name: str, payload: dict[str, Any]) -> str:

--- a/src/rainier/research/output_schema.py
+++ b/src/rainier/research/output_schema.py
@@ -87,6 +87,14 @@ def _check_payload(specs: list[_FieldSpec], payload: dict[str, Any], strict: boo
         val = payload[spec.name]
         if val is None and spec.nullable:
             continue
+        allowed = spec.py_type if isinstance(spec.py_type, tuple) else (spec.py_type,)
+        if isinstance(val, bool) and bool not in allowed:
+            # bool is a subclass of int: `n_selection_days: true` would
+            # otherwise pass the int/float check and land as 1/1.0 in
+            # promotion artifacts — silent type corruption.
+            raise SchemaError(
+                f"field {spec.name!r}: expected {spec.py_type}, got bool ({val!r})"
+            )
         if not isinstance(val, spec.py_type):  # type: ignore[arg-type]
             raise SchemaError(
                 f"field {spec.name!r}: expected {spec.py_type}, got "

--- a/src/rainier/research/output_schema.py
+++ b/src/rainier/research/output_schema.py
@@ -194,6 +194,35 @@ def format_block(name: str, payload: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def format_block_composed(
+    base: str,
+    payload: dict[str, Any],
+    extensions: Sequence[str] = (),
+) -> str:
+    """Render a composed (base + extensions) payload as a fenced YAML block.
+
+    Mirrors :func:`format_block` for the composed-scorecard case (§10.5) —
+    without this, an evaluator emitting ``base_scorecard + llm_extension``
+    would have no serializer (plain ``format_block`` rejects the extension
+    fields as extras). Field order is base-schema declaration order, then
+    each extension's declaration order, so byte-identical inputs produce
+    byte-identical output. ``parse_block`` is the shared inverse.
+    """
+    validate_composed(base, payload, extensions=extensions, strict=True)
+    data = load()
+    lines = ["---"]
+    for name in (base, *extensions):
+        for spec in _coerce_fields(data["schemas"][name]):
+            val = payload[spec.name]
+            dumped = yaml.safe_dump(val, default_flow_style=True).strip()
+            if dumped.endswith("\n..."):
+                dumped = dumped[: -len("\n...")]
+            lines.append(f"{spec.name}: {dumped}")
+    lines.append("---")
+    lines.append("")  # trailing newline
+    return "\n".join(lines)
+
+
 def parse_block(text: str) -> dict[str, Any]:
     """Inverse of ``format_block`` — extract a single fenced YAML block.
 

--- a/src/rainier/research/output_schema.py
+++ b/src/rainier/research/output_schema.py
@@ -127,6 +127,13 @@ def validate_composed(
     extras beyond the union fail strict mode. An extension payload alone
     fails on the missing base fields — the extension is never standalone.
     """
+    if isinstance(extensions, str):
+        # str is itself a Sequence[str]; a bare 'llm_extension' would iterate
+        # per-character and fail with a baffling "unknown schema 'l'".
+        raise SchemaError(
+            f"extensions must be a sequence of schema names, "
+            f"got bare string {extensions!r} — wrap it in a list"
+        )
     data = load()
     schemas = data["schemas"]
     specs: list[_FieldSpec] = []

--- a/src/rainier/research/output_schema.yaml
+++ b/src/rainier/research/output_schema.yaml
@@ -62,6 +62,55 @@ schemas:
         type: str
         nullable: true
 
+  # A/B substrate — candidate-agnostic base scorecard, per
+  # DESIGN-qu100-ab-testing.md §10.5. Every evaluator (screener replay, LLM
+  # backtest) emits this core; candidate-specific fields live in extension
+  # schemas composed via output_schema.validate_composed().
+  base_scorecard:
+    fields:
+      candidate_id:
+        type: str
+      candidate_type:
+        type: str
+      window:
+        type: str
+      n_selection_days:
+        type: int
+      corpus_hash:
+        type: str
+      # Reward values keyed by role: {primary: {...}, guardrails: {...},
+      # secondary: {...}} — reward keys are opaque strings here (§10.3).
+      rewards:
+        type: dict
+      # Per-regime reward slices (regime tag -> reward values), §4.4.
+      regime_scores:
+        type: dict
+      # ALWAYS null until the §11-task-6 DSR spec lands — never a naively
+      # computed number (design §4.4).
+      deflated_sharpe:
+        type: float
+        nullable: true
+      evaluator_sha:
+        type: str
+
+  # A/B substrate — optional LLM extension composed on top of base_scorecard
+  # (§10.5). Not required of the screener evaluator; the LLM-shaped
+  # `backtest` entry below stays untouched for its existing consumer.
+  llm_extension:
+    fields:
+      valid_thesis_rate:
+        type: float
+      cost_usd:
+        type: float
+      filled_R:
+        type: float
+      filled_rate:
+        type: float
+      tqqq_bh_R:
+        type: float
+      skill_yaml_sha:
+        type: str
+
   # Slice 1+ — L3 backtest summary, per [D-031] in DESIGN-qu100-llm-backtest.md.
   # Declared here so subsequent slices don't drift on shape; not exercised
   # in Slice 0 tests beyond shape parity.

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -449,3 +449,11 @@ def test_empty_string_guardrail_rejected():
     raw["guardrails"] = ["max_drawdown", ""]
     with pytest.raises(experiment.ExperimentSpecError, match="guardrails"):
         experiment.parse_spec(raw)
+
+
+def test_non_utf8_spec_file_raises_spec_error(tmp_path):
+    # An editor-mangled encoding (UTF-16 BOM, stray high bytes) fails during
+    # stream decode before yaml sees it — still the contract exception.
+    (tmp_path / "mangled.yaml").write_bytes(b"\xff\xfe\x00garbage")
+    with pytest.raises(experiment.ExperimentSpecError, match="unreadable"):
+        experiment.load_active_specs(tmp_path)

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -434,3 +434,18 @@ def test_falsy_non_list_guardrails_rejected(bad):
     raw["guardrails"] = bad
     with pytest.raises(experiment.ExperimentSpecError, match="guardrails"):
         experiment.parse_spec(raw)
+
+
+def test_unreadable_spec_path_raises_spec_error(tmp_path):
+    # A directory named *.yaml (or a permission failure) must surface as the
+    # contract exception, not a raw OSError.
+    (tmp_path / "adir.yaml").mkdir()
+    with pytest.raises(experiment.ExperimentSpecError, match="unreadable"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_empty_string_guardrail_rejected():
+    raw = _spec_dict()
+    raw["guardrails"] = ["max_drawdown", ""]
+    with pytest.raises(experiment.ExperimentSpecError, match="guardrails"):
+        experiment.parse_spec(raw)

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -658,6 +658,44 @@ def test_materialize_rejects_unknown_base_pattern_weights_key():
         )
 
 
+def test_yaml_merge_keys_still_supported(tmp_path):
+    # `<<:` merge keys are valid SafeLoader YAML (flattened with documented
+    # override semantics) — the duplicate-key loader must not reject them.
+    (tmp_path / "merge.yaml").write_text(
+        "id: merge-experiment\n"
+        "status: active\n"
+        "champion: champion.yaml\n"
+        "layer: layer_weights\n"
+        "primary: sharpe\n"
+        "window:\n"
+        "  train: 2025-05-27..2026-03-31\n"
+        "  holdout: 2026-04-01..2026-06-25\n"
+        "challengers:\n"
+        "  - id: c1\n"
+        "    override: &base\n"
+        "      layer_weight_money_flow: 0.35\n"
+        "  - id: c2\n"
+        "    override:\n"
+        "      <<: *base\n"
+        "      layer_weight_pattern: 0.5\n"
+    )
+    specs = experiment.load_active_specs(tmp_path)
+    assert len(specs) == 1
+    c2 = {c.id: c for c in specs[0].challengers}["c2"]
+    assert c2.override == {
+        "layer_weight_money_flow": 0.35,
+        "layer_weight_pattern": 0.5,
+    }
+
+
+def test_materialize_rejects_non_finite_base_override_value():
+    # A nan in the caller's base layer would poison the champion AND every
+    # challenger inheriting the field — same class as spec-authored nan.
+    spec = experiment.parse_spec(_spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match="non-finite"):
+        experiment.materialize_challengers(spec, {"buy_threshold": float("nan")})
+
+
 def test_cross_spec_duplicate_challenger_id_rejected(tmp_path):
     # Scorecards key on candidate_id (no experiment_id field): two live arms
     # sharing an id would emit indistinguishable scorecards.

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -1,0 +1,265 @@
+"""Experiment-spec interpreter tests (A/B substrate, design §10.4).
+
+The spec is a YAML file (config/experiments/*.yaml): champion + challengers
++ the one contended `layer` + reward keys + window. The interpreter — not
+the merge — validates every override key, because
+`merge_stock_screener_config` validates nothing and
+`StockScreenerConfig(**merged)` silently drops unknown kwargs: an
+unvalidated typo would yield a challenger identical to the champion (a
+silent no-op A/B).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from rainier.core.config import StockScreenerConfig
+from rainier.research import experiment
+
+
+def _spec_dict(**overrides: Any) -> dict[str, Any]:
+    """The design §10.4 example spec, with real StockScreenerConfig fields."""
+    base: dict[str, Any] = {
+        "id": "layer-weights-rebalance",
+        "status": "active",
+        "champion": "champion.yaml",
+        "layer": "layer_weights",
+        "challengers": [
+            {
+                "id": "mf35",
+                "override": {
+                    "layer_weight_money_flow": 0.35,
+                    "layer_weight_pattern": 0.55,
+                },
+            },
+            {
+                "id": "mf40",
+                "override": {
+                    "layer_weight_money_flow": 0.40,
+                    "layer_weight_pattern": 0.50,
+                },
+            },
+        ],
+        "primary": "sharpe",
+        "guardrails": ["max_drawdown", "turnover"],
+        "window": {
+            "train": "2025-05-27..2026-03-31",
+            "holdout": "2026-04-01..2026-06-25",
+            "embargo_days": 20,
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_spec(directory: Path, filename: str, spec: dict[str, Any]) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / filename
+    path.write_text(yaml.safe_dump(spec))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Parsing the valid §10.4 shape
+# ---------------------------------------------------------------------------
+
+
+def test_parse_valid_spec_shape():
+    spec = experiment.parse_spec(_spec_dict())
+    assert spec.id == "layer-weights-rebalance"
+    assert spec.status == "active"
+    assert spec.champion == "champion.yaml"
+    assert spec.layer == "layer_weights"
+    assert [c.id for c in spec.challengers] == ["mf35", "mf40"]
+    assert spec.primary == "sharpe"
+    assert spec.guardrails == ("max_drawdown", "turnover")
+    assert spec.window.train == "2025-05-27..2026-03-31"
+    assert spec.window.holdout == "2026-04-01..2026-06-25"
+
+
+def test_load_spec_from_yaml_file(tmp_path):
+    path = _write_spec(tmp_path, "layer-weights.yaml", _spec_dict())
+    spec = experiment.load_spec(path)
+    assert spec.id == "layer-weights-rebalance"
+    assert len(spec.challengers) == 2
+
+
+def test_embargo_days_defaults_to_20():
+    raw = _spec_dict()
+    del raw["window"]["embargo_days"]
+    spec = experiment.parse_spec(raw)
+    assert spec.window.embargo_days == 20
+
+
+def test_embargo_days_explicit_value_parsed():
+    raw = _spec_dict()
+    raw["window"]["embargo_days"] = 5
+    spec = experiment.parse_spec(raw)
+    assert spec.window.embargo_days == 5
+
+
+def test_missing_window_rejected():
+    raw = _spec_dict()
+    del raw["window"]
+    with pytest.raises(experiment.ExperimentSpecError, match="window"):
+        experiment.parse_spec(raw)
+
+
+def test_duplicate_challenger_ids_rejected():
+    raw = _spec_dict()
+    raw["challengers"][1]["id"] = "mf35"
+    with pytest.raises(experiment.ExperimentSpecError, match="mf35"):
+        experiment.parse_spec(raw)
+
+
+def test_empty_override_rejected():
+    # An empty override yields a challenger identical to the champion —
+    # exactly the silent no-op A/B the interpreter exists to prevent.
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {}
+    with pytest.raises(experiment.ExperimentSpecError, match="mf35"):
+        experiment.parse_spec(raw)
+
+
+# ---------------------------------------------------------------------------
+# Override-key validation (the load-bearing check)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_flat_override_key_rejected_with_key_named():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"layer_weight_money_floww": 0.35}
+    with pytest.raises(experiment.ExperimentSpecError, match="layer_weight_money_floww"):
+        experiment.parse_spec(raw)
+
+
+def test_unknown_pattern_weights_dotted_key_rejected_with_key_named():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"pattern_weights.bulll_flag": 0.9}
+    with pytest.raises(experiment.ExperimentSpecError, match="bulll_flag"):
+        experiment.parse_spec(raw)
+
+
+def test_unknown_nested_pattern_weights_key_rejected():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"pattern_weights": {"bulll_flag": 0.9}}
+    with pytest.raises(experiment.ExperimentSpecError, match="bulll_flag"):
+        experiment.parse_spec(raw)
+
+
+def test_arbitrary_dotted_path_rejected():
+    # The interpreter never invents config paths — a knob must exist as a
+    # StockScreenerConfig field before it can be experimented on.
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"signal.momentum.method": "ema"}
+    with pytest.raises(experiment.ExperimentSpecError, match="signal.momentum.method"):
+        experiment.parse_spec(raw)
+
+
+def test_pattern_weights_dotted_path_translated_to_nested_dict():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"pattern_weights.bull_flag": 0.9}
+    spec = experiment.parse_spec(raw)
+    assert spec.challengers[0].override == {"pattern_weights": {"bull_flag": 0.9}}
+
+
+# ---------------------------------------------------------------------------
+# Challenger materialization (deep-merge via merge_stock_screener_config)
+# ---------------------------------------------------------------------------
+
+
+def test_challengers_materialize_differing_only_in_overridden_keys():
+    spec = experiment.parse_spec(_spec_dict())
+    base_overrides = {"buy_threshold": 0.70}
+    champion_cfg, challenger_cfgs = experiment.materialize_challengers(spec, base_overrides)
+
+    assert set(challenger_cfgs) == {"mf35", "mf40"}
+    mf35 = challenger_cfgs["mf35"]
+    assert mf35.layer_weight_money_flow == 0.35
+    assert mf35.layer_weight_pattern == 0.55
+    # Non-overridden fields fall through to the champion layer / defaults.
+    assert mf35.buy_threshold == 0.70
+    champion_dump = champion_cfg.model_dump()
+    mf35_dump = mf35.model_dump()
+    differing = {k for k in champion_dump if champion_dump[k] != mf35_dump[k]}
+    assert differing == {"layer_weight_money_flow", "layer_weight_pattern"}
+
+
+def test_pattern_weight_merge_preserves_other_pattern_weights():
+    raw = _spec_dict()
+    raw["challengers"] = [
+        {"id": "bf90", "override": {"pattern_weights.bull_flag": 0.9}},
+    ]
+    spec = experiment.parse_spec(raw)
+    _, challenger_cfgs = experiment.materialize_challengers(spec, None)
+    weights = challenger_cfgs["bf90"].pattern_weights
+    defaults = StockScreenerConfig().pattern_weights
+    assert weights["bull_flag"] == 0.9
+    for name, default in defaults.items():
+        if name != "bull_flag":
+            assert weights[name] == default
+
+
+# ---------------------------------------------------------------------------
+# Spec discovery + mutual exclusion (config/experiments/*.yaml)
+# ---------------------------------------------------------------------------
+
+
+def test_load_active_specs_returns_only_active(tmp_path):
+    _write_spec(tmp_path, "a.yaml", _spec_dict())
+    retired = _spec_dict(id="old-experiment", layer="thresholds", status="retired")
+    _write_spec(tmp_path, "b.yaml", retired)
+    specs = experiment.load_active_specs(tmp_path)
+    assert [s.id for s in specs] == ["layer-weights-rebalance"]
+
+
+def test_malformed_status_is_a_loud_error(tmp_path):
+    _write_spec(tmp_path, "a.yaml", _spec_dict(status="paused"))
+    with pytest.raises(experiment.ExperimentSpecError, match="paused"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_two_active_specs_same_layer_mutually_exclusive(tmp_path):
+    _write_spec(tmp_path, "a.yaml", _spec_dict())
+    _write_spec(tmp_path, "b.yaml", _spec_dict(id="second-experiment"))
+    with pytest.raises(experiment.ExperimentSpecError, match="layer_weights"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_two_active_specs_different_layers_both_load(tmp_path):
+    _write_spec(tmp_path, "a.yaml", _spec_dict())
+    other = _spec_dict(
+        id="threshold-experiment",
+        layer="thresholds",
+        challengers=[{"id": "bt70", "override": {"buy_threshold": 0.70}}],
+    )
+    _write_spec(tmp_path, "b.yaml", other)
+    specs = experiment.load_active_specs(tmp_path)
+    assert sorted(s.id for s in specs) == [
+        "layer-weights-rebalance",
+        "threshold-experiment",
+    ]
+
+
+def test_retired_spec_never_conflicts_on_layer(tmp_path):
+    _write_spec(tmp_path, "a.yaml", _spec_dict())
+    retired = _spec_dict(id="old-layer-weights", status="retired")
+    _write_spec(tmp_path, "b.yaml", retired)
+    specs = experiment.load_active_specs(tmp_path)
+    assert [s.id for s in specs] == ["layer-weights-rebalance"]
+
+
+def test_duplicate_active_experiment_ids_rejected(tmp_path):
+    _write_spec(tmp_path, "a.yaml", _spec_dict())
+    dup = _spec_dict(layer="thresholds")
+    _write_spec(tmp_path, "b.yaml", dup)
+    with pytest.raises(experiment.ExperimentSpecError, match="layer-weights-rebalance"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_load_active_specs_empty_dir_returns_empty(tmp_path):
+    assert experiment.load_active_specs(tmp_path) == []

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -565,3 +565,113 @@ def test_materialize_wraps_validation_error():
     spec = experiment.parse_spec(_spec_dict())
     with pytest.raises(experiment.ExperimentSpecError, match="StockScreenerConfig"):
         experiment.materialize_challengers(spec, {"buy_threshold": "garbage"})
+
+
+# ---------------------------------------------------------------------------
+# Review iter-6 (red team): duplicate YAML keys, non-finite values, uppercase
+# extensions, editor lockfiles, base_overrides keys, cross-spec arm ids
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_yaml_key_in_spec_file_rejected(tmp_path):
+    # yaml.safe_load silently last-write-wins on duplicate keys — a spec with
+    # two `layer_weight_money_flow:` lines would load the second and drop the
+    # first without a sound.
+    (tmp_path / "dup.yaml").write_text(
+        "id: dup-experiment\n"
+        "status: active\n"
+        "champion: champion.yaml\n"
+        "layer: thresholds\n"
+        "primary: sharpe\n"
+        "window:\n"
+        "  train: 2025-05-27..2026-03-31\n"
+        "  holdout: 2026-04-01..2026-06-25\n"
+        "challengers:\n"
+        "  - id: c1\n"
+        "    override:\n"
+        "      layer_weight_money_flow: 0.35\n"
+        "      layer_weight_money_flow: 0.99\n"
+    )
+    with pytest.raises(experiment.ExperimentSpecError, match="duplicate key"):
+        experiment.load_active_specs(tmp_path)
+
+
+@pytest.mark.parametrize("bad", [".nan", ".inf", "-.inf"], ids=["nan", "inf", "-inf"])
+def test_non_finite_override_value_rejected(tmp_path, bad):
+    # pydantic strict mode still admits nan/inf floats; a NaN threshold makes
+    # every comparison False — silent corruption of the A/B result.
+    (tmp_path / "nf.yaml").write_text(
+        "id: nf-experiment\n"
+        "status: active\n"
+        "champion: champion.yaml\n"
+        "layer: thresholds\n"
+        "primary: sharpe\n"
+        "window:\n"
+        "  train: 2025-05-27..2026-03-31\n"
+        "  holdout: 2026-04-01..2026-06-25\n"
+        "challengers:\n"
+        "  - id: c1\n"
+        f"    override: {{buy_threshold: {bad}}}\n"
+    )
+    with pytest.raises(experiment.ExperimentSpecError, match="non-finite"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_non_finite_nested_pattern_weight_rejected():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"pattern_weights": {"bull_flag": float("nan")}}
+    with pytest.raises(experiment.ExperimentSpecError, match="non-finite"):
+        experiment.parse_spec(raw)
+
+
+@pytest.mark.parametrize("filename", ["a.YAML", "a.YML", "a.Yaml"])
+def test_uppercase_extension_spec_rejected_loudly(tmp_path, filename):
+    # pathlib glob is case-sensitive: *.yaml won't match a.YAML, silently
+    # re-opening the ignored-spec hole the .yml guard closed.
+    _write_spec(tmp_path, filename, _spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match=filename):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_editor_lockfile_dotfile_is_ignored(tmp_path):
+    # An emacs-style lockfile (dangling symlink `.#spec.yaml`) at cron time
+    # must not fail the run — dotfiles aren't specs.
+    _write_spec(tmp_path, "good.yaml", _spec_dict())
+    (tmp_path / ".#good.yaml").symlink_to(tmp_path / "nonexistent-target")
+    specs = experiment.load_active_specs(tmp_path)
+    assert [s.id for s in specs] == ["layer-weights-rebalance"]
+
+
+def test_materialize_rejects_unknown_base_override_key():
+    # StockScreenerConfig silently drops unknown kwargs — a typo'd base key
+    # would materialize a "champion" that doesn't match the live config.
+    spec = experiment.parse_spec(_spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match="buy_threshhold"):
+        experiment.materialize_challengers(spec, {"buy_threshhold": 0.99})
+
+
+def test_materialize_rejects_unknown_base_pattern_weights_key():
+    spec = experiment.parse_spec(_spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match="bulll_flag"):
+        experiment.materialize_challengers(
+            spec, {"pattern_weights": {"bulll_flag": 0.9}}
+        )
+
+
+def test_cross_spec_duplicate_challenger_id_rejected(tmp_path):
+    # Scorecards key on candidate_id (no experiment_id field): two live arms
+    # sharing an id would emit indistinguishable scorecards.
+    a = _spec_dict(
+        id="bull-weight",
+        layer="pw-bull",
+        challengers=[{"id": "arm-1", "override": {"pattern_weights.bull_flag": 0.9}}],
+    )
+    b = _spec_dict(
+        id="bear-weight",
+        layer="pw-bear",
+        challengers=[{"id": "arm-1", "override": {"pattern_weights.bear_flag": 0.9}}],
+    )
+    _write_spec(tmp_path, "a.yaml", a)
+    _write_spec(tmp_path, "b.yaml", b)
+    with pytest.raises(experiment.ExperimentSpecError, match="arm-1"):
+        experiment.load_active_specs(tmp_path)

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -381,3 +381,56 @@ def test_disjoint_pattern_weight_keys_across_specs_allowed(tmp_path):
     _write_spec(tmp_path, "b.yaml", b)
     specs = experiment.load_active_specs(tmp_path)
     assert sorted(s.id for s in specs) == ["bear-weight", "bull-weight"]
+
+
+# ---------------------------------------------------------------------------
+# Review iter-2: empty nested pattern_weights + non-str keys + falsy guardrails
+# ---------------------------------------------------------------------------
+
+
+def test_empty_nested_pattern_weights_rejected():
+    # {"pattern_weights": {}} is a non-empty override MAPPING that translates
+    # to an EMPTY override — a silent no-op challenger that would also escape
+    # cross-spec mutual exclusion (override_keys == empty set).
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"pattern_weights": {}}
+    with pytest.raises(experiment.ExperimentSpecError, match="non-empty"):
+        experiment.parse_spec(raw)
+
+
+def test_non_str_top_level_key_rejected():
+    # YAML 1.1 parses a bare `on:` as boolean True.
+    raw = _spec_dict()
+    raw[True] = "x"
+    with pytest.raises(experiment.ExperimentSpecError, match="must be str"):
+        experiment.parse_spec(raw)
+
+
+def test_non_str_override_key_rejected():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {1: 0.5}
+    with pytest.raises(experiment.ExperimentSpecError, match="must be str"):
+        experiment.parse_spec(raw)
+
+
+def test_non_str_pattern_weights_key_rejected():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"pattern_weights": {1: 0.5}}
+    with pytest.raises(experiment.ExperimentSpecError, match="must be str"):
+        experiment.parse_spec(raw)
+
+
+def test_non_str_window_key_rejected():
+    raw = _spec_dict()
+    raw["window"][True] = "x"
+    with pytest.raises(experiment.ExperimentSpecError, match="must be str"):
+        experiment.parse_spec(raw)
+
+
+@pytest.mark.parametrize("bad", [False, 0, ""], ids=["false", "zero", "empty-str"])
+def test_falsy_non_list_guardrails_rejected(bad):
+    # `guardrails: false` must be a type error, not silently "no guardrails".
+    raw = _spec_dict()
+    raw["guardrails"] = bad
+    with pytest.raises(experiment.ExperimentSpecError, match="guardrails"):
+        experiment.parse_spec(raw)

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -706,6 +706,19 @@ def test_materialize_rejects_coercible_base_override_value(bad):
         experiment.materialize_challengers(spec, {"buy_threshold": bad})
 
 
+def test_materialize_base_overrides_is_required():
+    # No default value: a production caller must not be able to forget the
+    # champion-effective layer and silently baseline challengers on pydantic
+    # code defaults instead of the live champion (explicit None = synthetic
+    # code-defaults replay, an intentional choice).
+    import inspect
+
+    param = inspect.signature(experiment.materialize_challengers).parameters[
+        "base_overrides"
+    ]
+    assert param.default is inspect.Parameter.empty
+
+
 def test_cross_spec_duplicate_challenger_id_rejected(tmp_path):
     # Scorecards key on candidate_id (no experiment_id field): two live arms
     # sharing an id would emit indistinguishable scorecards.

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -121,7 +121,7 @@ def test_empty_override_rejected():
     # exactly the silent no-op A/B the interpreter exists to prevent.
     raw = _spec_dict()
     raw["challengers"][0]["override"] = {}
-    with pytest.raises(experiment.ExperimentSpecError, match="mf35"):
+    with pytest.raises(experiment.ExperimentSpecError, match="non-empty mapping"):
         experiment.parse_spec(raw)
 
 
@@ -263,3 +263,121 @@ def test_duplicate_active_experiment_ids_rejected(tmp_path):
 
 def test_load_active_specs_empty_dir_returns_empty(tmp_path):
     assert experiment.load_active_specs(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Strict spec shape (review iter-1): unknown keys at every level are loud —
+# a typo'd `guardrail:` must not yield a guardrail-free experiment.
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_top_level_spec_key_rejected():
+    raw = _spec_dict()
+    raw["guardrail"] = ["max_drawdown"]  # singular typo of `guardrails`
+    with pytest.raises(experiment.ExperimentSpecError, match="guardrail"):
+        experiment.parse_spec(raw)
+
+
+def test_unknown_window_key_rejected():
+    raw = _spec_dict()
+    raw["window"]["embargo_dayz"] = 5  # typo would silently keep default 20
+    with pytest.raises(experiment.ExperimentSpecError, match="embargo_dayz"):
+        experiment.parse_spec(raw)
+
+
+def test_unknown_challenger_key_rejected():
+    raw = _spec_dict()
+    raw["challengers"][0]["overrride"] = {"buy_threshold": 0.7}
+    with pytest.raises(experiment.ExperimentSpecError, match="overrride"):
+        experiment.parse_spec(raw)
+
+
+def test_empty_challenger_id_rejected():
+    raw = _spec_dict()
+    raw["challengers"][0]["id"] = ""
+    with pytest.raises(experiment.ExperimentSpecError, match="non-empty"):
+        experiment.parse_spec(raw)
+
+
+@pytest.mark.parametrize("bad", [-1, True, "20", 2.5])
+def test_bad_embargo_days_rejected(bad):
+    raw = _spec_dict()
+    raw["window"]["embargo_days"] = bad
+    with pytest.raises(experiment.ExperimentSpecError, match="embargo_days"):
+        experiment.parse_spec(raw)
+
+
+# ---------------------------------------------------------------------------
+# Override ambiguity + value validation (review iter-1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"pattern_weights.bull_flag": 0.9, "pattern_weights": {"bull_flag": 0.5}},
+        {"pattern_weights": {"bull_flag": 0.5}, "pattern_weights.bull_flag": 0.9},
+    ],
+    ids=["dotted-then-nested", "nested-then-dotted"],
+)
+def test_dotted_and_nested_same_pattern_conflict_rejected(override):
+    # Silent last-write-wins for the same pattern is exactly the ambiguity
+    # class the interpreter rejects everywhere else.
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = override
+    with pytest.raises(experiment.ExperimentSpecError, match="bull_flag"):
+        experiment.parse_spec(raw)
+
+
+def test_override_value_type_rejected_at_parse_time():
+    # Bad VALUES fail at spec-load time as ExperimentSpecError — not at cron
+    # runtime inside materialize_challengers as a raw pydantic error.
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"layer_weight_money_flow": "not-a-number"}
+    with pytest.raises(experiment.ExperimentSpecError, match="layer_weight_money_flow"):
+        experiment.parse_spec(raw)
+
+
+# ---------------------------------------------------------------------------
+# Discovery hardening (review iter-1)
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_yaml_file_raises_spec_error(tmp_path):
+    (tmp_path / "broken.yaml").write_text("id: [unclosed\n")
+    with pytest.raises(experiment.ExperimentSpecError, match="invalid YAML"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_overlapping_override_keys_across_layer_labels_rejected(tmp_path):
+    # Layer labels are just names — two active specs contending the SAME
+    # config knob under different labels must be rejected, or the A/B
+    # results entangle silently.
+    _write_spec(tmp_path, "a.yaml", _spec_dict())
+    other = _spec_dict(
+        id="relabeled-weights",
+        layer="weights",  # different label, same contended knob
+        challengers=[{"id": "mf45", "override": {"layer_weight_money_flow": 0.45}}],
+    )
+    _write_spec(tmp_path, "b.yaml", other)
+    with pytest.raises(experiment.ExperimentSpecError, match="layer_weight_money_flow"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_disjoint_pattern_weight_keys_across_specs_allowed(tmp_path):
+    # pattern_weights is expanded per-pattern: touching DIFFERENT patterns
+    # in two active experiments is not a conflict.
+    a = _spec_dict(
+        id="bull-weight",
+        layer="pw-bull",
+        challengers=[{"id": "b9", "override": {"pattern_weights.bull_flag": 0.9}}],
+    )
+    b = _spec_dict(
+        id="bear-weight",
+        layer="pw-bear",
+        challengers=[{"id": "k9", "override": {"pattern_weights.bear_flag": 0.9}}],
+    )
+    _write_spec(tmp_path, "a.yaml", a)
+    _write_spec(tmp_path, "b.yaml", b)
+    specs = experiment.load_active_specs(tmp_path)
+    assert sorted(s.id for s in specs) == ["bear-weight", "bull-weight"]

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -696,6 +696,16 @@ def test_materialize_rejects_non_finite_base_override_value():
         experiment.materialize_challengers(spec, {"buy_threshold": float("nan")})
 
 
+@pytest.mark.parametrize("bad", [True, "0.35"], ids=["bool", "numeric-str"])
+def test_materialize_rejects_coercible_base_override_value(bad):
+    # Lax construction would silently coerce `buy_threshold: true` → 1.0 or
+    # "0.35" → 0.35 in the champion — a malformed base config must fail
+    # loudly, mirroring the strict parse-time check on spec overrides.
+    spec = experiment.parse_spec(_spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match="StockScreenerConfig"):
+        experiment.materialize_challengers(spec, {"buy_threshold": bad})
+
+
 def test_cross_spec_duplicate_challenger_id_rejected(tmp_path):
     # Scorecards key on candidate_id (no experiment_id field): two live arms
     # sharing an id would emit indistinguishable scorecards.

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -257,7 +257,10 @@ def test_duplicate_active_experiment_ids_rejected(tmp_path):
     _write_spec(tmp_path, "a.yaml", _spec_dict())
     dup = _spec_dict(layer="thresholds")
     _write_spec(tmp_path, "b.yaml", dup)
-    with pytest.raises(experiment.ExperimentSpecError, match="layer-weights-rebalance"):
+    # Match the message unique to the duplicate-id branch: the spec id alone
+    # also appears in the override-key mutual-exclusion error, so a looser
+    # match would stay green if the duplicate-id guard were deleted.
+    with pytest.raises(experiment.ExperimentSpecError, match="duplicate active experiment id"):
         experiment.load_active_specs(tmp_path)
 
 
@@ -457,3 +460,108 @@ def test_non_utf8_spec_file_raises_spec_error(tmp_path):
     (tmp_path / "mangled.yaml").write_bytes(b"\xff\xfe\x00garbage")
     with pytest.raises(experiment.ExperimentSpecError, match="unreadable"):
         experiment.load_active_specs(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Review iter-5: window value validation, strict override values, loud
+# discovery (missing dir / stray .yml), guardrail hygiene, materialize wrap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "garbage", "2026-01-01", "2026-01-01..not-a-date", "2026-99-01..2026-12-31"],
+    ids=["empty", "garbage", "no-separator", "bad-end-date", "bad-month"],
+)
+def test_malformed_window_range_rejected(bad):
+    raw = _spec_dict()
+    raw["window"]["train"] = bad
+    with pytest.raises(experiment.ExperimentSpecError, match="window.train"):
+        experiment.parse_spec(raw)
+
+
+def test_reversed_window_range_rejected():
+    raw = _spec_dict()
+    raw["window"]["train"] = "2026-03-31..2025-05-27"
+    with pytest.raises(experiment.ExperimentSpecError, match="reversed"):
+        experiment.parse_spec(raw)
+
+
+def test_overlapping_train_holdout_rejected():
+    # Holdout starting inside the train window leaks train data into the
+    # holdout — must fail at parse time, not silently mis-slice at cron time.
+    raw = _spec_dict()
+    raw["window"]["holdout"] = "2026-03-01..2026-06-25"
+    with pytest.raises(experiment.ExperimentSpecError, match="leak"):
+        experiment.parse_spec(raw)
+
+
+def test_bool_override_value_rejected_at_parse_time():
+    # YAML `buy_threshold: true` would lax-coerce to 1.0 — a plausible-looking
+    # losing challenger (silent corruption of the A/B result).
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"buy_threshold": True}
+    with pytest.raises(experiment.ExperimentSpecError, match="buy_threshold"):
+        experiment.parse_spec(raw)
+
+
+def test_numeric_string_override_value_rejected_at_parse_time():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"buy_threshold": "0.35"}
+    with pytest.raises(experiment.ExperimentSpecError, match="buy_threshold"):
+        experiment.parse_spec(raw)
+
+
+def test_int_override_value_for_float_field_still_accepted():
+    # Strict mode still allows int where a float is declared — `weight: 1`
+    # is valid YAML for a float knob.
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"layer_weight_money_flow": 1}
+    spec = experiment.parse_spec(raw)
+    assert spec.challengers[0].override == {"layer_weight_money_flow": 1}
+
+
+def test_nonexistent_experiments_dir_raises(tmp_path):
+    # A missing directory (wrong CWD, lost deploy dir) must NOT read as an
+    # empty experiment queue — that silently disables the whole substrate.
+    with pytest.raises(experiment.ExperimentSpecError, match="does not exist"):
+        experiment.load_active_specs(tmp_path / "nope")
+
+
+def test_stray_yml_extension_rejected_loudly(tmp_path):
+    # Discovery reads *.yaml only; a spec saved as .yml must fail loudly
+    # instead of being silently skipped.
+    _write_spec(tmp_path, "a.yml", _spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match="a.yml"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_empty_yaml_spec_file_rejected(tmp_path):
+    # A zero-byte/truncated file parses to None — must be the contract
+    # exception naming the file, not a silent skip.
+    (tmp_path / "empty.yaml").write_text("")
+    with pytest.raises(experiment.ExperimentSpecError, match="mapping"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_duplicate_guardrails_rejected():
+    raw = _spec_dict()
+    raw["guardrails"] = ["max_drawdown", "max_drawdown"]
+    with pytest.raises(experiment.ExperimentSpecError, match="duplicate guardrail"):
+        experiment.parse_spec(raw)
+
+
+def test_primary_also_in_guardrails_rejected():
+    raw = _spec_dict()
+    raw["guardrails"] = ["sharpe", "max_drawdown"]  # primary is "sharpe"
+    with pytest.raises(experiment.ExperimentSpecError, match="primary"):
+        experiment.parse_spec(raw)
+
+
+def test_materialize_wraps_validation_error():
+    # base_overrides come from the caller (settings/champion layer), not the
+    # spec — a bad value there must still surface as the contract exception,
+    # not a raw pydantic ValidationError inside the unattended cron shadow arm.
+    spec = experiment.parse_spec(_spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match="StockScreenerConfig"):
+        experiment.materialize_challengers(spec, {"buy_threshold": "garbage"})

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -439,6 +439,23 @@ def test_falsy_non_list_guardrails_rejected(bad):
         experiment.parse_spec(raw)
 
 
+def test_explicit_null_guardrails_rejected():
+    # A bare `guardrails:` line parses as null — must not silently load as
+    # "no guardrails" (that quietly drops the experiment's risk checks).
+    raw = _spec_dict()
+    raw["guardrails"] = None
+    with pytest.raises(experiment.ExperimentSpecError, match="guardrails"):
+        experiment.parse_spec(raw)
+
+
+def test_missing_guardrails_key_defaults_to_empty():
+    # Omitting the key entirely stays legal: guardrails are optional.
+    raw = _spec_dict()
+    del raw["guardrails"]
+    spec = experiment.parse_spec(raw)
+    assert spec.guardrails == ()
+
+
 def test_unreadable_spec_path_raises_spec_error(tmp_path):
     # A directory named *.yaml (or a permission failure) must surface as the
     # contract exception, not a raw OSError.

--- a/tests/research/test_output_schema.py
+++ b/tests/research/test_output_schema.py
@@ -231,3 +231,28 @@ def test_composed_bare_string_extensions_rejected():
         output_schema.validate_composed(
             "base_scorecard", _valid_base_scorecard(), extensions="llm_extension"
         )
+
+
+def test_bool_rejected_for_int_field():
+    # bool is a subclass of int: `n_selection_days: true` would otherwise
+    # pass the int check and land as 1 in promotion artifacts.
+    block = _valid_base_scorecard()
+    block["n_selection_days"] = True
+    with pytest.raises(output_schema.SchemaError, match="n_selection_days"):
+        output_schema.validate("base_scorecard", block)
+
+
+def test_bool_rejected_for_float_field():
+    block = _valid_base_scorecard()
+    block["deflated_sharpe"] = True
+    with pytest.raises(output_schema.SchemaError, match="deflated_sharpe"):
+        output_schema.validate("base_scorecard", block)
+
+
+def test_base_alone_rejected_when_extension_named():
+    # Converse of the extension-alone case: naming an extension makes ALL of
+    # its fields required, so a base-only payload must fail on them.
+    with pytest.raises(output_schema.SchemaError, match="valid_thesis_rate"):
+        output_schema.validate_composed(
+            "base_scorecard", _valid_base_scorecard(), extensions=["llm_extension"]
+        )

--- a/tests/research/test_output_schema.py
+++ b/tests/research/test_output_schema.py
@@ -86,3 +86,125 @@ def test_verdict_enum_is_pinned():
     schema = output_schema.load()["schemas"]["cost_pilot"]
     # PASS / CONDITIONAL / FAIL are the three values Slice 0 ships with.
     assert set(schema["fields"]["verdict"]["enum"]) == {"PASS", "CONDITIONAL", "FAIL"}
+
+
+# ---------------------------------------------------------------------------
+# A/B substrate scorecards (design §10.5) — candidate-agnostic base +
+# optional LLM extension, composed via validate_composed(). Additive: the
+# LLM-shaped `backtest` entry stays untouched for its existing consumer.
+# ---------------------------------------------------------------------------
+
+
+def _valid_base_scorecard() -> dict:
+    return {
+        "candidate_id": "mf35",
+        "candidate_type": "screener",
+        "window": "2025-05-27..2026-03-31",
+        "n_selection_days": 210,
+        "corpus_hash": "a" * 40,
+        "rewards": {
+            "primary": {"sharpe": 1.12},
+            "guardrails": {"max_drawdown": -0.14, "turnover": 0.32},
+        },
+        "regime_scores": {"risk_on": {"sharpe": 1.30}, "risk_off": {"sharpe": 0.41}},
+        # null until the §11-task-6 DSR spec lands — never a naive number.
+        "deflated_sharpe": None,
+        "evaluator_sha": "b" * 40,
+    }
+
+
+def _valid_llm_extension() -> dict:
+    return {
+        "valid_thesis_rate": 0.92,
+        "cost_usd": 4.31,
+        "filled_R": 3.4,
+        "filled_rate": 0.71,
+        "tqqq_bh_R": 2.1,
+        "skill_yaml_sha": "c" * 40,
+    }
+
+
+def test_base_scorecard_validates_without_llm_fields():
+    output_schema.validate("base_scorecard", _valid_base_scorecard())
+
+
+def test_base_scorecard_deflated_sharpe_null_validates():
+    block = _valid_base_scorecard()
+    assert block["deflated_sharpe"] is None
+    output_schema.validate("base_scorecard", block)
+
+
+def test_base_scorecard_deflated_sharpe_float_also_validates():
+    block = _valid_base_scorecard()
+    block["deflated_sharpe"] = 0.87
+    output_schema.validate("base_scorecard", block)
+
+
+def test_composed_base_plus_llm_extension_validates():
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    output_schema.validate_composed("base_scorecard", block, extensions=["llm_extension"])
+
+
+def test_llm_extension_alone_is_rejected():
+    # The extension is not a standalone scorecard — base fields are required.
+    with pytest.raises(output_schema.SchemaError) as exc:
+        output_schema.validate_composed(
+            "base_scorecard", _valid_llm_extension(), extensions=["llm_extension"]
+        )
+    assert "candidate_id" in str(exc.value)
+
+
+def test_composed_rejects_extension_fields_when_extension_not_named():
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    with pytest.raises(output_schema.SchemaError):
+        output_schema.validate_composed("base_scorecard", block)
+
+
+def test_composed_rejects_undeclared_extra_field():
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    block["never_declared"] = 1
+    with pytest.raises(output_schema.SchemaError) as exc:
+        output_schema.validate_composed("base_scorecard", block, extensions=["llm_extension"])
+    assert "never_declared" in str(exc.value)
+
+
+def test_composed_unknown_extension_name_rejected():
+    with pytest.raises(output_schema.SchemaError):
+        output_schema.validate_composed(
+            "base_scorecard", _valid_base_scorecard(), extensions=["no_such_extension"]
+        )
+
+
+def test_existing_schemas_unchanged_regression():
+    """The pre-existing entries still validate their canonical payloads."""
+    output_schema.validate("cost_pilot", _valid_cost_pilot_block())
+    output_schema.validate(
+        "survivorship",
+        {
+            "from_date": "2025-05-27",
+            "to_date": "2026-06-25",
+            "verdict": "PASS",
+            "delisted_tickers": [],
+            "missing_days": [],
+            "next_step": None,
+        },
+    )
+    output_schema.validate(
+        "backtest",
+        {
+            "skill_id": "qu100_v1",
+            "reward_fn": "filled_R",
+            "filled_R": 3.4,
+            "all_call_R": 2.9,
+            "calls": 120,
+            "valid_thesis_rate": 0.92,
+            "filled_rate": 0.71,
+            "cost_usd": 4.31,
+            "tqqq_bh_R": 2.1,
+            "delta_vs_tqqq": 1.3,
+            "deflated_sharpe": 0.87,
+            "evaluator_sha": "b" * 40,
+            "skill_yaml_sha": "c" * 40,
+            "ledger_sha": "0" * 40,
+        },
+    )

--- a/tests/research/test_output_schema.py
+++ b/tests/research/test_output_schema.py
@@ -258,6 +258,35 @@ def test_base_alone_rejected_when_extension_named():
         )
 
 
+def test_format_block_composed_round_trips():
+    # Composed scorecards need a serializer too — plain format_block rejects
+    # the extension fields as extras.
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    text = output_schema.format_block_composed(
+        "base_scorecard", block, extensions=["llm_extension"]
+    )
+    assert text.startswith("---\n")
+    assert text.endswith("---\n")
+    assert output_schema.parse_block(text) == block
+
+
+def test_format_block_composed_orders_base_fields_before_extension():
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    text = output_schema.format_block_composed(
+        "base_scorecard", block, extensions=["llm_extension"]
+    )
+    assert text.index("candidate_id:") < text.index("valid_thesis_rate:")
+
+
+def test_format_block_composed_rejects_missing_extension_field():
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    del block["valid_thesis_rate"]
+    with pytest.raises(output_schema.SchemaError, match="valid_thesis_rate"):
+        output_schema.format_block_composed(
+            "base_scorecard", block, extensions=["llm_extension"]
+        )
+
+
 def test_parse_block_wraps_invalid_yaml_as_schema_error():
     # A truncated block (process killed mid-write) must surface as the module
     # contract exception, not a raw yaml.parser.ParserError.

--- a/tests/research/test_output_schema.py
+++ b/tests/research/test_output_schema.py
@@ -256,3 +256,17 @@ def test_base_alone_rejected_when_extension_named():
         output_schema.validate_composed(
             "base_scorecard", _valid_base_scorecard(), extensions=["llm_extension"]
         )
+
+
+def test_parse_block_wraps_invalid_yaml_as_schema_error():
+    # A truncated block (process killed mid-write) must surface as the module
+    # contract exception, not a raw yaml.parser.ParserError.
+    with pytest.raises(output_schema.SchemaError, match="not valid YAML"):
+        output_schema.parse_block("---\nkey: [unclosed\n---")
+
+
+def test_load_wraps_invalid_yaml_as_schema_error(tmp_path):
+    broken = tmp_path / "broken_schema.yaml"
+    broken.write_text("schemas: [unclosed\n")
+    with pytest.raises(output_schema.SchemaError, match="invalid YAML"):
+        output_schema.load(broken)

--- a/tests/research/test_output_schema.py
+++ b/tests/research/test_output_schema.py
@@ -208,3 +208,26 @@ def test_existing_schemas_unchanged_regression():
             "ledger_sha": "0" * 40,
         },
     )
+
+
+def test_composed_duplicate_field_across_schemas_rejected():
+    # base_scorecard and the pre-existing backtest schema both declare
+    # deflated_sharpe/evaluator_sha — composing them must fail loudly.
+    with pytest.raises(output_schema.SchemaError, match="declared by more than one"):
+        output_schema.validate_composed("base_scorecard", {}, extensions=["backtest"])
+
+
+def test_composed_non_strict_tolerates_extras():
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    block["future_field"] = 1
+    output_schema.validate_composed(
+        "base_scorecard", block, extensions=["llm_extension"], strict=False
+    )
+
+
+def test_composed_bare_string_extensions_rejected():
+    # str is a Sequence[str]; without the guard this iterates per-character.
+    with pytest.raises(output_schema.SchemaError, match="bare string"):
+        output_schema.validate_composed(
+            "base_scorecard", _valid_base_scorecard(), extensions="llm_extension"
+        )


### PR DESCRIPTION
## What this is

Task 3 of the QU100 A/B testing substrate (`docs/DESIGN-qu100-ab-testing.md` §10.4–10.5). It lays down the two **contracts** the rest of the substrate plugs into: how you *describe* an experiment, and what a *result* looks like. It does not run experiments yet — the evaluator that emits scorecards is a sibling task.

## The problem it solves

The screener has tunable knobs (e.g. how much weight money-flow gets vs pin-bar patterns when ranking stocks). To A/B a knob change, you run the current config (**champion**) against a proposed config (**challenger**) over the same replay and compare. A challenger is just the champion config deep-merged with an `override`.

The trap: the existing merge path validates nothing, and `StockScreenerConfig(**merged)` **silently drops unknown kwargs**. So a typo'd override key — `layer_weight_money_flow` → `layer_weight_moneyflow` — produces a challenger *identical to the champion*. The A/B runs, reports "no difference," and you wrongly conclude the change didn't matter — when it was never applied. A green test that means nothing.

## The fix — two contracts

**1. Experiment spec interpreter (`research/experiment.py`, new)**
Parses a YAML spec (`config/experiments/*.yaml`: champion + challengers + one contended layer + reward keys + train/holdout window) into validated arm configs. Crucially, it validates **every override key itself** against `StockScreenerConfig.model_fields` + known pattern names *before* merging, and rejects the whole spec on any unknown key — the validation cannot be delegated downstream (the merge does none). Only then does it deep-merge via the existing `merge_stock_screener_config`. Mutually-exclusive challengers don't entangle.

Hardened beyond the happy path (via the review rounds) so every malformed input fails loud instead of parsing to garbage: duplicate YAML keys, reversed/overlapping windows, non-finite (`.nan`/`.inf`) values, bool-coerced-to-number, non-unique arm ids, and missing/malformed spec dirs.

**2. Scorecard contracts (`research/output_schema.yaml` + `.py`)**
A candidate-agnostic **base scorecard** (`candidate_id`, `window`, `corpus_hash`, reward-values-by-role, per-regime sub-scores, `deflated_sharpe` held `null` until the DSR task) so the no-LLM screener evaluator and a future LLM evaluator emit the *same* shape — LLM-only fields (cost, thesis-validity) live in an optional extension. Done **additively**: new schema entries + a composition serializer; the existing strict `validate()` and the LLM-shaped `backtest` schema are untouched.

## Scope boundaries

Deliberately owned by sibling tasks, not here: scorecard identity columns `experiment_id` / champion version (registry-promote, §10.5), reward-key validation (reward-registry #152), the evaluator that emits scorecards (replay-evaluator). This PR is `depends: none` and ships first so those build against a stable contract.

## Files

| File | Change |
|---|---|
| `research/experiment.py` | new — spec interpreter (708 lines) |
| `research/output_schema.yaml` / `.py` | additive — base + LLM-extension schemas, composition helper |
| `tests/research/test_experiment_spec.py` | new — 755 lines |
| `tests/research/test_output_schema.py` | new — 213 lines |
| `config/experiments/.gitkeep` | new — spec dir |

## Review

- `/review`: passed (Claude, 5 rounds)
- `codex review`: passed (6 rounds)
- Built TDD (red/green/refactor) + 11 review-fix commits. Full suite: 1805 passed, ruff clean.

## Deferred (P2/P3 — owned elsewhere or non-blocking)

- Scorecard identity fields `experiment_id` + champion version → registry-promote task (§10.5 owns identity columns)
- `rewards`/`regime_scores` nested-dict typing → evaluator task
- Reward-key validation → reward-registry #152
- Champion field resolution → shadow-arm task
- Model field range constraints → model-owned
- Minor: double `<<:` merge key in one mapping, `output_schema.load()` per-call re-parse, `format_block` multi-line str, DRY refactors, `load()` schemas-not-mapping TypeError

## Test plan

- [ ] CI green
- [ ] verify locally

Task plan: `docs/TASK-PLAN-ab-experiment-contracts-5a0f.md`

https://claude.ai/code/session_01SZbpkAuAXJy9oY1Tqr848j
