### PR TITLE
feat: generalized research/rewards registry for A/B substrate

### DIFF
--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -1,24 +1,188 @@
-"""Reward-function registry — concrete reward bodies land in Slice 1.
+"""Input-typed reward registry for the A/B substrate.
 
-Slice 0 ships the registry surface (an empty dict) so other modules can
-import it without breaking once Slice 1 lands the seven pre-registered
-reward functions (D-007).
+Design: docs/DESIGN-qu100-ab-testing.md §4.2, §10.3.
+
+A reward = a fact (the scored data) + an aggregation, declared as
+config-as-data. Each registered reward carries:
+
+  input_type  which candidate payload it can score —
+              "basket" (screener, BasketOutcomes) or "trades" (LLM,
+              TradeRecord series)
+  role        "primary" (the objective being optimized),
+              "guardrail" (blocks promotion on breach; carries threshold),
+              "secondary" (reported, not gating)
+  direction   "increase" (higher is better) or "decrease" (lower is better)
+  threshold   guardrail-only breach bound
+
+The registry REFUSES to score a candidate with a reward registered for a
+different input type — a loud ValueError, never silent mis-scoring (§4.2).
+
+Rewards are pure, deterministic, side-effect-free. The promote-time gate
+that consumes ``guardrail_breached`` is ab-registry-promote-84a7's scope.
+
+::
+
+    candidate payload ──► score(candidate_type, reward_name, payload)
+                              │
+                              ├─ input_type mismatch ──► ValueError (loud)
+                              └─ match ────────────────► spec.fn(payload)
 """
 
 from __future__ import annotations
 
-from typing import Callable
+from dataclasses import dataclass
+from typing import Any, Callable
 
-#: name → callable. Each callable takes a TradeRecord and returns a float.
-#: Slice 1 populates this with r_multiple_expectancy, all_call_R, etc.
-REGISTRY: dict[str, Callable] = {}
+INPUT_TYPES = frozenset({"basket", "trades"})
+ROLES = frozenset({"primary", "guardrail", "secondary"})
+DIRECTIONS = frozenset({"increase", "decrease"})
 
 
-def register(name: str, fn: Callable) -> Callable:
-    """Decorator-style registrar — placeholder for Slice 1."""
-    REGISTRY[name] = fn
-    return fn
+@dataclass(frozen=True)
+class RewardSpec:
+    """Registered reward: the callable plus its declarative metadata."""
+
+    name: str
+    fn: Callable[..., float]
+    input_type: str
+    role: str
+    direction: str
+    threshold: float | None = None
+
+
+#: name → RewardSpec. Populated by @register at import time (see the
+#: ``basket`` import at the bottom of this module) and by callers.
+REGISTRY: dict[str, RewardSpec] = {}
+
+
+def register(
+    name: str,
+    *,
+    input_type: str,
+    role: str,
+    direction: str,
+    threshold: float | None = None,
+) -> Callable[[Callable[..., float]], Callable[..., float]]:
+    """Decorator factory: declare a reward's metadata and register it.
+
+    Returns the function unwrapped, so the reward stays directly callable.
+    Guardrails must carry a threshold; other roles must not.
+    """
+    if input_type not in INPUT_TYPES:
+        raise ValueError(
+            f"reward {name!r}: unknown input_type {input_type!r} (expected one of "
+            f"{sorted(INPUT_TYPES)})"
+        )
+    if role not in ROLES:
+        raise ValueError(
+            f"reward {name!r}: unknown role {role!r} (expected one of {sorted(ROLES)})"
+        )
+    if direction not in DIRECTIONS:
+        raise ValueError(
+            f"reward {name!r}: unknown direction {direction!r} (expected one of "
+            f"{sorted(DIRECTIONS)})"
+        )
+    if role == "guardrail" and threshold is None:
+        raise ValueError(f"reward {name!r}: guardrail role requires a threshold")
+    if role != "guardrail" and threshold is not None:
+        raise ValueError(f"reward {name!r}: threshold is guardrail-only (role={role!r})")
+    if name in REGISTRY:
+        raise ValueError(f"reward {name!r} already registered")
+
+    def _decorator(fn: Callable[..., float]) -> Callable[..., float]:
+        REGISTRY[name] = RewardSpec(
+            name=name,
+            fn=fn,
+            input_type=input_type,
+            role=role,
+            direction=direction,
+            threshold=threshold,
+        )
+        return fn
+
+    return _decorator
+
+
+def get(name: str) -> RewardSpec:
+    """Look up a reward by name; unknown names raise with the known set."""
+    try:
+        return REGISTRY[name]
+    except KeyError:
+        raise ValueError(f"unknown reward {name!r}; registered: {names()}") from None
 
 
 def names() -> list[str]:
     return sorted(REGISTRY.keys())
+
+
+def score(candidate_type: str, reward_name: str, payload: Any, **kwargs: Any) -> float:
+    """Score a candidate's payload with a named reward.
+
+    Refuses an input_type mismatch (e.g. a ``trades`` reward applied to a
+    screener ``basket``) with a loud ValueError — no silent mis-scoring.
+    Extra kwargs (e.g. ``horizon=``) are forwarded to the reward.
+    """
+    spec = get(reward_name)
+    if spec.input_type != candidate_type:
+        raise ValueError(
+            f"reward {reward_name!r} has input_type {spec.input_type!r}; "
+            f"refusing to score a {candidate_type!r} candidate"
+        )
+    return spec.fn(payload, **kwargs)
+
+
+def guardrail_breached(reward_name: str, value: float) -> bool:
+    """Flag a guardrail breach: ``value`` vs the spec's threshold + direction.
+
+    direction="decrease" (lower is better): breach when value > threshold.
+    direction="increase" (higher is better): breach when value < threshold.
+    At-threshold is clean. Non-guardrail rewards are rejected.
+    """
+    spec = get(reward_name)
+    if spec.role != "guardrail":
+        raise ValueError(f"reward {reward_name!r} is not a guardrail (role={spec.role!r})")
+    assert spec.threshold is not None  # enforced at registration
+    if spec.direction == "decrease":
+        return value > spec.threshold
+    return value < spec.threshold
+
+
+def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
+    """Compose two registered aggregations into a ratio reward (§4.2).
+
+    Both must share an input_type. A zero denominator yields 0.0 (never a
+    ZeroDivisionError mid-evaluation). Register the result under its own
+    name to make it selectable.
+    """
+    num, den = get(numerator), get(denominator)
+    if num.input_type != den.input_type:
+        raise ValueError(
+            f"ratio {numerator!r}/{denominator!r}: input_type mismatch "
+            f"({num.input_type!r} vs {den.input_type!r})"
+        )
+
+    def _ratio(payload: Any, **kwargs: Any) -> float:
+        d = den.fn(payload, **kwargs)
+        if d == 0.0:
+            return 0.0
+        return num.fn(payload, **kwargs) / d
+
+    return _ratio
+
+
+# Import for side effect: registers the screener basket reward set.
+from rainier.research.rewards import basket as _basket  # noqa: E402,F401
+
+__all__ = [
+    "DIRECTIONS",
+    "INPUT_TYPES",
+    "REGISTRY",
+    "ROLES",
+    "RewardSpec",
+    "get",
+    "guardrail_breached",
+    "make_ratio",
+    "names",
+    "register",
+    "score",
+]

--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -103,6 +103,14 @@ def register(
         # before either decorator is applied must not silently clobber.
         if name in REGISTRY:
             raise ValueError(f"reward {name!r} already registered")
+        if role == "guardrail" and getattr(fn, "_is_ratio", False):
+            # A ratio's ±inf zero-denominator sentinel collides with
+            # guardrail_breached's non-finite rejection: the promote gate
+            # would raise on the BEST candidate instead of passing it.
+            raise ValueError(
+                f"reward {name!r}: ratio rewards cannot be guardrails "
+                f"(±inf sentinel vs non-finite rejection)"
+            )
         REGISTRY[name] = RewardSpec(
             name=name,
             fn=fn,
@@ -183,9 +191,10 @@ def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
     0/0 → 0.0 (no data). Register the result under its own name to make
     it selectable.
 
-    Do NOT register a ratio as a guardrail: the ``inf`` sentinel collides
-    with ``guardrail_breached``'s non-finite rejection — the promote gate
-    would raise on the best candidate instead of passing it.
+    Ratios cannot be registered as guardrails — register() rejects the
+    combination: the ``inf`` sentinel collides with ``guardrail_breached``'s
+    non-finite rejection (the promote gate would raise on the best
+    candidate instead of passing it).
     """
     num, den = get(numerator), get(denominator)
     if num.input_type != den.input_type:
