### PR TITLE
feat: A/B replay+score evaluator — driver, BasketOutcomes, base scorecard

### DIFF
--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -6622,3 +6622,108 @@ def db_backup_money_flow(do_verify: bool, skip_if_unconfigured: bool) -> None:
             click.echo("backup-money-flow — verify OK")
     finally:
         dst.dispose()
+
+
+# ---------------------------------------------------------------------------
+# experiment — A/B substrate: replay + score challengers vs champion (§4.4).
+# ---------------------------------------------------------------------------
+
+
+@cli.group(name="experiment")
+def experiment_group() -> None:
+    """QU100 A/B substrate — replay + score challengers against the champion."""
+
+
+@experiment_group.command(name="run")
+@click.argument("spec_path", type=click.Path(exists=True))
+@click.option(
+    "--config", "config_path", default="config/settings.yaml", show_default=True,
+    help="Settings file; its sibling model/ dir carries champion.yaml.",
+)
+@click.option(
+    "--output", "output_path", default=None,
+    help="Scorecard output (.json or .parquet). Default: JSON to stdout.",
+)
+@click.option(
+    "--segment", default="train", show_default=True,
+    type=click.Choice(["train", "holdout"]),
+    help="Walk-forward window to score (holdout stays reserved for promotion).",
+)
+@click.option(
+    "--basket-size", default=5, show_default=True, type=int,
+    help="Selected-basket size (top-N of the composite ranking).",
+)
+@click.option(
+    "--horizon", default=5, show_default=True, type=int,
+    help="Primary reward forward-return horizon (trading days).",
+)
+def experiment_run(
+    spec_path, config_path, output_path, segment, basket_size, horizon
+) -> None:
+    """Replay + score an experiment SPEC over the corpus (composition root).
+
+    Loads the spec, resolves the LIVE champion base layer (settings +
+    champion.yaml), replays the 3-layer ranking as-of each corpus day for the
+    champion AND every challenger, and writes one base scorecard per candidate.
+    Registry append + promote arrive with ab-registry-promote-84a7.
+    """
+    import json
+    from datetime import date as _date
+    from datetime import timedelta
+
+    from rainier.core.database import get_session
+    from rainier.paper.pattern_audit import universe_symbols
+    from rainier.paper.pattern_replay import LIVE_LOOKBACK_BARS, load_prices
+    from rainier.research.evaluator.screener import load_base_overrides, run_experiment
+    from rainier.research.experiment import load_spec
+
+    spec = load_spec(spec_path)
+    base_overrides = load_base_overrides(config_path)
+
+    # Bound the corpus to the spec's span; pad the SQL load left by the detector
+    # lookback so the earliest scored day still sees its full ~6-month window.
+    train_start = _date.fromisoformat(spec.window.train.split("..")[0])
+    holdout_end = _date.fromisoformat(spec.window.holdout.split("..")[1])
+    pad_days = LIVE_LOOKBACK_BARS * 2 + 14
+    load_start = pd.Timestamp(train_start - timedelta(days=pad_days), tz="UTC")
+
+    with get_session() as session:
+        universe = universe_symbols(session)
+        prices = load_prices(session, universe, start_date=load_start)
+        trading_days = sorted(
+            {
+                (ts.date() if hasattr(ts, "date") else ts)
+                for df in prices.values()
+                for ts in df.index
+                if train_start <= (ts.date() if hasattr(ts, "date") else ts) <= holdout_end
+            }
+        )
+        cards = run_experiment(
+            spec,
+            base_overrides,
+            session=session,
+            prices_by_symbol=prices,
+            trading_days=trading_days,
+            basket_size=basket_size,
+            primary_horizon=horizon,
+            segment=segment,
+        )
+
+    if not output_path:
+        click.echo(json.dumps(cards, indent=2, default=str))
+        return
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    if out.suffix == ".parquet":
+        # Nested reward/regime dicts are JSON-encoded per row (registry
+        # metrics_json convention) so the columnar schema stays flat + stable.
+        rows = []
+        for card in cards:
+            row = dict(card)
+            row["rewards"] = json.dumps(card["rewards"], sort_keys=True)
+            row["regime_scores"] = json.dumps(card["regime_scores"], sort_keys=True)
+            rows.append(row)
+        pd.DataFrame(rows).to_parquet(out, index=False)
+    else:
+        out.write_text(json.dumps(cards, indent=2, default=str), encoding="utf-8")
+    click.echo(f"wrote {len(cards)} scorecard(s) -> {out}")

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -6650,11 +6650,11 @@ def experiment_group() -> None:
     help="Walk-forward window to score (holdout stays reserved for promotion).",
 )
 @click.option(
-    "--basket-size", default=5, show_default=True, type=int,
+    "--basket-size", default=5, show_default=True, type=click.IntRange(min=1),
     help="Selected-basket size (top-N of the composite ranking).",
 )
 @click.option(
-    "--horizon", default=5, show_default=True, type=int,
+    "--horizon", default=5, show_default=True, type=click.IntRange(min=1),
     help="Primary reward forward-return horizon (trading days).",
 )
 def experiment_run(

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -6687,6 +6687,13 @@ def experiment_run(
     pad_days = LIVE_LOOKBACK_BARS * 2 + 14
     load_start = pd.Timestamp(train_start - timedelta(days=pad_days), tz="UTC")
 
+    # NOTE: `--config` selects only the CHAMPION LAYER (settings.yaml:stock_screener
+    # + sibling champion.yaml) via load_base_overrides. The corpus DB is orthogonal:
+    # core.database.get_session binds to `legacy_database_url`, sourced from the
+    # env var LEGACY_DATABASE_URL (never from settings.yaml — load_settings maps no
+    # yaml key onto it), so it is identical across every --config. --config cannot
+    # desync champion-vs-corpus. Rebinding the process-singleton engine per-config
+    # is a cross-cutting change out of this task's scope.
     with get_session() as session:
         universe = universe_symbols(session)
         prices = load_prices(session, universe, start_date=load_start)

--- a/src/rainier/paper/pattern_audit.py
+++ b/src/rainier/paper/pattern_audit.py
@@ -120,6 +120,57 @@ def forward_return(df: pd.DataFrame, t_idx: int, horizon: int) -> float | None:
     return float(cH) / float(c0) - 1.0
 
 
+def as_of_index(df: pd.DataFrame, as_of: date) -> int | None:
+    """Positional index of the as-of bar = last bar with ``date <= as_of``.
+
+    Aligns a CALENDAR as-of date to a symbol's positional row so the evaluator
+    can window (`window_as_of`) and score forward returns across symbols with
+    heterogeneous trading-day coverage from ONE shared trading-day axis. Returns
+    ``None`` when the symbol has no bar on/before ``as_of`` (not yet trading) or
+    the frame is not date-indexed. An ``as_of`` after the last bar clamps to the
+    newest bar (the live screen also reads the latest available bar).
+    """
+    if not isinstance(df.index, pd.DatetimeIndex) or len(df) == 0:
+        return None
+    ts = pd.Timestamp(as_of)
+    if df.index.tz is not None and ts.tz is None:
+        ts = ts.tz_localize(df.index.tz)
+    elif df.index.tz is None and ts.tz is not None:
+        ts = ts.tz_localize(None)
+    # side="right" → count of bars with date <= ts; minus 1 = last such row.
+    pos = int(df.index.searchsorted(ts, side="right")) - 1
+    if pos < 0:
+        return None
+    return pos
+
+
+def forward_returns_by_symbol(
+    prices_by_symbol: dict[str, pd.DataFrame],
+    as_of: date,
+    symbols,
+    *,
+    horizons: tuple[int, ...] = HORIZONS,
+) -> dict[int, dict[str, float | None]]:
+    """Per-symbol forward returns at each horizon, as-of ``as_of``.
+
+    Returns ``{H: {symbol: return | None}}`` covering EVERY requested symbol at
+    EVERY horizon. This is the screened-pool fan-out of the single-symbol
+    :func:`forward_return`: the evaluator feeds it the wider screened pool (not
+    just the selected basket) so ``dodged_loss`` can see the non-selected losers,
+    and every SELECTED symbol is guaranteed a key so the basket rewards' missing-
+    key guard never fires. A symbol with no price frame (money-flow-only), no bar
+    on/before ``as_of``, or fewer than H bars ahead → ``None`` — never 0, never
+    omitted.
+    """
+    out: dict[int, dict[str, float | None]] = {h: {} for h in horizons}
+    for symbol in symbols:
+        df = prices_by_symbol.get(symbol)
+        pos = as_of_index(df, as_of) if df is not None else None
+        for h in horizons:
+            out[h][symbol] = None if pos is None else forward_return(df, pos, h)
+    return out
+
+
 def directional_correct(direction: str, fwd_return: float | None) -> bool | None:
     """Did the pattern's direction match the realized move?
 

--- a/src/rainier/paper/pattern_audit.py
+++ b/src/rainier/paper/pattern_audit.py
@@ -161,7 +161,17 @@ def forward_returns_by_symbol(
     key guard never fires. A symbol with no price frame (money-flow-only), no bar
     on/before ``as_of``, or fewer than H bars ahead → ``None`` — never 0, never
     omitted.
+
+    A non-positive horizon is rejected loudly: ``forward_return`` reads
+    ``close[t_idx + horizon]``, so ``horizon <= 0`` would read the as-of bar
+    itself (a bogus 0.0 return) or, for a negative horizon, wrap ``iloc`` to a
+    FUTURE bar — a silent look-ahead leak into the scorecards.
     """
+    bad = sorted(h for h in horizons if h < 1)
+    if bad:
+        raise ValueError(
+            f"forward-return horizons must be positive trading-day counts, got {bad}"
+        )
     out: dict[int, dict[str, float | None]] = {h: {} for h in horizons}
     for symbol in symbols:
         df = prices_by_symbol.get(symbol)

--- a/src/rainier/research/evaluator/screener.py
+++ b/src/rainier/research/evaluator/screener.py
@@ -374,6 +374,17 @@ def run_experiment(
         raise ValueError(
             f"unknown segment {segment!r} (expected 'train' or 'holdout')"
         )
+    # An empty scored segment (window range outside the corpus, or embargo
+    # purging every train day) would emit all-zero scorecards that LOOK valid —
+    # a silent no-op contrary to this substrate's loud-never-silent stance
+    # (§4.2/§4.5). Fail loud so a misconfigured window can't be scored blind.
+    if not scored_days:
+        rng = spec.window.train if segment == "train" else spec.window.holdout
+        raise ValueError(
+            f"segment {segment!r} selected zero trading days for window {rng!r} — "
+            f"refusing to emit all-zero scorecards (check the window range and "
+            f"embargo against the corpus span)"
+        )
 
     corpus_hash_value = corpus_hash(prices_by_symbol)
     evaluator_sha_value = evaluator_sha()

--- a/src/rainier/research/evaluator/screener.py
+++ b/src/rainier/research/evaluator/screener.py
@@ -1,0 +1,421 @@
+"""Screener replay + score evaluator — the A/B substrate's corpus driver.
+
+Design: docs/DESIGN-qu100-ab-testing.md §4.4, §4.5, §11.4.
+
+Nothing else *runs* an experiment. This module walks each trading day of the
+corpus, reproduces the full live 3-layer ranking as-of that day for each
+candidate (champion + challengers), collects the selected basket + forward
+returns, and reduces them to comparable base scorecards — driven by the
+experiment spec. It COMPOSES the shipped pieces, it does not rebuild them:
+
+    for t in scored days:                (per candidate: champion + challengers)
+      _screen_money_flow_as_of(t)   ─┐   Layer 1 (as-of, casing-normalized)
+      analyze_sectors_at(t)          ├─► _apply_sector_boost ─► signals_by_symbol
+      window_as_of(prices, t)       ─┘   Layer 3 windows (bars <= t only)
+              │
+              ▼  replay_screen (live composite, sector double-count) ─► ranking
+      BasketDay(t, top-N basket, fwd_return[H]=screened-pool returns, regime)
+              ▼
+      BasketOutcomes ─► rewards (task b3b8) ─► base_scorecard (task 5a0f schema)
+
+Key invariants (see the task plan):
+- ``base_overrides`` is REQUIRED by :func:`materialize_challengers`; the driver
+  resolves the LIVE champion layer via :func:`load_base_overrides` so every
+  challenger baselines on the live champion, not pydantic code-defaults (§4.5).
+- forward returns are computed PER SELECTED SYMBOL (incl. money-flow-only names
+  with no price frame → ``None``, never omitted) plus the WIDER screened pool so
+  ``dodged_loss`` isn't 0-by-construction.
+- ``corpus_hash`` is over the SHARED ``(symbol, date, close)`` snapshot, so every
+  candidate in one run carries the same hash (co-evaluation, §4.5).
+- reward horizon is pinned to H=5 and recorded INSIDE ``rewards`` (a permissive
+  dict) — not a new top-level scorecard key (strict ``base_scorecard`` rejects
+  extras).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Callable
+
+import pandas as pd
+
+from rainier.analysis.sector_analyzer import analyze_sectors_at
+from rainier.analysis.stock_screener import (
+    _apply_sector_boost,
+    _screen_money_flow_as_of,
+)
+from rainier.core.config import StockScreenerConfig
+from rainier.paper.pattern_audit import (
+    HORIZONS,
+    as_of_index,
+    forward_returns_by_symbol,
+)
+from rainier.paper.pattern_replay import replay_screen, window_as_of
+from rainier.research.experiment import ExperimentSpec, ExperimentWindow, materialize_challengers
+from rainier.research.rewards import REGISTRY, score
+from rainier.research.rewards.basket import BasketDay, BasketOutcomes
+
+# The scorecard's candidate KIND (screener-config vs LLM-skill). Distinct from
+# the reward registry's input_type ("basket") — the screener candidate emits a
+# BasketOutcomes payload, so its rewards are scored under the "basket" shape.
+SCREENER_CANDIDATE_TYPE = "screener"
+BASKET_INPUT_TYPE = "basket"
+
+# Champion arm's candidate_id. Its config identity (version) is provenance
+# recorded by the registry (task 5), never a comparison baseline (§4.5).
+CHAMPION_CANDIDATE_ID = "champion"
+
+# Coordinator default: the primary reward horizon (shipped basket-reward
+# default). 10/20d returns are retained as provenance; per-horizon scoring is a
+# future spec extension. Recorded inside the scorecard's `window`/`rewards`.
+DEFAULT_PRIMARY_HORIZON = 5
+
+# The live LLM-fed actionable set is the top-5 (pipeline/post_scrape.py); the
+# basket mirrors that. Parameterized — NOT pinned by the spec schema.
+DEFAULT_BASKET_SIZE = 5
+
+
+RegimeFn = Callable[[date], str]
+
+
+def _default_regime_fn(as_of: date) -> str:
+    from rainier.llm_thesis.research import compute_market_regime
+
+    return compute_market_regime(as_of=as_of)
+
+
+# ---------------------------------------------------------------------------
+# Provenance hashes.
+# ---------------------------------------------------------------------------
+
+
+def evaluator_sha() -> str:
+    """Content SHA of THIS evaluator module.
+
+    Stamped on every scorecard so a result traces to the exact scoring code
+    (registry §10.5); it moves whenever the evaluator's logic changes.
+    """
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+def corpus_hash(prices_by_symbol: dict[str, pd.DataFrame]) -> str:
+    """SHA of the SHARED ``(symbol, date, close)`` corpus snapshot.
+
+    The common input universe scored across ALL candidates in a run — NOT any
+    per-candidate basket. Co-evaluation (§4.5) requires every candidate in one
+    run to carry the SAME hash; the registry refuses champion-vs-challenger
+    comparisons across mismatched hashes. Deterministic for a fixed snapshot
+    (symbols sorted, rows date-ascending).
+    """
+    h = hashlib.sha256()
+    for symbol in sorted(prices_by_symbol):
+        df = prices_by_symbol[symbol]
+        for ts, close in zip(df.index, df["close"]):
+            iso = ts.isoformat() if hasattr(ts, "isoformat") else str(ts)
+            h.update(f"{symbol}|{iso}|{float(close)!r}".encode())
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward windows — train/holdout split with a purged embargo gap.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WindowSplit:
+    """Trading days partitioned into train + holdout with the embargo applied."""
+
+    train_days: list[date]
+    holdout_days: list[date]
+    embargo_days: int
+
+
+def _parse_range(range_str: str) -> tuple[date, date]:
+    # The spec interpreter already validated the "start..end" shape at parse
+    # time (experiment.parse_spec); here it is safe to split.
+    start_s, end_s = range_str.split("..")
+    return date.fromisoformat(start_s), date.fromisoformat(end_s)
+
+
+def split_windows(trading_days, window: ExperimentWindow) -> WindowSplit:
+    """Partition ``trading_days`` into train + holdout with a purged embargo.
+
+    The holdout is the trailing out-of-sample window; it is NEVER read during
+    challenger selection (the driver scores the ``train`` segment by default).
+    The embargo PURGES the last ``embargo_days`` TRADING days of the train set
+    that fall within ``embargo_days`` trading days before the first holdout day
+    — so a train day's forward-return window (overlapping horizons up to H=20)
+    cannot reach into the holdout and leak it into selection.
+    """
+    days = sorted(trading_days)
+    train_start, train_end = _parse_range(window.train)
+    hold_start, hold_end = _parse_range(window.holdout)
+    train = [d for d in days if train_start <= d <= train_end]
+    holdout = [d for d in days if hold_start <= d <= hold_end]
+    if holdout and window.embargo_days > 0:
+        first_hold_idx = days.index(holdout[0])
+        embargo_zone = set(days[max(0, first_hold_idx - window.embargo_days):first_hold_idx])
+        train = [d for d in train if d not in embargo_zone]
+    return WindowSplit(
+        train_days=train, holdout_days=holdout, embargo_days=window.embargo_days
+    )
+
+
+def _window_str(window: ExperimentWindow, segment: str) -> str:
+    """Human/registry-readable window label for the scored segment."""
+    rng = window.train if segment == "train" else window.holdout
+    return f"{rng} [{segment}]"
+
+
+# ---------------------------------------------------------------------------
+# Per-day replay — the live 3-layer ranking as-of t, then basket + fwd returns.
+# ---------------------------------------------------------------------------
+
+
+def build_basket_outcomes(
+    session: Any,
+    config: StockScreenerConfig,
+    *,
+    days,
+    prices_by_symbol: dict[str, pd.DataFrame],
+    regime_fn: RegimeFn = _default_regime_fn,
+    basket_size: int = DEFAULT_BASKET_SIZE,
+    horizons: tuple[int, ...] = HORIZONS,
+    normalize_casing: bool = True,
+) -> BasketOutcomes:
+    """Replay the live 3-layer ranking as-of each day → per-day ``BasketDay``.
+
+    Layer 1 (money flow) and Layer 2 (sector) are config-independent — they read
+    the DB via the as-of selectors (``normalize_casing=True`` on the replay path,
+    §10.1). Layer 3 (patterns) + the composite are config-dependent, so the whole
+    ranking is re-run per candidate config (``replay_screen``). The selected
+    basket is the top-``basket_size`` of the composite ranking; ``fwd_return[H]``
+    carries the ENTIRE screened pool's returns so ``dodged_loss`` sees the
+    non-selected losers, and every selected symbol is guaranteed a key.
+    """
+    horizons = tuple(horizons)
+    basket_days: list[BasketDay] = []
+    for as_of in days:
+        signals = _screen_money_flow_as_of(
+            session, as_of, normalize_casing=normalize_casing
+        )
+        sector_trends = analyze_sectors_at(
+            as_of, session, normalize_casing=normalize_casing
+        )
+        boosted = _apply_sector_boost(signals, sector_trends)
+
+        signals_by_symbol: dict[str, float] = {}
+        sectors_by_symbol: dict[str, str] = {}
+        windows_by_symbol: dict[str, pd.DataFrame] = {}
+        for sig in boosted:
+            signals_by_symbol[sig.symbol] = sig.signal_strength
+            sectors_by_symbol[sig.symbol] = sig.sector
+            df = prices_by_symbol.get(sig.symbol)
+            if df is None:
+                continue  # money-flow-only symbol — ranks with best_confidence=0
+            pos = as_of_index(df, as_of)
+            if pos is not None:
+                windows_by_symbol[sig.symbol] = window_as_of(df, pos)
+
+        selections = replay_screen(
+            signals_by_symbol=signals_by_symbol,
+            sectors_by_symbol=sectors_by_symbol,
+            sector_trends=sector_trends,
+            windows_by_symbol=windows_by_symbol,
+            config=config,
+        )
+        screened_pool = [s.symbol for s in selections]
+        basket = screened_pool[:basket_size]
+        fwd = forward_returns_by_symbol(
+            prices_by_symbol, as_of, screened_pool, horizons=horizons
+        )
+        basket_days.append(
+            BasketDay(
+                date=as_of,
+                symbols=basket,
+                fwd_return=fwd,
+                regime=regime_fn(as_of),
+            )
+        )
+    return BasketOutcomes(days=basket_days)
+
+
+# ---------------------------------------------------------------------------
+# Scorecard reduction — reward values by role + per-regime slices.
+# ---------------------------------------------------------------------------
+
+
+def _secondary_basket_rewards() -> list[str]:
+    """Registered ``basket`` rewards whose role is ``secondary`` (reported)."""
+    return sorted(
+        name
+        for name, spec in REGISTRY.items()
+        if spec.input_type == BASKET_INPUT_TYPE and spec.role == "secondary"
+    )
+
+
+def _build_scorecard(
+    *,
+    candidate_id: str,
+    outcomes: BasketOutcomes,
+    spec: ExperimentSpec,
+    window_str: str,
+    corpus_hash_value: str,
+    horizon: int,
+    evaluator_sha_value: str,
+) -> dict[str, Any]:
+    """Reduce one candidate's ``BasketOutcomes`` to a base scorecard payload.
+
+    Reward keys resolve against the registry at scoring time — an unknown name
+    (or an input-type mismatch, e.g. a ``trades`` reward on a screener basket)
+    raises a loud ``ValueError`` here, symmetric to the interpreter's
+    unknown-override-key rejection.
+    """
+
+    def _score(name: str, payload: BasketOutcomes) -> float:
+        return score(BASKET_INPUT_TYPE, name, payload, horizon=horizon)
+
+    primary = {spec.primary: _score(spec.primary, outcomes)}
+    guardrails = {g: _score(g, outcomes) for g in spec.guardrails}
+    secondary_names = _secondary_basket_rewards()
+    secondary = {name: _score(name, outcomes) for name in secondary_names}
+    rewards = {
+        # H recorded in a permissive field, NOT a new top-level scorecard key.
+        "horizon": horizon,
+        "primary": primary,
+        "guardrails": guardrails,
+        "secondary": secondary,
+    }
+
+    # Per-regime slices: the same reward set over each regime's day subset.
+    scored_names: list[str] = []
+    for name in (spec.primary, *spec.guardrails, *secondary_names):
+        if name not in scored_names:
+            scored_names.append(name)
+    regime_scores: dict[str, dict[str, float]] = {}
+    for regime in sorted({d.regime for d in outcomes.days}):
+        sub = BasketOutcomes(days=[d for d in outcomes.days if d.regime == regime])
+        regime_scores[regime] = {name: _score(name, sub) for name in scored_names}
+
+    return {
+        "candidate_id": candidate_id,
+        "candidate_type": SCREENER_CANDIDATE_TYPE,
+        "window": window_str,
+        "n_selection_days": sum(1 for d in outcomes.days if d.symbols),
+        "corpus_hash": corpus_hash_value,
+        "rewards": rewards,
+        "regime_scores": regime_scores,
+        # ALWAYS null until the §11-task-6 DSR spec lands (design §4.4).
+        "deflated_sharpe": None,
+        "evaluator_sha": evaluator_sha_value,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The driver — champion + challengers co-evaluated over one corpus snapshot.
+# ---------------------------------------------------------------------------
+
+
+def run_experiment(
+    spec: ExperimentSpec,
+    base_overrides: dict[str, Any] | None,
+    *,
+    session: Any,
+    prices_by_symbol: dict[str, pd.DataFrame],
+    trading_days,
+    regime_fn: RegimeFn = _default_regime_fn,
+    basket_size: int = DEFAULT_BASKET_SIZE,
+    primary_horizon: int = DEFAULT_PRIMARY_HORIZON,
+    segment: str = "train",
+    horizons: tuple[int, ...] = HORIZONS,
+) -> list[dict[str, Any]]:
+    """Co-evaluate champion + all challengers over ONE corpus snapshot (§4.5).
+
+    ``base_overrides`` is the REQUIRED live champion layer (``None`` is test-only
+    — it baselines on code-defaults). Every candidate is materialized from ONE
+    :func:`materialize_challengers` call, scored over the SAME segment days, and
+    stamped with the SAME ``corpus_hash`` — stored scores are provenance, never a
+    comparison baseline. Returns one base_scorecard dict per candidate (champion
+    first, then challengers in spec order).
+    """
+    champion_cfg, challenger_cfgs = materialize_challengers(spec, base_overrides)
+
+    split = split_windows(trading_days, spec.window)
+    if segment == "train":
+        scored_days = split.train_days
+    elif segment == "holdout":
+        scored_days = split.holdout_days
+    else:
+        raise ValueError(
+            f"unknown segment {segment!r} (expected 'train' or 'holdout')"
+        )
+
+    corpus_hash_value = corpus_hash(prices_by_symbol)
+    evaluator_sha_value = evaluator_sha()
+    window_str = _window_str(spec.window, segment)
+    # Score at primary_horizon; ensure the driver populates it even if the
+    # caller's horizons omit it (else _require_horizon would raise).
+    horizons_used = tuple(sorted(set(horizons) | {primary_horizon}))
+
+    candidates: list[tuple[str, StockScreenerConfig]] = [
+        (CHAMPION_CANDIDATE_ID, champion_cfg),
+        *challenger_cfgs.items(),
+    ]
+    cards: list[dict[str, Any]] = []
+    for candidate_id, config in candidates:
+        outcomes = build_basket_outcomes(
+            session,
+            config,
+            days=scored_days,
+            prices_by_symbol=prices_by_symbol,
+            regime_fn=regime_fn,
+            basket_size=basket_size,
+            horizons=horizons_used,
+        )
+        cards.append(
+            _build_scorecard(
+                candidate_id=candidate_id,
+                outcomes=outcomes,
+                spec=spec,
+                window_str=window_str,
+                corpus_hash_value=corpus_hash_value,
+                horizon=primary_horizon,
+                evaluator_sha_value=evaluator_sha_value,
+            )
+        )
+    return cards
+
+
+# ---------------------------------------------------------------------------
+# Champion baseline resolution — the live settings + champion layer.
+# ---------------------------------------------------------------------------
+
+
+def load_base_overrides(config_path: str | Path = "config/settings.yaml") -> dict[str, Any]:
+    """Resolve the champion-effective override layer for the driver.
+
+    Mirrors ``core.config.load_settings`` EXACTLY: ``settings.yaml:stock_screener``
+    deep-merged UNDER ``champion.yaml`` (champion wins per key), resolving the
+    champion model dir as ``<settings_dir>/model``. The returned dict is the SAME
+    layer the live ``StockScreenerConfig`` is built from — passing it as the
+    REQUIRED ``base_overrides`` is what keeps challengers baselined on the LIVE
+    champion, not code-defaults (§4.5).
+    """
+    import yaml
+
+    from rainier.core.champion import (
+        load_champion_overrides,
+        merge_stock_screener_config,
+    )
+
+    path = Path(config_path)
+    yaml_config: dict[str, Any] = {}
+    if path.exists():
+        with open(path) as f:
+            yaml_config = yaml.safe_load(f) or {}
+    yaml_screener = yaml_config.get("stock_screener")
+    champion_overrides = load_champion_overrides(path.parent / "model")
+    return merge_stock_screener_config(yaml_screener, champion_overrides)

--- a/src/rainier/research/evaluator/screener.py
+++ b/src/rainier/research/evaluator/screener.py
@@ -240,6 +240,14 @@ def build_basket_outcomes(
             config=config,
         )
         screened_pool = [s.symbol for s in selections]
+        # The basket is the top-N of the COMPOSITE ranking — faithfully mirroring
+        # the live pipeline/post_scrape.py windows (all_candidates[:50/:20/:5] over
+        # the same composite-sorted list). The recommendation thresholds
+        # (strong_buy/buy/watch) only set a DISPLAY LABEL via _classify; live
+        # selection never filters the traded/LLM'd basket by them. So a
+        # threshold-only challenger correctly scores as a basket no-op here — that
+        # is faithful parity, NOT a silent bug (gating the basket by threshold
+        # would DIVERGE from the live top-N selection).
         basket = screened_pool[:basket_size]
         fwd = forward_returns_by_symbol(
             prices_by_symbol, as_of, screened_pool, horizons=horizons

--- a/src/rainier/research/evaluator/screener.py
+++ b/src/rainier/research/evaluator/screener.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass
 from datetime import date
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable
 
@@ -92,11 +93,13 @@ def _default_regime_fn(as_of: date) -> str:
 # ---------------------------------------------------------------------------
 
 
+@lru_cache(maxsize=1)
 def evaluator_sha() -> str:
     """Content SHA of THIS evaluator module.
 
     Stamped on every scorecard so a result traces to the exact scoring code
-    (registry §10.5); it moves whenever the evaluator's logic changes.
+    (registry §10.5); it moves whenever the evaluator's logic changes. Cached —
+    the module bytes are fixed for the process lifetime.
     """
     return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
 

--- a/src/rainier/research/evaluator/screener.py
+++ b/src/rainier/research/evaluator/screener.py
@@ -354,6 +354,16 @@ def run_experiment(
     first, then challengers in spec order).
     """
     champion_cfg, challenger_cfgs = materialize_challengers(spec, base_overrides)
+    # ``candidate_id`` is the scorecard/registry identity key. A challenger that
+    # (re)uses the reserved champion id would emit a SECOND card under the same
+    # id — the two arms become indistinguishable in the co-evaluation output and
+    # the registry cannot attribute a result to the right config (§4.5). Reject.
+    if CHAMPION_CANDIDATE_ID in challenger_cfgs:
+        raise ValueError(
+            f"challenger id {CHAMPION_CANDIDATE_ID!r} is reserved for the champion "
+            f"arm — rename it so the two scorecards stay distinguishable in the "
+            f"co-evaluation output/registry (§4.5)"
+        )
 
     split = split_windows(trading_days, spec.window)
     if segment == "train":
@@ -424,10 +434,19 @@ def load_base_overrides(config_path: str | Path = "config/settings.yaml") -> dic
     )
 
     path = Path(config_path)
-    yaml_config: dict[str, Any] = {}
-    if path.exists():
-        with open(path) as f:
-            yaml_config = yaml.safe_load(f) or {}
+    # Unlike core.config.load_settings (which tolerates a missing file and falls
+    # back to code-defaults), this loader's SOLE purpose is to resolve the live
+    # champion baseline. A missing file (typo'd --config, wrong cwd) would return
+    # {} → challengers baseline on pydantic code-defaults with no champion — the
+    # exact §4.5 silent no-op this whole substrate exists to prevent. Fail loud.
+    if not path.exists():
+        raise FileNotFoundError(
+            f"experiment settings file {path} does not exist — refusing to "
+            f"baseline challengers on code-defaults (§4.5); pass the live "
+            f"config path via --config"
+        )
+    with open(path) as f:
+        yaml_config = yaml.safe_load(f) or {}
     yaml_screener = yaml_config.get("stock_screener")
     champion_overrides = load_champion_overrides(path.parent / "model")
     return merge_stock_screener_config(yaml_screener, champion_overrides)

--- a/src/rainier/research/evaluator/screener.py
+++ b/src/rainier/research/evaluator/screener.py
@@ -220,8 +220,17 @@ def build_basket_outcomes(
             if df is None:
                 continue  # money-flow-only symbol — ranks with best_confidence=0
             pos = as_of_index(df, as_of)
-            if pos is not None:
-                windows_by_symbol[sig.symbol] = window_as_of(df, pos)
+            if pos is None:
+                continue  # no bar on/before t — money-flow-only, no pattern credit
+            windowed = window_as_of(df, pos)
+            # Mirror the live Layer-3 gate: screen_stocks feeds patterns via
+            # _fetch_stock_data(symbols, config.min_daily_bars), which DROPS any
+            # symbol whose as-of window carries < min_daily_bars bars and treats
+            # it as money-flow-only. Without this same cut a short-history symbol
+            # would earn pattern credit here that the live ranking never grants —
+            # a parity break in the A/B measuring instrument (best_confidence=0).
+            if len(windowed) >= config.min_daily_bars:
+                windows_by_symbol[sig.symbol] = windowed
 
         selections = replay_screen(
             signals_by_symbol=signals_by_symbol,

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -371,9 +371,15 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
     layer = _require_str(raw, "layer", source)
     primary = _require_str(raw, "primary", source)
 
-    guardrails_raw = raw.get("guardrails")
-    if guardrails_raw is None:
-        guardrails_raw = []
+    if "guardrails" in raw and raw["guardrails"] is None:
+        # A bare `guardrails:` line parses as null — silently loading it as
+        # "no guardrails" would quietly drop the experiment's risk checks.
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: `guardrails:` with no value "
+            f"parses as null — write `guardrails: []` to explicitly declare "
+            f"none, or list the reward keys"
+        )
+    guardrails_raw = raw.get("guardrails", [])
     if not isinstance(guardrails_raw, list) or not all(
         isinstance(g, str) and g for g in guardrails_raw
     ):

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -1,0 +1,302 @@
+"""Experiment-spec interpreter for the A/B substrate (design §10.4).
+
+An experiment is a YAML file, not engine code: champion + challengers +
+the one contended ``layer`` + reward keys + window. Specs live in
+``config/experiments/*.yaml``; each carries ``status: active | retired``
+and :func:`load_active_specs` is the single discovery entry point (cron
+shadow arm, evaluator CLI).
+
+    experiment.yaml ──► interpreter ──► validate override keys ──► deep-merge
+                            │             (model_fields +            (existing
+                            │              pattern names;             merge_stock_
+                            │              reject unknown)            screener_config)
+                            └──► layer = declared field set → mutual exclusion
+
+The override-key validation is load-bearing and CANNOT be delegated
+downstream: ``merge_stock_screener_config`` performs no key validation,
+and ``StockScreenerConfig(**merged)`` silently drops unknown kwargs
+(``core/champion.py:86-88``) — an unvalidated typo'd key would yield a
+challenger identical to the champion, a silent no-op A/B that "finds" no
+difference. The interpreter never invents config paths: a knob must exist
+as a ``StockScreenerConfig`` field before it can be experimented on.
+
+Reward keys (``primary`` / ``guardrails``) are opaque strings here,
+resolved at run time by the reward registry — no import of the rewards
+module (keeps this contract independent of the registry task).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Spec home (pinned in the task plan; consumed by the shadow arm + evaluator).
+DEFAULT_EXPERIMENTS_DIR = Path("config/experiments")
+
+# Default purge/embargo gap for walk-forward validation = the max
+# forward-return horizon H (20 trading days), per §10.4.
+DEFAULT_EMBARGO_DAYS = 20
+
+_VALID_STATUSES = ("active", "retired")
+
+
+class ExperimentSpecError(ValueError):
+    """Raised when an experiment spec fails parse or validation."""
+
+
+@dataclass(frozen=True)
+class ExperimentWindow:
+    """Train/holdout ranges (``start..end`` strings) + embargo gap."""
+
+    train: str
+    holdout: str
+    embargo_days: int = DEFAULT_EMBARGO_DAYS
+
+
+@dataclass(frozen=True)
+class Challenger:
+    """One challenger arm: id + validated override (dotted paths translated)."""
+
+    id: str
+    override: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ExperimentSpec:
+    """A parsed, validated experiment spec (design §10.4)."""
+
+    id: str
+    status: str
+    champion: str
+    layer: str
+    challengers: tuple[Challenger, ...]
+    primary: str
+    guardrails: tuple[str, ...]
+    window: ExperimentWindow
+    source: str = "<memory>"
+
+    @property
+    def is_active(self) -> bool:
+        return self.status == "active"
+
+
+def _validate_override(
+    override: Any, *, spec_id: str, challenger_id: str, source: str
+) -> dict[str, Any]:
+    """Validate every override key; translate ``pattern_weights.<p>`` dotted paths.
+
+    Reuses the check pattern from ``load_champion_overrides``
+    (``core/champion.py:91-110``): flat keys against
+    ``StockScreenerConfig.model_fields``, nested/dotted pattern keys against
+    the known pattern names. Rejects the spec on ANY unknown key — see the
+    module docstring for why this is interpreter-side.
+    """
+    from rainier.core.config import StockScreenerConfig
+
+    ctx = f"{source}: experiment {spec_id!r} challenger {challenger_id!r}"
+    if not isinstance(override, dict) or not override:
+        raise ExperimentSpecError(
+            f"{ctx}: override must be a non-empty mapping — an empty override "
+            f"yields a challenger identical to the champion (silent no-op A/B)"
+        )
+
+    known_fields = set(StockScreenerConfig.model_fields)
+    known_patterns = set(StockScreenerConfig().pattern_weights)
+    out: dict[str, Any] = {}
+    for key, value in override.items():
+        if key.startswith("pattern_weights."):
+            pattern = key.split(".", 1)[1]
+            if pattern not in known_patterns:
+                raise ExperimentSpecError(
+                    f"{ctx}: unknown pattern_weights key {pattern!r} "
+                    f"(typo? known: {sorted(known_patterns)})"
+                )
+            out.setdefault("pattern_weights", {})[pattern] = value
+        elif key == "pattern_weights":
+            if not isinstance(value, dict):
+                raise ExperimentSpecError(
+                    f"{ctx}: pattern_weights override must be a mapping, "
+                    f"got {type(value).__name__}"
+                )
+            unknown_pw = sorted(set(value) - known_patterns)
+            if unknown_pw:
+                raise ExperimentSpecError(
+                    f"{ctx}: unknown pattern_weights key(s): "
+                    f"{', '.join(unknown_pw)} (typo? known: {sorted(known_patterns)})"
+                )
+            out.setdefault("pattern_weights", {}).update(value)
+        elif key in known_fields:
+            out[key] = value
+        else:
+            raise ExperimentSpecError(
+                f"{ctx}: unknown override key {key!r} — override keys must be "
+                f"real StockScreenerConfig fields (or pattern_weights.<pattern> "
+                f"dotted paths); the interpreter never invents config paths"
+            )
+    return out
+
+
+def _require(raw: dict[str, Any], key: str, typ: type, source: str) -> Any:
+    val = raw.get(key)
+    if not isinstance(val, typ) or (typ is str and not val):
+        raise ExperimentSpecError(
+            f"{source}: spec field {key!r} must be a non-empty {typ.__name__}, "
+            f"got {val!r}"
+        )
+    return val
+
+
+def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
+    """Parse + validate one raw spec mapping into an :class:`ExperimentSpec`."""
+    if not isinstance(raw, dict):
+        raise ExperimentSpecError(
+            f"{source}: spec must be a YAML mapping, got {type(raw).__name__}"
+        )
+    spec_id = _require(raw, "id", str, source)
+    status = _require(raw, "status", str, source)
+    if status not in _VALID_STATUSES:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r} has invalid status {status!r} "
+            f"(must be one of {list(_VALID_STATUSES)})"
+        )
+    champion = _require(raw, "champion", str, source)
+    layer = _require(raw, "layer", str, source)
+    primary = _require(raw, "primary", str, source)
+
+    guardrails_raw = raw.get("guardrails") or []
+    if not isinstance(guardrails_raw, list) or not all(
+        isinstance(g, str) for g in guardrails_raw
+    ):
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: guardrails must be a list of strings"
+        )
+
+    window_raw = raw.get("window")
+    if not isinstance(window_raw, dict):
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: window must be a mapping with "
+            f"train/holdout (got {window_raw!r})"
+        )
+    train = window_raw.get("train")
+    holdout = window_raw.get("holdout")
+    if not isinstance(train, str) or not isinstance(holdout, str):
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: window.train and window.holdout "
+            f"are required strings (start..end)"
+        )
+    embargo_days = window_raw.get("embargo_days", DEFAULT_EMBARGO_DAYS)
+    if not isinstance(embargo_days, int) or isinstance(embargo_days, bool) or embargo_days < 0:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: embargo_days must be a "
+            f"non-negative int, got {embargo_days!r}"
+        )
+
+    challengers_raw = raw.get("challengers")
+    if not isinstance(challengers_raw, list) or not challengers_raw:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: challengers must be a non-empty list"
+        )
+    challengers: list[Challenger] = []
+    seen_ids: set[str] = set()
+    for entry in challengers_raw:
+        if not isinstance(entry, dict) or not isinstance(entry.get("id"), str):
+            raise ExperimentSpecError(
+                f"{source}: experiment {spec_id!r}: each challenger needs an "
+                f"`id` and an `override` mapping (got {entry!r})"
+            )
+        cid = entry["id"]
+        if cid in seen_ids:
+            raise ExperimentSpecError(
+                f"{source}: experiment {spec_id!r}: duplicate challenger id {cid!r}"
+            )
+        seen_ids.add(cid)
+        override = _validate_override(
+            entry.get("override"), spec_id=spec_id, challenger_id=cid, source=source
+        )
+        challengers.append(Challenger(id=cid, override=override))
+
+    return ExperimentSpec(
+        id=spec_id,
+        status=status,
+        champion=champion,
+        layer=layer,
+        challengers=tuple(challengers),
+        primary=primary,
+        guardrails=tuple(guardrails_raw),
+        window=ExperimentWindow(train=train, holdout=holdout, embargo_days=embargo_days),
+        source=source,
+    )
+
+
+def load_spec(path: str | Path) -> ExperimentSpec:
+    """Load + validate one experiment spec YAML file."""
+    p = Path(path)
+    with p.open("r") as fh:
+        raw = yaml.safe_load(fh)
+    return parse_spec(raw, source=str(p))
+
+
+def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpec]:
+    """Discover specs in ``config/experiments/*.yaml``; return ACTIVE ones only.
+
+    The single discovery entry point for every consumer. Every spec in the
+    directory must parse (a malformed spec — bad status, unknown override
+    key — fails the whole load loudly; retired-but-broken specs don't get to
+    rot silently). Mutual exclusion is evaluated across the ACTIVE set:
+    two active specs claiming the same ``layer`` is an error, and so are
+    duplicate active experiment ids. Retired specs never conflict.
+    """
+    base = Path(directory) if directory is not None else DEFAULT_EXPERIMENTS_DIR
+    active: list[ExperimentSpec] = []
+    layer_owner: dict[str, str] = {}
+    seen_ids: dict[str, str] = {}
+    for path in sorted(base.glob("*.yaml")):
+        spec = load_spec(path)
+        if not spec.is_active:
+            continue
+        if spec.id in seen_ids:
+            raise ExperimentSpecError(
+                f"duplicate active experiment id {spec.id!r}: "
+                f"{seen_ids[spec.id]} and {path}"
+            )
+        seen_ids[spec.id] = str(path)
+        if spec.layer in layer_owner:
+            raise ExperimentSpecError(
+                f"mutual exclusion: layer {spec.layer!r} claimed by two active "
+                f"experiments: {layer_owner[spec.layer]!r} and {spec.id!r} — "
+                f"retire one before activating the other"
+            )
+        layer_owner[spec.layer] = spec.id
+        active.append(spec)
+    return active
+
+
+def materialize_challengers(
+    spec: ExperimentSpec,
+    base_overrides: dict[str, Any] | None = None,
+) -> tuple[Any, dict[str, Any]]:
+    """Materialize (champion_config, {challenger_id: config}) for a spec.
+
+    ``base_overrides`` is the champion-effective override layer (e.g.
+    ``settings.yaml:stock_screener`` already merged with ``champion.yaml``
+    via the existing loaders). Each challenger = that layer deep-merged with
+    its validated override via the existing ``merge_stock_screener_config``
+    — so a challenger differs from the champion ONLY in the overridden keys,
+    and a partial ``pattern_weights`` override keeps every other pattern's
+    weight. Deep-merge happens only AFTER override-key validation (done at
+    parse time); this function never sees unvalidated keys.
+    """
+    from rainier.core.champion import merge_stock_screener_config
+    from rainier.core.config import StockScreenerConfig
+
+    champion_cfg = StockScreenerConfig(
+        **merge_stock_screener_config(base_overrides, None)
+    )
+    challenger_cfgs: dict[str, Any] = {}
+    for challenger in spec.challengers:
+        merged = merge_stock_screener_config(base_overrides, challenger.override)
+        challenger_cfgs[challenger.id] = StockScreenerConfig(**merged)
+    return champion_cfg, challenger_cfgs

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -50,6 +50,10 @@ if TYPE_CHECKING:  # runtime imports stay local (config load cost, cycle safety)
     from rainier.core.config import StockScreenerConfig
 
 # Spec home (pinned in the task plan; consumed by the shadow arm + evaluator).
+# CWD-relative by project convention — matches DEFAULT_MODEL_DIR in
+# core/champion.py; cron jobs run from the repo root (scripts/cron-wrapper.sh).
+# A wrong CWD fails LOUD (load_active_specs raises on a missing directory),
+# never as a silently empty experiment queue.
 DEFAULT_EXPERIMENTS_DIR = Path("config/experiments")
 
 # Default purge/embargo gap for walk-forward validation = the max
@@ -602,13 +606,17 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
 
 def materialize_challengers(
     spec: ExperimentSpec,
-    base_overrides: dict[str, Any] | None = None,
+    base_overrides: dict[str, Any] | None,
 ) -> tuple["StockScreenerConfig", dict[str, "StockScreenerConfig"]]:
     """Materialize (champion_config, {challenger_id: config}) for a spec.
 
     ``base_overrides`` is the champion-effective override layer (e.g.
     ``settings.yaml:stock_screener`` already merged with ``champion.yaml``
-    via the existing loaders). Each challenger = that layer deep-merged with
+    via the existing loaders). It is deliberately REQUIRED — no default —
+    so a production caller cannot forget it and silently baseline every
+    challenger on pydantic code defaults instead of the live champion.
+    Passing ``None`` explicitly means "code-defaults baseline" and is for
+    synthetic/test replays only. Each challenger = that layer deep-merged with
     its validated override via the existing ``merge_stock_screener_config``
     — so a challenger differs from the champion ONLY in the overridden keys,
     and a partial ``pattern_weights`` override keeps every other pattern's

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -364,8 +364,9 @@ def load_spec(path: str | Path) -> ExperimentSpec:
             raw = yaml.safe_load(fh)
     except yaml.YAMLError as exc:
         raise ExperimentSpecError(f"{p}: invalid YAML — {exc}") from exc
-    except OSError as exc:
-        # PermissionError, IsADirectoryError, … — same contract exception.
+    except (OSError, UnicodeDecodeError) as exc:
+        # PermissionError, IsADirectoryError, non-UTF8 bytes, … — same
+        # contract exception.
         raise ExperimentSpecError(f"{p}: unreadable — {exc}") from exc
     return parse_spec(raw, source=str(p))
 

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -257,10 +257,11 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
     if guardrails_raw is None:
         guardrails_raw = []
     if not isinstance(guardrails_raw, list) or not all(
-        isinstance(g, str) for g in guardrails_raw
+        isinstance(g, str) and g for g in guardrails_raw
     ):
         raise ExperimentSpecError(
-            f"{source}: experiment {spec_id!r}: guardrails must be a list of strings"
+            f"{source}: experiment {spec_id!r}: guardrails must be a list of "
+            f"non-empty strings"
         )
 
     window_raw = raw.get("window")
@@ -358,11 +359,14 @@ def load_spec(path: str | Path) -> ExperimentSpec:
     exception can't miss a broken file.
     """
     p = Path(path)
-    with p.open("r") as fh:
-        try:
+    try:
+        with p.open("r") as fh:
             raw = yaml.safe_load(fh)
-        except yaml.YAMLError as exc:
-            raise ExperimentSpecError(f"{p}: invalid YAML — {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise ExperimentSpecError(f"{p}: invalid YAML — {exc}") from exc
+    except OSError as exc:
+        # PermissionError, IsADirectoryError, … — same contract exception.
+        raise ExperimentSpecError(f"{p}: unreadable — {exc}") from exc
     return parse_spec(raw, source=str(p))
 
 

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -62,6 +62,31 @@ class ExperimentSpecError(ValueError):
     """Raised when an experiment spec fails parse or validation."""
 
 
+class _NoDuplicateKeysLoader(yaml.SafeLoader):
+    """SafeLoader that rejects duplicate mapping keys.
+
+    Plain ``yaml.safe_load`` silently last-write-wins on duplicate keys —
+    a spec with two ``buy_threshold:`` lines (or two ``window:`` blocks)
+    would load the second and drop the first without a sound, defeating
+    the interpreter's declare-it-once stance.
+    """
+
+    def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> dict:
+        seen: list[Any] = []
+        for key_node, _value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if key in seen:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key!r} — last-write-wins would be "
+                    f"silent; declare it once",
+                    key_node.start_mark,
+                )
+            seen.append(key)
+        return super().construct_mapping(node, deep)
+
+
 @dataclass(frozen=True)
 class ExperimentWindow:
     """Train/holdout ranges (``start..end`` strings) + embargo gap."""
@@ -218,6 +243,25 @@ def _validate_override(
         raise ExperimentSpecError(
             f"{ctx}: override value(s) rejected by StockScreenerConfig — {exc}"
         ) from exc
+
+    # Strict mode still admits `.nan` / `.inf` YAML floats: a NaN threshold
+    # makes every score comparison False and a NaN weight poisons composite
+    # scores — the same silent-corruption class, so reject non-finite here.
+    import math
+
+    def _reject_non_finite(label: str, value: Any) -> None:
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ExperimentSpecError(
+                f"{ctx}: override {label!r} is {value!r} — non-finite values "
+                f"(nan/inf) poison score comparisons silently"
+            )
+
+    for key, value in out.items():
+        if key == "pattern_weights" and isinstance(value, dict):
+            for pattern, weight in value.items():
+                _reject_non_finite(f"pattern_weights.{pattern}", weight)
+        else:
+            _reject_non_finite(key, value)
     return out
 
 
@@ -425,7 +469,7 @@ def load_spec(path: str | Path) -> ExperimentSpec:
     p = Path(path)
     try:
         with p.open("r") as fh:
-            raw = yaml.safe_load(fh)
+            raw = yaml.load(fh, Loader=_NoDuplicateKeysLoader)  # noqa: S506 — SafeLoader subclass
     except yaml.YAMLError as exc:
         raise ExperimentSpecError(f"{p}: invalid YAML — {exc}") from exc
     except (OSError, UnicodeDecodeError) as exc:
@@ -462,18 +506,32 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
             f"(indistinguishable from an empty queue); create it or pass "
             f"the right path"
         )
-    stray_yml = sorted(base.glob("*.yml"))
-    if stray_yml:
+    # Any yaml-ish file that `*.yaml` won't match (.yml, .YAML, .YML, …) is
+    # rejected loudly instead of silently skipped. Dotfiles (editor lockfiles
+    # like `.#spec.yaml`, backups) are not specs and are ignored entirely —
+    # an operator merely having a spec open in an editor at cron time must
+    # not fail the run.
+    stray = sorted(
+        p.name
+        for p in base.iterdir()
+        if not p.name.startswith(".")
+        and p.suffix.lower() in {".yml", ".yaml"}
+        and p.suffix != ".yaml"
+    )
+    if stray:
         raise ExperimentSpecError(
-            f"stray .yml spec file(s) in {base}: "
-            f"{', '.join(p.name for p in stray_yml)} — discovery only reads "
-            f"*.yaml; rename to .yaml so the spec isn't silently ignored"
+            f"stray spec file(s) in {base}: {', '.join(stray)} — discovery "
+            f"only reads *.yaml (lowercase); rename so the spec isn't "
+            f"silently ignored"
         )
     active: list[ExperimentSpec] = []
     layer_owner: dict[str, str] = {}
     key_owner: dict[str, str] = {}
+    challenger_owner: dict[str, str] = {}
     seen_ids: dict[str, str] = {}
     for path in sorted(base.glob("*.yaml")):
+        if path.name.startswith("."):
+            continue  # editor lockfiles / backups, not specs
         spec = load_spec(path)
         if not spec.is_active:
             continue
@@ -501,6 +559,17 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
             )
         for k in spec.override_keys:
             key_owner[k] = spec.id
+        for challenger in spec.challengers:
+            if challenger.id in challenger_owner:
+                # Scorecards key on candidate_id (base_scorecard carries no
+                # experiment_id), so two live arms sharing an id would emit
+                # indistinguishable scorecards — misattribution, silently.
+                raise ExperimentSpecError(
+                    f"challenger id {challenger.id!r} used by two active "
+                    f"experiments: {challenger_owner[challenger.id]!r} and "
+                    f"{spec.id!r} — arm ids must be unique across the active set"
+                )
+            challenger_owner[challenger.id] = spec.id
         active.append(spec)
     return active
 
@@ -531,6 +600,31 @@ def materialize_challengers(
 
     from rainier.core.champion import merge_stock_screener_config
     from rainier.core.config import StockScreenerConfig
+
+    if base_overrides:
+        # Key-check the caller's layer too: StockScreenerConfig silently
+        # drops unknown kwargs, so a typo'd base key would materialize a
+        # "champion" that doesn't match the live config — the silent-no-op
+        # class this module never delegates downstream.
+        known = set(StockScreenerConfig.model_fields)
+        unknown = sorted(
+            repr(k) for k in base_overrides if not isinstance(k, str) or k not in known
+        )
+        if unknown:
+            raise ExperimentSpecError(
+                f"experiment {spec.id!r}: unknown base_overrides key(s): "
+                f"{', '.join(unknown)} — StockScreenerConfig would silently "
+                f"drop them (materialized champion would not match the live config)"
+            )
+        base_pw = base_overrides.get("pattern_weights")
+        if isinstance(base_pw, dict):
+            known_patterns = set(StockScreenerConfig().pattern_weights)
+            unknown_pw = sorted(repr(p) for p in set(base_pw) - known_patterns)
+            if unknown_pw:
+                raise ExperimentSpecError(
+                    f"experiment {spec.id!r}: unknown base_overrides "
+                    f"pattern_weights key(s): {', '.join(unknown_pw)}"
+                )
 
     try:
         champion_cfg = StockScreenerConfig(

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -649,9 +649,14 @@ def materialize_challengers(
         )
 
     try:
-        champion_cfg = StockScreenerConfig(
-            **merge_stock_screener_config(base_overrides, None)
-        )
+        merged_champion = merge_stock_screener_config(base_overrides, None)
+        # Value smoke-check the base layer STRICTLY, mirroring the parse-time
+        # check on spec-authored overrides: lax construction would silently
+        # coerce `buy_threshold: true` → 1.0 or "0.35" → 0.35 in the champion
+        # (and every challenger inheriting the field). A malformed base
+        # config fails loudly here instead of skewing the A/B comparison.
+        StockScreenerConfig.model_validate(merged_champion, strict=True)
+        champion_cfg = StockScreenerConfig(**merged_champion)
     except ValidationError as exc:
         raise ExperimentSpecError(
             f"experiment {spec.id!r}: champion base overrides rejected by "

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -24,6 +24,17 @@ as a ``StockScreenerConfig`` field before it can be experimented on.
 Reward keys (``primary`` / ``guardrails``) are opaque strings here,
 resolved at run time by the reward registry — no import of the rewards
 module (keeps this contract independent of the registry task).
+
+``champion:`` names the champion model file the experiment was authored
+against (``champion.yaml`` — a file reference, not a version pin; §10.4
+has no version field). Champion-drift attribution across promotions is
+NOT this layer's job: the evaluator replays champion + challengers from
+ONE :func:`materialize_challengers` call over one corpus (so within any
+evaluation they share the exact base), and every result row is stamped
+with the champion ``version`` + ``corpus_hash`` in the results registry
+(§10.5) — a promotion mid-experiment changes future rows' recorded
+baseline, never silently mixes baselines within one comparison. The
+operator-gated promote flow is a separate task and does not exist yet.
 """
 
 from __future__ import annotations
@@ -610,6 +621,14 @@ def materialize_challengers(
     unattended cron shadow arm. Construction stays lax (parity with the live
     config loaders); spec-authored values were already strict-checked at
     parse time.
+
+    CONSUMER CONTRACT (champion-drift attribution, §10.5): every evaluation
+    must take champion AND challengers from ONE call to this function over
+    one corpus — never mix configs materialized before and after a champion
+    promotion — and must stamp the champion ``version`` + ``corpus_hash``
+    into the results registry row. ``spec.champion`` is a file reference,
+    not a version pin (§10.4 defines no version field); baseline identity is
+    recorded per-result by the registry, not frozen at parse time.
     """
     from pydantic import ValidationError
 

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -29,9 +29,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
+
+if TYPE_CHECKING:  # runtime imports stay local (config load cost, cycle safety)
+    from rainier.core.config import StockScreenerConfig
 
 # Spec home (pinned in the task plan; consumed by the shadow arm + evaluator).
 DEFAULT_EXPERIMENTS_DIR = Path("config/experiments")
@@ -139,12 +142,11 @@ def _validate_override(
     return out
 
 
-def _require(raw: dict[str, Any], key: str, typ: type, source: str) -> Any:
+def _require_str(raw: dict[str, Any], key: str, source: str) -> str:
     val = raw.get(key)
-    if not isinstance(val, typ) or (typ is str and not val):
+    if not isinstance(val, str) or not val:
         raise ExperimentSpecError(
-            f"{source}: spec field {key!r} must be a non-empty {typ.__name__}, "
-            f"got {val!r}"
+            f"{source}: spec field {key!r} must be a non-empty str, got {val!r}"
         )
     return val
 
@@ -155,16 +157,16 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
         raise ExperimentSpecError(
             f"{source}: spec must be a YAML mapping, got {type(raw).__name__}"
         )
-    spec_id = _require(raw, "id", str, source)
-    status = _require(raw, "status", str, source)
+    spec_id = _require_str(raw, "id", source)
+    status = _require_str(raw, "status", source)
     if status not in _VALID_STATUSES:
         raise ExperimentSpecError(
             f"{source}: experiment {spec_id!r} has invalid status {status!r} "
             f"(must be one of {list(_VALID_STATUSES)})"
         )
-    champion = _require(raw, "champion", str, source)
-    layer = _require(raw, "layer", str, source)
-    primary = _require(raw, "primary", str, source)
+    champion = _require_str(raw, "champion", source)
+    layer = _require_str(raw, "layer", source)
+    primary = _require_str(raw, "primary", source)
 
     guardrails_raw = raw.get("guardrails") or []
     if not isinstance(guardrails_raw, list) or not all(
@@ -277,7 +279,7 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
 def materialize_challengers(
     spec: ExperimentSpec,
     base_overrides: dict[str, Any] | None = None,
-) -> tuple[Any, dict[str, Any]]:
+) -> tuple["StockScreenerConfig", dict[str, "StockScreenerConfig"]]:
     """Materialize (champion_config, {challenger_id: config}) for a spec.
 
     ``base_overrides`` is the champion-effective override layer (e.g.
@@ -295,7 +297,7 @@ def materialize_challengers(
     champion_cfg = StockScreenerConfig(
         **merge_stock_screener_config(base_overrides, None)
     )
-    challenger_cfgs: dict[str, Any] = {}
+    challenger_cfgs: dict[str, StockScreenerConfig] = {}
     for challenger in spec.challengers:
         merged = merge_stock_screener_config(base_overrides, challenger.override)
         challenger_cfgs[challenger.id] = StockScreenerConfig(**merged)

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -138,6 +138,13 @@ def _validate_override(
     known_patterns = set(StockScreenerConfig().pattern_weights)
     out: dict[str, Any] = {}
     for key, value in override.items():
+        if not isinstance(key, str):
+            # YAML 1.1 quirks (`on:` → True, bare ints) must surface as the
+            # spec-contract exception, not a downstream TypeError.
+            raise ExperimentSpecError(
+                f"{ctx}: override keys must be str, got {key!r} "
+                f"({type(key).__name__})"
+            )
         if key.startswith("pattern_weights."):
             pattern = key.split(".", 1)[1]
             if pattern not in known_patterns:
@@ -154,10 +161,18 @@ def _validate_override(
                 )
             pw[pattern] = value
         elif key == "pattern_weights":
-            if not isinstance(value, dict):
+            if not isinstance(value, dict) or not value:
+                # An EMPTY mapping would translate to an empty override —
+                # a challenger identical to the champion (silent no-op A/B)
+                # that would also escape cross-spec mutual exclusion.
                 raise ExperimentSpecError(
-                    f"{ctx}: pattern_weights override must be a mapping, "
-                    f"got {type(value).__name__}"
+                    f"{ctx}: pattern_weights override must be a non-empty "
+                    f"mapping, got {value!r}"
+                )
+            non_str_pw = [p for p in value if not isinstance(p, str)]
+            if non_str_pw:
+                raise ExperimentSpecError(
+                    f"{ctx}: pattern_weights keys must be str, got {non_str_pw!r}"
                 )
             unknown_pw = sorted(set(value) - known_patterns)
             if unknown_pw:
@@ -214,6 +229,12 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
         raise ExperimentSpecError(
             f"{source}: spec must be a YAML mapping, got {type(raw).__name__}"
         )
+    non_str = [k for k in raw if not isinstance(k, str)]
+    if non_str:
+        raise ExperimentSpecError(
+            f"{source}: spec keys must be str, got {non_str!r} "
+            f"(YAML 1.1 parses bare `on`/`yes` as booleans — quote them)"
+        )
     unknown_keys = sorted(set(raw) - _ALLOWED_SPEC_KEYS)
     if unknown_keys:
         raise ExperimentSpecError(
@@ -232,7 +253,9 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
     layer = _require_str(raw, "layer", source)
     primary = _require_str(raw, "primary", source)
 
-    guardrails_raw = raw.get("guardrails") or []
+    guardrails_raw = raw.get("guardrails")
+    if guardrails_raw is None:
+        guardrails_raw = []
     if not isinstance(guardrails_raw, list) or not all(
         isinstance(g, str) for g in guardrails_raw
     ):
@@ -245,6 +268,12 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
         raise ExperimentSpecError(
             f"{source}: experiment {spec_id!r}: window must be a mapping with "
             f"train/holdout (got {window_raw!r})"
+        )
+    non_str_w = [k for k in window_raw if not isinstance(k, str)]
+    if non_str_w:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: window keys must be str, "
+            f"got {non_str_w!r}"
         )
     unknown_window = sorted(set(window_raw) - _ALLOWED_WINDOW_KEYS)
     if unknown_window:
@@ -279,6 +308,12 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
             raise ExperimentSpecError(
                 f"{source}: experiment {spec_id!r}: each challenger needs an "
                 f"`id` and an `override` mapping (got {entry!r})"
+            )
+        non_str_c = [k for k in entry if not isinstance(k, str)]
+        if non_str_c:
+            raise ExperimentSpecError(
+                f"{source}: experiment {spec_id!r}: challenger keys must be "
+                f"str, got {non_str_c!r}"
             )
         unknown_c = sorted(set(entry) - _ALLOWED_CHALLENGER_KEYS)
         if unknown_c:

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -29,6 +29,7 @@ module (keeps this contract independent of the registry task).
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -201,12 +202,18 @@ def _validate_override(
     # Value smoke-check at parse time: a bad value (e.g. a non-numeric weight)
     # must fail at spec-authoring/load time as ExperimentSpecError, not at
     # 8am inside the cron shadow arm as a raw pydantic ValidationError.
+    # STRICT validation: lax construction would coerce `buy_threshold: true`
+    # to 1.0 (a plausible-looking losing challenger — silent corruption of
+    # the A/B result) and accept numeric strings like "0.35". Strict mode
+    # still accepts int where a float is declared, so `weight: 1` stays valid.
     from pydantic import ValidationError
 
     from rainier.core.champion import merge_stock_screener_config
 
     try:
-        StockScreenerConfig(**merge_stock_screener_config(None, out))
+        StockScreenerConfig.model_validate(
+            merge_stock_screener_config(None, out), strict=True
+        )
     except ValidationError as exc:
         raise ExperimentSpecError(
             f"{ctx}: override value(s) rejected by StockScreenerConfig — {exc}"
@@ -221,6 +228,43 @@ def _require_str(raw: dict[str, Any], key: str, source: str) -> str:
             f"{source}: spec field {key!r} must be a non-empty str, got {val!r}"
         )
     return val
+
+
+_WINDOW_RANGE_HINT = "YYYY-MM-DD..YYYY-MM-DD"
+
+
+def _parse_date_range(value: Any, *, field: str, ctx: str) -> tuple[date, date]:
+    """Parse one ``start..end`` window string into (start, end) dates.
+
+    A garbage/empty/reversed range would otherwise parse cleanly here and
+    detonate (or worse, silently mis-slice) downstream in the evaluator at
+    cron time — the exact failure class the parse-time value smoke-check
+    exists to prevent for override values.
+    """
+    if not isinstance(value, str) or not value:
+        raise ExperimentSpecError(
+            f"{ctx}: window.{field} is a required non-empty string "
+            f"({_WINDOW_RANGE_HINT}), got {value!r}"
+        )
+    parts = value.split("..")
+    if len(parts) != 2:
+        raise ExperimentSpecError(
+            f"{ctx}: window.{field} must be {_WINDOW_RANGE_HINT!r} "
+            f"(exactly one `..` separator), got {value!r}"
+        )
+    try:
+        start, end = date.fromisoformat(parts[0]), date.fromisoformat(parts[1])
+    except ValueError as exc:
+        raise ExperimentSpecError(
+            f"{ctx}: window.{field} must be {_WINDOW_RANGE_HINT!r}, "
+            f"got {value!r} — {exc}"
+        ) from exc
+    if start > end:
+        raise ExperimentSpecError(
+            f"{ctx}: window.{field} start {parts[0]} is after end {parts[1]} "
+            f"— reversed range"
+        )
+    return start, end
 
 
 def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
@@ -263,6 +307,18 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
             f"{source}: experiment {spec_id!r}: guardrails must be a list of "
             f"non-empty strings"
         )
+    dup_guardrails = sorted({g for g in guardrails_raw if guardrails_raw.count(g) > 1})
+    if dup_guardrails:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: duplicate guardrail(s): "
+            f"{', '.join(dup_guardrails)}"
+        )
+    if primary in guardrails_raw:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: primary reward {primary!r} is "
+            f"also listed in guardrails — a reward key is either the "
+            f"optimization target or a guardrail, not both"
+        )
 
     window_raw = raw.get("window")
     if not isinstance(window_raw, dict):
@@ -283,12 +339,20 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
             f"{', '.join(unknown_window)} (allowed: {sorted(_ALLOWED_WINDOW_KEYS)}; "
             f"a typo'd `embargo_dayz:` would otherwise silently keep the default)"
         )
+    ctx = f"{source}: experiment {spec_id!r}"
     train = window_raw.get("train")
     holdout = window_raw.get("holdout")
-    if not isinstance(train, str) or not isinstance(holdout, str):
+    _, train_end = _parse_date_range(train, field="train", ctx=ctx)
+    holdout_start, _ = _parse_date_range(holdout, field="holdout", ctx=ctx)
+    if holdout_start <= train_end:
+        # Overlapping (or reversed) train/holdout leaks training data into
+        # the holdout. The embargo gap in TRADING days is enforced by the
+        # evaluator, which owns the trading calendar — here we can only pin
+        # the calendar-level ordering invariant.
         raise ExperimentSpecError(
-            f"{source}: experiment {spec_id!r}: window.train and window.holdout "
-            f"are required strings (start..end)"
+            f"{ctx}: window.holdout ({holdout}) must start after window.train "
+            f"ends ({train}) — overlapping windows leak train data into the "
+            f"holdout"
         )
     embargo_days = window_raw.get("embargo_days", DEFAULT_EMBARGO_DAYS)
     if not isinstance(embargo_days, int) or isinstance(embargo_days, bool) or embargo_days < 0:
@@ -383,8 +447,28 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
     name — two active specs overriding the SAME config knob under different
     labels is ALSO an error (entangled experiments would contaminate
     attribution silently). Retired specs never conflict.
+
+    Discovery itself fails loudly too: a MISSING directory raises (a wrong
+    CWD or a deploy that lost ``config/experiments`` would otherwise be
+    indistinguishable from a legitimately empty queue — the same silent-no-op
+    class the interpreter exists to kill), and stray ``*.yml`` files are
+    rejected rather than silently skipped.
     """
     base = Path(directory) if directory is not None else DEFAULT_EXPERIMENTS_DIR
+    if not base.is_dir():
+        raise ExperimentSpecError(
+            f"experiments directory {base} does not exist — a missing "
+            f"directory would silently disable every experiment "
+            f"(indistinguishable from an empty queue); create it or pass "
+            f"the right path"
+        )
+    stray_yml = sorted(base.glob("*.yml"))
+    if stray_yml:
+        raise ExperimentSpecError(
+            f"stray .yml spec file(s) in {base}: "
+            f"{', '.join(p.name for p in stray_yml)} — discovery only reads "
+            f"*.yaml; rename to .yaml so the spec isn't silently ignored"
+        )
     active: list[ExperimentSpec] = []
     layer_owner: dict[str, str] = {}
     key_owner: dict[str, str] = {}
@@ -435,15 +519,36 @@ def materialize_challengers(
     and a partial ``pattern_weights`` override keeps every other pattern's
     weight. Deep-merge happens only AFTER override-key validation (done at
     parse time); this function never sees unvalidated keys.
+
+    ``base_overrides`` come from the CALLER (settings/champion layer), not
+    the spec, so they are validated here — a bad value must still surface as
+    the contract exception, not a raw pydantic ``ValidationError`` inside the
+    unattended cron shadow arm. Construction stays lax (parity with the live
+    config loaders); spec-authored values were already strict-checked at
+    parse time.
     """
+    from pydantic import ValidationError
+
     from rainier.core.champion import merge_stock_screener_config
     from rainier.core.config import StockScreenerConfig
 
-    champion_cfg = StockScreenerConfig(
-        **merge_stock_screener_config(base_overrides, None)
-    )
+    try:
+        champion_cfg = StockScreenerConfig(
+            **merge_stock_screener_config(base_overrides, None)
+        )
+    except ValidationError as exc:
+        raise ExperimentSpecError(
+            f"experiment {spec.id!r}: champion base overrides rejected by "
+            f"StockScreenerConfig — {exc}"
+        ) from exc
     challenger_cfgs: dict[str, StockScreenerConfig] = {}
     for challenger in spec.challengers:
         merged = merge_stock_screener_config(base_overrides, challenger.override)
-        challenger_cfgs[challenger.id] = StockScreenerConfig(**merged)
+        try:
+            challenger_cfgs[challenger.id] = StockScreenerConfig(**merged)
+        except ValidationError as exc:
+            raise ExperimentSpecError(
+                f"experiment {spec.id!r} challenger {challenger.id!r}: merged "
+                f"config rejected by StockScreenerConfig — {exc}"
+            ) from exc
     return champion_cfg, challenger_cfgs

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -10,7 +10,8 @@ shadow arm, evaluator CLI).
                             │             (model_fields +            (existing
                             │              pattern names;             merge_stock_
                             │              reject unknown)            screener_config)
-                            └──► layer = declared field set → mutual exclusion
+                            └──► mutual exclusion across ACTIVE specs:
+                                 layer label unique AND override-key sets disjoint
 
 The override-key validation is load-bearing and CANNOT be delegated
 downstream: ``merge_stock_screener_config`` performs no key validation,
@@ -44,6 +45,16 @@ DEFAULT_EXPERIMENTS_DIR = Path("config/experiments")
 DEFAULT_EMBARGO_DAYS = 20
 
 _VALID_STATUSES = ("active", "retired")
+
+# Design §10.4 pins the exact spec shape — unknown keys are rejected loudly.
+# Without this, a typo'd `guardrail:` (singular) would parse cleanly into a
+# guardrail-free experiment, and `embargo_dayz:` would silently keep the
+# default embargo — the same silent-no-op class the override-key check kills.
+_ALLOWED_SPEC_KEYS = frozenset(
+    {"id", "status", "champion", "layer", "challengers", "primary", "guardrails", "window"}
+)
+_ALLOWED_WINDOW_KEYS = frozenset({"train", "holdout", "embargo_days"})
+_ALLOWED_CHALLENGER_KEYS = frozenset({"id", "override"})
 
 
 class ExperimentSpecError(ValueError):
@@ -85,6 +96,23 @@ class ExperimentSpec:
     def is_active(self) -> bool:
         return self.status == "active"
 
+    @property
+    def override_keys(self) -> frozenset[str]:
+        """Granular knob set this experiment contends, across all challengers.
+
+        ``pattern_weights`` is expanded to per-pattern ``pattern_weights.<p>``
+        keys so two experiments touching DIFFERENT patterns don't conflict.
+        Used by :func:`load_active_specs` for cross-spec mutual exclusion.
+        """
+        keys: set[str] = set()
+        for challenger in self.challengers:
+            for key, value in challenger.override.items():
+                if key == "pattern_weights" and isinstance(value, dict):
+                    keys.update(f"pattern_weights.{p}" for p in value)
+                else:
+                    keys.add(key)
+        return frozenset(keys)
+
 
 def _validate_override(
     override: Any, *, spec_id: str, challenger_id: str, source: str
@@ -117,7 +145,14 @@ def _validate_override(
                     f"{ctx}: unknown pattern_weights key {pattern!r} "
                     f"(typo? known: {sorted(known_patterns)})"
                 )
-            out.setdefault("pattern_weights", {})[pattern] = value
+            pw = out.setdefault("pattern_weights", {})
+            if pattern in pw:
+                raise ExperimentSpecError(
+                    f"{ctx}: pattern {pattern!r} assigned twice (dotted "
+                    f"`pattern_weights.{pattern}` AND nested `pattern_weights:`) "
+                    f"— last-write-wins would be silent; declare it once"
+                )
+            pw[pattern] = value
         elif key == "pattern_weights":
             if not isinstance(value, dict):
                 raise ExperimentSpecError(
@@ -130,7 +165,15 @@ def _validate_override(
                     f"{ctx}: unknown pattern_weights key(s): "
                     f"{', '.join(unknown_pw)} (typo? known: {sorted(known_patterns)})"
                 )
-            out.setdefault("pattern_weights", {}).update(value)
+            pw = out.setdefault("pattern_weights", {})
+            dup = sorted(set(value) & set(pw))
+            if dup:
+                raise ExperimentSpecError(
+                    f"{ctx}: pattern(s) {', '.join(dup)} assigned twice (dotted "
+                    f"`pattern_weights.<p>` AND nested `pattern_weights:`) "
+                    f"— last-write-wins would be silent; declare each once"
+                )
+            pw.update(value)
         elif key in known_fields:
             out[key] = value
         else:
@@ -139,6 +182,20 @@ def _validate_override(
                 f"real StockScreenerConfig fields (or pattern_weights.<pattern> "
                 f"dotted paths); the interpreter never invents config paths"
             )
+
+    # Value smoke-check at parse time: a bad value (e.g. a non-numeric weight)
+    # must fail at spec-authoring/load time as ExperimentSpecError, not at
+    # 8am inside the cron shadow arm as a raw pydantic ValidationError.
+    from pydantic import ValidationError
+
+    from rainier.core.champion import merge_stock_screener_config
+
+    try:
+        StockScreenerConfig(**merge_stock_screener_config(None, out))
+    except ValidationError as exc:
+        raise ExperimentSpecError(
+            f"{ctx}: override value(s) rejected by StockScreenerConfig — {exc}"
+        ) from exc
     return out
 
 
@@ -156,6 +213,13 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
     if not isinstance(raw, dict):
         raise ExperimentSpecError(
             f"{source}: spec must be a YAML mapping, got {type(raw).__name__}"
+        )
+    unknown_keys = sorted(set(raw) - _ALLOWED_SPEC_KEYS)
+    if unknown_keys:
+        raise ExperimentSpecError(
+            f"{source}: unknown spec key(s): {', '.join(unknown_keys)} — the "
+            f"§10.4 spec shape is exact (allowed: {sorted(_ALLOWED_SPEC_KEYS)}); "
+            f"a typo'd key (e.g. `guardrail:`) would otherwise be silently ignored"
         )
     spec_id = _require_str(raw, "id", source)
     status = _require_str(raw, "status", source)
@@ -181,6 +245,13 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
         raise ExperimentSpecError(
             f"{source}: experiment {spec_id!r}: window must be a mapping with "
             f"train/holdout (got {window_raw!r})"
+        )
+    unknown_window = sorted(set(window_raw) - _ALLOWED_WINDOW_KEYS)
+    if unknown_window:
+        raise ExperimentSpecError(
+            f"{source}: experiment {spec_id!r}: unknown window key(s): "
+            f"{', '.join(unknown_window)} (allowed: {sorted(_ALLOWED_WINDOW_KEYS)}; "
+            f"a typo'd `embargo_dayz:` would otherwise silently keep the default)"
         )
     train = window_raw.get("train")
     holdout = window_raw.get("holdout")
@@ -209,7 +280,18 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
                 f"{source}: experiment {spec_id!r}: each challenger needs an "
                 f"`id` and an `override` mapping (got {entry!r})"
             )
+        unknown_c = sorted(set(entry) - _ALLOWED_CHALLENGER_KEYS)
+        if unknown_c:
+            raise ExperimentSpecError(
+                f"{source}: experiment {spec_id!r}: unknown challenger key(s): "
+                f"{', '.join(unknown_c)} (allowed: id, override)"
+            )
         cid = entry["id"]
+        if not cid:
+            raise ExperimentSpecError(
+                f"{source}: experiment {spec_id!r}: challenger id must be a "
+                f"non-empty str"
+            )
         if cid in seen_ids:
             raise ExperimentSpecError(
                 f"{source}: experiment {spec_id!r}: duplicate challenger id {cid!r}"
@@ -234,10 +316,18 @@ def parse_spec(raw: Any, source: str = "<memory>") -> ExperimentSpec:
 
 
 def load_spec(path: str | Path) -> ExperimentSpec:
-    """Load + validate one experiment spec YAML file."""
+    """Load + validate one experiment spec YAML file.
+
+    Every failure — including a YAML syntax error — surfaces as
+    :class:`ExperimentSpecError`, so consumers catching the spec-contract
+    exception can't miss a broken file.
+    """
     p = Path(path)
     with p.open("r") as fh:
-        raw = yaml.safe_load(fh)
+        try:
+            raw = yaml.safe_load(fh)
+        except yaml.YAMLError as exc:
+            raise ExperimentSpecError(f"{p}: invalid YAML — {exc}") from exc
     return parse_spec(raw, source=str(p))
 
 
@@ -248,12 +338,16 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
     directory must parse (a malformed spec — bad status, unknown override
     key — fails the whole load loudly; retired-but-broken specs don't get to
     rot silently). Mutual exclusion is evaluated across the ACTIVE set:
-    two active specs claiming the same ``layer`` is an error, and so are
-    duplicate active experiment ids. Retired specs never conflict.
+    two active specs claiming the same ``layer`` label is an error, duplicate
+    active experiment ids are an error, and — because a layer label is just a
+    name — two active specs overriding the SAME config knob under different
+    labels is ALSO an error (entangled experiments would contaminate
+    attribution silently). Retired specs never conflict.
     """
     base = Path(directory) if directory is not None else DEFAULT_EXPERIMENTS_DIR
     active: list[ExperimentSpec] = []
     layer_owner: dict[str, str] = {}
+    key_owner: dict[str, str] = {}
     seen_ids: dict[str, str] = {}
     for path in sorted(base.glob("*.yaml")):
         spec = load_spec(path)
@@ -272,6 +366,17 @@ def load_active_specs(directory: str | Path | None = None) -> list[ExperimentSpe
                 f"retire one before activating the other"
             )
         layer_owner[spec.layer] = spec.id
+        overlap = sorted(k for k in spec.override_keys if k in key_owner)
+        if overlap:
+            raise ExperimentSpecError(
+                f"mutual exclusion: override key(s) {', '.join(overlap)} "
+                f"contended by two active experiments: "
+                f"{key_owner[overlap[0]]!r} and {spec.id!r} — a knob belongs "
+                f"to at most one active experiment (layer labels don't "
+                f"substitute for disjoint key sets)"
+            )
+        for k in spec.override_keys:
+            key_owner[k] = spec.id
         active.append(spec)
     return active
 

--- a/src/rainier/research/experiment.py
+++ b/src/rainier/research/experiment.py
@@ -74,6 +74,10 @@ class _NoDuplicateKeysLoader(yaml.SafeLoader):
     def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> dict:
         seen: list[Any] = []
         for key_node, _value_node in node.value:
+            if key_node.tag == "tag:yaml.org,2002:merge":
+                # `<<:` merge keys are flattened by SafeLoader with documented
+                # override semantics (explicit keys win) — not author duplicates.
+                continue
             key = self.construct_object(key_node, deep=deep)
             if key in seen:
                 raise yaml.constructor.ConstructorError(
@@ -247,22 +251,33 @@ def _validate_override(
     # Strict mode still admits `.nan` / `.inf` YAML floats: a NaN threshold
     # makes every score comparison False and a NaN weight poisons composite
     # scores — the same silent-corruption class, so reject non-finite here.
+    _require_finite_values(out, ctx)
+    return out
+
+
+def _require_finite_values(overrides: dict[str, Any], ctx: str) -> None:
+    """Reject nan/inf floats in an override layer (incl. nested pattern_weights).
+
+    pydantic strict mode admits ``.nan`` / ``.inf`` floats; non-finite
+    thresholds/weights poison score comparisons silently instead of failing.
+    Used for spec-authored overrides at parse time AND caller-supplied
+    ``base_overrides`` at materialization time.
+    """
     import math
 
-    def _reject_non_finite(label: str, value: Any) -> None:
+    def _check(label: str, value: Any) -> None:
         if isinstance(value, float) and not math.isfinite(value):
             raise ExperimentSpecError(
-                f"{ctx}: override {label!r} is {value!r} — non-finite values "
+                f"{ctx}: {label!r} is {value!r} — non-finite values "
                 f"(nan/inf) poison score comparisons silently"
             )
 
-    for key, value in out.items():
+    for key, value in overrides.items():
         if key == "pattern_weights" and isinstance(value, dict):
             for pattern, weight in value.items():
-                _reject_non_finite(f"pattern_weights.{pattern}", weight)
+                _check(f"pattern_weights.{pattern}", weight)
         else:
-            _reject_non_finite(key, value)
-    return out
+            _check(key, value)
 
 
 def _require_str(raw: dict[str, Any], key: str, source: str) -> str:
@@ -625,6 +640,13 @@ def materialize_challengers(
                     f"experiment {spec.id!r}: unknown base_overrides "
                     f"pattern_weights key(s): {', '.join(unknown_pw)}"
                 )
+        # A nan/inf in the base layer would materialize a champion (and every
+        # challenger inheriting the field) with non-finite thresholds/weights
+        # — the same silent-poisoning _validate_override guards against for
+        # spec-authored values.
+        _require_finite_values(
+            base_overrides, f"experiment {spec.id!r}: base_overrides"
+        )
 
     try:
         champion_cfg = StockScreenerConfig(

--- a/src/rainier/research/output_schema.py
+++ b/src/rainier/research/output_schema.py
@@ -43,8 +43,13 @@ class _FieldSpec:
 def load(path: str | Path | None = None) -> dict[str, Any]:
     """Read the schema YAML; returned dict is the raw shape (schemas: {...})."""
     p = Path(path) if path is not None else SCHEMA_PATH
-    with p.open("r") as fh:
-        data = yaml.safe_load(fh)
+    try:
+        with p.open("r") as fh:
+            data = yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        # Consumers catch SchemaError (the module contract) — a raw
+        # ParserError from a broken schema file must not bypass them.
+        raise SchemaError(f"{p}: invalid YAML — {exc}") from exc
     if not isinstance(data, dict) or "schemas" not in data:
         raise SchemaError(f"{p} has no top-level `schemas:` key")
     return data
@@ -200,7 +205,12 @@ def parse_block(text: str) -> dict[str, Any]:
         raise SchemaError("block is not `---` fenced")
     # Drop the fences.
     inner = stripped[3:-3].strip()
-    parsed = yaml.safe_load(inner)
+    try:
+        parsed = yaml.safe_load(inner)
+    except yaml.YAMLError as exc:
+        # A truncated block (process killed mid-write) must surface as the
+        # module contract exception, not a raw yaml ParserError.
+        raise SchemaError(f"block is not valid YAML — {exc}") from exc
     if not isinstance(parsed, dict):
         raise SchemaError(f"block must parse to a dict; got {type(parsed).__name__}")
     return parsed

--- a/src/rainier/research/output_schema.py
+++ b/src/rainier/research/output_schema.py
@@ -8,6 +8,7 @@ new verb adds a block (not by inventing fields ad-hoc in CLI code).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -69,18 +70,8 @@ def _coerce_fields(schema: dict[str, Any]) -> list[_FieldSpec]:
     return out
 
 
-def validate(name: str, payload: dict[str, Any], strict: bool = True) -> None:
-    """Validate ``payload`` against the schema named ``name``.
-
-    Strict mode (default) rejects any extra field not declared in the schema.
-    Non-strict mode tolerates forward-compatible extras — used at runtime so
-    a new field added in a future commit doesn't blow up an older CLI.
-    """
-    data = load()
-    schemas = data["schemas"]
-    if name not in schemas:
-        raise SchemaError(f"unknown schema {name!r}; known: {sorted(schemas)}")
-    specs = _coerce_fields(schemas[name])
+def _check_payload(specs: list[_FieldSpec], payload: dict[str, Any], strict: bool) -> None:
+    """Shared field checks: presence, strict extras, types, enums."""
     declared = {spec.name for spec in specs}
 
     missing = declared - payload.keys()
@@ -105,6 +96,53 @@ def validate(name: str, payload: dict[str, Any], strict: bool = True) -> None:
             raise SchemaError(
                 f"field {spec.name!r}: value {val!r} not in enum {spec.enum}"
             )
+
+
+def validate(name: str, payload: dict[str, Any], strict: bool = True) -> None:
+    """Validate ``payload`` against the schema named ``name``.
+
+    Strict mode (default) rejects any extra field not declared in the schema.
+    Non-strict mode tolerates forward-compatible extras — used at runtime so
+    a new field added in a future commit doesn't blow up an older CLI.
+    """
+    data = load()
+    schemas = data["schemas"]
+    if name not in schemas:
+        raise SchemaError(f"unknown schema {name!r}; known: {sorted(schemas)}")
+    _check_payload(_coerce_fields(schemas[name]), payload, strict)
+
+
+def validate_composed(
+    base: str,
+    payload: dict[str, Any],
+    extensions: Sequence[str] = (),
+    strict: bool = True,
+) -> None:
+    """Validate ``payload`` against a base schema plus optional extensions.
+
+    A/B-substrate scorecards (design §10.5) compose a candidate-agnostic
+    ``base_scorecard`` with optional per-candidate-type extensions (e.g.
+    ``llm_extension``). The composed field set is the union of the named
+    schemas: every field of the base AND every named extension is required;
+    extras beyond the union fail strict mode. An extension payload alone
+    fails on the missing base fields — the extension is never standalone.
+    """
+    data = load()
+    schemas = data["schemas"]
+    specs: list[_FieldSpec] = []
+    seen: set[str] = set()
+    for name in (base, *extensions):
+        if name not in schemas:
+            raise SchemaError(f"unknown schema {name!r}; known: {sorted(schemas)}")
+        for spec in _coerce_fields(schemas[name]):
+            if spec.name in seen:
+                raise SchemaError(
+                    f"field {spec.name!r} declared by more than one of "
+                    f"{[base, *extensions]}"
+                )
+            seen.add(spec.name)
+            specs.append(spec)
+    _check_payload(specs, payload, strict)
 
 
 def format_block(name: str, payload: dict[str, Any]) -> str:

--- a/src/rainier/research/output_schema.py
+++ b/src/rainier/research/output_schema.py
@@ -87,6 +87,14 @@ def _check_payload(specs: list[_FieldSpec], payload: dict[str, Any], strict: boo
         val = payload[spec.name]
         if val is None and spec.nullable:
             continue
+        allowed = spec.py_type if isinstance(spec.py_type, tuple) else (spec.py_type,)
+        if isinstance(val, bool) and bool not in allowed:
+            # bool is a subclass of int: `n_selection_days: true` would
+            # otherwise pass the int/float check and land as 1/1.0 in
+            # promotion artifacts — silent type corruption.
+            raise SchemaError(
+                f"field {spec.name!r}: expected {spec.py_type}, got bool ({val!r})"
+            )
         if not isinstance(val, spec.py_type):  # type: ignore[arg-type]
             raise SchemaError(
                 f"field {spec.name!r}: expected {spec.py_type}, got "

--- a/src/rainier/research/output_schema.py
+++ b/src/rainier/research/output_schema.py
@@ -194,6 +194,35 @@ def format_block(name: str, payload: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def format_block_composed(
+    base: str,
+    payload: dict[str, Any],
+    extensions: Sequence[str] = (),
+) -> str:
+    """Render a composed (base + extensions) payload as a fenced YAML block.
+
+    Mirrors :func:`format_block` for the composed-scorecard case (§10.5) —
+    without this, an evaluator emitting ``base_scorecard + llm_extension``
+    would have no serializer (plain ``format_block`` rejects the extension
+    fields as extras). Field order is base-schema declaration order, then
+    each extension's declaration order, so byte-identical inputs produce
+    byte-identical output. ``parse_block`` is the shared inverse.
+    """
+    validate_composed(base, payload, extensions=extensions, strict=True)
+    data = load()
+    lines = ["---"]
+    for name in (base, *extensions):
+        for spec in _coerce_fields(data["schemas"][name]):
+            val = payload[spec.name]
+            dumped = yaml.safe_dump(val, default_flow_style=True).strip()
+            if dumped.endswith("\n..."):
+                dumped = dumped[: -len("\n...")]
+            lines.append(f"{spec.name}: {dumped}")
+    lines.append("---")
+    lines.append("")  # trailing newline
+    return "\n".join(lines)
+
+
 def parse_block(text: str) -> dict[str, Any]:
     """Inverse of ``format_block`` — extract a single fenced YAML block.
 

--- a/src/rainier/research/output_schema.py
+++ b/src/rainier/research/output_schema.py
@@ -127,6 +127,13 @@ def validate_composed(
     extras beyond the union fail strict mode. An extension payload alone
     fails on the missing base fields — the extension is never standalone.
     """
+    if isinstance(extensions, str):
+        # str is itself a Sequence[str]; a bare 'llm_extension' would iterate
+        # per-character and fail with a baffling "unknown schema 'l'".
+        raise SchemaError(
+            f"extensions must be a sequence of schema names, "
+            f"got bare string {extensions!r} — wrap it in a list"
+        )
     data = load()
     schemas = data["schemas"]
     specs: list[_FieldSpec] = []

--- a/src/rainier/research/output_schema.yaml
+++ b/src/rainier/research/output_schema.yaml
@@ -62,6 +62,55 @@ schemas:
         type: str
         nullable: true
 
+  # A/B substrate — candidate-agnostic base scorecard, per
+  # DESIGN-qu100-ab-testing.md §10.5. Every evaluator (screener replay, LLM
+  # backtest) emits this core; candidate-specific fields live in extension
+  # schemas composed via output_schema.validate_composed().
+  base_scorecard:
+    fields:
+      candidate_id:
+        type: str
+      candidate_type:
+        type: str
+      window:
+        type: str
+      n_selection_days:
+        type: int
+      corpus_hash:
+        type: str
+      # Reward values keyed by role: {primary: {...}, guardrails: {...},
+      # secondary: {...}} — reward keys are opaque strings here (§10.3).
+      rewards:
+        type: dict
+      # Per-regime reward slices (regime tag -> reward values), §4.4.
+      regime_scores:
+        type: dict
+      # ALWAYS null until the §11-task-6 DSR spec lands — never a naively
+      # computed number (design §4.4).
+      deflated_sharpe:
+        type: float
+        nullable: true
+      evaluator_sha:
+        type: str
+
+  # A/B substrate — optional LLM extension composed on top of base_scorecard
+  # (§10.5). Not required of the screener evaluator; the LLM-shaped
+  # `backtest` entry below stays untouched for its existing consumer.
+  llm_extension:
+    fields:
+      valid_thesis_rate:
+        type: float
+      cost_usd:
+        type: float
+      filled_R:
+        type: float
+      filled_rate:
+        type: float
+      tqqq_bh_R:
+        type: float
+      skill_yaml_sha:
+        type: str
+
   # Slice 1+ — L3 backtest summary, per [D-031] in DESIGN-qu100-llm-backtest.md.
   # Declared here so subsequent slices don't drift on shape; not exercised
   # in Slice 0 tests beyond shape parity.

--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -1,24 +1,188 @@
-"""Reward-function registry — concrete reward bodies land in Slice 1.
+"""Input-typed reward registry for the A/B substrate.
 
-Slice 0 ships the registry surface (an empty dict) so other modules can
-import it without breaking once Slice 1 lands the seven pre-registered
-reward functions (D-007).
+Design: docs/DESIGN-qu100-ab-testing.md §4.2, §10.3.
+
+A reward = a fact (the scored data) + an aggregation, declared as
+config-as-data. Each registered reward carries:
+
+  input_type  which candidate payload it can score —
+              "basket" (screener, BasketOutcomes) or "trades" (LLM,
+              TradeRecord series)
+  role        "primary" (the objective being optimized),
+              "guardrail" (blocks promotion on breach; carries threshold),
+              "secondary" (reported, not gating)
+  direction   "increase" (higher is better) or "decrease" (lower is better)
+  threshold   guardrail-only breach bound
+
+The registry REFUSES to score a candidate with a reward registered for a
+different input type — a loud ValueError, never silent mis-scoring (§4.2).
+
+Rewards are pure, deterministic, side-effect-free. The promote-time gate
+that consumes ``guardrail_breached`` is ab-registry-promote-84a7's scope.
+
+::
+
+    candidate payload ──► score(candidate_type, reward_name, payload)
+                              │
+                              ├─ input_type mismatch ──► ValueError (loud)
+                              └─ match ────────────────► spec.fn(payload)
 """
 
 from __future__ import annotations
 
-from typing import Callable
+from dataclasses import dataclass
+from typing import Any, Callable
 
-#: name → callable. Each callable takes a TradeRecord and returns a float.
-#: Slice 1 populates this with r_multiple_expectancy, all_call_R, etc.
-REGISTRY: dict[str, Callable] = {}
+INPUT_TYPES = frozenset({"basket", "trades"})
+ROLES = frozenset({"primary", "guardrail", "secondary"})
+DIRECTIONS = frozenset({"increase", "decrease"})
 
 
-def register(name: str, fn: Callable) -> Callable:
-    """Decorator-style registrar — placeholder for Slice 1."""
-    REGISTRY[name] = fn
-    return fn
+@dataclass(frozen=True)
+class RewardSpec:
+    """Registered reward: the callable plus its declarative metadata."""
+
+    name: str
+    fn: Callable[..., float]
+    input_type: str
+    role: str
+    direction: str
+    threshold: float | None = None
+
+
+#: name → RewardSpec. Populated by @register at import time (see the
+#: ``basket`` import at the bottom of this module) and by callers.
+REGISTRY: dict[str, RewardSpec] = {}
+
+
+def register(
+    name: str,
+    *,
+    input_type: str,
+    role: str,
+    direction: str,
+    threshold: float | None = None,
+) -> Callable[[Callable[..., float]], Callable[..., float]]:
+    """Decorator factory: declare a reward's metadata and register it.
+
+    Returns the function unwrapped, so the reward stays directly callable.
+    Guardrails must carry a threshold; other roles must not.
+    """
+    if input_type not in INPUT_TYPES:
+        raise ValueError(
+            f"reward {name!r}: unknown input_type {input_type!r} (expected one of "
+            f"{sorted(INPUT_TYPES)})"
+        )
+    if role not in ROLES:
+        raise ValueError(
+            f"reward {name!r}: unknown role {role!r} (expected one of {sorted(ROLES)})"
+        )
+    if direction not in DIRECTIONS:
+        raise ValueError(
+            f"reward {name!r}: unknown direction {direction!r} (expected one of "
+            f"{sorted(DIRECTIONS)})"
+        )
+    if role == "guardrail" and threshold is None:
+        raise ValueError(f"reward {name!r}: guardrail role requires a threshold")
+    if role != "guardrail" and threshold is not None:
+        raise ValueError(f"reward {name!r}: threshold is guardrail-only (role={role!r})")
+    if name in REGISTRY:
+        raise ValueError(f"reward {name!r} already registered")
+
+    def _decorator(fn: Callable[..., float]) -> Callable[..., float]:
+        REGISTRY[name] = RewardSpec(
+            name=name,
+            fn=fn,
+            input_type=input_type,
+            role=role,
+            direction=direction,
+            threshold=threshold,
+        )
+        return fn
+
+    return _decorator
+
+
+def get(name: str) -> RewardSpec:
+    """Look up a reward by name; unknown names raise with the known set."""
+    try:
+        return REGISTRY[name]
+    except KeyError:
+        raise ValueError(f"unknown reward {name!r}; registered: {names()}") from None
 
 
 def names() -> list[str]:
     return sorted(REGISTRY.keys())
+
+
+def score(candidate_type: str, reward_name: str, payload: Any, **kwargs: Any) -> float:
+    """Score a candidate's payload with a named reward.
+
+    Refuses an input_type mismatch (e.g. a ``trades`` reward applied to a
+    screener ``basket``) with a loud ValueError — no silent mis-scoring.
+    Extra kwargs (e.g. ``horizon=``) are forwarded to the reward.
+    """
+    spec = get(reward_name)
+    if spec.input_type != candidate_type:
+        raise ValueError(
+            f"reward {reward_name!r} has input_type {spec.input_type!r}; "
+            f"refusing to score a {candidate_type!r} candidate"
+        )
+    return spec.fn(payload, **kwargs)
+
+
+def guardrail_breached(reward_name: str, value: float) -> bool:
+    """Flag a guardrail breach: ``value`` vs the spec's threshold + direction.
+
+    direction="decrease" (lower is better): breach when value > threshold.
+    direction="increase" (higher is better): breach when value < threshold.
+    At-threshold is clean. Non-guardrail rewards are rejected.
+    """
+    spec = get(reward_name)
+    if spec.role != "guardrail":
+        raise ValueError(f"reward {reward_name!r} is not a guardrail (role={spec.role!r})")
+    assert spec.threshold is not None  # enforced at registration
+    if spec.direction == "decrease":
+        return value > spec.threshold
+    return value < spec.threshold
+
+
+def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
+    """Compose two registered aggregations into a ratio reward (§4.2).
+
+    Both must share an input_type. A zero denominator yields 0.0 (never a
+    ZeroDivisionError mid-evaluation). Register the result under its own
+    name to make it selectable.
+    """
+    num, den = get(numerator), get(denominator)
+    if num.input_type != den.input_type:
+        raise ValueError(
+            f"ratio {numerator!r}/{denominator!r}: input_type mismatch "
+            f"({num.input_type!r} vs {den.input_type!r})"
+        )
+
+    def _ratio(payload: Any, **kwargs: Any) -> float:
+        d = den.fn(payload, **kwargs)
+        if d == 0.0:
+            return 0.0
+        return num.fn(payload, **kwargs) / d
+
+    return _ratio
+
+
+# Import for side effect: registers the screener basket reward set.
+from rainier.research.rewards import basket as _basket  # noqa: E402,F401
+
+__all__ = [
+    "DIRECTIONS",
+    "INPUT_TYPES",
+    "REGISTRY",
+    "ROLES",
+    "RewardSpec",
+    "get",
+    "guardrail_breached",
+    "make_ratio",
+    "names",
+    "register",
+    "score",
+]

--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -103,6 +103,14 @@ def register(
         # before either decorator is applied must not silently clobber.
         if name in REGISTRY:
             raise ValueError(f"reward {name!r} already registered")
+        if role == "guardrail" and getattr(fn, "_is_ratio", False):
+            # A ratio's ±inf zero-denominator sentinel collides with
+            # guardrail_breached's non-finite rejection: the promote gate
+            # would raise on the BEST candidate instead of passing it.
+            raise ValueError(
+                f"reward {name!r}: ratio rewards cannot be guardrails "
+                f"(±inf sentinel vs non-finite rejection)"
+            )
         REGISTRY[name] = RewardSpec(
             name=name,
             fn=fn,
@@ -183,9 +191,10 @@ def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
     0/0 → 0.0 (no data). Register the result under its own name to make
     it selectable.
 
-    Do NOT register a ratio as a guardrail: the ``inf`` sentinel collides
-    with ``guardrail_breached``'s non-finite rejection — the promote gate
-    would raise on the best candidate instead of passing it.
+    Ratios cannot be registered as guardrails — register() rejects the
+    combination: the ``inf`` sentinel collides with ``guardrail_breached``'s
+    non-finite rejection (the promote gate would raise on the best
+    candidate instead of passing it).
     """
     num, den = get(numerator), get(denominator)
     if num.input_type != den.input_type:
@@ -204,6 +213,7 @@ def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
         return num.fn(payload, **kwargs) / d
 
     _ratio.__name__ = f"ratio_{numerator}_over_{denominator}"
+    _ratio._is_ratio = True  # register() rejects guardrail role for ratios
     return _ratio
 
 

--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -111,6 +111,15 @@ def register(
                 f"reward {name!r}: ratio rewards cannot be guardrails "
                 f"(±inf sentinel vs non-finite rejection)"
             )
+        fn_input_type = getattr(fn, "_input_type", None)
+        if fn_input_type is not None and fn_input_type != input_type:
+            # A make_ratio closure carries its constituents' input_type;
+            # registering it under a different one would let score() route
+            # the wrong payload into the aggregators (silent mis-scoring).
+            raise ValueError(
+                f"reward {name!r}: fn is bound to input_type {fn_input_type!r}, "
+                f"cannot register as {input_type!r}"
+            )
         REGISTRY[name] = RewardSpec(
             name=name,
             fn=fn,
@@ -214,6 +223,7 @@ def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
 
     _ratio.__name__ = f"ratio_{numerator}_over_{denominator}"
     _ratio._is_ratio = True  # register() rejects guardrail role for ratios
+    _ratio._input_type = num.input_type  # register() enforces matching input_type
     return _ratio
 
 

--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -86,6 +86,13 @@ def register(
         )
     if role == "guardrail" and threshold is None:
         raise ValueError(f"reward {name!r}: guardrail role requires a threshold")
+    if role == "guardrail" and threshold is not None and not math.isfinite(threshold):
+        # NaN threshold fails every >/< comparison -> guardrail silently
+        # never breaches; inf is "unbounded" better expressed by not being
+        # a guardrail at all. Same failure family as non-finite values.
+        raise ValueError(
+            f"reward {name!r}: guardrail threshold must be finite (got {threshold!r})"
+        )
     if role != "guardrail" and threshold is not None:
         raise ValueError(f"reward {name!r}: threshold is guardrail-only (role={role!r})")
     if name in REGISTRY:
@@ -175,6 +182,10 @@ def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
     flawless candidate ranks first, not last), negative → ``-inf``, and
     0/0 → 0.0 (no data). Register the result under its own name to make
     it selectable.
+
+    Do NOT register a ratio as a guardrail: the ``inf`` sentinel collides
+    with ``guardrail_breached``'s non-finite rejection — the promote gate
+    would raise on the best candidate instead of passing it.
     """
     num, den = get(numerator), get(denominator)
     if num.input_type != den.input_type:

--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -30,6 +30,7 @@ that consumes ``guardrail_breached`` is ab-registry-promote-84a7's scope.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -50,8 +51,9 @@ class RewardSpec:
     threshold: float | None = None
 
 
-#: name → RewardSpec. Populated by @register at import time (see the
-#: ``basket`` import at the bottom of this module) and by callers.
+#: name → RewardSpec. Populated ONLY via @register (see the ``basket``
+#: import at the bottom of this module). Never insert directly — register()
+#: is the sole write path; it enforces every metadata invariant.
 REGISTRY: dict[str, RewardSpec] = {}
 
 
@@ -90,6 +92,10 @@ def register(
         raise ValueError(f"reward {name!r} already registered")
 
     def _decorator(fn: Callable[..., float]) -> Callable[..., float]:
+        # Re-check at insertion time: two register(...) factories obtained
+        # before either decorator is applied must not silently clobber.
+        if name in REGISTRY:
+            raise ValueError(f"reward {name!r} already registered")
         REGISTRY[name] = RewardSpec(
             name=name,
             fn=fn,
@@ -122,6 +128,11 @@ def score(candidate_type: str, reward_name: str, payload: Any, **kwargs: Any) ->
     screener ``basket``) with a loud ValueError — no silent mis-scoring.
     Extra kwargs (e.g. ``horizon=``) are forwarded to the reward.
     """
+    if candidate_type not in INPUT_TYPES:
+        raise ValueError(
+            f"unknown candidate_type {candidate_type!r} (expected one of "
+            f"{sorted(INPUT_TYPES)})"
+        )
     spec = get(reward_name)
     if spec.input_type != candidate_type:
         raise ValueError(
@@ -136,12 +147,21 @@ def guardrail_breached(reward_name: str, value: float) -> bool:
 
     direction="decrease" (lower is better): breach when value > threshold.
     direction="increase" (higher is better): breach when value < threshold.
-    At-threshold is clean. Non-guardrail rewards are rejected.
+    At-threshold is clean. Non-guardrail rewards are rejected. A non-finite
+    value (NaN/inf) is corrupt input and raises — NaN fails every ``>``/``<``
+    comparison, so it would otherwise read as "clean" and silently disarm
+    the guardrail (§4.2: loud, never silent).
     """
     spec = get(reward_name)
     if spec.role != "guardrail":
         raise ValueError(f"reward {reward_name!r} is not a guardrail (role={spec.role!r})")
-    assert spec.threshold is not None  # enforced at registration
+    if spec.threshold is None:  # unreachable via register(); guards direct REGISTRY writes
+        raise ValueError(f"guardrail {reward_name!r} has no threshold")
+    if not math.isfinite(value):
+        raise ValueError(
+            f"guardrail {reward_name!r}: non-finite value {value!r} — refusing to "
+            f"evaluate breach on corrupt input"
+        )
     if spec.direction == "decrease":
         return value > spec.threshold
     return value < spec.threshold
@@ -150,9 +170,11 @@ def guardrail_breached(reward_name: str, value: float) -> bool:
 def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
     """Compose two registered aggregations into a ratio reward (§4.2).
 
-    Both must share an input_type. A zero denominator yields 0.0 (never a
-    ZeroDivisionError mid-evaluation). Register the result under its own
-    name to make it selectable.
+    Both must share an input_type. Zero denominator is sign-aware (never a
+    ZeroDivisionError mid-evaluation): positive numerator → ``inf`` (a
+    flawless candidate ranks first, not last), negative → ``-inf``, and
+    0/0 → 0.0 (no data). Register the result under its own name to make
+    it selectable.
     """
     num, den = get(numerator), get(denominator)
     if num.input_type != den.input_type:
@@ -164,9 +186,13 @@ def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
     def _ratio(payload: Any, **kwargs: Any) -> float:
         d = den.fn(payload, **kwargs)
         if d == 0.0:
-            return 0.0
+            n = num.fn(payload, **kwargs)
+            if n == 0.0:
+                return 0.0
+            return math.inf if n > 0 else -math.inf
         return num.fn(payload, **kwargs) / d
 
+    _ratio.__name__ = f"ratio_{numerator}_over_{denominator}"
     return _ratio
 
 

--- a/src/rainier/research/rewards/__init__.py
+++ b/src/rainier/research/rewards/__init__.py
@@ -213,13 +213,22 @@ def make_ratio(numerator: str, denominator: str) -> Callable[..., float]:
         )
 
     def _ratio(payload: Any, **kwargs: Any) -> float:
+        n = num.fn(payload, **kwargs)
         d = den.fn(payload, **kwargs)
+        # A non-finite constituent would launder NaN/±inf straight into a
+        # candidate score: NaN/1.0 -> NaN, NaN/0.0 -> -inf (NaN>0 is False).
+        # The aggregators self-reject non-finite, but make_ratio composes ANY
+        # registered reward, so guard here too — loud, never silent (§4.2).
+        if not math.isfinite(n) or not math.isfinite(d):
+            raise ValueError(
+                f"ratio {numerator!r}/{denominator!r}: non-finite constituent "
+                f"(numerator={n!r}, denominator={d!r}) — refusing to aggregate"
+            )
         if d == 0.0:
-            n = num.fn(payload, **kwargs)
             if n == 0.0:
                 return 0.0
             return math.inf if n > 0 else -math.inf
-        return num.fn(payload, **kwargs) / d
+        return n / d
 
     _ratio.__name__ = f"ratio_{numerator}_over_{denominator}"
     _ratio._is_ratio = True  # register() rejects guardrail role for ratios

--- a/src/rainier/research/rewards/basket.py
+++ b/src/rainier/research/rewards/basket.py
@@ -63,6 +63,24 @@ def _require_horizon(outcomes: BasketOutcomes, horizon: int) -> None:
         )
 
 
+def _reject_duplicate_symbols(day: BasketDay) -> None:
+    """A rank-ordered selection must not list a symbol twice (design §10.3).
+
+    A duplicate would double-weight that symbol in every equal-weight mean and,
+    worse, EVADE the turnover guardrail — turnover's numerator dedups via
+    ``set`` while its denominator counts duplicates, so padding the basket with
+    repeats reports a fraction below the true replacement rate and slips under
+    the threshold. Same malformed-payload family as the missing-key guard:
+    loud, never silent (§4.2).
+    """
+    if len(set(day.symbols)) != len(day.symbols):
+        dupes = sorted({s for s in day.symbols if day.symbols.count(s) > 1})
+        raise ValueError(
+            f"duplicate symbols {dupes} in selected basket on {day.date} — "
+            f"malformed payload (a rank-ordered selection must be unique)"
+        )
+
+
 def _day_returns(outcomes: BasketOutcomes, horizon: int) -> list[float]:
     """Equal-weight basket return per day; days with no data are skipped.
 
@@ -73,6 +91,7 @@ def _day_returns(outcomes: BasketOutcomes, horizon: int) -> list[float]:
     _require_horizon(outcomes, horizon)
     out: list[float] = []
     for day in outcomes.days:
+        _reject_duplicate_symbols(day)
         if horizon not in day.fwd_return:
             continue  # this day lacks the horizon entirely — skipped, like None
         returns = day.fwd_return[horizon]
@@ -158,6 +177,8 @@ def turnover(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
     Horizon-independent (basket composition only); the parameter exists so
     every basket reward shares one call shape.
     """
+    for day in outcomes.days:
+        _reject_duplicate_symbols(day)
     days = [d for d in outcomes.days if d.symbols]
     if len(days) < 2:
         return 0.0
@@ -180,6 +201,7 @@ def dodged_loss(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> flo
     _require_horizon(outcomes, horizon)
     total = 0.0
     for day in outcomes.days:
+        _reject_duplicate_symbols(day)
         selected = set(day.symbols)
         for symbol, ret in day.fwd_return.get(horizon, {}).items():
             if ret is not None and not math.isfinite(ret):

--- a/src/rainier/research/rewards/basket.py
+++ b/src/rainier/research/rewards/basket.py
@@ -73,8 +73,20 @@ def _day_returns(outcomes: BasketOutcomes, horizon: int) -> list[float]:
     _require_horizon(outcomes, horizon)
     out: list[float] = []
     for day in outcomes.days:
-        returns = day.fwd_return.get(horizon, {})
-        available = [r for s in day.symbols if (r := returns.get(s)) is not None]
+        if horizon not in day.fwd_return:
+            continue  # this day lacks the horizon entirely — skipped, like None
+        returns = day.fwd_return[horizon]
+        # Contract (§10.3): a selected symbol with no return is emitted as
+        # None, never omitted. A missing KEY is a malformed payload —
+        # silently dropping it from the equal-weight mean would bias every
+        # basket metric (loud, never silent).
+        missing = [s for s in day.symbols if s not in returns]
+        if missing:
+            raise ValueError(
+                f"selected symbols {missing} absent from fwd_return[{horizon}] on "
+                f"{day.date} — malformed payload (emit None for no-data symbols)"
+            )
+        available = [r for s in day.symbols if (r := returns[s]) is not None]
         for r in available:
             if not math.isfinite(r):
                 raise ValueError(

--- a/src/rainier/research/rewards/basket.py
+++ b/src/rainier/research/rewards/basket.py
@@ -52,7 +52,7 @@ def _day_returns(outcomes: BasketOutcomes, horizon: int) -> list[float]:
     out: list[float] = []
     for day in outcomes.days:
         returns = day.fwd_return.get(horizon, {})
-        available = [returns[s] for s in day.symbols if returns.get(s) is not None]
+        available = [r for s in day.symbols if (r := returns.get(s)) is not None]
         if available:
             out.append(sum(available) / len(available))
     return out

--- a/src/rainier/research/rewards/basket.py
+++ b/src/rainier/research/rewards/basket.py
@@ -1,0 +1,146 @@
+"""BasketOutcomes (design §10.3, pinned) + the screener basket reward set.
+
+``BasketOutcomes`` is what the replay evaluator (ab-replay-evaluator-edb5)
+emits per candidate: one ``BasketDay`` per selection day, carrying the
+selected symbols in rank order and forward returns per horizon. Forward
+returns are ``None`` near the window end — never 0 — and every aggregation
+here EXCLUDES ``None`` entries rather than zeroing them.
+
+All rewards are pure and deterministic. Per-day basket return = equal-weight
+mean of the selected symbols' non-None forward returns at the chosen
+horizon; days with no available return are skipped entirely (they do not
+enter any mean, stdev, or hit-rate denominator).
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from datetime import date as date_type
+
+from rainier.research.rewards import register
+
+#: Default forward-return horizon (trading days) used by the basket rewards.
+DEFAULT_HORIZON = 5
+
+#: Guardrail bounds consumed by the promote-time gate (ab-registry-promote-84a7).
+#: max_drawdown: peak-to-trough fraction of basket equity; breach above 20%.
+MAX_DRAWDOWN_THRESHOLD = 0.20
+#: turnover: mean day-over-day fraction of the basket replaced; breach above 50%.
+TURNOVER_THRESHOLD = 0.50
+
+
+@dataclass(frozen=True)
+class BasketDay:
+    """One selection day t (design §10.3, pinned)."""
+
+    date: date_type
+    symbols: list[str]  # selected basket, rank order
+    fwd_return: dict[int, dict[str, float | None]]  # H → symbol → return; None near window end
+    regime: str  # from compute_market_regime
+
+
+@dataclass(frozen=True)
+class BasketOutcomes:
+    """Per-day basket + forward returns for one candidate over one window."""
+
+    days: list[BasketDay]
+
+
+def _day_returns(outcomes: BasketOutcomes, horizon: int) -> list[float]:
+    """Equal-weight basket return per day; days with no data are skipped."""
+    out: list[float] = []
+    for day in outcomes.days:
+        returns = day.fwd_return.get(horizon, {})
+        available = [returns[s] for s in day.symbols if returns.get(s) is not None]
+        if available:
+            out.append(sum(available) / len(available))
+    return out
+
+
+@register("total_return", input_type="basket", role="secondary", direction="increase")
+def total_return(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
+    """Arithmetic sum of per-day equal-weight basket returns."""
+    return sum(_day_returns(outcomes, horizon))
+
+
+@register("sharpe", input_type="basket", role="primary", direction="increase")
+def sharpe(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
+    """Mean over sample stdev (ddof=1) of daily basket returns; 0.0 if undefined."""
+    day_returns = _day_returns(outcomes, horizon)
+    if len(day_returns) < 2:
+        return 0.0
+    stdev = statistics.stdev(day_returns)
+    if stdev == 0.0:
+        return 0.0
+    return statistics.mean(day_returns) / stdev
+
+
+@register("hit_rate", input_type="basket", role="secondary", direction="increase")
+def hit_rate(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
+    """Fraction of aggregated days with a positive basket return."""
+    day_returns = _day_returns(outcomes, horizon)
+    if not day_returns:
+        return 0.0
+    return sum(1 for r in day_returns if r > 0) / len(day_returns)
+
+
+@register(
+    "max_drawdown",
+    input_type="basket",
+    role="guardrail",
+    direction="decrease",
+    threshold=MAX_DRAWDOWN_THRESHOLD,
+)
+def max_drawdown(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
+    """Max peak-to-trough decline of compounded basket equity, as a positive fraction."""
+    equity = 1.0
+    peak = 1.0
+    worst = 0.0
+    for r in _day_returns(outcomes, horizon):
+        equity *= 1.0 + r
+        peak = max(peak, equity)
+        worst = max(worst, (peak - equity) / peak)
+    return worst
+
+
+@register(
+    "turnover",
+    input_type="basket",
+    role="guardrail",
+    direction="decrease",
+    threshold=TURNOVER_THRESHOLD,
+)
+def turnover(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
+    """Mean day-over-day fraction of the basket replaced.
+
+    For consecutive days (t-1, t): |symbols_t \\ symbols_{t-1}| / |symbols_t|.
+    Horizon-independent (basket composition only); the parameter exists so
+    every basket reward shares one call shape.
+    """
+    days = [d for d in outcomes.days if d.symbols]
+    if len(days) < 2:
+        return 0.0
+    fractions = []
+    for prev, curr in zip(days, days[1:]):
+        entered = set(curr.symbols) - set(prev.symbols)
+        fractions.append(len(entered) / len(curr.symbols))
+    return sum(fractions) / len(fractions)
+
+
+@register("dodged_loss", input_type="basket", role="secondary", direction="increase")
+def dodged_loss(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> float:
+    """Sum of losses avoided by NOT selecting a symbol.
+
+    For each day, sums |negative forward return| over symbols present in
+    ``fwd_return[H]`` but absent from the selected basket. Requires the
+    evaluator to populate ``fwd_return`` with the wider screened pool; if it
+    only carries the selected symbols, dodged_loss is 0.0.
+    """
+    total = 0.0
+    for day in outcomes.days:
+        selected = set(day.symbols)
+        for symbol, ret in day.fwd_return.get(horizon, {}).items():
+            if symbol not in selected and ret is not None and ret < 0:
+                total += -ret
+    return total

--- a/src/rainier/research/rewards/basket.py
+++ b/src/rainier/research/rewards/basket.py
@@ -14,6 +14,7 @@ enter any mean, stdev, or hit-rate denominator).
 
 from __future__ import annotations
 
+import math
 import statistics
 from dataclasses import dataclass
 from datetime import date as date_type
@@ -47,12 +48,39 @@ class BasketOutcomes:
     days: list[BasketDay]
 
 
+def _require_horizon(outcomes: BasketOutcomes, horizon: int) -> None:
+    """Raise when a horizon is absent from EVERY day (config typo, §4.2 loud).
+
+    Silently returning 0.0 for a typo'd/unconfigured horizon would make every
+    candidate score 0.0 with clean guardrails — valid-looking noise. Days may
+    individually lack the key (skipped, like None returns); all-absent with a
+    non-empty window is a configuration error.
+    """
+    if outcomes.days and not any(horizon in day.fwd_return for day in outcomes.days):
+        known = sorted({h for day in outcomes.days for h in day.fwd_return})
+        raise ValueError(
+            f"horizon {horizon} absent from every BasketDay (available horizons: {known})"
+        )
+
+
 def _day_returns(outcomes: BasketOutcomes, horizon: int) -> list[float]:
-    """Equal-weight basket return per day; days with no data are skipped."""
+    """Equal-weight basket return per day; days with no data are skipped.
+
+    Non-finite returns (NaN/inf, e.g. from a corrupt upstream price) raise:
+    NaN propagates through mean/stdev/drawdown comparisons in ways that read
+    as "clean" (NaN fails every ``>``), silently disarming guardrails.
+    """
+    _require_horizon(outcomes, horizon)
     out: list[float] = []
     for day in outcomes.days:
         returns = day.fwd_return.get(horizon, {})
         available = [r for s in day.symbols if (r := returns.get(s)) is not None]
+        for r in available:
+            if not math.isfinite(r):
+                raise ValueError(
+                    f"non-finite forward return {r!r} on {day.date} (horizon {horizon}) — "
+                    f"corrupt input, refusing to aggregate"
+                )
         if available:
             out.append(sum(available) / len(available))
     return out
@@ -137,10 +165,16 @@ def dodged_loss(outcomes: BasketOutcomes, horizon: int = DEFAULT_HORIZON) -> flo
     evaluator to populate ``fwd_return`` with the wider screened pool; if it
     only carries the selected symbols, dodged_loss is 0.0.
     """
+    _require_horizon(outcomes, horizon)
     total = 0.0
     for day in outcomes.days:
         selected = set(day.symbols)
         for symbol, ret in day.fwd_return.get(horizon, {}).items():
+            if ret is not None and not math.isfinite(ret):
+                raise ValueError(
+                    f"non-finite forward return {ret!r} for {symbol} on {day.date} "
+                    f"(horizon {horizon}) — corrupt input, refusing to aggregate"
+                )
             if symbol not in selected and ret is not None and ret < 0:
                 total += -ret
     return total

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -449,3 +449,11 @@ def test_empty_string_guardrail_rejected():
     raw["guardrails"] = ["max_drawdown", ""]
     with pytest.raises(experiment.ExperimentSpecError, match="guardrails"):
         experiment.parse_spec(raw)
+
+
+def test_non_utf8_spec_file_raises_spec_error(tmp_path):
+    # An editor-mangled encoding (UTF-16 BOM, stray high bytes) fails during
+    # stream decode before yaml sees it — still the contract exception.
+    (tmp_path / "mangled.yaml").write_bytes(b"\xff\xfe\x00garbage")
+    with pytest.raises(experiment.ExperimentSpecError, match="unreadable"):
+        experiment.load_active_specs(tmp_path)

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -434,3 +434,18 @@ def test_falsy_non_list_guardrails_rejected(bad):
     raw["guardrails"] = bad
     with pytest.raises(experiment.ExperimentSpecError, match="guardrails"):
         experiment.parse_spec(raw)
+
+
+def test_unreadable_spec_path_raises_spec_error(tmp_path):
+    # A directory named *.yaml (or a permission failure) must surface as the
+    # contract exception, not a raw OSError.
+    (tmp_path / "adir.yaml").mkdir()
+    with pytest.raises(experiment.ExperimentSpecError, match="unreadable"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_empty_string_guardrail_rejected():
+    raw = _spec_dict()
+    raw["guardrails"] = ["max_drawdown", ""]
+    with pytest.raises(experiment.ExperimentSpecError, match="guardrails"):
+        experiment.parse_spec(raw)

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -658,6 +658,44 @@ def test_materialize_rejects_unknown_base_pattern_weights_key():
         )
 
 
+def test_yaml_merge_keys_still_supported(tmp_path):
+    # `<<:` merge keys are valid SafeLoader YAML (flattened with documented
+    # override semantics) — the duplicate-key loader must not reject them.
+    (tmp_path / "merge.yaml").write_text(
+        "id: merge-experiment\n"
+        "status: active\n"
+        "champion: champion.yaml\n"
+        "layer: layer_weights\n"
+        "primary: sharpe\n"
+        "window:\n"
+        "  train: 2025-05-27..2026-03-31\n"
+        "  holdout: 2026-04-01..2026-06-25\n"
+        "challengers:\n"
+        "  - id: c1\n"
+        "    override: &base\n"
+        "      layer_weight_money_flow: 0.35\n"
+        "  - id: c2\n"
+        "    override:\n"
+        "      <<: *base\n"
+        "      layer_weight_pattern: 0.5\n"
+    )
+    specs = experiment.load_active_specs(tmp_path)
+    assert len(specs) == 1
+    c2 = {c.id: c for c in specs[0].challengers}["c2"]
+    assert c2.override == {
+        "layer_weight_money_flow": 0.35,
+        "layer_weight_pattern": 0.5,
+    }
+
+
+def test_materialize_rejects_non_finite_base_override_value():
+    # A nan in the caller's base layer would poison the champion AND every
+    # challenger inheriting the field — same class as spec-authored nan.
+    spec = experiment.parse_spec(_spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match="non-finite"):
+        experiment.materialize_challengers(spec, {"buy_threshold": float("nan")})
+
+
 def test_cross_spec_duplicate_challenger_id_rejected(tmp_path):
     # Scorecards key on candidate_id (no experiment_id field): two live arms
     # sharing an id would emit indistinguishable scorecards.

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -1,0 +1,265 @@
+"""Experiment-spec interpreter tests (A/B substrate, design §10.4).
+
+The spec is a YAML file (config/experiments/*.yaml): champion + challengers
++ the one contended `layer` + reward keys + window. The interpreter — not
+the merge — validates every override key, because
+`merge_stock_screener_config` validates nothing and
+`StockScreenerConfig(**merged)` silently drops unknown kwargs: an
+unvalidated typo would yield a challenger identical to the champion (a
+silent no-op A/B).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from rainier.core.config import StockScreenerConfig
+from rainier.research import experiment
+
+
+def _spec_dict(**overrides: Any) -> dict[str, Any]:
+    """The design §10.4 example spec, with real StockScreenerConfig fields."""
+    base: dict[str, Any] = {
+        "id": "layer-weights-rebalance",
+        "status": "active",
+        "champion": "champion.yaml",
+        "layer": "layer_weights",
+        "challengers": [
+            {
+                "id": "mf35",
+                "override": {
+                    "layer_weight_money_flow": 0.35,
+                    "layer_weight_pattern": 0.55,
+                },
+            },
+            {
+                "id": "mf40",
+                "override": {
+                    "layer_weight_money_flow": 0.40,
+                    "layer_weight_pattern": 0.50,
+                },
+            },
+        ],
+        "primary": "sharpe",
+        "guardrails": ["max_drawdown", "turnover"],
+        "window": {
+            "train": "2025-05-27..2026-03-31",
+            "holdout": "2026-04-01..2026-06-25",
+            "embargo_days": 20,
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_spec(directory: Path, filename: str, spec: dict[str, Any]) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / filename
+    path.write_text(yaml.safe_dump(spec))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Parsing the valid §10.4 shape
+# ---------------------------------------------------------------------------
+
+
+def test_parse_valid_spec_shape():
+    spec = experiment.parse_spec(_spec_dict())
+    assert spec.id == "layer-weights-rebalance"
+    assert spec.status == "active"
+    assert spec.champion == "champion.yaml"
+    assert spec.layer == "layer_weights"
+    assert [c.id for c in spec.challengers] == ["mf35", "mf40"]
+    assert spec.primary == "sharpe"
+    assert spec.guardrails == ("max_drawdown", "turnover")
+    assert spec.window.train == "2025-05-27..2026-03-31"
+    assert spec.window.holdout == "2026-04-01..2026-06-25"
+
+
+def test_load_spec_from_yaml_file(tmp_path):
+    path = _write_spec(tmp_path, "layer-weights.yaml", _spec_dict())
+    spec = experiment.load_spec(path)
+    assert spec.id == "layer-weights-rebalance"
+    assert len(spec.challengers) == 2
+
+
+def test_embargo_days_defaults_to_20():
+    raw = _spec_dict()
+    del raw["window"]["embargo_days"]
+    spec = experiment.parse_spec(raw)
+    assert spec.window.embargo_days == 20
+
+
+def test_embargo_days_explicit_value_parsed():
+    raw = _spec_dict()
+    raw["window"]["embargo_days"] = 5
+    spec = experiment.parse_spec(raw)
+    assert spec.window.embargo_days == 5
+
+
+def test_missing_window_rejected():
+    raw = _spec_dict()
+    del raw["window"]
+    with pytest.raises(experiment.ExperimentSpecError, match="window"):
+        experiment.parse_spec(raw)
+
+
+def test_duplicate_challenger_ids_rejected():
+    raw = _spec_dict()
+    raw["challengers"][1]["id"] = "mf35"
+    with pytest.raises(experiment.ExperimentSpecError, match="mf35"):
+        experiment.parse_spec(raw)
+
+
+def test_empty_override_rejected():
+    # An empty override yields a challenger identical to the champion —
+    # exactly the silent no-op A/B the interpreter exists to prevent.
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {}
+    with pytest.raises(experiment.ExperimentSpecError, match="mf35"):
+        experiment.parse_spec(raw)
+
+
+# ---------------------------------------------------------------------------
+# Override-key validation (the load-bearing check)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_flat_override_key_rejected_with_key_named():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"layer_weight_money_floww": 0.35}
+    with pytest.raises(experiment.ExperimentSpecError, match="layer_weight_money_floww"):
+        experiment.parse_spec(raw)
+
+
+def test_unknown_pattern_weights_dotted_key_rejected_with_key_named():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"pattern_weights.bulll_flag": 0.9}
+    with pytest.raises(experiment.ExperimentSpecError, match="bulll_flag"):
+        experiment.parse_spec(raw)
+
+
+def test_unknown_nested_pattern_weights_key_rejected():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"pattern_weights": {"bulll_flag": 0.9}}
+    with pytest.raises(experiment.ExperimentSpecError, match="bulll_flag"):
+        experiment.parse_spec(raw)
+
+
+def test_arbitrary_dotted_path_rejected():
+    # The interpreter never invents config paths — a knob must exist as a
+    # StockScreenerConfig field before it can be experimented on.
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"signal.momentum.method": "ema"}
+    with pytest.raises(experiment.ExperimentSpecError, match="signal.momentum.method"):
+        experiment.parse_spec(raw)
+
+
+def test_pattern_weights_dotted_path_translated_to_nested_dict():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"pattern_weights.bull_flag": 0.9}
+    spec = experiment.parse_spec(raw)
+    assert spec.challengers[0].override == {"pattern_weights": {"bull_flag": 0.9}}
+
+
+# ---------------------------------------------------------------------------
+# Challenger materialization (deep-merge via merge_stock_screener_config)
+# ---------------------------------------------------------------------------
+
+
+def test_challengers_materialize_differing_only_in_overridden_keys():
+    spec = experiment.parse_spec(_spec_dict())
+    base_overrides = {"buy_threshold": 0.70}
+    champion_cfg, challenger_cfgs = experiment.materialize_challengers(spec, base_overrides)
+
+    assert set(challenger_cfgs) == {"mf35", "mf40"}
+    mf35 = challenger_cfgs["mf35"]
+    assert mf35.layer_weight_money_flow == 0.35
+    assert mf35.layer_weight_pattern == 0.55
+    # Non-overridden fields fall through to the champion layer / defaults.
+    assert mf35.buy_threshold == 0.70
+    champion_dump = champion_cfg.model_dump()
+    mf35_dump = mf35.model_dump()
+    differing = {k for k in champion_dump if champion_dump[k] != mf35_dump[k]}
+    assert differing == {"layer_weight_money_flow", "layer_weight_pattern"}
+
+
+def test_pattern_weight_merge_preserves_other_pattern_weights():
+    raw = _spec_dict()
+    raw["challengers"] = [
+        {"id": "bf90", "override": {"pattern_weights.bull_flag": 0.9}},
+    ]
+    spec = experiment.parse_spec(raw)
+    _, challenger_cfgs = experiment.materialize_challengers(spec, None)
+    weights = challenger_cfgs["bf90"].pattern_weights
+    defaults = StockScreenerConfig().pattern_weights
+    assert weights["bull_flag"] == 0.9
+    for name, default in defaults.items():
+        if name != "bull_flag":
+            assert weights[name] == default
+
+
+# ---------------------------------------------------------------------------
+# Spec discovery + mutual exclusion (config/experiments/*.yaml)
+# ---------------------------------------------------------------------------
+
+
+def test_load_active_specs_returns_only_active(tmp_path):
+    _write_spec(tmp_path, "a.yaml", _spec_dict())
+    retired = _spec_dict(id="old-experiment", layer="thresholds", status="retired")
+    _write_spec(tmp_path, "b.yaml", retired)
+    specs = experiment.load_active_specs(tmp_path)
+    assert [s.id for s in specs] == ["layer-weights-rebalance"]
+
+
+def test_malformed_status_is_a_loud_error(tmp_path):
+    _write_spec(tmp_path, "a.yaml", _spec_dict(status="paused"))
+    with pytest.raises(experiment.ExperimentSpecError, match="paused"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_two_active_specs_same_layer_mutually_exclusive(tmp_path):
+    _write_spec(tmp_path, "a.yaml", _spec_dict())
+    _write_spec(tmp_path, "b.yaml", _spec_dict(id="second-experiment"))
+    with pytest.raises(experiment.ExperimentSpecError, match="layer_weights"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_two_active_specs_different_layers_both_load(tmp_path):
+    _write_spec(tmp_path, "a.yaml", _spec_dict())
+    other = _spec_dict(
+        id="threshold-experiment",
+        layer="thresholds",
+        challengers=[{"id": "bt70", "override": {"buy_threshold": 0.70}}],
+    )
+    _write_spec(tmp_path, "b.yaml", other)
+    specs = experiment.load_active_specs(tmp_path)
+    assert sorted(s.id for s in specs) == [
+        "layer-weights-rebalance",
+        "threshold-experiment",
+    ]
+
+
+def test_retired_spec_never_conflicts_on_layer(tmp_path):
+    _write_spec(tmp_path, "a.yaml", _spec_dict())
+    retired = _spec_dict(id="old-layer-weights", status="retired")
+    _write_spec(tmp_path, "b.yaml", retired)
+    specs = experiment.load_active_specs(tmp_path)
+    assert [s.id for s in specs] == ["layer-weights-rebalance"]
+
+
+def test_duplicate_active_experiment_ids_rejected(tmp_path):
+    _write_spec(tmp_path, "a.yaml", _spec_dict())
+    dup = _spec_dict(layer="thresholds")
+    _write_spec(tmp_path, "b.yaml", dup)
+    with pytest.raises(experiment.ExperimentSpecError, match="layer-weights-rebalance"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_load_active_specs_empty_dir_returns_empty(tmp_path):
+    assert experiment.load_active_specs(tmp_path) == []

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -565,3 +565,113 @@ def test_materialize_wraps_validation_error():
     spec = experiment.parse_spec(_spec_dict())
     with pytest.raises(experiment.ExperimentSpecError, match="StockScreenerConfig"):
         experiment.materialize_challengers(spec, {"buy_threshold": "garbage"})
+
+
+# ---------------------------------------------------------------------------
+# Review iter-6 (red team): duplicate YAML keys, non-finite values, uppercase
+# extensions, editor lockfiles, base_overrides keys, cross-spec arm ids
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_yaml_key_in_spec_file_rejected(tmp_path):
+    # yaml.safe_load silently last-write-wins on duplicate keys — a spec with
+    # two `layer_weight_money_flow:` lines would load the second and drop the
+    # first without a sound.
+    (tmp_path / "dup.yaml").write_text(
+        "id: dup-experiment\n"
+        "status: active\n"
+        "champion: champion.yaml\n"
+        "layer: thresholds\n"
+        "primary: sharpe\n"
+        "window:\n"
+        "  train: 2025-05-27..2026-03-31\n"
+        "  holdout: 2026-04-01..2026-06-25\n"
+        "challengers:\n"
+        "  - id: c1\n"
+        "    override:\n"
+        "      layer_weight_money_flow: 0.35\n"
+        "      layer_weight_money_flow: 0.99\n"
+    )
+    with pytest.raises(experiment.ExperimentSpecError, match="duplicate key"):
+        experiment.load_active_specs(tmp_path)
+
+
+@pytest.mark.parametrize("bad", [".nan", ".inf", "-.inf"], ids=["nan", "inf", "-inf"])
+def test_non_finite_override_value_rejected(tmp_path, bad):
+    # pydantic strict mode still admits nan/inf floats; a NaN threshold makes
+    # every comparison False — silent corruption of the A/B result.
+    (tmp_path / "nf.yaml").write_text(
+        "id: nf-experiment\n"
+        "status: active\n"
+        "champion: champion.yaml\n"
+        "layer: thresholds\n"
+        "primary: sharpe\n"
+        "window:\n"
+        "  train: 2025-05-27..2026-03-31\n"
+        "  holdout: 2026-04-01..2026-06-25\n"
+        "challengers:\n"
+        "  - id: c1\n"
+        f"    override: {{buy_threshold: {bad}}}\n"
+    )
+    with pytest.raises(experiment.ExperimentSpecError, match="non-finite"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_non_finite_nested_pattern_weight_rejected():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"pattern_weights": {"bull_flag": float("nan")}}
+    with pytest.raises(experiment.ExperimentSpecError, match="non-finite"):
+        experiment.parse_spec(raw)
+
+
+@pytest.mark.parametrize("filename", ["a.YAML", "a.YML", "a.Yaml"])
+def test_uppercase_extension_spec_rejected_loudly(tmp_path, filename):
+    # pathlib glob is case-sensitive: *.yaml won't match a.YAML, silently
+    # re-opening the ignored-spec hole the .yml guard closed.
+    _write_spec(tmp_path, filename, _spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match=filename):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_editor_lockfile_dotfile_is_ignored(tmp_path):
+    # An emacs-style lockfile (dangling symlink `.#spec.yaml`) at cron time
+    # must not fail the run — dotfiles aren't specs.
+    _write_spec(tmp_path, "good.yaml", _spec_dict())
+    (tmp_path / ".#good.yaml").symlink_to(tmp_path / "nonexistent-target")
+    specs = experiment.load_active_specs(tmp_path)
+    assert [s.id for s in specs] == ["layer-weights-rebalance"]
+
+
+def test_materialize_rejects_unknown_base_override_key():
+    # StockScreenerConfig silently drops unknown kwargs — a typo'd base key
+    # would materialize a "champion" that doesn't match the live config.
+    spec = experiment.parse_spec(_spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match="buy_threshhold"):
+        experiment.materialize_challengers(spec, {"buy_threshhold": 0.99})
+
+
+def test_materialize_rejects_unknown_base_pattern_weights_key():
+    spec = experiment.parse_spec(_spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match="bulll_flag"):
+        experiment.materialize_challengers(
+            spec, {"pattern_weights": {"bulll_flag": 0.9}}
+        )
+
+
+def test_cross_spec_duplicate_challenger_id_rejected(tmp_path):
+    # Scorecards key on candidate_id (no experiment_id field): two live arms
+    # sharing an id would emit indistinguishable scorecards.
+    a = _spec_dict(
+        id="bull-weight",
+        layer="pw-bull",
+        challengers=[{"id": "arm-1", "override": {"pattern_weights.bull_flag": 0.9}}],
+    )
+    b = _spec_dict(
+        id="bear-weight",
+        layer="pw-bear",
+        challengers=[{"id": "arm-1", "override": {"pattern_weights.bear_flag": 0.9}}],
+    )
+    _write_spec(tmp_path, "a.yaml", a)
+    _write_spec(tmp_path, "b.yaml", b)
+    with pytest.raises(experiment.ExperimentSpecError, match="arm-1"):
+        experiment.load_active_specs(tmp_path)

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -381,3 +381,56 @@ def test_disjoint_pattern_weight_keys_across_specs_allowed(tmp_path):
     _write_spec(tmp_path, "b.yaml", b)
     specs = experiment.load_active_specs(tmp_path)
     assert sorted(s.id for s in specs) == ["bear-weight", "bull-weight"]
+
+
+# ---------------------------------------------------------------------------
+# Review iter-2: empty nested pattern_weights + non-str keys + falsy guardrails
+# ---------------------------------------------------------------------------
+
+
+def test_empty_nested_pattern_weights_rejected():
+    # {"pattern_weights": {}} is a non-empty override MAPPING that translates
+    # to an EMPTY override — a silent no-op challenger that would also escape
+    # cross-spec mutual exclusion (override_keys == empty set).
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"pattern_weights": {}}
+    with pytest.raises(experiment.ExperimentSpecError, match="non-empty"):
+        experiment.parse_spec(raw)
+
+
+def test_non_str_top_level_key_rejected():
+    # YAML 1.1 parses a bare `on:` as boolean True.
+    raw = _spec_dict()
+    raw[True] = "x"
+    with pytest.raises(experiment.ExperimentSpecError, match="must be str"):
+        experiment.parse_spec(raw)
+
+
+def test_non_str_override_key_rejected():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {1: 0.5}
+    with pytest.raises(experiment.ExperimentSpecError, match="must be str"):
+        experiment.parse_spec(raw)
+
+
+def test_non_str_pattern_weights_key_rejected():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"pattern_weights": {1: 0.5}}
+    with pytest.raises(experiment.ExperimentSpecError, match="must be str"):
+        experiment.parse_spec(raw)
+
+
+def test_non_str_window_key_rejected():
+    raw = _spec_dict()
+    raw["window"][True] = "x"
+    with pytest.raises(experiment.ExperimentSpecError, match="must be str"):
+        experiment.parse_spec(raw)
+
+
+@pytest.mark.parametrize("bad", [False, 0, ""], ids=["false", "zero", "empty-str"])
+def test_falsy_non_list_guardrails_rejected(bad):
+    # `guardrails: false` must be a type error, not silently "no guardrails".
+    raw = _spec_dict()
+    raw["guardrails"] = bad
+    with pytest.raises(experiment.ExperimentSpecError, match="guardrails"):
+        experiment.parse_spec(raw)

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -706,6 +706,19 @@ def test_materialize_rejects_coercible_base_override_value(bad):
         experiment.materialize_challengers(spec, {"buy_threshold": bad})
 
 
+def test_materialize_base_overrides_is_required():
+    # No default value: a production caller must not be able to forget the
+    # champion-effective layer and silently baseline challengers on pydantic
+    # code defaults instead of the live champion (explicit None = synthetic
+    # code-defaults replay, an intentional choice).
+    import inspect
+
+    param = inspect.signature(experiment.materialize_challengers).parameters[
+        "base_overrides"
+    ]
+    assert param.default is inspect.Parameter.empty
+
+
 def test_cross_spec_duplicate_challenger_id_rejected(tmp_path):
     # Scorecards key on candidate_id (no experiment_id field): two live arms
     # sharing an id would emit indistinguishable scorecards.

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -121,7 +121,7 @@ def test_empty_override_rejected():
     # exactly the silent no-op A/B the interpreter exists to prevent.
     raw = _spec_dict()
     raw["challengers"][0]["override"] = {}
-    with pytest.raises(experiment.ExperimentSpecError, match="mf35"):
+    with pytest.raises(experiment.ExperimentSpecError, match="non-empty mapping"):
         experiment.parse_spec(raw)
 
 
@@ -263,3 +263,121 @@ def test_duplicate_active_experiment_ids_rejected(tmp_path):
 
 def test_load_active_specs_empty_dir_returns_empty(tmp_path):
     assert experiment.load_active_specs(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Strict spec shape (review iter-1): unknown keys at every level are loud —
+# a typo'd `guardrail:` must not yield a guardrail-free experiment.
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_top_level_spec_key_rejected():
+    raw = _spec_dict()
+    raw["guardrail"] = ["max_drawdown"]  # singular typo of `guardrails`
+    with pytest.raises(experiment.ExperimentSpecError, match="guardrail"):
+        experiment.parse_spec(raw)
+
+
+def test_unknown_window_key_rejected():
+    raw = _spec_dict()
+    raw["window"]["embargo_dayz"] = 5  # typo would silently keep default 20
+    with pytest.raises(experiment.ExperimentSpecError, match="embargo_dayz"):
+        experiment.parse_spec(raw)
+
+
+def test_unknown_challenger_key_rejected():
+    raw = _spec_dict()
+    raw["challengers"][0]["overrride"] = {"buy_threshold": 0.7}
+    with pytest.raises(experiment.ExperimentSpecError, match="overrride"):
+        experiment.parse_spec(raw)
+
+
+def test_empty_challenger_id_rejected():
+    raw = _spec_dict()
+    raw["challengers"][0]["id"] = ""
+    with pytest.raises(experiment.ExperimentSpecError, match="non-empty"):
+        experiment.parse_spec(raw)
+
+
+@pytest.mark.parametrize("bad", [-1, True, "20", 2.5])
+def test_bad_embargo_days_rejected(bad):
+    raw = _spec_dict()
+    raw["window"]["embargo_days"] = bad
+    with pytest.raises(experiment.ExperimentSpecError, match="embargo_days"):
+        experiment.parse_spec(raw)
+
+
+# ---------------------------------------------------------------------------
+# Override ambiguity + value validation (review iter-1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"pattern_weights.bull_flag": 0.9, "pattern_weights": {"bull_flag": 0.5}},
+        {"pattern_weights": {"bull_flag": 0.5}, "pattern_weights.bull_flag": 0.9},
+    ],
+    ids=["dotted-then-nested", "nested-then-dotted"],
+)
+def test_dotted_and_nested_same_pattern_conflict_rejected(override):
+    # Silent last-write-wins for the same pattern is exactly the ambiguity
+    # class the interpreter rejects everywhere else.
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = override
+    with pytest.raises(experiment.ExperimentSpecError, match="bull_flag"):
+        experiment.parse_spec(raw)
+
+
+def test_override_value_type_rejected_at_parse_time():
+    # Bad VALUES fail at spec-load time as ExperimentSpecError — not at cron
+    # runtime inside materialize_challengers as a raw pydantic error.
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"layer_weight_money_flow": "not-a-number"}
+    with pytest.raises(experiment.ExperimentSpecError, match="layer_weight_money_flow"):
+        experiment.parse_spec(raw)
+
+
+# ---------------------------------------------------------------------------
+# Discovery hardening (review iter-1)
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_yaml_file_raises_spec_error(tmp_path):
+    (tmp_path / "broken.yaml").write_text("id: [unclosed\n")
+    with pytest.raises(experiment.ExperimentSpecError, match="invalid YAML"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_overlapping_override_keys_across_layer_labels_rejected(tmp_path):
+    # Layer labels are just names — two active specs contending the SAME
+    # config knob under different labels must be rejected, or the A/B
+    # results entangle silently.
+    _write_spec(tmp_path, "a.yaml", _spec_dict())
+    other = _spec_dict(
+        id="relabeled-weights",
+        layer="weights",  # different label, same contended knob
+        challengers=[{"id": "mf45", "override": {"layer_weight_money_flow": 0.45}}],
+    )
+    _write_spec(tmp_path, "b.yaml", other)
+    with pytest.raises(experiment.ExperimentSpecError, match="layer_weight_money_flow"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_disjoint_pattern_weight_keys_across_specs_allowed(tmp_path):
+    # pattern_weights is expanded per-pattern: touching DIFFERENT patterns
+    # in two active experiments is not a conflict.
+    a = _spec_dict(
+        id="bull-weight",
+        layer="pw-bull",
+        challengers=[{"id": "b9", "override": {"pattern_weights.bull_flag": 0.9}}],
+    )
+    b = _spec_dict(
+        id="bear-weight",
+        layer="pw-bear",
+        challengers=[{"id": "k9", "override": {"pattern_weights.bear_flag": 0.9}}],
+    )
+    _write_spec(tmp_path, "a.yaml", a)
+    _write_spec(tmp_path, "b.yaml", b)
+    specs = experiment.load_active_specs(tmp_path)
+    assert sorted(s.id for s in specs) == ["bear-weight", "bull-weight"]

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -696,6 +696,16 @@ def test_materialize_rejects_non_finite_base_override_value():
         experiment.materialize_challengers(spec, {"buy_threshold": float("nan")})
 
 
+@pytest.mark.parametrize("bad", [True, "0.35"], ids=["bool", "numeric-str"])
+def test_materialize_rejects_coercible_base_override_value(bad):
+    # Lax construction would silently coerce `buy_threshold: true` → 1.0 or
+    # "0.35" → 0.35 in the champion — a malformed base config must fail
+    # loudly, mirroring the strict parse-time check on spec overrides.
+    spec = experiment.parse_spec(_spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match="StockScreenerConfig"):
+        experiment.materialize_challengers(spec, {"buy_threshold": bad})
+
+
 def test_cross_spec_duplicate_challenger_id_rejected(tmp_path):
     # Scorecards key on candidate_id (no experiment_id field): two live arms
     # sharing an id would emit indistinguishable scorecards.

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -257,7 +257,10 @@ def test_duplicate_active_experiment_ids_rejected(tmp_path):
     _write_spec(tmp_path, "a.yaml", _spec_dict())
     dup = _spec_dict(layer="thresholds")
     _write_spec(tmp_path, "b.yaml", dup)
-    with pytest.raises(experiment.ExperimentSpecError, match="layer-weights-rebalance"):
+    # Match the message unique to the duplicate-id branch: the spec id alone
+    # also appears in the override-key mutual-exclusion error, so a looser
+    # match would stay green if the duplicate-id guard were deleted.
+    with pytest.raises(experiment.ExperimentSpecError, match="duplicate active experiment id"):
         experiment.load_active_specs(tmp_path)
 
 
@@ -457,3 +460,108 @@ def test_non_utf8_spec_file_raises_spec_error(tmp_path):
     (tmp_path / "mangled.yaml").write_bytes(b"\xff\xfe\x00garbage")
     with pytest.raises(experiment.ExperimentSpecError, match="unreadable"):
         experiment.load_active_specs(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Review iter-5: window value validation, strict override values, loud
+# discovery (missing dir / stray .yml), guardrail hygiene, materialize wrap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "garbage", "2026-01-01", "2026-01-01..not-a-date", "2026-99-01..2026-12-31"],
+    ids=["empty", "garbage", "no-separator", "bad-end-date", "bad-month"],
+)
+def test_malformed_window_range_rejected(bad):
+    raw = _spec_dict()
+    raw["window"]["train"] = bad
+    with pytest.raises(experiment.ExperimentSpecError, match="window.train"):
+        experiment.parse_spec(raw)
+
+
+def test_reversed_window_range_rejected():
+    raw = _spec_dict()
+    raw["window"]["train"] = "2026-03-31..2025-05-27"
+    with pytest.raises(experiment.ExperimentSpecError, match="reversed"):
+        experiment.parse_spec(raw)
+
+
+def test_overlapping_train_holdout_rejected():
+    # Holdout starting inside the train window leaks train data into the
+    # holdout — must fail at parse time, not silently mis-slice at cron time.
+    raw = _spec_dict()
+    raw["window"]["holdout"] = "2026-03-01..2026-06-25"
+    with pytest.raises(experiment.ExperimentSpecError, match="leak"):
+        experiment.parse_spec(raw)
+
+
+def test_bool_override_value_rejected_at_parse_time():
+    # YAML `buy_threshold: true` would lax-coerce to 1.0 — a plausible-looking
+    # losing challenger (silent corruption of the A/B result).
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"buy_threshold": True}
+    with pytest.raises(experiment.ExperimentSpecError, match="buy_threshold"):
+        experiment.parse_spec(raw)
+
+
+def test_numeric_string_override_value_rejected_at_parse_time():
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"buy_threshold": "0.35"}
+    with pytest.raises(experiment.ExperimentSpecError, match="buy_threshold"):
+        experiment.parse_spec(raw)
+
+
+def test_int_override_value_for_float_field_still_accepted():
+    # Strict mode still allows int where a float is declared — `weight: 1`
+    # is valid YAML for a float knob.
+    raw = _spec_dict()
+    raw["challengers"][0]["override"] = {"layer_weight_money_flow": 1}
+    spec = experiment.parse_spec(raw)
+    assert spec.challengers[0].override == {"layer_weight_money_flow": 1}
+
+
+def test_nonexistent_experiments_dir_raises(tmp_path):
+    # A missing directory (wrong CWD, lost deploy dir) must NOT read as an
+    # empty experiment queue — that silently disables the whole substrate.
+    with pytest.raises(experiment.ExperimentSpecError, match="does not exist"):
+        experiment.load_active_specs(tmp_path / "nope")
+
+
+def test_stray_yml_extension_rejected_loudly(tmp_path):
+    # Discovery reads *.yaml only; a spec saved as .yml must fail loudly
+    # instead of being silently skipped.
+    _write_spec(tmp_path, "a.yml", _spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match="a.yml"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_empty_yaml_spec_file_rejected(tmp_path):
+    # A zero-byte/truncated file parses to None — must be the contract
+    # exception naming the file, not a silent skip.
+    (tmp_path / "empty.yaml").write_text("")
+    with pytest.raises(experiment.ExperimentSpecError, match="mapping"):
+        experiment.load_active_specs(tmp_path)
+
+
+def test_duplicate_guardrails_rejected():
+    raw = _spec_dict()
+    raw["guardrails"] = ["max_drawdown", "max_drawdown"]
+    with pytest.raises(experiment.ExperimentSpecError, match="duplicate guardrail"):
+        experiment.parse_spec(raw)
+
+
+def test_primary_also_in_guardrails_rejected():
+    raw = _spec_dict()
+    raw["guardrails"] = ["sharpe", "max_drawdown"]  # primary is "sharpe"
+    with pytest.raises(experiment.ExperimentSpecError, match="primary"):
+        experiment.parse_spec(raw)
+
+
+def test_materialize_wraps_validation_error():
+    # base_overrides come from the caller (settings/champion layer), not the
+    # spec — a bad value there must still surface as the contract exception,
+    # not a raw pydantic ValidationError inside the unattended cron shadow arm.
+    spec = experiment.parse_spec(_spec_dict())
+    with pytest.raises(experiment.ExperimentSpecError, match="StockScreenerConfig"):
+        experiment.materialize_challengers(spec, {"buy_threshold": "garbage"})

--- a/tests/research/test_experiment_spec.py
+++ b/tests/research/test_experiment_spec.py
@@ -439,6 +439,23 @@ def test_falsy_non_list_guardrails_rejected(bad):
         experiment.parse_spec(raw)
 
 
+def test_explicit_null_guardrails_rejected():
+    # A bare `guardrails:` line parses as null — must not silently load as
+    # "no guardrails" (that quietly drops the experiment's risk checks).
+    raw = _spec_dict()
+    raw["guardrails"] = None
+    with pytest.raises(experiment.ExperimentSpecError, match="guardrails"):
+        experiment.parse_spec(raw)
+
+
+def test_missing_guardrails_key_defaults_to_empty():
+    # Omitting the key entirely stays legal: guardrails are optional.
+    raw = _spec_dict()
+    del raw["guardrails"]
+    spec = experiment.parse_spec(raw)
+    assert spec.guardrails == ()
+
+
 def test_unreadable_spec_path_raises_spec_error(tmp_path):
     # A directory named *.yaml (or a permission failure) must surface as the
     # contract exception, not a raw OSError.

--- a/tests/research/test_output_schema.py
+++ b/tests/research/test_output_schema.py
@@ -231,3 +231,28 @@ def test_composed_bare_string_extensions_rejected():
         output_schema.validate_composed(
             "base_scorecard", _valid_base_scorecard(), extensions="llm_extension"
         )
+
+
+def test_bool_rejected_for_int_field():
+    # bool is a subclass of int: `n_selection_days: true` would otherwise
+    # pass the int check and land as 1 in promotion artifacts.
+    block = _valid_base_scorecard()
+    block["n_selection_days"] = True
+    with pytest.raises(output_schema.SchemaError, match="n_selection_days"):
+        output_schema.validate("base_scorecard", block)
+
+
+def test_bool_rejected_for_float_field():
+    block = _valid_base_scorecard()
+    block["deflated_sharpe"] = True
+    with pytest.raises(output_schema.SchemaError, match="deflated_sharpe"):
+        output_schema.validate("base_scorecard", block)
+
+
+def test_base_alone_rejected_when_extension_named():
+    # Converse of the extension-alone case: naming an extension makes ALL of
+    # its fields required, so a base-only payload must fail on them.
+    with pytest.raises(output_schema.SchemaError, match="valid_thesis_rate"):
+        output_schema.validate_composed(
+            "base_scorecard", _valid_base_scorecard(), extensions=["llm_extension"]
+        )

--- a/tests/research/test_output_schema.py
+++ b/tests/research/test_output_schema.py
@@ -86,3 +86,125 @@ def test_verdict_enum_is_pinned():
     schema = output_schema.load()["schemas"]["cost_pilot"]
     # PASS / CONDITIONAL / FAIL are the three values Slice 0 ships with.
     assert set(schema["fields"]["verdict"]["enum"]) == {"PASS", "CONDITIONAL", "FAIL"}
+
+
+# ---------------------------------------------------------------------------
+# A/B substrate scorecards (design §10.5) — candidate-agnostic base +
+# optional LLM extension, composed via validate_composed(). Additive: the
+# LLM-shaped `backtest` entry stays untouched for its existing consumer.
+# ---------------------------------------------------------------------------
+
+
+def _valid_base_scorecard() -> dict:
+    return {
+        "candidate_id": "mf35",
+        "candidate_type": "screener",
+        "window": "2025-05-27..2026-03-31",
+        "n_selection_days": 210,
+        "corpus_hash": "a" * 40,
+        "rewards": {
+            "primary": {"sharpe": 1.12},
+            "guardrails": {"max_drawdown": -0.14, "turnover": 0.32},
+        },
+        "regime_scores": {"risk_on": {"sharpe": 1.30}, "risk_off": {"sharpe": 0.41}},
+        # null until the §11-task-6 DSR spec lands — never a naive number.
+        "deflated_sharpe": None,
+        "evaluator_sha": "b" * 40,
+    }
+
+
+def _valid_llm_extension() -> dict:
+    return {
+        "valid_thesis_rate": 0.92,
+        "cost_usd": 4.31,
+        "filled_R": 3.4,
+        "filled_rate": 0.71,
+        "tqqq_bh_R": 2.1,
+        "skill_yaml_sha": "c" * 40,
+    }
+
+
+def test_base_scorecard_validates_without_llm_fields():
+    output_schema.validate("base_scorecard", _valid_base_scorecard())
+
+
+def test_base_scorecard_deflated_sharpe_null_validates():
+    block = _valid_base_scorecard()
+    assert block["deflated_sharpe"] is None
+    output_schema.validate("base_scorecard", block)
+
+
+def test_base_scorecard_deflated_sharpe_float_also_validates():
+    block = _valid_base_scorecard()
+    block["deflated_sharpe"] = 0.87
+    output_schema.validate("base_scorecard", block)
+
+
+def test_composed_base_plus_llm_extension_validates():
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    output_schema.validate_composed("base_scorecard", block, extensions=["llm_extension"])
+
+
+def test_llm_extension_alone_is_rejected():
+    # The extension is not a standalone scorecard — base fields are required.
+    with pytest.raises(output_schema.SchemaError) as exc:
+        output_schema.validate_composed(
+            "base_scorecard", _valid_llm_extension(), extensions=["llm_extension"]
+        )
+    assert "candidate_id" in str(exc.value)
+
+
+def test_composed_rejects_extension_fields_when_extension_not_named():
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    with pytest.raises(output_schema.SchemaError):
+        output_schema.validate_composed("base_scorecard", block)
+
+
+def test_composed_rejects_undeclared_extra_field():
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    block["never_declared"] = 1
+    with pytest.raises(output_schema.SchemaError) as exc:
+        output_schema.validate_composed("base_scorecard", block, extensions=["llm_extension"])
+    assert "never_declared" in str(exc.value)
+
+
+def test_composed_unknown_extension_name_rejected():
+    with pytest.raises(output_schema.SchemaError):
+        output_schema.validate_composed(
+            "base_scorecard", _valid_base_scorecard(), extensions=["no_such_extension"]
+        )
+
+
+def test_existing_schemas_unchanged_regression():
+    """The pre-existing entries still validate their canonical payloads."""
+    output_schema.validate("cost_pilot", _valid_cost_pilot_block())
+    output_schema.validate(
+        "survivorship",
+        {
+            "from_date": "2025-05-27",
+            "to_date": "2026-06-25",
+            "verdict": "PASS",
+            "delisted_tickers": [],
+            "missing_days": [],
+            "next_step": None,
+        },
+    )
+    output_schema.validate(
+        "backtest",
+        {
+            "skill_id": "qu100_v1",
+            "reward_fn": "filled_R",
+            "filled_R": 3.4,
+            "all_call_R": 2.9,
+            "calls": 120,
+            "valid_thesis_rate": 0.92,
+            "filled_rate": 0.71,
+            "cost_usd": 4.31,
+            "tqqq_bh_R": 2.1,
+            "delta_vs_tqqq": 1.3,
+            "deflated_sharpe": 0.87,
+            "evaluator_sha": "b" * 40,
+            "skill_yaml_sha": "c" * 40,
+            "ledger_sha": "0" * 40,
+        },
+    )

--- a/tests/research/test_output_schema.py
+++ b/tests/research/test_output_schema.py
@@ -258,6 +258,35 @@ def test_base_alone_rejected_when_extension_named():
         )
 
 
+def test_format_block_composed_round_trips():
+    # Composed scorecards need a serializer too — plain format_block rejects
+    # the extension fields as extras.
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    text = output_schema.format_block_composed(
+        "base_scorecard", block, extensions=["llm_extension"]
+    )
+    assert text.startswith("---\n")
+    assert text.endswith("---\n")
+    assert output_schema.parse_block(text) == block
+
+
+def test_format_block_composed_orders_base_fields_before_extension():
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    text = output_schema.format_block_composed(
+        "base_scorecard", block, extensions=["llm_extension"]
+    )
+    assert text.index("candidate_id:") < text.index("valid_thesis_rate:")
+
+
+def test_format_block_composed_rejects_missing_extension_field():
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    del block["valid_thesis_rate"]
+    with pytest.raises(output_schema.SchemaError, match="valid_thesis_rate"):
+        output_schema.format_block_composed(
+            "base_scorecard", block, extensions=["llm_extension"]
+        )
+
+
 def test_parse_block_wraps_invalid_yaml_as_schema_error():
     # A truncated block (process killed mid-write) must surface as the module
     # contract exception, not a raw yaml.parser.ParserError.

--- a/tests/research/test_output_schema.py
+++ b/tests/research/test_output_schema.py
@@ -256,3 +256,17 @@ def test_base_alone_rejected_when_extension_named():
         output_schema.validate_composed(
             "base_scorecard", _valid_base_scorecard(), extensions=["llm_extension"]
         )
+
+
+def test_parse_block_wraps_invalid_yaml_as_schema_error():
+    # A truncated block (process killed mid-write) must surface as the module
+    # contract exception, not a raw yaml.parser.ParserError.
+    with pytest.raises(output_schema.SchemaError, match="not valid YAML"):
+        output_schema.parse_block("---\nkey: [unclosed\n---")
+
+
+def test_load_wraps_invalid_yaml_as_schema_error(tmp_path):
+    broken = tmp_path / "broken_schema.yaml"
+    broken.write_text("schemas: [unclosed\n")
+    with pytest.raises(output_schema.SchemaError, match="invalid YAML"):
+        output_schema.load(broken)

--- a/tests/research/test_output_schema.py
+++ b/tests/research/test_output_schema.py
@@ -208,3 +208,26 @@ def test_existing_schemas_unchanged_regression():
             "ledger_sha": "0" * 40,
         },
     )
+
+
+def test_composed_duplicate_field_across_schemas_rejected():
+    # base_scorecard and the pre-existing backtest schema both declare
+    # deflated_sharpe/evaluator_sha — composing them must fail loudly.
+    with pytest.raises(output_schema.SchemaError, match="declared by more than one"):
+        output_schema.validate_composed("base_scorecard", {}, extensions=["backtest"])
+
+
+def test_composed_non_strict_tolerates_extras():
+    block = {**_valid_base_scorecard(), **_valid_llm_extension()}
+    block["future_field"] = 1
+    output_schema.validate_composed(
+        "base_scorecard", block, extensions=["llm_extension"], strict=False
+    )
+
+
+def test_composed_bare_string_extensions_rejected():
+    # str is a Sequence[str]; without the guard this iterates per-character.
+    with pytest.raises(output_schema.SchemaError, match="bare string"):
+        output_schema.validate_composed(
+            "base_scorecard", _valid_base_scorecard(), extensions="llm_extension"
+        )

--- a/tests/research/test_rewards.py
+++ b/tests/research/test_rewards.py
@@ -353,6 +353,25 @@ class TestNoneHandling:
         # total_return pins this: 0.06 - 0.04 + 0.06 = 0.08.
         assert score("basket", "total_return", basket) == pytest.approx(0.08)
 
+    def test_selected_symbol_missing_from_map_raises(self):
+        # Regression (codex): a selected symbol whose KEY is absent from
+        # fwd_return[H] used to be silently dropped from the equal-weight
+        # mean (0.10 instead of loud failure). §10.3 pins "None, never
+        # omitted" for no-data symbols — a missing key is malformed.
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA", "BBB"],
+                    fwd_return={5: {"AAA": 0.10}},  # BBB key omitted, not None
+                    regime="bull",
+                ),
+            ]
+        )
+        for name in ("total_return", "sharpe", "hit_rate", "max_drawdown"):
+            with pytest.raises(ValueError, match="BBB"):
+                score("basket", name, outcomes)
+
 
 # ---------------------------------------------------------------------------
 # Non-finite input rejection (§4.2: loud, never silent)
@@ -528,6 +547,21 @@ class TestRatio:
     def test_ratio_closure_has_descriptive_name(self):
         fn = make_ratio("total_return", "max_drawdown")
         assert fn.__name__ == "ratio_total_return_over_max_drawdown"
+
+    def test_ratio_cannot_be_registered_as_guardrail(self):
+        # Regression (codex): the ratio ±inf sentinel collides with
+        # guardrail_breached's non-finite rejection — the promote gate
+        # would crash on the BEST candidate. register() must refuse.
+        fn = make_ratio("total_return", "max_drawdown")
+        with pytest.raises(ValueError, match="guardrail"):
+            register(
+                "ratio_guard",
+                input_type="basket",
+                role="guardrail",
+                direction="decrease",
+                threshold=0.5,
+            )(fn)
+        assert "ratio_guard" not in names()  # nothing half-registered
 
     def test_ratio_requires_matching_input_types(self):
         @register("trades_num", input_type="trades", role="secondary", direction="increase")

--- a/tests/research/test_rewards.py
+++ b/tests/research/test_rewards.py
@@ -181,6 +181,19 @@ class TestRegister:
         with pytest.raises(ValueError, match="threshold"):
             register("bad", input_type="basket", role="guardrail", direction="decrease")
 
+    def test_guardrail_non_finite_threshold_rejected(self):
+        # Regression: a NaN threshold fails every >/< comparison, so the
+        # guardrail would silently never breach.
+        for bad in (math.nan, math.inf, -math.inf):
+            with pytest.raises(ValueError, match="finite"):
+                register(
+                    "bad",
+                    input_type="basket",
+                    role="guardrail",
+                    direction="decrease",
+                    threshold=bad,
+                )
+
     def test_non_guardrail_with_threshold_rejected(self):
         with pytest.raises(ValueError, match="threshold"):
             register(

--- a/tests/research/test_rewards.py
+++ b/tests/research/test_rewards.py
@@ -374,6 +374,55 @@ class TestNoneHandling:
 
 
 # ---------------------------------------------------------------------------
+# Duplicate-symbol rejection (§4.2: loud, never silent)
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateSymbols:
+    def test_duplicate_symbol_raises_for_aggregations(self):
+        # Regression (review): a symbol listed twice used to double-weight the
+        # equal-weight mean silently — total_return (0.30+0.30+0)/3 = 0.20
+        # instead of the deduped 0.15.
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA", "AAA", "BBB"],
+                    fwd_return={5: {"AAA": 0.30, "BBB": 0.00}},
+                    regime="bull",
+                ),
+            ]
+        )
+        for name in ("total_return", "sharpe", "hit_rate", "max_drawdown", "dodged_loss"):
+            with pytest.raises(ValueError, match="duplicate symbols"):
+                score("basket", name, outcomes)
+
+    def test_duplicate_symbols_cannot_evade_turnover_guardrail(self):
+        # Regression (review): turnover's numerator dedups via set() while its
+        # denominator counts duplicates, so padding a 100%-replaced basket with
+        # repeats reported 0.333 — under the 0.50 guardrail it should breach.
+        # The duplicate payload must now raise, never silently disarm.
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["A", "B"],
+                    fwd_return={5: {"A": 0.01, "B": 0.01}},
+                    regime="bull",
+                ),
+                BasketDay(
+                    date=date(2026, 1, 6),
+                    symbols=["C", "D", "C", "D", "C", "D"],
+                    fwd_return={5: {"C": 0.01, "D": 0.01}},
+                    regime="bull",
+                ),
+            ]
+        )
+        with pytest.raises(ValueError, match="duplicate symbols"):
+            score("basket", "turnover", outcomes)
+
+
+# ---------------------------------------------------------------------------
 # Non-finite input rejection (§4.2: loud, never silent)
 # ---------------------------------------------------------------------------
 
@@ -593,6 +642,35 @@ class TestRatio:
                 direction="increase",
             )(fn)
         assert "ratio_wrong_type" not in names()
+
+    def test_ratio_rejects_non_finite_constituent(self):
+        # Regression (review): make_ratio composes ANY registered reward, and a
+        # non-finite constituent used to launder straight into a score
+        # (nan/1.0 -> nan, nan/0.0 -> -inf since nan>0 is False) — corrupt input
+        # silently ranking a candidate. The shipped basket rewards self-reject,
+        # so use custom aggregations to exercise the composer's own guard.
+        @register("nan_const", input_type="basket", role="secondary", direction="increase")
+        def nan_const(outcomes, **kwargs):
+            return math.nan
+
+        @register("one_const", input_type="basket", role="secondary", direction="increase")
+        def one_const(outcomes, **kwargs):
+            return 1.0
+
+        @register("zero_const2", input_type="basket", role="secondary", direction="increase")
+        def zero_const2(outcomes, **kwargs):
+            return 0.0
+
+        outcomes = BasketOutcomes(days=[])
+        # non-finite numerator, finite (non-zero) denominator -> would be nan
+        with pytest.raises(ValueError, match="non-finite constituent"):
+            make_ratio("nan_const", "one_const")(outcomes)
+        # non-finite numerator, zero denominator -> would be silently sentinel'd
+        with pytest.raises(ValueError, match="non-finite constituent"):
+            make_ratio("nan_const", "zero_const2")(outcomes)
+        # non-finite denominator -> would be nan
+        with pytest.raises(ValueError, match="non-finite constituent"):
+            make_ratio("one_const", "nan_const")(outcomes)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/research/test_rewards.py
+++ b/tests/research/test_rewards.py
@@ -1,0 +1,376 @@
+"""Tests for the generalized reward registry + screener basket rewards.
+
+Design: docs/DESIGN-qu100-ab-testing.md §4.2, §10.3, §11.2
+Task plan: docs/TASK-PLAN-ab-reward-registry-b3b8.md
+
+Fixture baskets are constructed by hand (no evaluator dependency — that is
+ab-replay-evaluator-edb5's scope) and every shipped reward is pinned to a
+hand-computed expected value.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from rainier.research import rewards
+from rainier.research.rewards import (
+    REGISTRY,
+    RewardSpec,
+    get,
+    guardrail_breached,
+    make_ratio,
+    names,
+    register,
+    score,
+)
+from rainier.research.rewards.basket import BasketDay, BasketOutcomes
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _registry_guard():
+    """Snapshot/restore REGISTRY so test-registered rewards never leak."""
+    snapshot = dict(REGISTRY)
+    yield
+    REGISTRY.clear()
+    REGISTRY.update(snapshot)
+
+
+@pytest.fixture
+def basket() -> BasketOutcomes:
+    """Hand-computed three-day fixture.
+
+    Per-day equal-weight basket returns at H=5 (selected, non-None only):
+      d1: (0.10 + 0.02) / 2 = 0.06
+      d2: (0.04 - 0.12) / 2 = -0.04
+      d3: BBB is None -> only DDD  = 0.06
+
+    Hand-computed expectations:
+      total_return = 0.06 - 0.04 + 0.06                  = 0.08
+      sharpe       = mean/stdev(ddof=1) = 0.0266667/0.0577350 = 0.4618802
+      hit_rate     = 2 positive days / 3                 = 2/3
+      max_drawdown = 1.06 -> 1.0176 peak-to-trough       = 0.04
+      turnover     = mean(1/2, 2/2)                      = 0.75
+      dodged_loss  = |−0.08| (CCC d1) + |−0.05| (DDD d2) = 0.13
+    """
+    return BasketOutcomes(
+        days=[
+            BasketDay(
+                date=date(2026, 1, 5),
+                symbols=["AAA", "BBB"],
+                fwd_return={5: {"AAA": 0.10, "BBB": 0.02, "CCC": -0.08}},
+                regime="bull",
+            ),
+            BasketDay(
+                date=date(2026, 1, 6),
+                symbols=["AAA", "CCC"],
+                fwd_return={5: {"AAA": 0.04, "CCC": -0.12, "DDD": -0.05}},
+                regime="bull",
+            ),
+            BasketDay(
+                date=date(2026, 1, 7),
+                symbols=["BBB", "DDD"],
+                fwd_return={5: {"BBB": None, "DDD": 0.06, "EEE": 0.03}},
+                regime="bear",
+            ),
+        ]
+    )
+
+
+@pytest.fixture
+def empty_basket() -> BasketOutcomes:
+    return BasketOutcomes(days=[])
+
+
+# ---------------------------------------------------------------------------
+# Registration + metadata
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+    def test_register_new_basket_reward_selectable_with_metadata(self):
+        @register("my_reward", input_type="basket", role="secondary", direction="increase")
+        def my_reward(outcomes: BasketOutcomes) -> float:
+            return 1.0
+
+        assert "my_reward" in names()
+        spec = get("my_reward")
+        assert isinstance(spec, RewardSpec)
+        assert spec.input_type == "basket"
+        assert spec.role == "secondary"
+        assert spec.direction == "increase"
+        assert spec.threshold is None
+        assert spec.fn is my_reward  # decorator returns the fn unwrapped
+
+    def test_register_guardrail_carries_threshold(self):
+        @register(
+            "my_guardrail",
+            input_type="basket",
+            role="guardrail",
+            direction="decrease",
+            threshold=0.3,
+        )
+        def my_guardrail(outcomes: BasketOutcomes) -> float:
+            return 0.0
+
+        assert get("my_guardrail").threshold == 0.3
+
+    def test_duplicate_name_rejected(self):
+        @register("dup", input_type="basket", role="secondary", direction="increase")
+        def first(outcomes):
+            return 0.0
+
+        with pytest.raises(ValueError, match="dup"):
+
+            @register("dup", input_type="basket", role="secondary", direction="increase")
+            def second(outcomes):
+                return 0.0
+
+    def test_invalid_input_type_rejected(self):
+        with pytest.raises(ValueError, match="input_type"):
+            register("bad", input_type="portfolio", role="primary", direction="increase")
+
+    def test_invalid_role_rejected(self):
+        with pytest.raises(ValueError, match="role"):
+            register("bad", input_type="basket", role="tertiary", direction="increase")
+
+    def test_invalid_direction_rejected(self):
+        with pytest.raises(ValueError, match="direction"):
+            register("bad", input_type="basket", role="primary", direction="up")
+
+    def test_guardrail_without_threshold_rejected(self):
+        with pytest.raises(ValueError, match="threshold"):
+            register("bad", input_type="basket", role="guardrail", direction="decrease")
+
+    def test_non_guardrail_with_threshold_rejected(self):
+        with pytest.raises(ValueError, match="threshold"):
+            register(
+                "bad", input_type="basket", role="primary", direction="increase", threshold=0.1
+            )
+
+    def test_get_unknown_name_raises_with_known_names(self):
+        with pytest.raises(ValueError, match="no_such_reward"):
+            get("no_such_reward")
+
+
+# ---------------------------------------------------------------------------
+# Input-type refusal (§4.2: no silent mis-scoring)
+# ---------------------------------------------------------------------------
+
+
+class TestInputTypeRefusal:
+    def test_trades_reward_refuses_basket_candidate(self, basket):
+        @register("trades_only", input_type="trades", role="primary", direction="increase")
+        def trades_only(records) -> float:
+            return 1.0
+
+        with pytest.raises(ValueError, match="input_type"):
+            score("basket", "trades_only", basket)
+
+    def test_basket_reward_refuses_trades_candidate(self):
+        with pytest.raises(ValueError, match="input_type"):
+            score("trades", "sharpe", [])
+
+    def test_matching_input_type_scores(self, basket):
+        assert score("basket", "total_return", basket) == pytest.approx(0.08)
+
+
+# ---------------------------------------------------------------------------
+# Shipped basket rewards — hand-computed fixtures
+# ---------------------------------------------------------------------------
+
+
+class TestShippedRewards:
+    def test_shipped_set_registered(self):
+        expected = {
+            "total_return",
+            "sharpe",
+            "hit_rate",
+            "max_drawdown",
+            "turnover",
+            "dodged_loss",
+        }
+        assert expected <= set(names())
+        for name in expected:
+            assert get(name).input_type == "basket"
+
+    def test_roles_and_directions(self):
+        assert get("sharpe").role == "primary"
+        assert get("max_drawdown").role == "guardrail"
+        assert get("max_drawdown").direction == "decrease"
+        assert get("max_drawdown").threshold is not None
+        assert get("turnover").role == "guardrail"
+        assert get("turnover").direction == "decrease"
+        assert get("turnover").threshold is not None
+        assert get("total_return").direction == "increase"
+        assert get("dodged_loss").direction == "increase"
+
+    def test_total_return(self, basket):
+        assert score("basket", "total_return", basket) == pytest.approx(0.08)
+
+    def test_sharpe(self, basket):
+        assert score("basket", "sharpe", basket) == pytest.approx(0.4618802, abs=1e-6)
+
+    def test_hit_rate(self, basket):
+        assert score("basket", "hit_rate", basket) == pytest.approx(2 / 3)
+
+    def test_max_drawdown(self, basket):
+        assert score("basket", "max_drawdown", basket) == pytest.approx(0.04)
+
+    def test_turnover(self, basket):
+        assert score("basket", "turnover", basket) == pytest.approx(0.75)
+
+    def test_dodged_loss(self, basket):
+        assert score("basket", "dodged_loss", basket) == pytest.approx(0.13)
+
+    def test_empty_basket_all_rewards_zero(self, empty_basket):
+        for name in ("total_return", "sharpe", "hit_rate", "max_drawdown", "turnover"):
+            assert score("basket", name, empty_basket) == 0.0
+        assert score("basket", "dodged_loss", empty_basket) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# None handling (§10.3: None near window end, never 0)
+# ---------------------------------------------------------------------------
+
+
+class TestNoneHandling:
+    def test_none_excluded_not_zeroed(self):
+        # Two days: d1 all-None (excluded entirely), d2 = 0.10.
+        # If None were treated as 0, sharpe's mean/stdev and hit_rate's
+        # denominator would both change.
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA"],
+                    fwd_return={5: {"AAA": None}},
+                    regime="bull",
+                ),
+                BasketDay(
+                    date=date(2026, 1, 6),
+                    symbols=["AAA"],
+                    fwd_return={5: {"AAA": 0.10}},
+                    regime="bull",
+                ),
+            ]
+        )
+        assert score("basket", "total_return", outcomes) == pytest.approx(0.10)
+        assert score("basket", "hit_rate", outcomes) == pytest.approx(1.0)  # 1/1, not 1/2
+
+    def test_partial_none_within_day_excluded(self, basket):
+        # d3 has BBB=None; the day return must be 0.06 (DDD only), not 0.03.
+        # total_return pins this: 0.06 - 0.04 + 0.06 = 0.08.
+        assert score("basket", "total_return", basket) == pytest.approx(0.08)
+
+
+# ---------------------------------------------------------------------------
+# Guardrail evaluation helper
+# ---------------------------------------------------------------------------
+
+
+class TestGuardrail:
+    def test_decrease_direction_breach_when_above_threshold(self):
+        @register(
+            "gd_dec", input_type="basket", role="guardrail", direction="decrease", threshold=0.20
+        )
+        def gd_dec(outcomes):
+            return 0.0
+
+        assert guardrail_breached("gd_dec", 0.25) is True
+        assert guardrail_breached("gd_dec", 0.04) is False
+        assert guardrail_breached("gd_dec", 0.20) is False  # at threshold = clean
+
+    def test_increase_direction_breach_when_below_threshold(self):
+        @register(
+            "gd_inc", input_type="basket", role="guardrail", direction="increase", threshold=0.5
+        )
+        def gd_inc(outcomes):
+            return 0.0
+
+        assert guardrail_breached("gd_inc", 0.4) is True
+        assert guardrail_breached("gd_inc", 0.6) is False
+
+    def test_non_guardrail_rejected(self):
+        with pytest.raises(ValueError, match="guardrail"):
+            guardrail_breached("sharpe", 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Ratio composition (§4.2: ratio rewards compose two aggregations)
+# ---------------------------------------------------------------------------
+
+
+class TestRatio:
+    def test_ratio_composes_two_registered_rewards(self, basket):
+        fn = make_ratio("total_return", "max_drawdown")
+        assert fn(basket) == pytest.approx(0.08 / 0.04)
+
+    def test_ratio_zero_denominator_is_zero(self, empty_basket):
+        fn = make_ratio("total_return", "max_drawdown")
+        assert fn(empty_basket) == 0.0
+
+    def test_ratio_requires_matching_input_types(self):
+        @register("trades_num", input_type="trades", role="secondary", direction="increase")
+        def trades_num(records):
+            return 1.0
+
+        with pytest.raises(ValueError, match="input_type"):
+            make_ratio("trades_num", "max_drawdown")
+
+    def test_ratio_result_registrable(self, basket):
+        register(
+            "return_over_drawdown",
+            input_type="basket",
+            role="secondary",
+            direction="increase",
+        )(make_ratio("total_return", "max_drawdown"))
+        assert score("basket", "return_over_drawdown", basket) == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Determinism + purity
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_same_outcomes_identical_value_across_calls(self, basket):
+        for name in ("total_return", "sharpe", "hit_rate", "max_drawdown", "turnover",
+                     "dodged_loss"):
+            assert score("basket", name, basket) == score("basket", name, basket)
+
+    def test_scoring_does_not_mutate_outcomes(self, basket):
+        before = [(d.date, list(d.symbols), {h: dict(m) for h, m in d.fwd_return.items()})
+                  for d in basket.days]
+        score("basket", "sharpe", basket)
+        score("basket", "turnover", basket)
+        after = [(d.date, list(d.symbols), {h: dict(m) for h, m in d.fwd_return.items()})
+                 for d in basket.days]
+        assert before == after
+
+
+# ---------------------------------------------------------------------------
+# BasketOutcomes shape (design §10.3, pinned)
+# ---------------------------------------------------------------------------
+
+
+class TestBasketOutcomesShape:
+    def test_frozen(self, basket):
+        with pytest.raises(AttributeError):
+            basket.days = []
+        with pytest.raises(AttributeError):
+            basket.days[0].regime = "bear"
+
+    def test_names_sorted(self):
+        assert names() == sorted(names())
+
+    def test_registry_module_reexports(self):
+        # The package surface other tasks import against.
+        assert rewards.REGISTRY is REGISTRY
+        assert callable(rewards.register)
+        assert callable(rewards.score)

--- a/tests/research/test_rewards.py
+++ b/tests/research/test_rewards.py
@@ -10,6 +10,7 @@ hand-computed expected value.
 
 from __future__ import annotations
 
+import math
 from datetime import date
 
 import pytest
@@ -87,6 +88,21 @@ def empty_basket() -> BasketOutcomes:
     return BasketOutcomes(days=[])
 
 
+def _uniform_basket(day_returns: list[float], horizon: int = 5) -> BasketOutcomes:
+    """One-symbol basket with the given per-day forward returns."""
+    return BasketOutcomes(
+        days=[
+            BasketDay(
+                date=date(2026, 1, 5 + i),
+                symbols=["AAA"],
+                fwd_return={horizon: {"AAA": r}},
+                regime="bull",
+            )
+            for i, r in enumerate(day_returns)
+        ]
+    )
+
+
 # ---------------------------------------------------------------------------
 # Registration + metadata
 # ---------------------------------------------------------------------------
@@ -130,6 +146,24 @@ class TestRegister:
             @register("dup", input_type="basket", role="secondary", direction="increase")
             def second(outcomes):
                 return 0.0
+
+    def test_duplicate_name_rejected_at_decoration_time(self):
+        # Regression: two factories obtained BEFORE either decorator is
+        # applied must not silently clobber — the dup check must also run
+        # at insertion time, not only in the factory.
+        deco_a = register("dup2", input_type="basket", role="secondary", direction="increase")
+        deco_b = register("dup2", input_type="basket", role="secondary", direction="increase")
+
+        def first(outcomes):
+            return 1.0
+
+        def second(outcomes):
+            return 2.0
+
+        deco_a(first)
+        with pytest.raises(ValueError, match="dup2"):
+            deco_b(second)
+        assert get("dup2").fn is first  # first registration survives intact
 
     def test_invalid_input_type_rejected(self):
         with pytest.raises(ValueError, match="input_type"):
@@ -179,6 +213,12 @@ class TestInputTypeRefusal:
     def test_matching_input_type_scores(self, basket):
         assert score("basket", "total_return", basket) == pytest.approx(0.08)
 
+    def test_unknown_candidate_type_rejected(self, basket):
+        # A typo'd candidate_type must be flagged as such, not blamed on
+        # the reward's input_type.
+        with pytest.raises(ValueError, match="candidate_type"):
+            score("baskets", "total_return", basket)
+
 
 # ---------------------------------------------------------------------------
 # Shipped basket rewards — hand-computed fixtures
@@ -203,10 +243,10 @@ class TestShippedRewards:
         assert get("sharpe").role == "primary"
         assert get("max_drawdown").role == "guardrail"
         assert get("max_drawdown").direction == "decrease"
-        assert get("max_drawdown").threshold is not None
+        assert get("max_drawdown").threshold == 0.20  # design-pinned promote-gate bound
         assert get("turnover").role == "guardrail"
         assert get("turnover").direction == "decrease"
-        assert get("turnover").threshold is not None
+        assert get("turnover").threshold == 0.50  # design-pinned promote-gate bound
         assert get("total_return").direction == "increase"
         assert get("dodged_loss").direction == "increase"
 
@@ -232,6 +272,38 @@ class TestShippedRewards:
         for name in ("total_return", "sharpe", "hit_rate", "max_drawdown", "turnover"):
             assert score("basket", name, empty_basket) == 0.0
         assert score("basket", "dodged_loss", empty_basket) == 0.0
+
+    def test_sharpe_single_day_zero(self):
+        outcomes = _uniform_basket([0.10])
+        assert score("basket", "sharpe", outcomes) == 0.0
+
+    def test_sharpe_zero_stdev_zero(self):
+        # Identical day returns -> stdev 0 -> 0.0, not ZeroDivisionError.
+        outcomes = _uniform_basket([0.05, 0.05, 0.05])
+        assert score("basket", "sharpe", outcomes) == 0.0
+
+    def test_turnover_skips_empty_symbol_days(self):
+        # [A,B], [], [A,B]: the empty day is dropped, so day1->day3 is the
+        # consecutive pair — nothing entered — turnover 0.0 (pinned skip
+        # semantics; the empty day never enters the denominator).
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA", "BBB"],
+                    fwd_return={5: {"AAA": 0.01, "BBB": 0.01}},
+                    regime="bull",
+                ),
+                BasketDay(date=date(2026, 1, 6), symbols=[], fwd_return={5: {}}, regime="bull"),
+                BasketDay(
+                    date=date(2026, 1, 7),
+                    symbols=["AAA", "BBB"],
+                    fwd_return={5: {"AAA": 0.01, "BBB": 0.01}},
+                    regime="bull",
+                ),
+            ]
+        )
+        assert score("basket", "turnover", outcomes) == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -270,6 +342,102 @@ class TestNoneHandling:
 
 
 # ---------------------------------------------------------------------------
+# Non-finite input rejection (§4.2: loud, never silent)
+# ---------------------------------------------------------------------------
+
+
+class TestNonFiniteRejection:
+    def test_nan_return_raises_not_disarms_drawdown(self):
+        # Regression: NaN on day 1 then two -30% days used to yield
+        # max_drawdown == 0.0 (equity *= nan; max(worst, nan) keeps worst)
+        # — a clean-looking guardrail on corrupt data.
+        outcomes = _uniform_basket([math.nan, -0.30, -0.30])
+        with pytest.raises(ValueError, match="non-finite"):
+            score("basket", "max_drawdown", outcomes)
+
+    def test_nan_return_raises_for_aggregations(self):
+        outcomes = _uniform_basket([0.10, math.nan])
+        for name in ("total_return", "sharpe", "hit_rate"):
+            with pytest.raises(ValueError, match="non-finite"):
+                score("basket", name, outcomes)
+
+    def test_inf_return_raises(self):
+        outcomes = _uniform_basket([math.inf])
+        with pytest.raises(ValueError, match="non-finite"):
+            score("basket", "total_return", outcomes)
+
+    def test_nan_in_dodged_loss_pool_raises(self):
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA"],
+                    fwd_return={5: {"AAA": 0.01, "CCC": math.nan}},
+                    regime="bull",
+                ),
+            ]
+        )
+        with pytest.raises(ValueError, match="non-finite"):
+            score("basket", "dodged_loss", outcomes)
+
+
+# ---------------------------------------------------------------------------
+# Horizon handling (kwargs forwarding + missing-horizon loudness)
+# ---------------------------------------------------------------------------
+
+
+class TestHorizon:
+    def test_kwargs_horizon_forwarded(self):
+        # Two horizons with different returns: score() must forward horizon=
+        # to the reward and aggregate the requested one.
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA"],
+                    fwd_return={5: {"AAA": 0.10}, 10: {"AAA": 0.25}},
+                    regime="bull",
+                ),
+            ]
+        )
+        assert score("basket", "total_return", outcomes) == pytest.approx(0.10)
+        assert score("basket", "total_return", outcomes, horizon=10) == pytest.approx(0.25)
+
+    def test_horizon_absent_from_every_day_raises(self, basket):
+        # A typo'd/unconfigured horizon must not silently score 0.0 for
+        # every candidate (valid-looking noise).
+        with pytest.raises(ValueError, match="horizon 10"):
+            score("basket", "total_return", basket, horizon=10)
+        with pytest.raises(ValueError, match="horizon 10"):
+            score("basket", "dodged_loss", basket, horizon=10)
+
+    def test_horizon_missing_on_some_days_skips_them(self):
+        # Partially missing horizon: days without the key are skipped
+        # (like None returns), not fatal.
+        outcomes = BasketOutcomes(
+            days=[
+                BasketDay(
+                    date=date(2026, 1, 5),
+                    symbols=["AAA"],
+                    fwd_return={5: {"AAA": 0.10}},
+                    regime="bull",
+                ),
+                BasketDay(
+                    date=date(2026, 1, 6),
+                    symbols=["AAA"],
+                    fwd_return={5: {"AAA": 0.02}, 10: {"AAA": 0.30}},
+                    regime="bull",
+                ),
+            ]
+        )
+        assert score("basket", "total_return", outcomes, horizon=10) == pytest.approx(0.30)
+
+    def test_empty_basket_any_horizon_zero(self, empty_basket):
+        # No days at all -> nothing to validate against; stays 0.0.
+        assert score("basket", "total_return", empty_basket, horizon=10) == 0.0
+
+
+# ---------------------------------------------------------------------------
 # Guardrail evaluation helper
 # ---------------------------------------------------------------------------
 
@@ -295,10 +463,19 @@ class TestGuardrail:
 
         assert guardrail_breached("gd_inc", 0.4) is True
         assert guardrail_breached("gd_inc", 0.6) is False
+        assert guardrail_breached("gd_inc", 0.5) is False  # at threshold = clean
 
     def test_non_guardrail_rejected(self):
         with pytest.raises(ValueError, match="guardrail"):
             guardrail_breached("sharpe", 1.0)
+
+    def test_non_finite_value_rejected(self):
+        # Regression: NaN fails every >/< comparison, so it used to read as
+        # "clean" — silently disarming the guardrail on corrupt input.
+        with pytest.raises(ValueError, match="non-finite"):
+            guardrail_breached("max_drawdown", math.nan)
+        with pytest.raises(ValueError, match="non-finite"):
+            guardrail_breached("max_drawdown", math.inf)
 
 
 # ---------------------------------------------------------------------------
@@ -311,9 +488,33 @@ class TestRatio:
         fn = make_ratio("total_return", "max_drawdown")
         assert fn(basket) == pytest.approx(0.08 / 0.04)
 
-    def test_ratio_zero_denominator_is_zero(self, empty_basket):
+    def test_ratio_zero_over_zero_is_zero(self, empty_basket):
+        # Empty window: numerator and denominator both 0 -> 0.0 (no data).
         fn = make_ratio("total_return", "max_drawdown")
         assert fn(empty_basket) == 0.0
+
+    def test_ratio_positive_over_zero_is_inf(self):
+        # Regression: a flawless candidate (positive return, zero drawdown)
+        # used to score 0.0 — ranking BELOW every mediocre candidate.
+        fn = make_ratio("total_return", "max_drawdown")
+        outcomes = _uniform_basket([0.05, 0.10])
+        assert fn(outcomes) == math.inf
+
+    def test_ratio_negative_over_zero_is_neg_inf(self):
+        @register("neg_const", input_type="basket", role="secondary", direction="increase")
+        def neg_const(outcomes, **kwargs):
+            return -1.0
+
+        @register("zero_const", input_type="basket", role="secondary", direction="increase")
+        def zero_const(outcomes, **kwargs):
+            return 0.0
+
+        fn = make_ratio("neg_const", "zero_const")
+        assert fn(BasketOutcomes(days=[])) == -math.inf
+
+    def test_ratio_closure_has_descriptive_name(self):
+        fn = make_ratio("total_return", "max_drawdown")
+        assert fn.__name__ == "ratio_total_return_over_max_drawdown"
 
     def test_ratio_requires_matching_input_types(self):
         @register("trades_num", input_type="trades", role="secondary", direction="increase")
@@ -366,6 +567,8 @@ class TestBasketOutcomesShape:
         with pytest.raises(AttributeError):
             basket.days[0].regime = "bear"
 
+
+class TestModuleSurface:
     def test_names_sorted(self):
         assert names() == sorted(names())
 

--- a/tests/research/test_rewards.py
+++ b/tests/research/test_rewards.py
@@ -580,6 +580,20 @@ class TestRatio:
         )(make_ratio("total_return", "max_drawdown"))
         assert score("basket", "return_over_drawdown", basket) == pytest.approx(2.0)
 
+    def test_ratio_cannot_be_registered_under_wrong_input_type(self):
+        # Regression (codex): make_ratio's input_type was discarded, so a
+        # basket-composed ratio could register as input_type="trades" and
+        # score() would route a trades payload into the basket aggregators.
+        fn = make_ratio("total_return", "max_drawdown")
+        with pytest.raises(ValueError, match="input_type"):
+            register(
+                "ratio_wrong_type",
+                input_type="trades",
+                role="secondary",
+                direction="increase",
+            )(fn)
+        assert "ratio_wrong_type" not in names()
+
 
 # ---------------------------------------------------------------------------
 # Determinism + purity

--- a/tests/research/test_screener_evaluator.py
+++ b/tests/research/test_screener_evaluator.py
@@ -1,0 +1,414 @@
+"""Replay + score evaluator — corpus driver, BasketOutcomes, base scorecard.
+
+Task ab-replay-evaluator-edb5 (design §4.4/§4.5/§11.4). Composes the shipped
+pattern replay + as-of selectors into per-day BasketOutcomes → rewards → the
+candidate-agnostic base scorecard, driven by an experiment spec.
+
+Each test names the contract/bug it guards:
+- parity: driver selection == live screen_stocks on one pinned fixture.
+- champion baseline: challenger differs from the live champion only in the
+  overridden key, NOT from pydantic code-defaults (the §4.5 silent no-op).
+- basket coverage: money-flow-only selected symbol → fwd_return[H] key present
+  (None), never omitted; dodged_loss sees the wider screened pool.
+- co-evaluation: one run emits champion + all challengers with equal corpus_hash.
+- no look-ahead: bars after t never move the as-of ranking.
+- regime slices: per-regime scores match a hand-sliced fixture; DSR is null.
+- windows: train/holdout disjoint; embargo purge gap respected.
+- unknown reward name → loud error.
+- scorecard validates against base_scorecard (no LLM fields).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from rainier.core.config import Settings, StockScreenerConfig
+from rainier.core.types import MoneyFlowSignal, SectorTrend
+from rainier.research import output_schema
+from rainier.research.evaluator import screener
+from rainier.research.evaluator.screener import (
+    build_basket_outcomes,
+    corpus_hash,
+    evaluator_sha,
+    load_base_overrides,
+    run_experiment,
+    split_windows,
+)
+from rainier.research.experiment import ExperimentWindow, materialize_challengers, parse_spec
+from rainier.research.rewards.basket import dodged_loss
+
+# ---------------------------------------------------------------------------
+# fixtures — date-indexed OHLCV; money-flow + sector inputs pinned so the
+# ranking is identical between the live path and the driver.
+# ---------------------------------------------------------------------------
+
+_CONFIG = StockScreenerConfig(
+    swing_lookback=3, min_pattern_bars=3, max_pattern_bars=50,
+    neckline_tolerance_pct=0.05,
+)
+
+
+def _ohlcv(prices: list[float], *, end: str = "2026-03-31") -> pd.DataFrame:
+    n = len(prices)
+    df = pd.DataFrame(
+        {
+            "open": [prices[max(0, i - 1)] for i in range(n)],
+            "high": [p * 1.01 for p in prices],
+            "low": [p * 0.99 for p in prices],
+            "close": prices,
+            "volume": [1000.0] * n,
+        }
+    )
+    df.index = pd.date_range(end=end, periods=n, freq="D", tz="UTC")
+    return df
+
+
+def _false_breakdown() -> list[float]:
+    p = [95.0, 93.0, 91.0, 90.0, 91.0, 93.0, 95.0, 93.0, 91.0, 90.0]
+    p += [92.0, 93.0, 91.0, 89.0, 88.0, 87.0, 89.0, 91.0, 92.0]
+    p += [92.5, 92.0, 92.5, 92.0, 92.5]
+    return p
+
+
+def _signal(symbol, strength, *, rank=5, sector="Technology") -> MoneyFlowSignal:
+    return MoneyFlowSignal(
+        symbol=symbol, rank=rank, rank_change=1, long_short="Long in",
+        capital_flow_direction="+", days_in_top100=3, sector=sector,
+        industry="X", signal_strength=strength,
+    )
+
+
+def _sector_trends() -> list[SectorTrend]:
+    return [
+        SectorTrend(
+            sector="Technology", long_in_count=10, short_in_count=1,
+            net_sentiment=0.8, top_stocks=["AAA"], trend_direction="bullish",
+            sector_rank=1,
+        ),
+        SectorTrend(
+            sector="Energy", long_in_count=2, short_in_count=2,
+            net_sentiment=0.0, top_stocks=["BBB"], trend_direction="neutral",
+            sector_rank=2,
+        ),
+    ]
+
+
+def _settings_with(config: StockScreenerConfig) -> Settings:
+    s = Settings()
+    s.stock_screener = config
+    return s
+
+
+def _spec(challengers, *, primary="sharpe", guardrails=("max_drawdown",),
+          train="2026-01-01..2026-03-31", holdout="2026-05-01..2026-06-25",
+          embargo_days=20):
+    raw = {
+        "id": "exp-test",
+        "status": "active",
+        "champion": "champion.yaml",
+        "layer": "layer_weights",
+        "challengers": challengers,
+        "primary": primary,
+        "guardrails": list(guardrails),
+        "window": {"train": train, "holdout": holdout, "embargo_days": embargo_days},
+    }
+    return parse_spec(raw, source="<test>")
+
+
+# ---------------------------------------------------------------------------
+# parity — driver's per-day selection == live screen_stocks (pinned fixture).
+# ---------------------------------------------------------------------------
+
+
+def test_parity_driver_selection_matches_live_screen_stocks():
+    df_a = _ohlcv(_false_breakdown())              # actionable pattern
+    df_b = _ohlcv([100.0] * 40)                    # flat → no pattern
+    frames = {"AAA": df_a, "BBB": df_b}
+    as_of = df_a.index[-1].date()
+
+    raw = [_signal("AAA", 0.95, sector="Technology"),
+           _signal("BBB", 0.70, rank=20, sector="Energy")]
+    trends = _sector_trends()
+
+    cm = MagicMock()
+    cm.__enter__.return_value = MagicMock()
+    cm.__exit__.return_value = False
+    with patch("rainier.analysis.stock_screener._screen_money_flow", return_value=raw), \
+         patch("rainier.analysis.stock_screener.analyze_sectors", return_value=trends), \
+         patch("rainier.analysis.stock_screener._fetch_stock_data", return_value=frames), \
+         patch("rainier.analysis.stock_screener.get_session", return_value=cm):
+        from rainier.analysis.stock_screener import screen_stocks
+        candidates, _ = screen_stocks(_settings_with(_CONFIG))
+
+    with patch.object(screener, "_screen_money_flow_as_of", return_value=raw), \
+         patch.object(screener, "analyze_sectors_at", return_value=trends):
+        outcomes = build_basket_outcomes(
+            session=object(), config=_CONFIG, days=[as_of],
+            prices_by_symbol=frames, regime_fn=lambda d: "bull",
+            basket_size=10,
+        )
+
+    day = outcomes.days[0]
+    # Identical ranking (ordering) between the driver basket and the live screen.
+    assert day.symbols == [c.symbol for c in candidates]
+
+
+# ---------------------------------------------------------------------------
+# champion baseline — the §4.5 silent no-op guard: a challenger differs from the
+# LIVE champion only in the overridden key, never from pydantic code-defaults.
+# ---------------------------------------------------------------------------
+
+
+def test_champion_baseline_from_live_settings_not_code_defaults(tmp_path):
+    # settings.yaml carries a non-default layer weight; champion.yaml a
+    # non-default threshold. The live champion is their merge — NOT the defaults.
+    (tmp_path / "settings.yaml").write_text(
+        "stock_screener:\n  layer_weight_pattern: 0.70\n"
+    )
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "champion.yaml").write_text(
+        "version: 1\nstrong_buy_threshold: 0.85\n"
+    )
+
+    base = load_base_overrides(tmp_path / "settings.yaml")
+    assert base["layer_weight_pattern"] == 0.70   # from settings.yaml
+    assert base["strong_buy_threshold"] == 0.85   # from champion.yaml
+
+    spec = _spec([{"id": "bt60", "override": {"buy_threshold": 0.60}}])
+    champ, challengers = materialize_challengers(spec, base)
+    chall = challengers["bt60"]
+
+    # champion inherits the LIVE layer, not code-defaults (default lw_pattern=0.65).
+    assert champ.layer_weight_pattern == 0.70
+    assert champ.strong_buy_threshold == 0.85
+    # challenger differs from champion ONLY in the overridden key.
+    assert chall.buy_threshold == 0.60
+    assert chall.layer_weight_pattern == champ.layer_weight_pattern
+    assert chall.strong_buy_threshold == champ.strong_buy_threshold
+
+
+# ---------------------------------------------------------------------------
+# basket coverage — money-flow-only selected symbol; wider screened pool.
+# ---------------------------------------------------------------------------
+
+
+def test_money_flow_only_symbol_and_dodged_loss_pool():
+    df_win = _ohlcv([100.0, 101.0, 102.0, 103.0, 104.0, 105.0])   # SEL: +5d
+    df_loser = _ohlcv([100.0, 99.0, 98.0, 97.0, 90.0, 80.0])      # LOSER: -20%
+    frames = {"SEL": df_win, "LOSER": df_loser}    # MFONLY has NO price frame
+    as_of = df_win.index[0].date()   # t=0 so 5 bars ahead exist
+
+    # MFONLY outranks LOSER on money-flow so it lands in the top-2 basket
+    # despite having no price (best_confidence=0), exactly like the live screen.
+    raw = [_signal("SEL", 0.95), _signal("MFONLY", 0.90), _signal("LOSER", 0.30)]
+
+    with patch.object(screener, "_screen_money_flow_as_of", return_value=raw), \
+         patch.object(screener, "analyze_sectors_at", return_value=[]):
+        outcomes = build_basket_outcomes(
+            session=object(), config=_CONFIG, days=[as_of],
+            prices_by_symbol=frames, regime_fn=lambda d: "bull",
+            basket_size=2, horizons=(5,),
+        )
+
+    day = outcomes.days[0]
+    assert "MFONLY" in day.symbols              # selected despite no price
+    # every selected symbol is a fwd_return key (None for the price-less one)
+    assert "MFONLY" in day.fwd_return[5]
+    assert day.fwd_return[5]["MFONLY"] is None
+    # the wider screened pool carries the non-selected LOSER, so dodged_loss > 0
+    assert "LOSER" in day.fwd_return[5]
+    assert "LOSER" not in day.symbols
+    assert dodged_loss(outcomes, horizon=5) > 0.0
+
+
+# ---------------------------------------------------------------------------
+# co-evaluation — one run scores champion + all challengers, equal corpus_hash.
+# ---------------------------------------------------------------------------
+
+
+def _patch_selectors(raw, trends=()):
+    return (
+        patch.object(screener, "_screen_money_flow_as_of", return_value=raw),
+        patch.object(screener, "analyze_sectors_at", return_value=list(trends)),
+    )
+
+
+def test_co_evaluation_equal_corpus_hash_all_candidates():
+    frames = {"AAA": _ohlcv([100.0] * 40)}
+    days = [date(2026, 1, 5), date(2026, 1, 6), date(2026, 1, 7)]
+    raw = [_signal("AAA", 0.9)]
+    spec = _spec(
+        [
+            {"id": "mf35", "override": {"layer_weight_money_flow": 0.35}},
+            {"id": "mf40", "override": {"layer_weight_money_flow": 0.40}},
+        ],
+        primary="total_return", guardrails=(),
+    )
+    p1, p2 = _patch_selectors(raw)
+    with p1, p2:
+        cards = run_experiment(
+            spec, base_overrides=None, session=object(),
+            prices_by_symbol=frames, trading_days=days,
+            regime_fn=lambda d: "bull", segment="train",
+        )
+    ids = {c["candidate_id"] for c in cards}
+    assert ids == {"champion", "mf35", "mf40"}
+    hashes = {c["corpus_hash"] for c in cards}
+    assert len(hashes) == 1                    # one shared corpus snapshot
+    # corpus_hash is the shared (symbol,date,close) content hash, not per-basket.
+    assert next(iter(hashes)) == corpus_hash(frames)
+
+
+# ---------------------------------------------------------------------------
+# no look-ahead — bars strictly after t never move the as-of ranking.
+# ---------------------------------------------------------------------------
+
+
+def test_no_look_ahead_future_bars_do_not_change_selection():
+    base_prices = _false_breakdown()
+    df = _ohlcv(base_prices)
+    as_of = df.index[-1].date()
+    raw = [_signal("AAA", 0.95), _signal("BBB", 0.70, rank=20)]
+    frames_now = {"AAA": df, "BBB": _ohlcv([100.0] * 40)}
+
+    with (p := _patch_selectors(raw))[0], p[1]:
+        before = build_basket_outcomes(
+            session=object(), config=_CONFIG, days=[as_of],
+            prices_by_symbol=frames_now, regime_fn=lambda d: "bull", basket_size=10,
+        ).days[0]
+
+    # append wildly different FUTURE bars (dates strictly after as_of)
+    future = _ohlcv(base_prices + [200.0, 5.0, 250.0, 1.0, 300.0], end="2026-04-07")
+    frames_future = {"AAA": future, "BBB": _ohlcv([100.0] * 45, end="2026-04-07")}
+    with (p := _patch_selectors(raw))[0], p[1]:
+        after = build_basket_outcomes(
+            session=object(), config=_CONFIG, days=[as_of],
+            prices_by_symbol=frames_future, regime_fn=lambda d: "bull", basket_size=10,
+        ).days[0]
+
+    # the as-of ranking is identical — only bars <= t fed the detector.
+    assert after.symbols == before.symbols
+
+
+# ---------------------------------------------------------------------------
+# regime slices — per-regime scores match a hand-sliced fixture; DSR null.
+# ---------------------------------------------------------------------------
+
+
+def test_regime_scores_match_hand_sliced_fixture_and_dsr_null():
+    frames = {"AAA": _ohlcv([100.0 + i for i in range(60)])}
+    days = [date(2026, 1, 5), date(2026, 1, 6), date(2026, 1, 7), date(2026, 1, 8)]
+    raw = [_signal("AAA", 0.9)]
+    # two bull days, two bear days
+    regime_map = {days[0]: "bull", days[1]: "bull", days[2]: "bear", days[3]: "bear"}
+    spec = _spec(
+        [{"id": "c1", "override": {"layer_weight_money_flow": 0.35}}],
+        primary="total_return", guardrails=(),
+    )
+    p1, p2 = _patch_selectors(raw)
+    with p1, p2:
+        cards = run_experiment(
+            spec, base_overrides=None, session=object(),
+            prices_by_symbol=frames, trading_days=days,
+            regime_fn=lambda d: regime_map[d], segment="train", primary_horizon=5,
+        )
+    champ = next(c for c in cards if c["candidate_id"] == "champion")
+    assert set(champ["regime_scores"]) == {"bull", "bear"}
+    # each regime slice carries the primary reward, hand-verifiable (non-null).
+    assert "total_return" in champ["regime_scores"]["bull"]
+    assert champ["deflated_sharpe"] is None       # null until the DSR spec lands
+
+
+# ---------------------------------------------------------------------------
+# windows — train/holdout disjoint; embargo purge gap respected; holdout intact.
+# ---------------------------------------------------------------------------
+
+
+def test_split_windows_disjoint_and_embargo_purge():
+    # 30 consecutive business days spanning the train and holdout ranges.
+    days = [d.date() for d in pd.bdate_range("2026-01-01", periods=40, tz="UTC")]
+    window = ExperimentWindow(
+        train=f"{days[0]}..{days[19]}",
+        holdout=f"{days[25]}..{days[39]}",
+        embargo_days=3,
+    )
+    split = split_windows(days, window)
+
+    train_set, hold_set = set(split.train_days), set(split.holdout_days)
+    assert train_set.isdisjoint(hold_set)          # no leakage across the split
+    assert hold_set == set(days[25:40])            # holdout matches its range
+    # embargo=3 purges the 3 train days immediately before the holdout start.
+    # holdout starts at days[25]; the 3 trading days before it are days[22..24],
+    # but those already fall outside the train range (train ends days[19]).
+    # Purge bites when it overlaps train: shift holdout adjacent to train.
+    window2 = ExperimentWindow(
+        train=f"{days[0]}..{days[19]}",
+        holdout=f"{days[20]}..{days[39]}",
+        embargo_days=3,
+    )
+    split2 = split_windows(days, window2)
+    # the last 3 train days (days[17,18,19]) are purged — within 3 trading days
+    # of the holdout start days[20].
+    assert days[19] not in split2.train_days
+    assert days[17] not in split2.train_days
+    assert days[16] in split2.train_days           # just outside the embargo gap
+    assert set(split2.holdout_days) == set(days[20:40])   # holdout untouched
+
+
+# ---------------------------------------------------------------------------
+# unknown reward name → loud error (symmetric to unknown-override-key rejection).
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_reward_name_raises():
+    frames = {"AAA": _ohlcv([100.0] * 30)}
+    days = [date(2026, 1, 5), date(2026, 1, 6)]
+    raw = [_signal("AAA", 0.9)]
+    spec = _spec(
+        [{"id": "c1", "override": {"layer_weight_money_flow": 0.35}}],
+        primary="no_such_reward", guardrails=(),
+    )
+    p1, p2 = _patch_selectors(raw)
+    with p1, p2, pytest.raises(ValueError, match="no_such_reward"):
+        run_experiment(
+            spec, base_overrides=None, session=object(),
+            prices_by_symbol=frames, trading_days=days,
+            regime_fn=lambda d: "bull", segment="train",
+        )
+
+
+# ---------------------------------------------------------------------------
+# scorecard contract — validates against base_scorecard with no LLM fields.
+# ---------------------------------------------------------------------------
+
+
+def test_scorecard_validates_against_base_schema():
+    frames = {"AAA": _ohlcv([100.0 + i for i in range(30)])}
+    days = [date(2026, 1, 5), date(2026, 1, 6), date(2026, 1, 7)]
+    raw = [_signal("AAA", 0.9)]
+    spec = _spec(
+        [{"id": "c1", "override": {"layer_weight_money_flow": 0.35}}],
+        primary="sharpe", guardrails=("max_drawdown", "turnover"),
+    )
+    p1, p2 = _patch_selectors(raw)
+    with p1, p2:
+        cards = run_experiment(
+            spec, base_overrides=None, session=object(),
+            prices_by_symbol=frames, trading_days=days,
+            regime_fn=lambda d: "bull", segment="train", primary_horizon=5,
+        )
+    for card in cards:
+        # strict validation: every base_scorecard field present, no extras,
+        # and crucially NO llm_extension fields on the screener evaluator.
+        output_schema.validate("base_scorecard", card, strict=True)
+        assert card["candidate_type"] == "screener"
+        assert card["evaluator_sha"] == evaluator_sha()
+        # H recorded inside a permissive field, not a new top-level key.
+        assert card["rewards"]["horizon"] == 5
+        assert "sharpe" in card["rewards"]["primary"]
+        assert set(card["rewards"]["guardrails"]) == {"max_drawdown", "turnover"}

--- a/tests/research/test_screener_evaluator.py
+++ b/tests/research/test_screener_evaluator.py
@@ -273,29 +273,41 @@ def test_co_evaluation_equal_corpus_hash_all_candidates():
 
 
 def test_no_look_ahead_future_bars_do_not_change_selection():
-    base_prices = _false_breakdown()
-    df = _ohlcv(base_prices)
-    as_of = df.index[-1].date()
-    raw = [_signal("AAA", 0.95), _signal("BBB", 0.70, rank=20)]
-    frames_now = {"AAA": df, "BBB": _ohlcv([100.0] * 40)}
+    # AAA has LOWER money-flow than BBB; its as-of pattern credit is the ONLY
+    # thing lifting it above BBB. So the ranking depends on the as-of pattern
+    # window — a look-ahead leak that changed AAA's pattern would flip the order.
+    base_prices = _false_breakdown()                       # 24 bars, actionable as-of t
+    hist = _ohlcv(base_prices)                             # pos 23 = 2026-03-31 = as_of
+    as_of = hist.index[-1].date()
+    raw = [_signal("AAA", 0.50), _signal("BBB", 0.55, rank=20)]
+    frames_hist = {"AAA": hist, "BBB": _ohlcv([100.0] * 40)}   # BBB flat, no pattern
 
-    with (p := _patch_selectors(raw))[0], p[1]:
+    p1, p2 = _patch_selectors(raw)
+    with p1, p2:
         before = build_basket_outcomes(
             session=object(), config=_CONFIG, days=[as_of],
-            prices_by_symbol=frames_now, regime_fn=lambda d: "bull", basket_size=10,
+            prices_by_symbol=frames_hist, regime_fn=lambda d: "bull", basket_size=10,
         ).days[0]
+    assert before.symbols == ["AAA", "BBB"]                # pattern credit lifts AAA
 
-    # append wildly different FUTURE bars (dates strictly after as_of)
-    future = _ohlcv(base_prices + [200.0, 5.0, 250.0, 1.0, 300.0], end="2026-04-07")
-    frames_future = {"AAA": future, "BBB": _ohlcv([100.0] * 45, end="2026-04-07")}
-    with (p := _patch_selectors(raw))[0], p[1]:
+    # Append 5 WILD future bars to the SAME index: shift end forward by 5 days so
+    # positions 0..23 keep their exact dates + prices and 24..28 are strictly
+    # after t. The as-of window (bars <= t) is therefore byte-identical — if the
+    # driver leaked future bars into the detector, AAA's pattern (and the order)
+    # would change.
+    future_end = (hist.index[-1] + pd.Timedelta(days=5)).strftime("%Y-%m-%d")
+    ext = _ohlcv(base_prices + [200.0, 5.0, 250.0, 1.0, 300.0], end=future_end)
+    assert ext.index[23].date() == as_of                  # shared prefix preserved
+    frames_future = {"AAA": ext, "BBB": _ohlcv([100.0] * 45, end=future_end)}
+    p1b, p2b = _patch_selectors(raw)
+    with p1b, p2b:
         after = build_basket_outcomes(
             session=object(), config=_CONFIG, days=[as_of],
             prices_by_symbol=frames_future, regime_fn=lambda d: "bull", basket_size=10,
         ).days[0]
 
-    # the as-of ranking is identical — only bars <= t fed the detector.
-    assert after.symbols == before.symbols
+    # identical as-of ranking — only bars <= t fed the detector; future bars ignored.
+    assert after.symbols == before.symbols == ["AAA", "BBB"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/research/test_screener_evaluator.py
+++ b/tests/research/test_screener_evaluator.py
@@ -304,10 +304,14 @@ def test_no_look_ahead_future_bars_do_not_change_selection():
 
 
 def test_regime_scores_match_hand_sliced_fixture_and_dsr_null():
-    frames = {"AAA": _ohlcv([100.0 + i for i in range(60)])}
-    days = [date(2026, 1, 5), date(2026, 1, 6), date(2026, 1, 7), date(2026, 1, 8)]
+    # closes 100..139 on a daily index; forward_return(pos, H=5) = 5 / (100+pos)
+    # exactly. Basket is [AAA] each day, so total_return per regime = the sum of
+    # its sliced days' single-symbol forward returns — hand-computable.
+    df = _ohlcv([100.0 + i for i in range(40)])
+    days = [df.index[i].date() for i in range(4)]     # positions 0..3 (t+5 in range)
+    frames = {"AAA": df}
     raw = [_signal("AAA", 0.9)]
-    # two bull days, two bear days
+    # two bull days (pos 0,1), two bear days (pos 2,3)
     regime_map = {days[0]: "bull", days[1]: "bull", days[2]: "bear", days[3]: "bear"}
     spec = _spec(
         [{"id": "c1", "override": {"layer_weight_money_flow": 0.35}}],
@@ -322,8 +326,10 @@ def test_regime_scores_match_hand_sliced_fixture_and_dsr_null():
         )
     champ = next(c for c in cards if c["candidate_id"] == "champion")
     assert set(champ["regime_scores"]) == {"bull", "bear"}
-    # each regime slice carries the primary reward, hand-verifiable (non-null).
-    assert "total_return" in champ["regime_scores"]["bull"]
+    # exact per-regime values, not just key presence — the slice must carry the
+    # right days (a mis-slice keeping the {bull,bear} key set would be caught).
+    assert champ["regime_scores"]["bull"]["total_return"] == pytest.approx(5 / 100 + 5 / 101)
+    assert champ["regime_scores"]["bear"]["total_return"] == pytest.approx(5 / 102 + 5 / 103)
     assert champ["deflated_sharpe"] is None       # null until the DSR spec lands
 
 
@@ -333,7 +339,7 @@ def test_regime_scores_match_hand_sliced_fixture_and_dsr_null():
 
 
 def test_split_windows_disjoint_and_embargo_purge():
-    # 30 consecutive business days spanning the train and holdout ranges.
+    # 40 consecutive business days spanning the train and holdout ranges.
     days = [d.date() for d in pd.bdate_range("2026-01-01", periods=40, tz="UTC")]
     window = ExperimentWindow(
         train=f"{days[0]}..{days[19]}",
@@ -572,3 +578,140 @@ def test_run_experiment_rejects_challenger_named_champion():
             prices_by_symbol=frames, trading_days=days,
             regime_fn=lambda d: "bull", segment="train",
         )
+
+
+def test_run_experiment_rejects_empty_scored_segment():
+    # An empty scored segment (train range disjoint from the corpus days) must
+    # fail loud rather than emit all-zero scorecards.
+    frames = {"AAA": _ohlcv([100.0] * 30)}
+    raw = [_signal("AAA", 0.9)]
+    spec = _spec(
+        [{"id": "c1", "override": {"layer_weight_money_flow": 0.35}}],
+        primary="total_return", guardrails=(), train="2026-01-01..2026-01-31",
+    )
+    days = [date(2026, 3, 10), date(2026, 3, 11)]   # outside the train range
+    p1, p2 = _patch_selectors(raw)
+    with p1, p2, pytest.raises(ValueError, match="zero trading days"):
+        run_experiment(
+            spec, base_overrides=None, session=object(),
+            prices_by_symbol=frames, trading_days=days,
+            regime_fn=lambda d: "bull", segment="train",
+        )
+
+
+# ---------------------------------------------------------------------------
+# corpus_hash — deterministic (symbol-order-independent) + content-sensitive.
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_hash_deterministic_and_content_sensitive():
+    a = _ohlcv([100.0, 101.0, 102.0])
+    b = _ohlcv([50.0, 51.0, 52.0])
+    # symbol insertion order must not change the hash (symbols sorted internally)
+    assert corpus_hash({"AAA": a, "BBB": b}) == corpus_hash({"BBB": b, "AAA": a})
+    # a changed close changes the hash — it is content-sensitive, not a constant
+    b2 = _ohlcv([50.0, 51.0, 999.0])
+    assert corpus_hash({"AAA": a, "BBB": b}) != corpus_hash({"AAA": a, "BBB": b2})
+
+
+# ---------------------------------------------------------------------------
+# segment routing — holdout scores the holdout window; unknown segment raises.
+# ---------------------------------------------------------------------------
+
+
+def test_run_experiment_holdout_segment_and_unknown_segment():
+    frames = {"AAA": _ohlcv([100.0] * 30)}
+    raw = [_signal("AAA", 0.9)]
+    spec = _spec(
+        [{"id": "c1", "override": {"layer_weight_money_flow": 0.35}}],
+        primary="total_return", guardrails=(),
+    )
+    trading_days = [
+        date(2026, 1, 5), date(2026, 1, 6),        # train range
+        date(2026, 5, 5), date(2026, 5, 6),        # holdout range
+    ]
+    p1, p2 = _patch_selectors(raw)
+    with p1, p2:
+        cards = run_experiment(
+            spec, base_overrides=None, session=object(),
+            prices_by_symbol=frames, trading_days=trading_days,
+            regime_fn=lambda d: "bull", segment="holdout",
+        )
+    champ = next(c for c in cards if c["candidate_id"] == "champion")
+    assert "[holdout]" in champ["window"]                 # labeled with the segment
+    assert spec.window.holdout in champ["window"]
+    assert champ["n_selection_days"] == 2                 # only the 2 holdout days
+    # an unknown segment is rejected loudly (before any scoring).
+    p1b, p2b = _patch_selectors(raw)
+    with p1b, p2b, pytest.raises(ValueError, match="unknown segment"):
+        run_experiment(
+            spec, base_overrides=None, session=object(),
+            prices_by_symbol=frames, trading_days=trading_days,
+            regime_fn=lambda d: "bull", segment="weekly",
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI parquet output — nested reward/regime dicts round-trip as JSON strings.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_experiment_run_writes_parquet(tmp_path):
+    import json
+
+    from click.testing import CliRunner
+
+    from rainier.cli import cli
+
+    (tmp_path / "settings.yaml").write_text(
+        "stock_screener:\n  layer_weight_pattern: 0.70\n"
+    )
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "champion.yaml").write_text("version: 1\n")
+    spec_file = tmp_path / "exp.yaml"
+    spec_file.write_text(
+        "id: cli-test\n"
+        "status: active\n"
+        "champion: champion.yaml\n"
+        "layer: layer_weights\n"
+        "challengers:\n"
+        "  - id: c1\n"
+        "    override: {layer_weight_money_flow: 0.35}\n"
+        "primary: sharpe\n"
+        "guardrails: [max_drawdown]\n"
+        "window: {train: 2026-01-01..2026-03-31, holdout: 2026-05-01..2026-06-25, "
+        "embargo_days: 20}\n"
+    )
+    out = tmp_path / "cards.parquet"
+    fixture_cards = [
+        {
+            "candidate_id": "champion", "candidate_type": "screener",
+            "window": "2026-01-01..2026-03-31 [train]", "n_selection_days": 3,
+            "corpus_hash": "abc", "rewards": {"horizon": 5, "primary": {"sharpe": 1.0}},
+            "regime_scores": {"bull": {"sharpe": 1.0}}, "deflated_sharpe": None,
+            "evaluator_sha": "def",
+        }
+    ]
+
+    cm = MagicMock()
+    cm.__enter__.return_value = MagicMock()
+    cm.__exit__.return_value = False
+    with patch("rainier.paper.pattern_audit.universe_symbols", return_value=["AAA"]), \
+         patch("rainier.paper.pattern_replay.load_prices",
+               return_value={"AAA": _ohlcv([100.0] * 30)}), \
+         patch("rainier.core.database.get_session", return_value=cm), \
+         patch.object(screener, "run_experiment", return_value=fixture_cards):
+        result = CliRunner().invoke(
+            cli,
+            ["experiment", "run", str(spec_file),
+             "--config", str(tmp_path / "settings.yaml"),
+             "--output", str(out)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    back = pd.read_parquet(out)
+    # nested dicts are JSON-encoded per row so the columnar schema stays flat.
+    assert json.loads(back.iloc[0]["rewards"]) == {"horizon": 5, "primary": {"sharpe": 1.0}}
+    assert json.loads(back.iloc[0]["regime_scores"]) == {"bull": {"sharpe": 1.0}}

--- a/tests/research/test_screener_evaluator.py
+++ b/tests/research/test_screener_evaluator.py
@@ -412,3 +412,60 @@ def test_scorecard_validates_against_base_schema():
         assert card["rewards"]["horizon"] == 5
         assert "sharpe" in card["rewards"]["primary"]
         assert set(card["rewards"]["guardrails"]) == {"max_drawdown", "turnover"}
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring (composition root) — spec load + LIVE base_overrides + output write.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_experiment_run_resolves_champion_base_and_writes(tmp_path):
+    from click.testing import CliRunner
+
+    from rainier.cli import cli
+
+    # Hermetic champion layer: settings.yaml (non-default weight) + champion.yaml.
+    (tmp_path / "settings.yaml").write_text(
+        "stock_screener:\n  layer_weight_pattern: 0.70\n"
+    )
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "champion.yaml").write_text("version: 1\n")
+    spec_file = tmp_path / "exp.yaml"
+    spec_file.write_text(
+        "id: cli-test\n"
+        "status: active\n"
+        "champion: champion.yaml\n"
+        "layer: layer_weights\n"
+        "challengers:\n"
+        "  - id: c1\n"
+        "    override: {layer_weight_money_flow: 0.35}\n"
+        "primary: sharpe\n"
+        "guardrails: [max_drawdown]\n"
+        "window: {train: 2026-01-01..2026-03-31, holdout: 2026-05-01..2026-06-25, "
+        "embargo_days: 20}\n"
+    )
+    out = tmp_path / "cards.json"
+    fixture_cards = [{"candidate_id": "champion", "n_selection_days": 3}]
+
+    cm = MagicMock()
+    cm.__enter__.return_value = MagicMock()
+    cm.__exit__.return_value = False
+    with patch("rainier.paper.pattern_audit.universe_symbols", return_value=["AAA"]), \
+         patch("rainier.paper.pattern_replay.load_prices",
+               return_value={"AAA": _ohlcv([100.0] * 30)}), \
+         patch("rainier.core.database.get_session", return_value=cm), \
+         patch.object(screener, "run_experiment", return_value=fixture_cards) as mock_run:
+        result = CliRunner().invoke(
+            cli,
+            ["experiment", "run", str(spec_file),
+             "--config", str(tmp_path / "settings.yaml"),
+             "--output", str(out)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    # The driver received the LIVE champion base layer (settings lw_pattern=0.70),
+    # NOT None/code-defaults — the §4.5 silent-no-op guard at the composition root.
+    base_arg = mock_run.call_args.args[1]
+    assert base_arg["layer_weight_pattern"] == 0.70

--- a/tests/research/test_screener_evaluator.py
+++ b/tests/research/test_screener_evaluator.py
@@ -540,3 +540,35 @@ def test_run_experiment_rejects_nonpositive_primary_horizon():
                 regime_fn=lambda d: "bull", segment="train",
                 primary_horizon=bad_horizon,
             )
+
+
+# ---------------------------------------------------------------------------
+# baseline integrity — a missing --config must NOT silently baseline on
+# code-defaults (§4.5); the champion id is reserved from challenger reuse.
+# ---------------------------------------------------------------------------
+
+
+def test_load_base_overrides_missing_config_raises(tmp_path):
+    # A typo'd/absent settings file would return {} → challengers baseline on
+    # code-defaults with no champion — the exact silent no-op §4.5 prevents.
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        load_base_overrides(tmp_path / "nope.yaml")
+
+
+def test_run_experiment_rejects_challenger_named_champion():
+    frames = {"AAA": _ohlcv([100.0] * 30)}
+    days = [date(2026, 1, 5), date(2026, 1, 6)]
+    raw = [_signal("AAA", 0.9)]
+    # parse_spec allows id: champion; the driver must reject it so the two arms
+    # do not collide on candidate_id in the co-evaluation output/registry.
+    spec = _spec(
+        [{"id": "champion", "override": {"layer_weight_money_flow": 0.35}}],
+        primary="total_return", guardrails=(),
+    )
+    p1, p2 = _patch_selectors(raw)
+    with p1, p2, pytest.raises(ValueError, match="reserved"):
+        run_experiment(
+            spec, base_overrides=None, session=object(),
+            prices_by_symbol=frames, trading_days=days,
+            regime_fn=lambda d: "bull", segment="train",
+        )

--- a/tests/research/test_screener_evaluator.py
+++ b/tests/research/test_screener_evaluator.py
@@ -46,9 +46,12 @@ from rainier.research.rewards.basket import dodged_loss
 # ranking is identical between the live path and the driver.
 # ---------------------------------------------------------------------------
 
+# min_daily_bars=10: the synthetic fixtures below are 24-40 bars by design, so
+# pin the live Layer-3 gate below them to keep them pattern-eligible (the driver
+# mirrors _fetch_stock_data's min_daily_bars cut — see the short-history test).
 _CONFIG = StockScreenerConfig(
     swing_lookback=3, min_pattern_bars=3, max_pattern_bars=50,
-    neckline_tolerance_pct=0.05,
+    neckline_tolerance_pct=0.05, min_daily_bars=10,
 )
 
 
@@ -469,3 +472,71 @@ def test_cli_experiment_run_resolves_champion_base_and_writes(tmp_path):
     # NOT None/code-defaults — the §4.5 silent-no-op guard at the composition root.
     base_arg = mock_run.call_args.args[1]
     assert base_arg["layer_weight_pattern"] == 0.70
+
+
+# ---------------------------------------------------------------------------
+# short-history parity — a symbol whose as-of window has fewer than
+# config.min_daily_bars bars is money-flow-only in the driver, exactly as the
+# live _fetch_stock_data(symbols, config.min_daily_bars) gate drops it. Without
+# the cut it would earn pattern credit the live ranking never grants.
+# ---------------------------------------------------------------------------
+
+
+def test_short_history_symbol_is_money_flow_only_like_live_gate():
+    # STRONG carries a strong actionable pattern but only 24 bars; PLAIN is flat
+    # (no pattern) with 80 bars and a slightly higher money-flow strength.
+    strong = _ohlcv(_false_breakdown())            # 24 bars, w_bottom pattern
+    plain = _ohlcv([100.0] * 80)                   # 80 flat bars, no pattern
+    frames = {"STRONG": strong, "PLAIN": plain}
+    as_of = strong.index[-1].date()
+    raw = [_signal("STRONG", 0.50), _signal("PLAIN", 0.55)]
+
+    eligible = StockScreenerConfig(
+        swing_lookback=3, min_pattern_bars=3, max_pattern_bars=50,
+        neckline_tolerance_pct=0.05, min_daily_bars=10,  # 24-bar STRONG passes
+    )
+    gated = eligible.model_copy(update={"min_daily_bars": 60})  # 24-bar STRONG fails
+
+    p1, p2 = _patch_selectors(raw)
+    with p1, p2:
+        pattern_credited = build_basket_outcomes(
+            session=object(), config=eligible, days=[as_of],
+            prices_by_symbol=frames, regime_fn=lambda d: "bull",
+            basket_size=2, horizons=(5,),
+        ).days[0]
+        money_flow_only = build_basket_outcomes(
+            session=object(), config=gated, days=[as_of],
+            prices_by_symbol=frames, regime_fn=lambda d: "bull",
+            basket_size=2, horizons=(5,),
+        ).days[0]
+
+    # min_daily_bars=10: STRONG's pattern credit (w_pattern=0.65) lifts it first.
+    assert pattern_credited.symbols == ["STRONG", "PLAIN"]
+    # min_daily_bars=60: STRONG has too little history → money-flow-only, so its
+    # lower money-flow strength ranks it BELOW PLAIN — the live-gate parity.
+    assert money_flow_only.symbols == ["PLAIN", "STRONG"]
+
+
+# ---------------------------------------------------------------------------
+# horizon guard — a non-positive primary horizon is a look-ahead footgun
+# (forward_return would read the as-of bar or wrap to a future bar); reject it.
+# ---------------------------------------------------------------------------
+
+
+def test_run_experiment_rejects_nonpositive_primary_horizon():
+    frames = {"AAA": _ohlcv([100.0] * 30)}
+    days = [date(2026, 1, 5), date(2026, 1, 6)]
+    raw = [_signal("AAA", 0.9)]
+    spec = _spec(
+        [{"id": "c1", "override": {"layer_weight_money_flow": 0.35}}],
+        primary="total_return", guardrails=(),
+    )
+    for bad_horizon in (0, -5):
+        p1, p2 = _patch_selectors(raw)
+        with p1, p2, pytest.raises(ValueError, match="positive"):
+            run_experiment(
+                spec, base_overrides=None, session=object(),
+                prices_by_symbol=frames, trading_days=days,
+                regime_fn=lambda d: "bull", segment="train",
+                primary_horizon=bad_horizon,
+            )

--- a/tests/test_paper/test_pattern_audit.py
+++ b/tests/test_paper/test_pattern_audit.py
@@ -548,12 +548,28 @@ def test_as_of_index_resolves_last_bar_on_or_before():
     df = _make_ohlcv([100.0, 101.0, 102.0])  # 2025-01-01..03, tz-aware UTC index
     assert as_of_index(df, date(2025, 1, 1)) == 0
     assert as_of_index(df, date(2025, 1, 3)) == 2
-    # a non-trading as_of resolves to the nearest bar strictly before it
+    # an as_of that IS a trading day resolves to that day's own bar
     assert as_of_index(df, date(2025, 1, 2)) == 1
     # before the first bar → None (symbol not yet trading as-of that date)
     assert as_of_index(df, date(2024, 12, 31)) is None
     # after the last bar → last bar (as-of clamps to newest available)
     assert as_of_index(df, date(2025, 6, 1)) == 2
+
+
+def test_as_of_index_guard_branches():
+    # non-DatetimeIndex frame → None (no calendar axis to align a bar to)
+    plain = pd.DataFrame({"close": [1.0, 2.0]})  # RangeIndex
+    assert as_of_index(plain, date(2025, 1, 1)) is None
+    # empty (0-row) frame → None even with a DatetimeIndex
+    empty = pd.DataFrame({"close": []}, index=pd.DatetimeIndex([], tz="UTC"))
+    assert as_of_index(empty, date(2025, 1, 1)) is None
+    # tz-NAIVE index resolves against a calendar date (heterogeneous-tz path)
+    naive = pd.DataFrame(
+        {"close": [1.0, 2.0, 3.0]},
+        index=pd.date_range("2025-01-01", periods=3, freq="D"),  # tz-naive
+    )
+    assert as_of_index(naive, date(2025, 1, 2)) == 1
+    assert as_of_index(naive, date(2024, 12, 31)) is None
 
 
 def test_forward_returns_by_symbol_covers_every_requested_symbol():

--- a/tests/test_paper/test_pattern_audit.py
+++ b/tests/test_paper/test_pattern_audit.py
@@ -10,6 +10,8 @@ Acceptance (task plan):
 
 from __future__ import annotations
 
+from datetime import date
+
 import pandas as pd
 
 from rainier.core.config import StockScreenerConfig
@@ -17,10 +19,12 @@ from rainier.paper.pattern_audit import (
     HORIZONS,
     aggregate,
     aggregate_to_frame,
+    as_of_index,
     build_corpus,
     corpus_path,
     directional_correct,
     forward_return,
+    forward_returns_by_symbol,
     render_report_markdown,
     write_corpus,
 )
@@ -531,3 +535,52 @@ def test_render_report_empty_corpus():
     agg = aggregate_to_frame(empty)
     md = render_report_markdown(empty, agg, window_label="n/a")
     assert "no emissions" in md.lower()
+
+
+# ---------------------------------------------------------------------------
+# as_of_index + forward_returns_by_symbol — the screened-pool fan-out the
+# replay evaluator drives (per-symbol + money-flow-only coverage).
+# ---------------------------------------------------------------------------
+
+
+def test_as_of_index_resolves_last_bar_on_or_before():
+    df = _make_ohlcv([100.0, 101.0, 102.0])  # 2025-01-01..03, tz-aware UTC index
+    assert as_of_index(df, date(2025, 1, 1)) == 0
+    assert as_of_index(df, date(2025, 1, 3)) == 2
+    # a non-trading as_of resolves to the nearest bar strictly before it
+    assert as_of_index(df, date(2025, 1, 2)) == 1
+    # before the first bar → None (symbol not yet trading as-of that date)
+    assert as_of_index(df, date(2024, 12, 31)) is None
+    # after the last bar → last bar (as-of clamps to newest available)
+    assert as_of_index(df, date(2025, 6, 1)) == 2
+
+
+def test_forward_returns_by_symbol_covers_every_requested_symbol():
+    """Every requested symbol is a key at every horizon — the evaluator must
+    never omit a selected key (basket rewards raise on a missing key). A
+    money-flow-only symbol with no price frame → None, present, never omitted."""
+    up = _make_ohlcv([100.0, 101.0, 102.0, 103.0, 110.0, 120.0])
+    out = forward_returns_by_symbol(
+        {"UP": up}, date(2025, 1, 1), ["UP", "MFONLY"], horizons=(5,)
+    )
+    # UP as-of t=0: close[5]/close[0]-1 = 120/100 - 1 = 0.20
+    assert abs(out[5]["UP"] - 0.20) < 1e-12
+    # money-flow-only symbol (absent from prices) → key present, value None
+    assert "MFONLY" in out[5]
+    assert out[5]["MFONLY"] is None
+
+
+def test_forward_returns_by_symbol_null_near_window_end_not_zero():
+    flat = _make_ohlcv([100.0] * 10)
+    out = forward_returns_by_symbol({"X": flat}, date(2025, 1, 9), ["X"], horizons=(5,))
+    # as-of t=8 → t+5=13 >= len(10) → None (never 0.0 near the window end)
+    assert out[5]["X"] is None
+
+
+def test_forward_returns_by_symbol_all_horizons_present():
+    up = _make_ohlcv([100.0 + i for i in range(30)])
+    out = forward_returns_by_symbol({"X": up}, date(2025, 1, 1), ["X"])
+    # default HORIZONS (5,10,20) all present, all non-null with 30 bars ahead
+    assert set(out.keys()) == set(HORIZONS)
+    for h in HORIZONS:
+        assert out[h]["X"] is not None

--- a/tests/test_paper/test_pattern_audit.py
+++ b/tests/test_paper/test_pattern_audit.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from datetime import date
 
 import pandas as pd
+import pytest
 
 from rainier.core.config import StockScreenerConfig
 from rainier.paper.pattern_audit import (
@@ -584,3 +585,12 @@ def test_forward_returns_by_symbol_all_horizons_present():
     assert set(out.keys()) == set(HORIZONS)
     for h in HORIZONS:
         assert out[h]["X"] is not None
+
+
+def test_forward_returns_by_symbol_rejects_nonpositive_horizon():
+    """horizon <= 0 would read close[t_idx] (bogus 0) or wrap iloc to a FUTURE
+    bar (look-ahead) — reject it loudly rather than emit a leaked scorecard."""
+    up = _make_ohlcv([100.0 + i for i in range(10)])
+    for bad in ((0,), (-5,), (5, 0)):
+        with pytest.raises(ValueError, match="positive"):
+            forward_returns_by_symbol({"X": up}, date(2025, 1, 1), ["X"], horizons=bad)


### PR DESCRIPTION
## Summary
Stacked on #151, #152.
- Replay + score evaluator for the A/B substrate: corpus driver reproduces the live 3-layer ranking as-of each day per candidate (champion + challengers), collects selected baskets + per-symbol forward returns, reduces to comparable base scorecards.
- Required `base_overrides` resolved from the live settings+champion layer (challengers baseline on the live champion, never code-defaults); per-selected-symbol forward returns incl. money-flow-only names + screened pool for dodged_loss; H=5 inside rewards; shared corpus_hash; thin `rainier experiment run <spec.yaml>` CLI.
- Diff includes upstream #151/#152 until they land; merge those first, then this rebases onto main to just its own diff (research/evaluator/screener.py, paper/pattern_audit.py, cli.py + 2 test files).

## Review
- /review: passed (claude rounds: 3)
- codex review: passed (codex rounds: 5)

## Test plan
- [ ] CI green
- [ ] verify locally