@@ -204,6 +213,7 @@ def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
         return num.fn(payload, **kwargs) / d
 
     _ratio.__name__ = f"ratio_{numerator}_over_{denominator}"
+    _ratio._is_ratio = True  # register() rejects guardrail role for ratios
     return _ratio
 
 

--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -111,6 +111,15 @@ def register(
                 f"reward {name!r}: ratio rewards cannot be guardrails "
                 f"(±inf sentinel vs non-finite rejection)"
             )
+        fn_input_type = getattr(fn, "_input_type", None)
+        if fn_input_type is not None and fn_input_type != input_type:
+            # A make_ratio closure carries its constituents' input_type;
+            # registering it under a different one would let score() route
+            # the wrong payload into the aggregators (silent mis-scoring).
+            raise ValueError(
+                f"reward {name!r}: fn is bound to input_type {fn_input_type!r}, "
+                f"cannot register as {input_type!r}"
+            )
         REGISTRY[name] = RewardSpec(
             name=name,
             fn=fn,
@@ -214,6 +223,7 @@ def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
 
     _ratio.__name__ = f"ratio_{numerator}_over_{denominator}"
     _ratio._is_ratio = True  # register() rejects guardrail role for ratios
+    _ratio._input_type = num.input_type  # register() enforces matching input_type
     return _ratio
 
 

--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -86,6 +86,13 @@ def register(
         )
     if role == "guardrail" and threshold is None:
         raise ValueError(f"reward {name!r}: guardrail role requires a threshold")
+    if role == "guardrail" and threshold is not None and not math.isfinite(threshold):
+        # NaN threshold fails every >/< comparison -> guardrail silently
+        # never breaches; inf is "unbounded" better expressed by not being
+        # a guardrail at all. Same failure family as non-finite values.
+        raise ValueError(
+            f"reward {name!r}: guardrail threshold must be finite (got {threshold!r})"
+        )
     if role != "guardrail" and threshold is not None:
         raise ValueError(f"reward {name!r}: threshold is guardrail-only (role={role!r})")
     if name in REGISTRY:
@@ -175,6 +182,10 @@ def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
     flawless candidate ranks first, not last), negative → ``-inf``, and
     0/0 → 0.0 (no data). Register the result under its own name to make
     it selectable.
+
+    Do NOT register a ratio as a guardrail: the ``inf`` sentinel collides
+    with ``guardrail_breached``'s non-finite rejection — the promote gate
+    would raise on the best candidate instead of passing it.
     """
     num, den = get(numerator), get(denominator)
     if num.input_type != den.input_type:

--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -30,6 +30,7 @@ that consumes ``guardrail_breached`` is ab-registry-promote-84a7's scope.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -50,8 +51,9 @@ class RewardSpec:
     threshold: float | None = None
 
 
-#: name → RewardSpec. Populated by @register at import time (see the
-#: ``basket`` import at the bottom of this module) and by callers.
+#: name → RewardSpec. Populated ONLY via @register (see the ``basket``
+#: import at the bottom of this module). Never insert directly — register()
+#: is the sole write path; it enforces every metadata invariant.
 REGISTRY: dict[str, RewardSpec] = {}
 
 
@@ -90,6 +92,10 @@ def register(
         raise ValueError(f"reward {name!r} already registered")
 
     def _decorator(fn: Callable[..., float]) -> Callable[..., float]:
+        # Re-check at insertion time: two register(...) factories obtained
+        # before either decorator is applied must not silently clobber.
+        if name in REGISTRY:
+            raise ValueError(f"reward {name!r} already registered")
         REGISTRY[name] = RewardSpec(
             name=name,
             fn=fn,
@@ -122,6 +128,11 @@ def score(candidate_type: str, reward_name: str, payload: Any, **kwargs: Any) ->
     screener ``basket``) with a loud ValueError — no silent mis-scoring.
     Extra kwargs (e.g. ``horizon=``) are forwarded to the reward.
     """
+    if candidate_type not in INPUT_TYPES:
+        raise ValueError(
+            f"unknown candidate_type {candidate_type!r} (expected one of "
+            f"{sorted(INPUT_TYPES)})"
+        )
     spec = get(reward_name)
     if spec.input_type != candidate_type:
         raise ValueError(
@@ -136,12 +147,21 @@ def guardrail_breached(reward_name: str, value: float) -> bool:
 
     direction="decrease" (lower is better): breach when value > threshold.
     direction="increase" (higher is better): breach when value < threshold.
-    At-threshold is clean. Non-guardrail rewards are rejected.
+    At-threshold is clean. Non-guardrail rewards are rejected. A non-finite
+    value (NaN/inf) is corrupt input and raises — NaN fails every ``>``/``<``
+    comparison, so it would otherwise read as "clean" and silently disarm
+    the guardrail (§4.2: loud, never silent).
     """
     spec = get(reward_name)
     if spec.role != "guardrail":
         raise ValueError(f"reward {reward_name!r} is not a guardrail (role={spec.role!r})")
-    assert spec.threshold is not None  # enforced at registration
+    if spec.threshold is None:  # unreachable via register(); guards direct REGISTRY writes
+        raise ValueError(f"guardrail {reward_name!r} has no threshold")
+    if not math.isfinite(value):
+        raise ValueError(
+            f"guardrail {reward_name!r}: non-finite value {value!r} — refusing to "
+            f"evaluate breach on corrupt input"
+        )
     if spec.direction == "decrease":
         return value > spec.threshold
     return value < spec.threshold
@@ -150,9 +170,11 @@ def guardrail_breached(reward_name: str, value: float) -> bool:
 def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
     """Compose two registered aggregations into a ratio reward (§4.2).
 
-    Both must share an input_type. A zero denominator yields 0.0 (never a
-    ZeroDivisionError mid-evaluation). Register the result under its own
-    name to make it selectable.
+    Both must share an input_type. Zero denominator is sign-aware (never a
+    ZeroDivisionError mid-evaluation): positive numerator → ``inf`` (a
+    flawless candidate ranks first, not last), negative → ``-inf``, and
+    0/0 → 0.0 (no data). Register the result under its own name to make
+    it selectable.
     """
     num, den = get(numerator), get(denominator)
     if num.input_type != den.input_type:
@@ -164,9 +186,13 @@ def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
     def _ratio(payload: Any, **kwargs: Any) -> float:
         d = den.fn(payload, **kwargs)
         if d == 0.0:
-            return 0.0
+            n = num.fn(payload, **kwargs)
+            if n == 0.0:
+                return 0.0
+            return math.inf if n > 0 else -math.inf
         return num.fn(payload, **kwargs) / d
 
+    _ratio.__name__ = f"ratio_{numerator}_over_{denominator}"
     return _ratio
 
 

--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -213,13 +213,22 @@ def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
         )
 
     def _ratio(payload: Any, **kwargs: Any) -> float:
+        n = num.fn(payload, **kwargs)
         d = den.fn(payload, **kwargs)
+        # A non-finite constituent would launder NaN/±inf straight into a
+        # candidate score: NaN/1.0 -> NaN, NaN/0.0 -> -inf (NaN>0 is False).
+        # The aggregators self-reject non-finite, but make_ratio composes ANY
+        # registered reward, so guard here too — loud, never silent (§4.2).
+        if not math.isfinite(n) or not math.isfinite(d):
+            raise ValueError(
+                f"ratio {numerator!r}/{denominator!r}: non-finite constituent "
+                f"(numerator={n!r}, denominator={d!r}) — refusing to aggregate"
+            )
         if d == 0.0:
-            n = num.fn(payload, **kwargs)
             if n == 0.0:
                 return 0.0
             return math.inf if n > 0 else -math.inf
-        return num.fn(payload, **kwargs) / d
+        return n / d
 
     _ratio.__name__ = f"ratio_{numerator}_over_{denominator}"
     _ratio._is_ratio = True  # register() rejects guardrail role for ratios

--- a/src/rainier/research/rewards/basket.py
+++ b/src/rainier/research/rewards/basket.py
@@ -63,6 +63,24 @@ def _require_horizon(outcomes: BasketOutcomes, horizon: int) -> None:
         )
 
 
+def _reject_duplicate_symbols(day: BasketDay) -> None:
+    """A rank-ordered selection must not list a symbol twice (design §10.3).
+
+    A duplicate would double-weight that symbol in every equal-weight mean and,
+    worse, EVADE the turnover guardrail — turnover's numerator dedups via
+    ``set`` while its denominator counts duplicates, so padding the basket with
+    repeats reports a fraction below the true replacement rate and slips under
+    the threshold. Same malformed-payload family as the missing-key guard:
+    loud, never silent (§4.2).
+    """
+    if len(set(day.symbols)) != len(day.symbols):
+        dupes = sorted({s for s in day.symbols if day.symbols.count(s) > 1})
+        raise ValueError(
+            f"duplicate symbols {dupes} in selected basket on {day.date} — "
+            f"malformed payload (a rank-ordered selection must be unique)"
+        )
+
+
 def _day_returns(outcomes: BasketOutcomes, horizon: int) -> list[float]:
     """Equal-weight basket return per day; days with no data are skipped.
 
@@ -73,6 +91,7 @@ def _day_returns(outcomes: BasketOutcomes, horizon: int) -> list[float]:
     _require_horizon(outcomes, horizon)
     out: list[float] = []
     for day in outcomes.days:
+        _reject_duplicate_symbols(day)
         if horizon not in day.fwd_return:
             continue  # this day lacks the horizon entirely — skipped, like None
         returns = day.fwd_return[horizon]
@@ -158,6 +177,8 @@ def turnover(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
     Horizon-independent (basket composition only); the parameter exists so
     every basket reward shares one call shape.
     """
+    for day in outcomes.days:
+        _reject_duplicate_symbols(day)
     days = [d for d in outcomes.days if d.symbols]
     if len(days) < 2:
         return 0.0
@@ -180,6 +201,7 @@ def dodged_loss(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> flo
     _require_horizon(outcomes, horizon)
     total = 0.0
     for day in outcomes.days:
+        _reject_duplicate_symbols(day)
         selected = set(day.symbols)
         for symbol, ret in day.fwd_return.get(horizon, {}).items():
             if ret is not None and not math.isfinite(ret):

--- a/src/rainier/research/rewards/basket.py
+++ b/src/rainier/research/rewards/basket.py
@@ -73,8 +73,20 @@ def _day_returns(outcomes: BasketOutcomes, horizon: int) -> list[float]:
     _require_horizon(outcomes, horizon)
     out: list[float] = []
     for day in outcomes.days:
-        returns = day.fwd_return.get(horizon, {})
-        available = [r for s in day.symbols if (r := returns.get(s)) is not None]
+        if horizon not in day.fwd_return:
+            continue  # this day lacks the horizon entirely — skipped, like None
+        returns = day.fwd_return[horizon]
+        # Contract (§10.3): a selected symbol with no return is emitted as
+        # None, never omitted. A missing KEY is a malformed payload —
+        # silently dropping it from the equal-weight mean would bias every
+        # basket metric (loud, never silent).
+        missing = [s for s in day.symbols if s not in returns]
+        if missing:
+            raise ValueError(
+                f"selected symbols {missing} absent from fwd_return[{horizon}] on "
+                f"{day.date} — malformed payload (emit None for no-data symbols)"
+            )
+        available = [r for s in day.symbols if (r := returns[s]) is not None]
         for r in available:
             if not math.isfinite(r):
                 raise ValueError(

--- a/src/rainier/research/rewards/basket.py
+++ b/src/rainier/research/rewards/basket.py
@@ -52,7 +52,7 @@ def _day_returns(outcomes: BasketOutcomes, horizon: int) -> list[float]:
     out: list[float] = []
     for day in outcomes.days:
         returns = day.fwd_return.get(horizon, {})
-        available = [returns[s] for s in day.symbols if returns.get(s) is not None]
+        available = [r for s in day.symbols if (r := returns.get(s)) is not None]
         if available:
             out.append(sum(available) / len(available))
     return out

--- a/src/rainier/research/rewards/basket.py
+++ b/src/rainier/research/rewards/basket.py
@@ -1,0 +1,146 @@
+"""BasketOutcomes (design §10.3, pinned) + the screener basket reward set.
+
+``BasketOutcomes`` is what the replay evaluator (ab-replay-evaluator-edb5)
+emits per candidate: one ``BasketDay`` per selection day, carrying the
+selected symbols in rank order and forward returns per horizon. Forward
+returns are ``None`` near the window end — never 0 — and every aggregation
+here EXCLUDES ``None`` entries rather than zeroing them.
+
+All rewards are pure and deterministic. Per-day basket return = equal-weight
+mean of the selected symbols' non-None forward returns at the chosen
+horizon; days with no available return are skipped entirely (they do not
+enter any mean, stdev, or hit-rate denominator).
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from datetime import date as date_type
+
+from rainier.research.rewards import register
+
+#: Default forward-return horizon (trading days) used by the basket rewards.
+DEFAULT_HORIZON = 5
+
+#: Guardrail bounds consumed by the promote-time gate (ab-registry-promote-84a7).
+#: max_drawdown: peak-to-trough fraction of basket equity; breach above 20%.
+MAX_DRAWDOWN_THRESHOLD = 0.20
+#: turnover: mean day-over-day fraction of the basket replaced; breach above 50%.
+TURNOVER_THRESHOLD = 0.50
+
+
+@dataclass(frozen=True)
+class BasketDay:
+    """One selection day t (design §10.3, pinned)."""
+
+    date: date_type
+    symbols: list[str]  # selected basket, rank order
+    fwd_return: dict[int, dict[str, float | None]]  # H → symbol → return; None near window end
+    regime: str  # from compute_market_regime
+
+
+@dataclass(frozen=True)
+class BasketOutcomes:
+    """Per-day basket + forward returns for one candidate over one window."""
+
+    days: list[BasketDay]
+
+
+def _day_returns(outcomes: BasketOutcomes, horizon: int) -> list[float]:
+    """Equal-weight basket return per day; days with no data are skipped."""
+    out: list[float] = []
+    for day in outcomes.days:
+        returns = day.fwd_return.get(horizon, {})
+        available = [returns[s] for s in day.symbols if returns.get(s) is not None]
+        if available:
+            out.append(sum(available) / len(available))
+    return out
+
+
+@register("total_return", input_type="basket", role="secondary", direction="increase")
+def total_return(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
+    """Arithmetic sum of per-day equal-weight basket returns."""
+    return sum(_day_returns(outcomes, horizon))
+
+
+@register("sharpe", input_type="basket", role="primary", direction="increase")
+def sharpe(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
+    """Mean over sample stdev (ddof=1) of daily basket returns; 0.0 if undefined."""
+    day_returns = _day_returns(outcomes, horizon)
+    if len(day_returns) < 2:
+        return 0.0
+    stdev = statistics.stdev(day_returns)
+    if stdev == 0.0:
+        return 0.0
+    return statistics.mean(day_returns) / stdev
+
+
+@register("hit_rate", input_type="basket", role="secondary", direction="increase")
+def hit_rate(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
+    """Fraction of aggregated days with a positive basket return."""
+    day_returns = _day_returns(outcomes, horizon)
+    if not day_returns:
+        return 0.0
+    return sum(1 for r in day_returns if r > 0) / len(day_returns)
+
+
+@register(
+    "max_drawdown",
+    input_type="basket",
+    role="guardrail",
+    direction="decrease",
+    threshold=MAX_DRAWDOWN_THRESHOLD,
+)
+def max_drawdown(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
+    """Max peak-to-trough decline of compounded basket equity, as a positive fraction."""
+    equity = 1.0
+    peak = 1.0
+    worst = 0.0
+    for r in _day_returns(outcomes, horizon):
+        equity *= 1.0 + r
+        peak = max(peak, equity)
+        worst = max(worst, (peak - equity) / peak)
+    return worst
+
+
+@register(
+    "turnover",
+    input_type="basket",
+    role="guardrail",
+    direction="decrease",
+    threshold=TURNOVER_THRESHOLD,
+)
+def turnover(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
+    """Mean day-over-day fraction of the basket replaced.
+
+    For consecutive days (t-1, t): |symbols_t \\ symbols_{t-1}| / |symbols_t|.
+    Horizon-independent (basket composition only); the parameter exists so
+    every basket reward shares one call shape.
+    """
+    days = [d for d in outcomes.days if d.symbols]
+    if len(days) < 2:
+        return 0.0
+    fractions = []
+    for prev, curr in zip(days, days[1:]):
+        entered = set(curr.symbols) - set(prev.symbols)
+        fractions.append(len(entered) / len(curr.symbols))
+    return sum(fractions) / len(fractions)
+
+
+@register("dodged_loss", input_type="basket", role="secondary", direction="increase")
+def dodged_loss(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
+    """Sum of losses avoided by NOT selecting a symbol.
+
+    For each day, sums |negative forward return| over symbols present in
+    ``fwd_return[H]`` but absent from the selected basket. Requires the
+    evaluator to populate ``fwd_return`` with the wider screened pool; if it
+    only carries the selected symbols, dodged_loss is 0.0.
+    """
+    total = 0.0
+    for day in outcomes.days:
+        selected = set(day.symbols)
+        for symbol, ret in day.fwd_return.get(horizon, {}).items():
+            if symbol not in selected and ret is not None and ret < 0:
+                total += -ret
+    return total

--- a/src/rainier/research/rewards/basket.py
+++ b/src/rainier/research/rewards/basket.py
@@ -14,6 +14,7 @@ enter any mean, stdev, or hit-rate denominator).
 
 from __future__ import annotations
 
+import math
 import statistics
 from dataclasses import dataclass
 from datetime import date as date_type
@@ -47,12 +48,39 @@ class BasketOutcomes:
     days: list[BasketDay]
 
 
+def _require_horizon(outcomes: BasketOutcomes, horizon: int) -> None:
+    """Raise when a horizon is absent from EVERY day (config typo, §4.2 loud).
+
+    Silently returning 0.0 for a typo'd/unconfigured horizon would make every
+    candidate score 0.0 with clean guardrails — valid-looking noise. Days may
+    individually lack the key (skipped, like None returns); all-absent with a
+    non-empty window is a configuration error.
+    """
+    if outcomes.days and not any(horizon in day.fwd_return for day in outcomes.days):
+        known = sorted({h for day in outcomes.days for h in day.fwd_return})
+        raise ValueError(
+            f"horizon {horizon} absent from every BasketDay (available horizons: {known})"
+        )
+
+
 def _day_returns(outcomes: BasketOutcomes, horizon: int) -> list[float]:
-    """Equal-weight basket return per day; days with no data are skipped."""
+    """Equal-weight basket return per day; days with no data are skipped.
+
+    Non-finite returns (NaN/inf, e.g. from a corrupt upstream price) raise:
+    NaN propagates through mean/stdev/drawdown comparisons in ways that read
+    as "clean" (NaN fails every ``>``), silently disarming guardrails.
+    """
+    _require_horizon(outcomes, horizon)
     out: list[float] = []
     for day in outcomes.days:
         returns = day.fwd_return.get(horizon, {})
         available = [r for s in day.symbols if (r := returns.get(s)) is not None]
+        for r in available:
+            if not math.isfinite(r):
+                raise ValueError(
+                    f"non-finite forward return {r!r} on {day.date} (horizon {horizon}) — "
+                    f"corrupt input, refusing to aggregate"
+                )
         if available:
             out.append(sum(available) / len(available))
     return out
@@ -137,10 +165,16 @@ def dodged_loss(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> flo
     evaluator to populate ``fwd_return`` with the wider screened pool; if it
     only carries the selected symbols, dodged_loss is 0.0.
     """
+    _require_horizon(outcomes, horizon)
     total = 0.0
     for day in outcomes.days:
         selected = set(day.symbols)
         for symbol, ret in day.fwd_return.get(horizon, {}).items():
+            if ret is not None and not math.isfinite(ret):
+                raise ValueError(
+                    f"non-finite forward return {ret!r} for {symbol} on {day.date} "
+                    f"(horizon {horizon}) — corrupt input, refusing to aggregate"
+                )
             if symbol not in selected and ret is not None and ret < 0:
                 total += -ret
     return total

--- a/tests/research/test_rewards.py
+++ b/tests/research/test_rewards.py
@@ -353,6 +353,25 @@ class TestNoneHandling:
         # total_return pins this: 0.06 - 0.04 + 0.06 = 0.08.
         assert score("basket", "total_return", basket) == pytest.approx(0.08)
 
+    def test_selected_symbol_missing_from_map_raises(self):
+        # Regression (codex): a selected symbol whose KEY is absent from
+        # fwd_return[H] used to be silently dropped from the equal-weight
+        # mean (0.10 instead of loud failure). §10.3 pins "None, never
+        # omitted" for no-data symbols — a missing key is malformed.
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA", "BBB"],
+                    fwd_return={5: {"AAA": 0.10}},  # BBB key omitted, not None
+                    regime="bull",
+                ),
+            ]
+        )
+        for name in ("total_return", "sharpe", "hit_rate", "max_drawdown"):
+            with pytest.raises(ValueError, match="BBB"):
+                score("basket", name, outcomes)
+
 
 # ---------------------------------------------------------------------------
 # Non-finite input rejection (§4.2: loud, never silent)
@@ -528,6 +547,21 @@ class TestRatio:
     def test_ratio_closure_has_descriptive_name(self):
         fn = make_ratio("total_return", "max_drawdown")
         assert fn.__name__ == "ratio_total_return_over_max_drawdown"
+
+    def test_ratio_cannot_be_registered_as_guardrail(self):
+        # Regression (codex): the ratio ±inf sentinel collides with
+        # guardrail_breached's non-finite rejection — the promote gate
+        # would crash on the BEST candidate. register() must refuse.
+        fn = make_ratio("total_return", "max_drawdown")
+        with pytest.raises(ValueError, match="guardrail"):
+            register(
+                "ratio_guard",
+                input_type="basket",
+                role="guardrail",
+                direction="decrease",
+                threshold=0.5,
+            )(fn)
+        assert "ratio_guard" not in names()  # nothing half-registered
 
     def test_ratio_requires_matching_input_types(self):
         @register("trades_num", input_type="trades", role="secondary", direction="increase")

--- a/tests/research/test_rewards.py
+++ b/tests/research/test_rewards.py
@@ -181,6 +181,19 @@ class TestRegister:
         with pytest.raises(ValueError, match="threshold"):
             register("bad", input_type="basket", role="guardrail", direction="decrease")
 
+    def test_guardrail_non_finite_threshold_rejected(self):
+        # Regression: a NaN threshold fails every >/< comparison, so the
+        # guardrail would silently never breach.
+        for bad in (math.nan, math.inf, -math.inf):
+            with pytest.raises(ValueError, match="finite"):
+                register(
+                    "bad",
+                    input_type="basket",
+                    role="guardrail",
+                    direction="decrease",
+                    threshold=bad,
+                )
+
     def test_non_guardrail_with_threshold_rejected(self):
         with pytest.raises(ValueError, match="threshold"):
             register(

--- a/tests/research/test_rewards.py
+++ b/tests/research/test_rewards.py
@@ -374,6 +374,55 @@ class TestNoneHandling:
 
 
 # ---------------------------------------------------------------------------
+# Duplicate-symbol rejection (§4.2: loud, never silent)
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateSymbols:
+    def test_duplicate_symbol_raises_for_aggregations(self):
+        # Regression (review): a symbol listed twice used to double-weight the
+        # equal-weight mean silently — total_return (0.30+0.30+0)/3 = 0.20
+        # instead of the deduped 0.15.
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA", "AAA", "BBB"],
+                    fwd_return={5: {"AAA": 0.30, "BBB": 0.00}},
+                    regime="bull",
+                ),
+            ]
+        )
+        for name in ("total_return", "sharpe", "hit_rate", "max_drawdown", "dodged_loss"):
+            with pytest.raises(ValueError, match="duplicate symbols"):
+                score("basket", name, outcomes)
+
+    def test_duplicate_symbols_cannot_evade_turnover_guardrail(self):
+        # Regression (review): turnover's numerator dedups via set() while its
+        # denominator counts duplicates, so padding a 100%-replaced basket with
+        # repeats reported 0.333 — under the 0.50 guardrail it should breach.
+        # The duplicate payload must now raise, never silently disarm.
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["A", "B"],
+                    fwd_return={5: {"A": 0.01, "B": 0.01}},
+                    regime="bull",
+                ),
+                BasketDay(
+                    date=date(2026, 1, 6),
+                    symbols=["C", "D", "C", "D", "C", "D"],
+                    fwd_return={5: {"C": 0.01, "D": 0.01}},
+                    regime="bull",
+                ),
+            ]
+        )
+        with pytest.raises(ValueError, match="duplicate symbols"):
+            score("basket", "turnover", outcomes)
+
+
+# ---------------------------------------------------------------------------
 # Non-finite input rejection (§4.2: loud, never silent)
 # ---------------------------------------------------------------------------
 
@@ -593,6 +642,35 @@ class TestRatio:
                 direction="increase",
             )(fn)
         assert "ratio_wrong_type" not in names()
+
+    def test_ratio_rejects_non_finite_constituent(self):
+        # Regression (review): make_ratio composes ANY registered reward, and a
+        # non-finite constituent used to launder straight into a score
+        # (nan/1.0 -> nan, nan/0.0 -> -inf since nan>0 is False) — corrupt input
+        # silently ranking a candidate. The shipped basket rewards self-reject,
+        # so use custom aggregations to exercise the composer's own guard.
+        @register("nan_const", input_type="basket", role="secondary", direction="increase")
+        def nan_const(outcomes, **kwargs):
+            return math.nan
+
+        @register("one_const", input_type="basket", role="secondary", direction="increase")
+        def one_const(outcomes, **kwargs):
+            return 1.0
+
+        @register("zero_const2", input_type="basket", role="secondary", direction="increase")
+        def zero_const2(outcomes, **kwargs):
+            return 0.0
+
+        outcomes = BasketOutcomes(days=[])
+        # non-finite numerator, finite (non-zero) denominator -> would be nan
+        with pytest.raises(ValueError, match="non-finite constituent"):
+            make_ratio("nan_const", "one_const")(outcomes)
+        # non-finite numerator, zero denominator -> would be silently sentinel'd
+        with pytest.raises(ValueError, match="non-finite constituent"):
+            make_ratio("nan_const", "zero_const2")(outcomes)
+        # non-finite denominator -> would be nan
+        with pytest.raises(ValueError, match="non-finite constituent"):
+            make_ratio("one_const", "nan_const")(outcomes)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/research/test_rewards.py
+++ b/tests/research/test_rewards.py
@@ -1,0 +1,376 @@
+"""Tests for the generalized reward registry + screener basket rewards.
+
+Design: docs/DESIGN-qu100-ab-testing.md §4.2, §10.3, §11.2
+Task plan: docs/TASK-PLAN-ab-reward-registry-b3b8.md
+
+Fixture baskets are constructed by hand (no evaluator dependency — that is
+ab-replay-evaluator-edb5's scope) and every shipped reward is pinned to a
+hand-computed expected value.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from rainier.research import rewards
+from rainier.research.rewards import (
+    REGISTRY,
+    RewardSpec,
+    get,
+    guardrail_breached,
+    make_ratio,
+    names,
+    register,
+    score,
+)
+from rainier.research.rewards.basket import BasketDay, BasketOutcomes
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _registry_guard():
+    """Snapshot/restore REGISTRY so test-registered rewards never leak."""
+    snapshot = dict(REGISTRY)
+    yield
+    REGISTRY.clear()
+    REGISTRY.update(snapshot)
+
+
+@pytest.fixture
+def basket() -> BasketOutcomes:
+    """Hand-computed three-day fixture.
+
+    Per-day equal-weight basket returns at H=5 (selected, non-None only):
+      d1: (0.10 + 0.02) / 2 = 0.06
+      d2: (0.04 - 0.12) / 2 = -0.04
+      d3: BBB is None -> only DDD  = 0.06
+
+    Hand-computed expectations:
+      total_return = 0.06 - 0.04 + 0.06                  = 0.08
+      sharpe       = mean/stdev(ddof=1) = 0.0266667/0.0577350 = 0.4618802
+      hit_rate     = 2 positive days / 3                 = 2/3
+      max_drawdown = 1.06 -> 1.0176 peak-to-trough       = 0.04
+      turnover     = mean(1/2, 2/2)                      = 0.75
+      dodged_loss  = |−0.08| (CCC d1) + |−0.05| (DDD d2) = 0.13
+    """
+    return BasketOutcomes(
+        days=[
+            BasketDay(
+                date=date(2026, 1, 5),
+                symbols=["AAA", "BBB"],
+                fwd_return={5: {"AAA": 0.10, "BBB": 0.02, "CCC": -0.08}},
+                regime="bull",
+            ),
+            BasketDay(
+                date=date(2026, 1, 6),
+                symbols=["AAA", "CCC"],
+                fwd_return={5: {"AAA": 0.04, "CCC": -0.12, "DDD": -0.05}},
+                regime="bull",
+            ),
+            BasketDay(
+                date=date(2026, 1, 7),
+                symbols=["BBB", "DDD"],
+                fwd_return={5: {"BBB": None, "DDD": 0.06, "EEE": 0.03}},
+                regime="bear",
+            ),
+        ]
+    )
+
+
+@pytest.fixture
+def empty_basket() -> BasketOutcomes:
+    return BasketOutcomes(days=[])
+
+
+# ---------------------------------------------------------------------------
+# Registration + metadata
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+    def test_register_new_basket_reward_selectable_with_metadata(self):
+        @register("my_reward", input_type="basket", role="secondary", direction="increase")
+        def my_reward(outcomes: BasketOutcomes) -> float:
+            return 1.0
+
+        assert "my_reward" in names()
+        spec = get("my_reward")
+        assert isinstance(spec, RewardSpec)
+        assert spec.input_type == "basket"
+        assert spec.role == "secondary"
+        assert spec.direction == "increase"
+        assert spec.threshold is None
+        assert spec.fn is my_reward  # decorator returns the fn unwrapped
+
+    def test_register_guardrail_carries_threshold(self):
+        @register(
+            "my_guardrail",
+            input_type="basket",
+            role="guardrail",
+            direction="decrease",
+            threshold=0.3,
+        )
+        def my_guardrail(outcomes: BasketOutcomes) -> float:
+            return 0.0
+
+        assert get("my_guardrail").threshold == 0.3
+
+    def test_duplicate_name_rejected(self):
+        @register("dup", input_type="basket", role="secondary", direction="increase")
+        def first(outcomes):
+            return 0.0
+
+        with pytest.raises(ValueError, match="dup"):
+
+            @register("dup", input_type="basket", role="secondary", direction="increase")
+            def second(outcomes):
+                return 0.0
+
+    def test_invalid_input_type_rejected(self):
+        with pytest.raises(ValueError, match="input_type"):
+            register("bad", input_type="portfolio", role="primary", direction="increase")
+
+    def test_invalid_role_rejected(self):
+        with pytest.raises(ValueError, match="role"):
+            register("bad", input_type="basket", role="tertiary", direction="increase")
+
+    def test_invalid_direction_rejected(self):
+        with pytest.raises(ValueError, match="direction"):
+            register("bad", input_type="basket", role="primary", direction="up")
+
+    def test_guardrail_without_threshold_rejected(self):
+        with pytest.raises(ValueError, match="threshold"):
+            register("bad", input_type="basket", role="guardrail", direction="decrease")
+
+    def test_non_guardrail_with_threshold_rejected(self):
+        with pytest.raises(ValueError, match="threshold"):
+            register(
+                "bad", input_type="basket", role="primary", direction="increase", threshold=0.1
+            )
+
+    def test_get_unknown_name_raises_with_known_names(self):
+        with pytest.raises(ValueError, match="no_such_reward"):
+            get("no_such_reward")
+
+
+# ---------------------------------------------------------------------------
+# Input-type refusal (§4.2: no silent mis-scoring)
+# ---------------------------------------------------------------------------
+
+
+class TestInputTypeRefusal:
+    def test_trades_reward_refuses_basket_candidate(self, basket):
+        @register("trades_only", input_type="trades", role="primary", direction="increase")
+        def trades_only(records) -> float:
+            return 1.0
+
+        with pytest.raises(ValueError, match="input_type"):
+            score("basket", "trades_only", basket)
+
+    def test_basket_reward_refuses_trades_candidate(self):
+        with pytest.raises(ValueError, match="input_type"):
+            score("trades", "sharpe", [])
+
+    def test_matching_input_type_scores(self, basket):
+        assert score("basket", "total_return", basket) == pytest.approx(0.08)
+
+
+# ---------------------------------------------------------------------------
+# Shipped basket rewards — hand-computed fixtures
+# ---------------------------------------------------------------------------
+
+
+class TestShippedRewards:
+    def test_shipped_set_registered(self):
+        expected = {
+            "total_return",
+            "sharpe",
+            "hit_rate",
+            "max_drawdown",
+            "turnover",
+            "dodged_loss",
+        }
+        assert expected <= set(names())
+        for name in expected:
+            assert get(name).input_type == "basket"
+
+    def test_roles_and_directions(self):
+        assert get("sharpe").role == "primary"
+        assert get("max_drawdown").role == "guardrail"
+        assert get("max_drawdown").direction == "decrease"
+        assert get("max_drawdown").threshold is not None
+        assert get("turnover").role == "guardrail"
+        assert get("turnover").direction == "decrease"
+        assert get("turnover").threshold is not None
+        assert get("total_return").direction == "increase"
+        assert get("dodged_loss").direction == "increase"
+
+    def test_total_return(self, basket):
+        assert score("basket", "total_return", basket) == pytest.approx(0.08)
+
+    def test_sharpe(self, basket):
+        assert score("basket", "sharpe", basket) == pytest.approx(0.4618802, abs=1e-6)
+
+    def test_hit_rate(self, basket):
+        assert score("basket", "hit_rate", basket) == pytest.approx(2 / 3)
+
+    def test_max_drawdown(self, basket):
+        assert score("basket", "max_drawdown", basket) == pytest.approx(0.04)
+
+    def test_turnover(self, basket):
+        assert score("basket", "turnover", basket) == pytest.approx(0.75)
+
+    def test_dodged_loss(self, basket):
+        assert score("basket", "dodged_loss", basket) == pytest.approx(0.13)
+
+    def test_empty_basket_all_rewards_zero(self, empty_basket):
+        for name in ("total_return", "sharpe", "hit_rate", "max_drawdown", "turnover"):
+            assert score("basket", name, empty_basket) == 0.0
+        assert score("basket", "dodged_loss", empty_basket) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# None handling (§10.3: None near window end, never 0)
+# ---------------------------------------------------------------------------
+
+
+class TestNoneHandling:
+    def test_none_excluded_not_zeroed(self):
+        # Two days: d1 all-None (excluded entirely), d2 = 0.10.
+        # If None were treated as 0, sharpe's mean/stdev and hit_rate's
+        # denominator would both change.
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA"],
+                    fwd_return={5: {"AAA": None}},
+                    regime="bull",
+                ),
+                BasketDay(
+                    date=date(2026, 1, 6),
+                    symbols=["AAA"],
+                    fwd_return={5: {"AAA": 0.10}},
+                    regime="bull",
+                ),
+            ]
+        )
+        assert score("basket", "total_return", outcomes) == pytest.approx(0.10)
+        assert score("basket", "hit_rate", outcomes) == pytest.approx(1.0)  # 1/1, not 1/2
+
+    def test_partial_none_within_day_excluded(self, basket):
+        # d3 has BBB=None; the day return must be 0.06 (DDD only), not 0.03.
+        # total_return pins this: 0.06 - 0.04 + 0.06 = 0.08.
+        assert score("basket", "total_return", basket) == pytest.approx(0.08)
+
+
+# ---------------------------------------------------------------------------
+# Guardrail evaluation helper
+# ---------------------------------------------------------------------------
+
+
+class TestGuardrail:
+    def test_decrease_direction_breach_when_above_threshold(self):
+        @register(
+            "gd_dec", input_type="basket", role="guardrail", direction="decrease", threshold=0.20
+        )
+        def gd_dec(outcomes):
+            return 0.0
+
+        assert guardrail_breached("gd_dec", 0.25) is True
+        assert guardrail_breached("gd_dec", 0.04) is False
+        assert guardrail_breached("gd_dec", 0.20) is False  # at threshold = clean
+
+    def test_increase_direction_breach_when_below_threshold(self):
+        @register(
+            "gd_inc", input_type="basket", role="guardrail", direction="increase", threshold=0.5
+        )
+        def gd_inc(outcomes):
+            return 0.0
+
+        assert guardrail_breached("gd_inc", 0.4) is True
+        assert guardrail_breached("gd_inc", 0.6) is False
+
+    def test_non_guardrail_rejected(self):
+        with pytest.raises(ValueError, match="guardrail"):
+            guardrail_breached("sharpe", 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Ratio composition (§4.2: ratio rewards compose two aggregations)
+# ---------------------------------------------------------------------------
+
+
+class TestRatio:
+    def test_ratio_composes_two_registered_rewards(self, basket):
+        fn = make_ratio("total_return", "max_drawdown")
+        assert fn(basket) == pytest.approx(0.08 / 0.04)
+
+    def test_ratio_zero_denominator_is_zero(self, empty_basket):
+        fn = make_ratio("total_return", "max_drawdown")
+        assert fn(empty_basket) == 0.0
+
+    def test_ratio_requires_matching_input_types(self):
+        @register("trades_num", input_type="trades", role="secondary", direction="increase")
+        def trades_num(records):
+            return 1.0
+
+        with pytest.raises(ValueError, match="input_type"):
+            make_ratio("trades_num", "max_drawdown")
+
+    def test_ratio_result_registrable(self, basket):
+        register(
+            "return_over_drawdown",
+            input_type="basket",
+            role="secondary",
+            direction="increase",
+        )(make_ratio("total_return", "max_drawdown"))
+        assert score("basket", "return_over_drawdown", basket) == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Determinism + purity
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_same_outcomes_identical_value_across_calls(self, basket):
+        for name in ("total_return", "sharpe", "hit_rate", "max_drawdown", "turnover",
+                     "dodged_loss"):
+            assert score("basket", name, basket) == score("basket", name, basket)
+
+    def test_scoring_does_not_mutate_outcomes(self, basket):
+        before = [(d.date, list(d.symbols), {h: dict(m) for h, m in d.fwd_return.items()})
+                  for d in basket.days]
+        score("basket", "sharpe", basket)
+        score("basket", "turnover", basket)
+        after = [(d.date, list(d.symbols), {h: dict(m) for h, m in d.fwd_return.items()})
+                 for d in basket.days]
+        assert before == after
+
+
+# ---------------------------------------------------------------------------
+# BasketOutcomes shape (design §10.3, pinned)
+# ---------------------------------------------------------------------------
+
+
+class TestBasketOutcomesShape:
+    def test_frozen(self, basket):
+        with pytest.raises(AttributeError):
+            basket.days = []
+        with pytest.raises(AttributeError):
+            basket.days[0].regime = "bear"
+
+    def test_names_sorted(self):
+        assert names() == sorted(names())
+
+    def test_registry_module_reexports(self):
+        # The package surface other tasks import against.
+        assert rewards.REGISTRY is REGISTRY
+        assert callable(rewards.register)
+        assert callable(rewards.score)

--- a/tests/research/test_rewards.py
+++ b/tests/research/test_rewards.py
@@ -10,6 +10,7 @@ hand-computed expected value.
 
 from __future__ import annotations
 
+import math
 from datetime import date
 
 import pytest
@@ -87,6 +88,21 @@ def empty_basket() -> BasketOutcomes:
     return BasketOutcomes(days=[])
 
 
+def _uniform_basket(day_returns: list[float], horizon: int = 5) -> BasketOutcomes:
+    """One-symbol basket with the given per-day forward returns."""
+    return BasketOutcomes(
+        days=[
+            BasketDay(
+                date=date(2026, 1, 5 + i),
+                symbols=["AAA"],
+                fwd_return={horizon: {"AAA": r}},
+                regime="bull",
+            )
+            for i, r in enumerate(day_returns)
+        ]
+    )
+
+
 # ---------------------------------------------------------------------------
 # Registration + metadata
 # ---------------------------------------------------------------------------
@@ -130,6 +146,24 @@ class TestRegister:
             @register("dup", input_type="basket", role="secondary", direction="increase")
             def second(outcomes):
                 return 0.0
+
+    def test_duplicate_name_rejected_at_decoration_time(self):
+        # Regression: two factories obtained BEFORE either decorator is
+        # applied must not silently clobber — the dup check must also run
+        # at insertion time, not only in the factory.
+        deco_a = register("dup2", input_type="basket", role="secondary", direction="increase")
+        deco_b = register("dup2", input_type="basket", role="secondary", direction="increase")
+
+        def first(outcomes):
+            return 1.0
+
+        def second(outcomes):
+            return 2.0
+
+        deco_a(first)
+        with pytest.raises(ValueError, match="dup2"):
+            deco_b(second)
+        assert get("dup2").fn is first  # first registration survives intact
 
     def test_invalid_input_type_rejected(self):
         with pytest.raises(ValueError, match="input_type"):
@@ -179,6 +213,12 @@ class TestInputTypeRefusal:
     def test_matching_input_type_scores(self, basket):
         assert score("basket", "total_return", basket) == pytest.approx(0.08)
 
+    def test_unknown_candidate_type_rejected(self, basket):
+        # A typo'd candidate_type must be flagged as such, not blamed on
+        # the reward's input_type.
+        with pytest.raises(ValueError, match="candidate_type"):
+            score("baskets", "total_return", basket)
+
 
 # ---------------------------------------------------------------------------
 # Shipped basket rewards — hand-computed fixtures
@@ -203,10 +243,10 @@ class TestShippedRewards:
         assert get("sharpe").role == "primary"
         assert get("max_drawdown").role == "guardrail"
         assert get("max_drawdown").direction == "decrease"
-        assert get("max_drawdown").threshold is not None
+        assert get("max_drawdown").threshold == 0.20  # design-pinned promote-gate bound
         assert get("turnover").role == "guardrail"
         assert get("turnover").direction == "decrease"
-        assert get("turnover").threshold is not None
+        assert get("turnover").threshold == 0.50  # design-pinned promote-gate bound
         assert get("total_return").direction == "increase"
         assert get("dodged_loss").direction == "increase"
 
@@ -232,6 +272,38 @@ class TestShippedRewards:
         for name in ("total_return", "sharpe", "hit_rate", "max_drawdown", "turnover"):
             assert score("basket", name, empty_basket) == 0.0
         assert score("basket", "dodged_loss", empty_basket) == 0.0
+
+    def test_sharpe_single_day_zero(self):
+        outcomes = _uniform_basket([0.10])
+        assert score("basket", "sharpe", outcomes) == 0.0
+
+    def test_sharpe_zero_stdev_zero(self):
+        # Identical day returns -> stdev 0 -> 0.0, not ZeroDivisionError.
+        outcomes = _uniform_basket([0.05, 0.05, 0.05])
+        assert score("basket", "sharpe", outcomes) == 0.0
+
+    def test_turnover_skips_empty_symbol_days(self):
+        # [A,B], [], [A,B]: the empty day is dropped, so day1->day3 is the
+        # consecutive pair — nothing entered — turnover 0.0 (pinned skip
+        # semantics; the empty day never enters the denominator).
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA", "BBB"],
+                    fwd_return={5: {"AAA": 0.01, "BBB": 0.01}},
+                    regime="bull",
+                ),
+                BasketDay(date=date(2026, 1, 6), symbols=[], fwd_return={5: {}}, regime="bull"),
+                BasketDay(
+                    date=date(2026, 1, 7),
+                    symbols=["AAA", "BBB"],
+                    fwd_return={5: {"AAA": 0.01, "BBB": 0.01}},
+                    regime="bull",
+                ),
+            ]
+        )
+        assert score("basket", "turnover", outcomes) == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -270,6 +342,102 @@ class TestNoneHandling:
 
 
 # ---------------------------------------------------------------------------
+# Non-finite input rejection (§4.2: loud, never silent)
+# ---------------------------------------------------------------------------
+
+
+class TestNonFiniteRejection:
+    def test_nan_return_raises_not_disarms_drawdown(self):
+        # Regression: NaN on day 1 then two -30% days used to yield
+        # max_drawdown == 0.0 (equity *= nan; max(worst, nan) keeps worst)
+        # — a clean-looking guardrail on corrupt data.
+        outcomes = _uniform_basket([math.nan, -0.30, -0.30])
+        with pytest.raises(ValueError, match="non-finite"):
+            score("basket", "max_drawdown", outcomes)
+
+    def test_nan_return_raises_for_aggregations(self):
+        outcomes = _uniform_basket([0.10, math.nan])
+        for name in ("total_return", "sharpe", "hit_rate"):
+            with pytest.raises(ValueError, match="non-finite"):
+                score("basket", name, outcomes)
+
+    def test_inf_return_raises(self):
+        outcomes = _uniform_basket([math.inf])
+        with pytest.raises(ValueError, match="non-finite"):
+            score("basket", "total_return", outcomes)
+
+    def test_nan_in_dodged_loss_pool_raises(self):
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA"],
+                    fwd_return={5: {"AAA": 0.01, "CCC": math.nan}},
+                    regime="bull",
+                ),
+            ]
+        )
+        with pytest.raises(ValueError, match="non-finite"):
+            score("basket", "dodged_loss", outcomes)
+
+
+# ---------------------------------------------------------------------------
+# Horizon handling (kwargs forwarding + missing-horizon loudness)
+# ---------------------------------------------------------------------------
+
+
+class TestHorizon:
+    def test_kwargs_horizon_forwarded(self):
+        # Two horizons with different returns: score() must forward horizon=
+        # to the reward and aggregate the requested one.
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA"],
+                    fwd_return={5: {"AAA": 0.10}, 10: {"AAA": 0.25}},
+                    regime="bull",
+                ),
+            ]
+        )
+        assert score("basket", "total_return", outcomes) == pytest.approx(0.10)
+        assert score("basket", "total_return", outcomes, horizon=10) == pytest.approx(0.25)
+
+    def test_horizon_absent_from_every_day_raises(self, basket):
+        # A typo'd/unconfigured horizon must not silently score 0.0 for
+        # every candidate (valid-looking noise).
+        with pytest.raises(ValueError, match="horizon 10"):
+            score("basket", "total_return", basket, horizon=10)
+        with pytest.raises(ValueError, match="horizon 10"):
+            score("basket", "dodged_loss", basket, horizon=10)
+
+    def test_horizon_missing_on_some_days_skips_them(self):
+        # Partially missing horizon: days without the key are skipped
+        # (like None returns), not fatal.
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA"],
+                    fwd_return={5: {"AAA": 0.10}},
+                    regime="bull",
+                ),
+                BasketDay(
+                    date=date(2026, 1, 6),
+                    symbols=["AAA"],
+                    fwd_return={5: {"AAA": 0.02}, 10: {"AAA": 0.30}},
+                    regime="bull",
+                ),
+            ]
+        )
+        assert score("basket", "total_return", outcomes, horizon=10) == pytest.approx(0.30)
+
+    def test_empty_basket_any_horizon_zero(self, empty_basket):
+        # No days at all -> nothing to validate against; stays 0.0.
+        assert score("basket", "total_return", empty_basket, horizon=10) == 0.0
+
+
+# ---------------------------------------------------------------------------
 # Guardrail evaluation helper
 # ---------------------------------------------------------------------------
 
@@ -295,10 +463,19 @@ class TestGuardrail:
 
         assert guardrail_breached("gd_inc", 0.4) is True
         assert guardrail_breached("gd_inc", 0.6) is False
+        assert guardrail_breached("gd_inc", 0.5) is False  # at threshold = clean
 
     def test_non_guardrail_rejected(self):
         with pytest.raises(ValueError, match="guardrail"):
             guardrail_breached("sharpe", 1.0)
+
+    def test_non_finite_value_rejected(self):
+        # Regression: NaN fails every >/< comparison, so it used to read as
+        # "clean" — silently disarming the guardrail on corrupt input.
+        with pytest.raises(ValueError, match="non-finite"):
+            guardrail_breached("max_drawdown", math.nan)
+        with pytest.raises(ValueError, match="non-finite"):
+            guardrail_breached("max_drawdown", math.inf)
 
 
 # ---------------------------------------------------------------------------
@@ -311,9 +488,33 @@ class TestRatio:
         fn = make_ratio("total_return", "max_drawdown")
         assert fn(basket) == pytest.approx(0.08 / 0.04)
 
-    def test_ratio_zero_denominator_is_zero(self, empty_basket):
+    def test_ratio_zero_over_zero_is_zero(self, empty_basket):
+        # Empty window: numerator and denominator both 0 -> 0.0 (no data).
         fn = make_ratio("total_return", "max_drawdown")
         assert fn(empty_basket) == 0.0
+
+    def test_ratio_positive_over_zero_is_inf(self):
+        # Regression: a flawless candidate (positive return, zero drawdown)
+        # used to score 0.0 — ranking BELOW every mediocre candidate.
+        fn = make_ratio("total_return", "max_drawdown")
+        outcomes = _uniform_basket([0.05, 0.10])
+        assert fn(outcomes) == math.inf
+
+    def test_ratio_negative_over_zero_is_neg_inf(self):
+        @register("neg_const", input_type="basket", role="secondary", direction="increase")
+        def neg_const(outcomes, **kwargs):
+            return -1.0
+
+        @register("zero_const", input_type="basket", role="secondary", direction="increase")
+        def zero_const(outcomes, **kwargs):
+            return 0.0
+
+        fn = make_ratio("neg_const", "zero_const")
+        assert fn(BasketOutcomes(days=[])) == -math.inf
+
+    def test_ratio_closure_has_descriptive_name(self):
+        fn = make_ratio("total_return", "max_drawdown")
+        assert fn.__name__ == "ratio_total_return_over_max_drawdown"
 
     def test_ratio_requires_matching_input_types(self):
         @register("trades_num", input_type="trades", role="secondary", direction="increase")
@@ -366,6 +567,8 @@ class TestBasketOutcomesShape:
         with pytest.raises(AttributeError):
             basket.days[0].regime = "bear"
 
+
+class TestModuleSurface:
     def test_names_sorted(self):
         assert names() == sorted(names())
 

--- a/tests/research/test_rewards.py
+++ b/tests/research/test_rewards.py
@@ -580,6 +580,20 @@ class TestRatio:
         )(make_ratio("total_return", "max_drawdown"))
         assert score("basket", "return_over_drawdown", basket) == pytest.approx(2.0)
 
+    def test_ratio_cannot_be_registered_under_wrong_input_type(self):
+        # Regression (codex): make_ratio's input_type was discarded, so a
+        # basket-composed ratio could register as input_type="trades" and
+        # score() would route a trades payload into the basket aggregators.
+        fn = make_ratio("total_return", "max_drawdown")
+        with pytest.raises(ValueError, match="input_type"):
+            register(
+                "ratio_wrong_type",
+                input_type="trades",
+                role="secondary",
+                direction="increase",
+            )(fn)
+        assert "ratio_wrong_type" not in names()
+
 
 # ---------------------------------------------------------------------------
 # Determinism + purity


### PR DESCRIPTION
## What this is

Task 2 of the QU100 A/B testing substrate (`docs/DESIGN-qu100-ab-testing.md` §10.3). It generalizes the reward registry — the component that turns a candidate's outcomes into the single scored number an A/B comparison ranks on. It does not run experiments yet; the evaluator that feeds it outcomes is a sibling task.

## The problem it solves

To decide whether a challenger config beats the champion, each arm's replay outcomes have to collapse to comparable **reward** values — a primary number to rank on (e.g. Sharpe) plus guardrails that can veto a winner (e.g. max-drawdown, turnover). The as-built registry was a Phase-0 stub: `register(name, fn)` with no notion of *what kind of candidate* a reward can score or *what role* it plays.

Two hazards that stub allows:
- **Wrong-candidate scoring.** A reward written for LLM `trades` outcomes could be silently handed a screener `basket` candidate and return a meaningless number — a comparison built on nonsense.
- **Guardrails with no teeth.** Nothing distinguished a primary reward (maximize) from a guardrail (must stay under a threshold), so a guardrail breach couldn't be detected structurally.

## The fix

**Registry becomes a typed decorator-factory (`research/rewards/__init__.py`)**
`register(name, input_type, role, direction, threshold)` — every reward now declares the candidate type it accepts (`basket` = screener, `trades` = LLM), its role (`primary` | `guardrail` | `secondary`), optimization direction, and (for guardrails) a threshold. `score()` **refuses loudly** when a reward is applied to the wrong candidate type; `guardrail_breached()` evaluates a breach against the declared threshold. `make_ratio()` composes two aggregations (e.g. return/risk) with sign-aware zero-denominator handling.

**`BasketOutcomes` — the screener candidate shape (`research/rewards/basket.py`)**
A frozen dataclass (§10.3): per selection day, the ranked basket + forward returns at H∈{5,10,20} + regime tag. Ships with six basket rewards: `total_return`, `sharpe` (primary), `hit_rate`, `max_drawdown` (guardrail 0.20), `turnover` (guardrail 0.50), `dodged_loss`. Every reward fails loud on missing symbols, non-finite returns, or an all-absent horizon — never silently scores partial data.

## Notable bug caught in review

A **P1** the review rounds surfaced and fixed: **duplicate basket symbols** double-weighted the equal-weight mean *and* evaded the turnover guardrail — the numerator deduped via a `set` while the denominator counted dupes, so a true 100%-turnover basket reported 33% and slipped under the 0.50 threshold. Now all six rewards reject duplicate symbols. `make_ratio` also stopped laundering non-finite constituents (`nan/0.0 → -inf`) into scores. Both carry regression tests.

## Scope boundaries

Owned elsewhere, not here: reward-key validation against experiment specs (experiment-contracts #151), the evaluator that maps replay corpus rows into `BasketOutcomes` (replay-evaluator), the promote-time guardrail gate (registry-promote).

## Files

| File | Change |
|---|---|
| `research/rewards/__init__.py` | registry → typed decorator-factory, `score()` / `guardrail_breached()` / `make_ratio()` |
| `research/rewards/basket.py` | new — `BasketDay` / `BasketOutcomes` + six basket rewards |
| `tests/research/test_rewards.py` | new — 718 lines, 59 tests |

## Review

- `/review`: passed (Claude, 2 rounds) — caught the duplicate-symbol P1
- `codex review`: passed (1 round)
- Full suite: 1780 passed, ruff clean.

## Deferred (P2/P3 — non-blocking)

- P2: empty no-pick window crashes `_require_horizon` (deliberate loudness; payload shape is the evaluator's scope)
- P2: `importlib.reload` non-idempotent (notebook-autoreload-only)
- P3: frozen dataclasses expose mutable list/dict (caller-side; `test_frozen` pins the attr-reassignment contract)

## Test plan

- [ ] CI green
- [ ] verify locally

Task plan: `docs/TASK-PLAN-ab-reward-registry-b3b8.md`

https://claude.ai/code/session_01SZbpkAuAXJy9oY1Tqr848j
