### PR TITLE
feat: switch daily LLM thesis to Sonnet 4.6 xhigh extended thinking

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -167,7 +167,15 @@ llm:
 llm_thesis:
   enabled: true
   model: "claude-sonnet-4-6"
-  max_usd_per_scan: 1.0
+  # xhigh extended thinking: thinking tokens bill as OUTPUT ($15/M), so a
+  # 5-ticker scan runs ~$1.0-1.9. Cap raised 1.0 -> 2.5 so the per-scan kill
+  # switch doesn't trip mid-scan and drop tickers.
+  max_usd_per_scan: 2.5
+  # "xhigh" extended-thinking budget (tokens) for the thesis LLM call. Passed
+  # explicitly as thinking={"type": "enabled", "budget_tokens": ...}. Must be a
+  # positive int; service._call_llm sets max_tokens = budget + 2000 headroom and
+  # forces temperature=1.0 (anthropic rejects temperature!=1 with thinking on).
+  thinking_budget_tokens: 24000
   # v2: D7a calibration block. v3: R-A last-K reflections block. This runtime
   # value is what builds the Tier-1 cache key (not prompt.PROMPT_VERSION) —
   # keep it == the module constant.

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -176,10 +176,11 @@ llm_thesis:
   # positive int; service._call_llm sets max_tokens = budget + 2000 headroom and
   # forces temperature=1.0 (anthropic rejects temperature!=1 with thinking on).
   thinking_budget_tokens: 24000
-  # v2: D7a calibration block. v3: R-A last-K reflections block. This runtime
-  # value is what builds the Tier-1 cache key (not prompt.PROMPT_VERSION) —
-  # keep it == the module constant.
-  prompt_version: "v3"
+  # v2: D7a calibration block. v3: R-A last-K reflections block. v4: switch to
+  # xhigh extended thinking (behavioral change busts the Tier-1 cache). This
+  # runtime value is what builds the Tier-1 cache key (not prompt.PROMPT_VERSION)
+  # — keep it == the module constant.
+  prompt_version: "v4"
   enabled_sessions:
     - afternoon
     - close

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -3257,7 +3257,13 @@ def thesis():
 @click.option("--top-n", default=5, type=int, help="How many top candidates to LLM-thesis.")
 @click.option("--discord/--no-discord", default=False, help="Post results to Discord.")
 @click.option("--dry-run", is_flag=True, help="Skip Discord, print theses to stdout.")
-@click.option("--max-usd", default=1.0, type=float, help="Hard kill switch on cumulative spend.")
+@click.option(
+    "--max-usd",
+    default=None,
+    type=float,
+    help="Hard kill switch on cumulative spend. Defaults to config "
+    "(llm_thesis.max_usd_per_scan) when omitted.",
+)
 @click.pass_context
 def thesis_daily(ctx, session_name, top_n, discord, dry_run, max_usd):
     """Manual scheduler-hook trigger — runs the same pipeline as `rainier run`."""
@@ -3270,8 +3276,11 @@ def thesis_daily(ctx, session_name, top_n, discord, dry_run, max_usd):
     from rainier.llm_thesis.service import compute_theses_and_persist
 
     settings = load_settings_fresh(_settings_path(ctx))
-    # Override the kill switch via CLI.
-    settings.llm_thesis.max_usd_per_scan = float(max_usd)
+    # Override the kill switch only when explicitly passed; otherwise inherit the
+    # config value (raised to 2.5 for xhigh thinking) instead of a stale default.
+    if max_usd is not None:
+        settings.llm_thesis.max_usd_per_scan = float(max_usd)
+    effective_max_usd = settings.llm_thesis.max_usd_per_scan
 
     click.echo(f"Running screener for session={session_name}...")
     all_candidates, ohlcv_by_symbol = screen_stocks(settings)
@@ -3288,7 +3297,7 @@ def thesis_daily(ctx, session_name, top_n, discord, dry_run, max_usd):
         scan_candidates, scan_date=scan_date, session_name=session_name
     )
 
-    click.echo(f"Running LLM thesis on top {top_n} (max_usd={max_usd:.2f})...")
+    click.echo(f"Running LLM thesis on top {top_n} (max_usd={effective_max_usd:.2f})...")
     theses = compute_theses_and_persist(
         candidates[:top_n],
         ohlcv_by_symbol,
@@ -3324,7 +3333,13 @@ def thesis_daily(ctx, session_name, top_n, discord, dry_run, max_usd):
     "--session", "session_name", default="afternoon",
     type=click.Choice(["morning", "midday", "afternoon", "close"]),
 )
-@click.option("--max-usd", default=1.0, type=float)
+@click.option(
+    "--max-usd",
+    default=None,
+    type=float,
+    help="Hard kill switch on cumulative spend. Defaults to config "
+    "(llm_thesis.max_usd_per_scan) when omitted.",
+)
 @click.pass_context
 def thesis_ticker(ctx, symbol, session_name, max_usd):
     """Single-ticker debug pipeline against the latest QU100 snapshot."""
@@ -3335,7 +3350,9 @@ def thesis_ticker(ctx, symbol, session_name, max_usd):
     from rainier.llm_thesis.service import compute_theses_and_persist
 
     settings = load_settings_fresh(_settings_path(ctx))
-    settings.llm_thesis.max_usd_per_scan = float(max_usd)
+    # Inherit the config cap unless the operator explicitly overrides it.
+    if max_usd is not None:
+        settings.llm_thesis.max_usd_per_scan = float(max_usd)
 
     click.echo(f"Running screener (will filter to {symbol})...")
     candidates, ohlcv = screen_stocks(settings)

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -312,9 +312,11 @@ class LLMThesisConfig(BaseModel):
     # "budget_tokens": <this>} (deterministic form — litellm's reasoning_effort
     # low/medium/high map to much smaller anthropic budgets, not xhigh). When
     # thinking is enabled the anthropic API requires temperature==1.0 and
-    # max_tokens > budget_tokens; both are handled in service._call_llm. Positive
-    # int; 0 or negative would violate the max_tokens > budget invariant.
-    thinking_budget_tokens: int = Field(24000, gt=0)
+    # max_tokens > budget_tokens; both are handled in service._call_llm.
+    # Floor is Anthropic's documented minimum thinking budget (1024) — a smaller
+    # value loads fine but the provider rejects every thesis call, so we fail
+    # fast at config load instead.
+    thinking_budget_tokens: int = Field(24000, ge=1024)
     # Bumped v1->v2 with the D7a calibration block, v2->v3 with the R-A
     # reflections block. The Tier-1 cache key is built from THIS runtime value
     # (service.generate_thesis reads settings.llm_thesis.prompt_version), so it

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -302,7 +302,19 @@ class LLMThesisConfig(BaseModel):
 
     enabled: bool = True
     model: str = "claude-sonnet-4-6"
-    max_usd_per_scan: float = 1.0
+    # Raised 1.0 -> 2.5 when the thesis call switched to xhigh extended thinking
+    # (thinking_budget_tokens below). At the xhigh budget a 5-ticker scan bills
+    # ~$1.0-1.9 (thinking tokens are billed as OUTPUT at $15/M); the old $1.00
+    # cap would trip the per-scan kill switch mid-scan and silently drop tickers.
+    max_usd_per_scan: float = 2.5
+    # Extended-thinking budget for the daily thesis call ("xhigh" tier = 24000).
+    # Passed to litellm.completion as thinking={"type": "enabled",
+    # "budget_tokens": <this>} (deterministic form — litellm's reasoning_effort
+    # low/medium/high map to much smaller anthropic budgets, not xhigh). When
+    # thinking is enabled the anthropic API requires temperature==1.0 and
+    # max_tokens > budget_tokens; both are handled in service._call_llm. Positive
+    # int; 0 or negative would violate the max_tokens > budget invariant.
+    thinking_budget_tokens: int = Field(24000, gt=0)
     # Bumped v1->v2 with the D7a calibration block, v2->v3 with the R-A
     # reflections block. The Tier-1 cache key is built from THIS runtime value
     # (service.generate_thesis reads settings.llm_thesis.prompt_version), so it

--- a/src/rainier/core/config.py
+++ b/src/rainier/core/config.py
@@ -318,12 +318,13 @@ class LLMThesisConfig(BaseModel):
     # fast at config load instead.
     thinking_budget_tokens: int = Field(24000, ge=1024)
     # Bumped v1->v2 with the D7a calibration block, v2->v3 with the R-A
-    # reflections block. The Tier-1 cache key is built from THIS runtime value
-    # (service.generate_thesis reads settings.llm_thesis.prompt_version), so it
-    # must track prompt.PROMPT_VERSION — the module constant alone never busts
-    # the cache. Keep the two (plus settings.yaml) in lockstep
+    # reflections block, v3->v4 with the switch to xhigh extended thinking. The
+    # Tier-1 cache key is built from THIS runtime value (service.generate_thesis
+    # reads settings.llm_thesis.prompt_version), so it must track
+    # prompt.PROMPT_VERSION — the module constant alone never busts the cache.
+    # Keep the two (plus settings.yaml) in lockstep
     # (test_prompt_version_config_tracks_module guards the invariant).
-    prompt_version: str = "v3"
+    prompt_version: str = "v4"
     enabled_sessions: list[str] = Field(
         default_factory=lambda: ["afternoon", "close"]
     )

--- a/src/rainier/llm_thesis/prompt.py
+++ b/src/rainier/llm_thesis/prompt.py
@@ -15,7 +15,12 @@ from __future__ import annotations
 # the calibration section — same Tier-1-bust rationale. Bump IN LOCKSTEP with
 # core/config.py LLMThesisConfig.prompt_version and settings.yaml
 # llm_thesis.prompt_version (the runtime cache key uses the config value).
-PROMPT_VERSION = "v3"
+# v4: the thesis call switched to Sonnet 4.6 xhigh extended thinking — a
+# BEHAVIORAL change to the LLM output that compute_input_hash can't see (it
+# hashes only the EvidencePack + image). Bumping busts Tier-1 so same-day
+# reruns after the switch regenerate with thinking instead of serving a stale
+# no-thinking thesis; likewise when thinking_budget_tokens is retuned.
+PROMPT_VERSION = "v4"
 
 OUTPUT_SCHEMA = """{
   "verdict": "setup_long" | "watch" | "no_setup",

--- a/src/rainier/llm_thesis/schemas.py
+++ b/src/rainier/llm_thesis/schemas.py
@@ -68,13 +68,24 @@ class EvidencePack(BaseModel):
     image_sha256: str | None = None
 
 
-def compute_input_hash(pack: EvidencePack, image_bytes: bytes | None) -> str:
-    """Deterministic sha256 of the evidence pack + image bytes.
+def compute_input_hash(
+    pack: EvidencePack,
+    image_bytes: bytes | None,
+    thinking_budget_tokens: int | None = None,
+) -> str:
+    """Deterministic sha256 of the evidence pack + image bytes (+ thinking budget).
 
     Used as the idempotency key on `analysis_results.input_hash`. Two re-runs
-    of the same scan with the same (symbol, signals, image) compute to the
-    same value, so `INSERT ... ON CONFLICT DO NOTHING` guarantees zero
-    duplicate LLM calls.
+    of the same scan with the same (symbol, signals, image, thinking budget)
+    compute to the same value, so `INSERT ... ON CONFLICT DO NOTHING` guarantees
+    zero duplicate LLM calls.
+
+    ``thinking_budget_tokens`` is folded in because it changes the amount of
+    reasoning the LLM does — a retuned budget must yield a DIFFERENT idempotency
+    key so the regenerated thesis persists as its own row instead of colliding
+    with the old-budget row on the (day, symbols, model, prompt, input_hash)
+    unique index. It is NOT prompt text; the pack/image are still the only
+    content inputs. ``None`` (the default) keeps legacy callers byte-identical.
     """
     pack_json = pack.model_dump(exclude={"image_sha256"})
     serialized = json.dumps(pack_json, sort_keys=True, default=str).encode("utf-8")
@@ -83,4 +94,9 @@ def compute_input_hash(pack: EvidencePack, image_bytes: bytes | None) -> str:
         if image_bytes is not None
         else "no-image"
     )
-    return hashlib.sha256(serialized + image_hash.encode("ascii")).hexdigest()
+    digest = serialized + image_hash.encode("ascii")
+    if thinking_budget_tokens is not None:
+        # Append only when provided so the legacy 2-arg form stays byte-identical
+        # (other callers' idempotency keys are unaffected by this addition).
+        digest += f"|budget:{int(thinking_budget_tokens)}".encode("ascii")
+    return hashlib.sha256(digest).hexdigest()

--- a/src/rainier/llm_thesis/service.py
+++ b/src/rainier/llm_thesis/service.py
@@ -283,9 +283,9 @@ def _call_llm(
     is ANTHROPIC-specific (OpenAI reasoning models use ``reasoning_effort``), so
     we attach it (and the temperature==1.0 / max_tokens invariants it requires)
     only when the resolved provider is anthropic AND the model supports
-    reasoning. If the thesis model is ever reconfigured to another provider, we
-    fall back to the legacy plain call (temperature=0.2, no thinking) instead of
-    letting LiteLLM raise ``UnsupportedParamsError``.
+    reasoning. If the configured thesis model can't enable thinking, we RAISE
+    (the thesis pipeline requires thinking) rather than silently produce a
+    no-thinking thesis that would be persisted + cached as a valid xhigh result.
 
     Cost note: anthropic bills thinking tokens as OUTPUT tokens and folds them
     into ``usage.output_tokens``, which LiteLLM surfaces as ``completion_tokens``.
@@ -334,19 +334,19 @@ def _call_llm(
             thinking_budget_tokens + _FINAL_ANSWER_HEADROOM_TOKENS
         )
     else:
-        # Non-anthropic / non-reasoning model: no thinking payload (it would
-        # 400). For the pinned Sonnet 4.6 config this branch is a DEGRADATION —
-        # e.g. a litellm registry drop would silently turn every thesis into a
-        # cheap no-thinking call while the persisted row still stamps v4 +
-        # budget. Fail loud so the drop shows up as a WARNING, not just a
-        # suspiciously low bill.
-        log.warning(
-            "thesis_thinking_disabled model=%s provider=%s — thinking payload "
-            "skipped, using plain temperature=0.2 call",
-            model,
-            _provider,
+        # The thesis pipeline REQUIRES extended thinking. If the configured model
+        # can't enable it (non-anthropic provider, or dropped from litellm's
+        # reasoning registry), REFUSE loudly rather than fall back to a cheap
+        # no-thinking call: that plain thesis would still be persisted and
+        # stamped v4 + budget=24000, and Tier-1 would then serve the degraded
+        # row as a valid xhigh result for the rest of the day (cache poisoning —
+        # flagged by both codex and /review). Raising instead means the caller's
+        # retry loop drops the ticker and nothing degraded is ever cached.
+        raise RuntimeError(
+            f"extended thinking unavailable for thesis model {model!r} "
+            f"(provider={_provider or 'unknown'}); refusing to generate a "
+            "degraded no-thinking thesis"
         )
-        completion_kwargs["temperature"] = 0.2
 
     resp = litellm.completion(**completion_kwargs)
     text = resp["choices"][0]["message"]["content"]

--- a/src/rainier/llm_thesis/service.py
+++ b/src/rainier/llm_thesis/service.py
@@ -420,7 +420,12 @@ async def generate_thesis(
         return None, 0.0, None
 
     pack, renders, image_bytes = await asyncio.to_thread(evidence_provider)
-    input_hash = compute_input_hash(pack, image_bytes)
+    # Fold the thinking budget into the Tier-2 idempotency key so a retuned
+    # budget persists as its own row instead of colliding with the old-budget
+    # row on the unique index (which would re-read the stale id).
+    input_hash = compute_input_hash(
+        pack, image_bytes, thinking_budget_tokens=thesis_cfg.thinking_budget_tokens
+    )
 
     candidate_summary = json.dumps(pack.candidate, sort_keys=True, default=str)
     # D7a: inject the calibration section (how prior theses graded out). Loaded

--- a/src/rainier/llm_thesis/service.py
+++ b/src/rainier/llm_thesis/service.py
@@ -148,6 +148,7 @@ def _tier1_lookup(
     session_name: str,
     llm_model: str,
     enabled_signals: list[str] | None = None,
+    thinking_budget_tokens: int | None = None,
 ) -> tuple[int, dict[str, Any]] | None:
     """Cheap cache lookup — match (date, symbol, prompt, session, model).
 
@@ -220,6 +221,18 @@ def _tier1_lookup(
                 if isinstance(cached_signals, list):
                     if frozenset(cached_signals) != enabled_set:
                         continue
+            # Thinking-budget drift check: a row stamped with a different
+            # _thinking_budget_tokens was generated with a different amount of
+            # reasoning, so retuning the budget mid-day must regenerate rather
+            # than serve the stale thesis. Rows written before the budget was
+            # stamped carry no key and are left reusable (PROMPT_VERSION already
+            # gates out all pre-thinking rows).
+            if thinking_budget_tokens is not None and isinstance(output, dict):
+                cached_budget = output.get("_thinking_budget_tokens")
+                if cached_budget is not None and int(cached_budget) != int(
+                    thinking_budget_tokens
+                ):
+                    continue
             return int(rec_id), dict(output)
         return None
 
@@ -381,6 +394,7 @@ async def generate_thesis(
         session_name=session_name,
         llm_model=thesis_cfg.model,
         enabled_signals=enabled_signal_names,
+        thinking_budget_tokens=thesis_cfg.thinking_budget_tokens,
     )
     if cached is not None:
         record_id, raw_output = cached
@@ -554,6 +568,9 @@ def _persist_thesis(
     # Stash the originating session inside structured_output so Tier-1
     # can refuse cross-session reuse on later same-day scans.
     payload["_session_name"] = session_name
+    # Stamp the thinking budget so Tier-1 can refuse to reuse a thesis that was
+    # generated with a different amount of reasoning after the budget is retuned.
+    payload["_thinking_budget_tokens"] = int(settings.llm_thesis.thinking_budget_tokens)
     with get_session() as session:
         rec = LLMAnalysisRecord(
             llm_provider="anthropic",

--- a/src/rainier/llm_thesis/service.py
+++ b/src/rainier/llm_thesis/service.py
@@ -46,6 +46,11 @@ log = logging.getLogger(__name__)
 _DEFAULT_INPUT_RATE = 3.0   # USD per 1M tokens (Sonnet 4.6 input)
 _DEFAULT_OUTPUT_RATE = 15.0  # USD per 1M tokens (Sonnet 4.6 output)
 
+# Anthropic requires max_tokens > thinking.budget_tokens. We reserve this many
+# tokens ABOVE the thinking budget for the final JSON answer. The thesis JSON is
+# ~650 output tokens in practice; 2000 is comfortable headroom.
+_FINAL_ANSWER_HEADROOM_TOKENS = 2000
+
 
 # ---------------------------------------------------------------------------
 # Evidence assembly
@@ -242,10 +247,31 @@ def _call_llm(
     system_prompt: str,
     user_prompt: str,
     image_bytes: bytes | None,
+    thinking_budget_tokens: int,
 ) -> tuple[str, int, int]:
     """Single LiteLLM completion. Returns (content, prompt_tokens, completion_tokens).
 
     Image bytes are passed as base64 data URL when present.
+
+    Extended thinking ("xhigh") is enabled via the deterministic explicit form
+    ``thinking={"type": "enabled", "budget_tokens": N}`` — LiteLLM's
+    ``reasoning_effort`` (low/medium/high) maps to much smaller anthropic budgets,
+    so we pass the budget directly. When thinking is on, anthropic enforces two
+    request invariants, both handled here:
+      * ``temperature`` MUST be 1.0 (anthropic 400s on any other value), and
+      * ``max_tokens`` MUST be strictly greater than ``budget_tokens``.
+
+    The response carries reasoning under a separate ``reasoning_content`` /
+    ``thinking_blocks`` field; ``message["content"]`` is still the final answer
+    text (the JSON thesis _parse_thesis expects), so we keep reading ``content``
+    and thinking text never leaks into the parsed thesis.
+
+    Cost note: anthropic bills thinking tokens as OUTPUT tokens and folds them
+    into ``usage.output_tokens``, which LiteLLM surfaces as ``completion_tokens``.
+    So ``completion_tokens`` already includes the thinking spend — any
+    ``reasoning_tokens`` LiteLLM reports in ``completion_tokens_details`` is a
+    SUBSET of it (adding it would double-count). The per-scan kill switch bills
+    ``completion_tokens`` at $15/M and therefore reflects true thinking spend.
     """
     import base64
 
@@ -261,17 +287,22 @@ def _call_llm(
             }
         )
 
+    # max_tokens must exceed the thinking budget (final-answer headroom on top).
+    max_tokens = thinking_budget_tokens + _FINAL_ANSWER_HEADROOM_TOKENS
     resp = litellm.completion(
         model=model,
         messages=[
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": content_parts},
         ],
-        temperature=0.2,
+        thinking={"type": "enabled", "budget_tokens": thinking_budget_tokens},
+        temperature=1.0,  # anthropic rejects temperature != 1 with thinking enabled
+        max_tokens=max_tokens,
     )
     text = resp["choices"][0]["message"]["content"]
     usage = resp.get("usage") or {}
     prompt_tokens = int(usage.get("prompt_tokens", 0))
+    # completion_tokens already includes thinking tokens (billed as output).
     completion_tokens = int(usage.get("completion_tokens", 0))
     return text, prompt_tokens, completion_tokens
 
@@ -420,6 +451,7 @@ async def generate_thesis(
                 system_prompt=SYSTEM_PROMPT,
                 user_prompt=attempt_user_prompt,
                 image_bytes=image_bytes,
+                thinking_budget_tokens=thesis_cfg.thinking_budget_tokens,
             )
         except Exception as exc:
             last_error = f"llm_call_failed: {exc}"

--- a/src/rainier/llm_thesis/service.py
+++ b/src/rainier/llm_thesis/service.py
@@ -266,6 +266,13 @@ def _call_llm(
     text (the JSON thesis _parse_thesis expects), so we keep reading ``content``
     and thinking text never leaks into the parsed thesis.
 
+    Model gate: the ``thinking`` param is anthropic/reasoning-model-specific.
+    We only attach it (and the temperature==1.0 / max_tokens invariants it
+    requires) when ``litellm.supports_reasoning(model)`` is True. If the thesis
+    model is ever reconfigured to a non-reasoning provider, we fall back to the
+    legacy plain call (temperature=0.2, no thinking) instead of letting LiteLLM
+    raise ``UnsupportedParamsError``.
+
     Cost note: anthropic bills thinking tokens as OUTPUT tokens and folds them
     into ``usage.output_tokens``, which LiteLLM surfaces as ``completion_tokens``.
     So ``completion_tokens`` already includes the thinking spend — any
@@ -287,18 +294,29 @@ def _call_llm(
             }
         )
 
-    # max_tokens must exceed the thinking budget (final-answer headroom on top).
-    max_tokens = thinking_budget_tokens + _FINAL_ANSWER_HEADROOM_TOKENS
-    resp = litellm.completion(
-        model=model,
-        messages=[
+    completion_kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": content_parts},
         ],
-        thinking={"type": "enabled", "budget_tokens": thinking_budget_tokens},
-        temperature=1.0,  # anthropic rejects temperature != 1 with thinking enabled
-        max_tokens=max_tokens,
-    )
+    }
+    if litellm.supports_reasoning(model=model):
+        # Extended thinking: temperature MUST be 1.0 and max_tokens MUST exceed
+        # the thinking budget (final-answer headroom on top).
+        completion_kwargs["thinking"] = {
+            "type": "enabled",
+            "budget_tokens": thinking_budget_tokens,
+        }
+        completion_kwargs["temperature"] = 1.0
+        completion_kwargs["max_tokens"] = (
+            thinking_budget_tokens + _FINAL_ANSWER_HEADROOM_TOKENS
+        )
+    else:
+        # Non-reasoning provider: keep the original deterministic-ish call.
+        completion_kwargs["temperature"] = 0.2
+
+    resp = litellm.completion(**completion_kwargs)
     text = resp["choices"][0]["message"]["content"]
     usage = resp.get("usage") or {}
     prompt_tokens = int(usage.get("prompt_tokens", 0))
@@ -410,7 +428,7 @@ async def generate_thesis(
     # on day D is written end-of-day D — a day-D scan must not see it) and the
     # same best-effort isolation: a load failure costs the block, not the
     # thesis. Like the calibration text this is invisible to compute_input_hash,
-    # so PROMPT_VERSION ("v3") busts the Tier-1 cache instead.
+    # so PROMPT_VERSION busts the Tier-1 cache instead.
     try:
         from rainier.paper.reflection import reflection_prompt_section
 

--- a/src/rainier/llm_thesis/service.py
+++ b/src/rainier/llm_thesis/service.py
@@ -266,12 +266,13 @@ def _call_llm(
     text (the JSON thesis _parse_thesis expects), so we keep reading ``content``
     and thinking text never leaks into the parsed thesis.
 
-    Model gate: the ``thinking`` param is anthropic/reasoning-model-specific.
-    We only attach it (and the temperature==1.0 / max_tokens invariants it
-    requires) when ``litellm.supports_reasoning(model)`` is True. If the thesis
-    model is ever reconfigured to a non-reasoning provider, we fall back to the
-    legacy plain call (temperature=0.2, no thinking) instead of letting LiteLLM
-    raise ``UnsupportedParamsError``.
+    Model gate: the ``thinking={"type": "enabled", "budget_tokens": N}`` payload
+    is ANTHROPIC-specific (OpenAI reasoning models use ``reasoning_effort``), so
+    we attach it (and the temperature==1.0 / max_tokens invariants it requires)
+    only when the resolved provider is anthropic AND the model supports
+    reasoning. If the thesis model is ever reconfigured to another provider, we
+    fall back to the legacy plain call (temperature=0.2, no thinking) instead of
+    letting LiteLLM raise ``UnsupportedParamsError``.
 
     Cost note: anthropic bills thinking tokens as OUTPUT tokens and folds them
     into ``usage.output_tokens``, which LiteLLM surfaces as ``completion_tokens``.
@@ -301,7 +302,14 @@ def _call_llm(
             {"role": "user", "content": content_parts},
         ],
     }
-    if litellm.supports_reasoning(model=model):
+    try:
+        _provider = litellm.get_llm_provider(model)[1]
+    except Exception:
+        _provider = ""
+    anthropic_thinking = _provider == "anthropic" and litellm.supports_reasoning(
+        model=model
+    )
+    if anthropic_thinking:
         # Extended thinking: temperature MUST be 1.0 and max_tokens MUST exceed
         # the thinking budget (final-answer headroom on top).
         completion_kwargs["thinking"] = {

--- a/src/rainier/llm_thesis/service.py
+++ b/src/rainier/llm_thesis/service.py
@@ -334,7 +334,18 @@ def _call_llm(
             thinking_budget_tokens + _FINAL_ANSWER_HEADROOM_TOKENS
         )
     else:
-        # Non-reasoning provider: keep the original deterministic-ish call.
+        # Non-anthropic / non-reasoning model: no thinking payload (it would
+        # 400). For the pinned Sonnet 4.6 config this branch is a DEGRADATION —
+        # e.g. a litellm registry drop would silently turn every thesis into a
+        # cheap no-thinking call while the persisted row still stamps v4 +
+        # budget. Fail loud so the drop shows up as a WARNING, not just a
+        # suspiciously low bill.
+        log.warning(
+            "thesis_thinking_disabled model=%s provider=%s — thinking payload "
+            "skipped, using plain temperature=0.2 call",
+            model,
+            _provider,
+        )
         completion_kwargs["temperature"] = 0.2
 
     resp = litellm.completion(**completion_kwargs)

--- a/tests/test_llm_thesis/test_call_llm_thinking.py
+++ b/tests/test_llm_thesis/test_call_llm_thinking.py
@@ -144,6 +144,25 @@ def test_call_llm_falls_back_for_non_reasoning_model():
     assert kwargs["temperature"] == 0.2
 
 
+def test_call_llm_does_not_send_thinking_to_non_anthropic_reasoning_model():
+    """The anthropic thinking payload is provider-specific: an OpenAI reasoning
+    model (supports_reasoning True, provider != anthropic) must fall back rather
+    than receive thinking={...}."""
+    with patch("litellm.supports_reasoning", return_value=True), \
+            patch("litellm.get_llm_provider", return_value=("o3", "openai", None, None)), \
+            patch("litellm.completion", return_value=_mock_resp("{}")) as mock_comp:
+        _call_llm(
+            model="o3",
+            system_prompt="sys",
+            user_prompt="user",
+            image_bytes=None,
+            thinking_budget_tokens=24000,
+        )
+    kwargs = mock_comp.call_args.kwargs
+    assert "thinking" not in kwargs
+    assert kwargs["temperature"] == 0.2
+
+
 def test_cost_estimate_bills_thinking_tokens_as_output():
     """A large completion-token count (thinking folded into output) must be
     billed at the $15/M output rate."""

--- a/tests/test_llm_thesis/test_call_llm_thinking.py
+++ b/tests/test_llm_thesis/test_call_llm_thinking.py
@@ -1,0 +1,133 @@
+"""Tests for the xhigh extended-thinking thesis LLM call.
+
+Covers the deterministic thinking config passed to litellm.completion
+(temperature==1.0, max_tokens > budget_tokens), response parsing when reasoning
+is surfaced separately from the final answer, and cost accounting that bills
+thinking tokens as output.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from rainier.llm_thesis.schemas import TradeThesis
+from rainier.llm_thesis.service import (
+    _FINAL_ANSWER_HEADROOM_TOKENS,
+    _call_llm,
+    _estimate_cost_usd,
+    _parse_thesis,
+)
+
+
+def _valid_thesis_json() -> str:
+    return json.dumps(
+        {
+            "verdict": "setup_long",
+            "setup_quality": 7,
+            "llm_confidence": 7,
+            "paragraph_radar": "Why on radar.",
+            "paragraph_evidence": "Evidence text.",
+            "paragraph_invalidation": "Invalidation rules.",
+            "risks": ["earnings"],
+            "watch_items": ["volume"],
+            "evidence_used": ["pattern"],
+            "signals_used": ["rank_trajectory"],
+            "patterns_in_chart_not_in_indicators": ["narrowing volume"],
+        }
+    )
+
+
+def _mock_resp(content: str, *, completion_tokens: int = 12000, reasoning: str = ""):
+    """A minimal litellm-shaped response dict (supports [] access and .get)."""
+    message = {"content": content}
+    if reasoning:
+        # litellm surfaces extended-thinking text on a separate key.
+        message["reasoning_content"] = reasoning
+    return {
+        "choices": [{"message": message}],
+        "usage": {"prompt_tokens": 2800, "completion_tokens": completion_tokens},
+    }
+
+
+def test_call_llm_enables_thinking_with_budget_and_temp_one():
+    budget = 24000
+    with patch("litellm.completion", return_value=_mock_resp("{}")) as mock_comp:
+        _call_llm(
+            model="claude-sonnet-4-6",
+            system_prompt="sys",
+            user_prompt="user",
+            image_bytes=None,
+            thinking_budget_tokens=budget,
+        )
+
+    assert mock_comp.call_count == 1
+    kwargs = mock_comp.call_args.kwargs
+    # Extended thinking enabled at the exact configured budget.
+    assert kwargs["thinking"] == {"type": "enabled", "budget_tokens": budget}
+    # Anthropic requires temperature == 1.0 with thinking on.
+    assert kwargs["temperature"] == 1.0
+    # Anthropic requires max_tokens > budget_tokens (headroom for the answer).
+    assert kwargs["max_tokens"] == budget + _FINAL_ANSWER_HEADROOM_TOKENS
+    assert kwargs["max_tokens"] > budget
+
+
+def test_call_llm_budget_scales_max_tokens():
+    with patch("litellm.completion", return_value=_mock_resp("{}")) as mock_comp:
+        _call_llm(
+            model="claude-sonnet-4-6",
+            system_prompt="sys",
+            user_prompt="user",
+            image_bytes=None,
+            thinking_budget_tokens=8000,
+        )
+    kwargs = mock_comp.call_args.kwargs
+    assert kwargs["thinking"]["budget_tokens"] == 8000
+    assert kwargs["max_tokens"] == 8000 + _FINAL_ANSWER_HEADROOM_TOKENS
+
+
+def test_call_llm_returns_content_and_token_counts():
+    resp = _mock_resp(_valid_thesis_json(), completion_tokens=13500)
+    with patch("litellm.completion", return_value=resp):
+        text, p_tok, c_tok = _call_llm(
+            model="claude-sonnet-4-6",
+            system_prompt="sys",
+            user_prompt="user",
+            image_bytes=None,
+            thinking_budget_tokens=24000,
+        )
+    assert p_tok == 2800
+    # completion_tokens is the output total (already includes thinking spend).
+    assert c_tok == 13500
+    assert json.loads(text)["verdict"] == "setup_long"
+
+
+def test_thinking_text_does_not_leak_into_parsed_thesis():
+    """content carries the final JSON; reasoning is on a separate key. The parsed
+    thesis must come only from content, with no thinking text bleeding in."""
+    reasoning = "SECRET CHAIN OF THOUGHT — must not appear in the thesis."
+    resp = _mock_resp(_valid_thesis_json(), reasoning=reasoning)
+    with patch("litellm.completion", return_value=resp):
+        text, _, _ = _call_llm(
+            model="claude-sonnet-4-6",
+            system_prompt="sys",
+            user_prompt="user",
+            image_bytes=None,
+            thinking_budget_tokens=24000,
+        )
+    assert "SECRET" not in text
+    thesis = _parse_thesis(text)
+    assert isinstance(thesis, TradeThesis)
+    assert thesis.verdict == "setup_long"
+    assert "SECRET" not in thesis.paragraph_evidence
+
+
+def test_cost_estimate_bills_thinking_tokens_as_output():
+    """A large completion-token count (thinking folded into output) must be
+    billed at the $15/M output rate."""
+    # 2800 input, 13500 output (incl. ~11k thinking).
+    cost = _estimate_cost_usd(2800, 13500)
+    expected = 2800 / 1_000_000 * 3.0 + 13500 / 1_000_000 * 15.0
+    assert cost == expected
+    # Sanity: a single xhigh ticker lands in the measured ~$0.15-0.40 range.
+    assert 0.15 <= cost <= 0.40

--- a/tests/test_llm_thesis/test_call_llm_thinking.py
+++ b/tests/test_llm_thesis/test_call_llm_thinking.py
@@ -52,7 +52,8 @@ def _mock_resp(content: str, *, completion_tokens: int = 12000, reasoning: str =
 
 def test_call_llm_enables_thinking_with_budget_and_temp_one():
     budget = 24000
-    with patch("litellm.completion", return_value=_mock_resp("{}")) as mock_comp:
+    with patch("litellm.supports_reasoning", return_value=True), \
+            patch("litellm.completion", return_value=_mock_resp("{}")) as mock_comp:
         _call_llm(
             model="claude-sonnet-4-6",
             system_prompt="sys",
@@ -73,7 +74,8 @@ def test_call_llm_enables_thinking_with_budget_and_temp_one():
 
 
 def test_call_llm_budget_scales_max_tokens():
-    with patch("litellm.completion", return_value=_mock_resp("{}")) as mock_comp:
+    with patch("litellm.supports_reasoning", return_value=True), \
+            patch("litellm.completion", return_value=_mock_resp("{}")) as mock_comp:
         _call_llm(
             model="claude-sonnet-4-6",
             system_prompt="sys",
@@ -88,7 +90,8 @@ def test_call_llm_budget_scales_max_tokens():
 
 def test_call_llm_returns_content_and_token_counts():
     resp = _mock_resp(_valid_thesis_json(), completion_tokens=13500)
-    with patch("litellm.completion", return_value=resp):
+    with patch("litellm.supports_reasoning", return_value=True), \
+            patch("litellm.completion", return_value=resp):
         text, p_tok, c_tok = _call_llm(
             model="claude-sonnet-4-6",
             system_prompt="sys",
@@ -107,7 +110,8 @@ def test_thinking_text_does_not_leak_into_parsed_thesis():
     thesis must come only from content, with no thinking text bleeding in."""
     reasoning = "SECRET CHAIN OF THOUGHT — must not appear in the thesis."
     resp = _mock_resp(_valid_thesis_json(), reasoning=reasoning)
-    with patch("litellm.completion", return_value=resp):
+    with patch("litellm.supports_reasoning", return_value=True), \
+            patch("litellm.completion", return_value=resp):
         text, _, _ = _call_llm(
             model="claude-sonnet-4-6",
             system_prompt="sys",
@@ -120,6 +124,24 @@ def test_thinking_text_does_not_leak_into_parsed_thesis():
     assert isinstance(thesis, TradeThesis)
     assert thesis.verdict == "setup_long"
     assert "SECRET" not in thesis.paragraph_evidence
+
+
+def test_call_llm_falls_back_for_non_reasoning_model():
+    """A non-reasoning provider must NOT receive thinking/max_tokens (LiteLLM
+    would raise UnsupportedParamsError); fall back to the legacy temp=0.2 call."""
+    with patch("litellm.supports_reasoning", return_value=False), \
+            patch("litellm.completion", return_value=_mock_resp("{}")) as mock_comp:
+        _call_llm(
+            model="gpt-some-non-reasoning",
+            system_prompt="sys",
+            user_prompt="user",
+            image_bytes=None,
+            thinking_budget_tokens=24000,
+        )
+    kwargs = mock_comp.call_args.kwargs
+    assert "thinking" not in kwargs
+    assert "max_tokens" not in kwargs
+    assert kwargs["temperature"] == 0.2
 
 
 def test_cost_estimate_bills_thinking_tokens_as_output():

--- a/tests/test_llm_thesis/test_call_llm_thinking.py
+++ b/tests/test_llm_thesis/test_call_llm_thinking.py
@@ -50,6 +50,22 @@ def _mock_resp(content: str, *, completion_tokens: int = 12000, reasoning: str =
     }
 
 
+def test_committed_model_actually_engages_thinking_path():
+    """Un-mocked guard against a silent no-op: the model in the committed config
+    must resolve to the anthropic provider AND support reasoning in litellm's
+    registry, or _call_llm falls through to the plain temp=0.2 call and every
+    thesis silently degrades to non-thinking. Reads the model from config so a
+    rename can't disable the whole feature undetected. No network — litellm's
+    provider/registry lookups are local."""
+    import litellm
+
+    from rainier.core.config import LLMThesisConfig
+
+    model = LLMThesisConfig().model
+    assert litellm.get_llm_provider(model)[1] == "anthropic"
+    assert litellm.supports_reasoning(model=model) is True
+
+
 def test_call_llm_enables_thinking_with_budget_and_temp_one():
     budget = 24000
     with patch("litellm.supports_reasoning", return_value=True), \

--- a/tests/test_llm_thesis/test_call_llm_thinking.py
+++ b/tests/test_llm_thesis/test_call_llm_thinking.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import json
 from unittest.mock import patch
 
+import pytest
+
 from rainier.llm_thesis.schemas import TradeThesis
 from rainier.llm_thesis.service import (
     _FINAL_ANSWER_HEADROOM_TOKENS,
@@ -142,41 +144,39 @@ def test_thinking_text_does_not_leak_into_parsed_thesis():
     assert "SECRET" not in thesis.paragraph_evidence
 
 
-def test_call_llm_falls_back_for_non_reasoning_model():
-    """A non-reasoning provider must NOT receive thinking/max_tokens (LiteLLM
-    would raise UnsupportedParamsError); fall back to the legacy temp=0.2 call."""
+def test_call_llm_raises_for_non_reasoning_model():
+    """A non-reasoning model can't enable thinking; the thesis pipeline requires
+    it, so _call_llm must RAISE (never make a degraded no-thinking call that
+    could be persisted + cached as a valid xhigh result)."""
     with patch("litellm.supports_reasoning", return_value=False), \
             patch("litellm.completion", return_value=_mock_resp("{}")) as mock_comp:
-        _call_llm(
-            model="gpt-some-non-reasoning",
-            system_prompt="sys",
-            user_prompt="user",
-            image_bytes=None,
-            thinking_budget_tokens=24000,
-        )
-    kwargs = mock_comp.call_args.kwargs
-    assert "thinking" not in kwargs
-    assert "max_tokens" not in kwargs
-    assert kwargs["temperature"] == 0.2
+        with pytest.raises(RuntimeError, match="extended thinking unavailable"):
+            _call_llm(
+                model="gpt-some-non-reasoning",
+                system_prompt="sys",
+                user_prompt="user",
+                image_bytes=None,
+                thinking_budget_tokens=24000,
+            )
+    mock_comp.assert_not_called()  # no degraded thesis produced
 
 
-def test_call_llm_does_not_send_thinking_to_non_anthropic_reasoning_model():
+def test_call_llm_raises_for_non_anthropic_reasoning_model():
     """The anthropic thinking payload is provider-specific: an OpenAI reasoning
-    model (supports_reasoning True, provider != anthropic) must fall back rather
-    than receive thinking={...}."""
+    model (supports_reasoning True, provider != anthropic) must RAISE rather than
+    silently produce a no-thinking thesis."""
     with patch("litellm.supports_reasoning", return_value=True), \
             patch("litellm.get_llm_provider", return_value=("o3", "openai", None, None)), \
             patch("litellm.completion", return_value=_mock_resp("{}")) as mock_comp:
-        _call_llm(
-            model="o3",
-            system_prompt="sys",
-            user_prompt="user",
-            image_bytes=None,
-            thinking_budget_tokens=24000,
-        )
-    kwargs = mock_comp.call_args.kwargs
-    assert "thinking" not in kwargs
-    assert kwargs["temperature"] == 0.2
+        with pytest.raises(RuntimeError, match="extended thinking unavailable"):
+            _call_llm(
+                model="o3",
+                system_prompt="sys",
+                user_prompt="user",
+                image_bytes=None,
+                thinking_budget_tokens=24000,
+            )
+    mock_comp.assert_not_called()
 
 
 def test_cost_estimate_bills_thinking_tokens_as_output():

--- a/tests/test_llm_thesis/test_cli_max_usd.py
+++ b/tests/test_llm_thesis/test_cli_max_usd.py
@@ -1,0 +1,55 @@
+"""The thesis CLI must inherit the config kill-switch cap unless --max-usd is
+explicitly passed.
+
+Regression: the CLI hardcoded --max-usd default 1.0 and unconditionally wrote
+it onto settings.llm_thesis.max_usd_per_scan, so manual `rainier thesis daily`
+runs ignored the config cap (raised to 2.5 for xhigh thinking) and could trip
+the old $1.00 kill switch mid-scan.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from rainier.cli import cli
+
+
+def _fake_settings(cap: float = 2.5):
+    return SimpleNamespace(llm_thesis=SimpleNamespace(max_usd_per_scan=cap))
+
+
+def _run(args):
+    """Run `thesis daily` with an empty screener so it early-returns after the
+    cap is (or isn't) overridden, and capture the settings it built."""
+    captured: dict = {}
+
+    def _fake_load(config_path: str = "config/settings.yaml"):
+        s = _fake_settings()
+        captured["settings"] = s
+        return s
+
+    def _fake_screen(settings):
+        return [], {}  # no candidates → command returns before the pipeline
+
+    with patch("rainier.core.config.load_settings_fresh", side_effect=_fake_load), \
+            patch("rainier.analysis.stock_screener.screen_stocks", side_effect=_fake_screen):
+        result = CliRunner().invoke(cli, args)
+    return result, captured["settings"]
+
+
+def test_daily_inherits_config_cap_when_max_usd_omitted():
+    result, settings = _run(["thesis", "daily", "--session", "afternoon"])
+    assert result.exit_code == 0, result.output
+    # Config cap (2.5) preserved — NOT clobbered by a stale 1.0 default.
+    assert settings.llm_thesis.max_usd_per_scan == 2.5
+
+
+def test_daily_explicit_max_usd_overrides_config():
+    result, settings = _run(
+        ["thesis", "daily", "--session", "afternoon", "--max-usd", "0.5"]
+    )
+    assert result.exit_code == 0, result.output
+    assert settings.llm_thesis.max_usd_per_scan == 0.5

--- a/tests/test_llm_thesis/test_schemas.py
+++ b/tests/test_llm_thesis/test_schemas.py
@@ -122,3 +122,25 @@ def test_compute_input_hash_handles_no_image():
     )
     h = compute_input_hash(pack, None)
     assert len(h) == 64
+
+
+def test_compute_input_hash_changes_with_thinking_budget():
+    """A retuned thinking budget must change the Tier-2 idempotency key so the
+    regenerated thesis persists as its own row (no unique-index collision)."""
+    pack = EvidencePack(
+        symbol="NVDA", scan_date="2026-05-07", session_name="afternoon",
+        candidate={"rank": 5},
+    )
+    assert compute_input_hash(pack, b"img", thinking_budget_tokens=24000) != \
+        compute_input_hash(pack, b"img", thinking_budget_tokens=8000)
+
+
+def test_compute_input_hash_none_budget_matches_legacy_two_arg():
+    """Omitting the budget (default None) must keep the legacy 2-arg hash
+    byte-identical so other callers' idempotency keys are unaffected."""
+    pack = EvidencePack(
+        symbol="NVDA", scan_date="2026-05-07", session_name="afternoon",
+        candidate={"rank": 5},
+    )
+    assert compute_input_hash(pack, b"img") == \
+        compute_input_hash(pack, b"img", thinking_budget_tokens=None)

--- a/tests/test_llm_thesis/test_service.py
+++ b/tests/test_llm_thesis/test_service.py
@@ -439,6 +439,68 @@ def test_tier1_lookup_hits_when_signals_used_matches():
     assert rec_id == 123
 
 
+def test_tier1_lookup_invalidates_when_thinking_budget_differs():
+    """Retuning llm_thesis.thinking_budget_tokens must invalidate a same-day
+    cached thesis — it was generated with a different amount of reasoning."""
+    payload = {
+        **_valid_thesis_dict(),
+        "_session_name": "afternoon",
+        "_thinking_budget_tokens": 24000,
+    }
+    q, _ = _stub_query_returning([(123, payload, "afternoon")])
+    cm = _patched_get_session(q)
+    with patch("rainier.llm_thesis.service.get_session", return_value=cm):
+        result = _tier1_lookup(
+            "NVDA",
+            date(2026, 5, 7),
+            "v1",
+            session_name="afternoon",
+            llm_model="test-model",
+            thinking_budget_tokens=8000,  # budget was retuned down
+        )
+    assert result is None
+
+
+def test_tier1_lookup_hits_when_thinking_budget_matches():
+    payload = {
+        **_valid_thesis_dict(),
+        "_session_name": "afternoon",
+        "_thinking_budget_tokens": 24000,
+    }
+    q, _ = _stub_query_returning([(123, payload, "afternoon")])
+    cm = _patched_get_session(q)
+    with patch("rainier.llm_thesis.service.get_session", return_value=cm):
+        result = _tier1_lookup(
+            "NVDA",
+            date(2026, 5, 7),
+            "v1",
+            session_name="afternoon",
+            llm_model="test-model",
+            thinking_budget_tokens=24000,
+        )
+    assert result is not None
+    assert result[0] == 123
+
+
+def test_tier1_lookup_hits_legacy_row_without_budget_stamp():
+    """Rows written before the budget stamp (no _thinking_budget_tokens) stay
+    reusable — PROMPT_VERSION already gates out pre-thinking rows."""
+    payload = {**_valid_thesis_dict(), "_session_name": "afternoon"}
+    q, _ = _stub_query_returning([(123, payload, "afternoon")])
+    cm = _patched_get_session(q)
+    with patch("rainier.llm_thesis.service.get_session", return_value=cm):
+        result = _tier1_lookup(
+            "NVDA",
+            date(2026, 5, 7),
+            "v1",
+            session_name="afternoon",
+            llm_model="test-model",
+            thinking_budget_tokens=24000,
+        )
+    assert result is not None
+    assert result[0] == 123
+
+
 def test_tier1_lookup_session_column_takes_precedence_over_jsonb_legacy():
     """[P3] fix #6: with the new session_name column populated, the lookup
     must filter on the column directly. A row whose JSONB stamp says one
@@ -532,7 +594,7 @@ async def test_generate_thesis_close_session_misses_afternoon_cache():
 
     def _fake_lookup(
         symbol, scan_date, prompt_version, *, session_name, llm_model,
-        enabled_signals=None,
+        enabled_signals=None, **_kwargs,
     ):
         captured_kwargs["session_name"] = session_name
         captured_kwargs["llm_model"] = llm_model
@@ -577,7 +639,7 @@ async def test_generate_thesis_same_session_hits_cache_no_llm_call():
 
     def _fake_lookup(
         symbol, scan_date, prompt_version, *, session_name, llm_model,
-        enabled_signals=None,
+        enabled_signals=None, **_kwargs,
     ):
         # Hit only when session+model match.
         if session_name == "afternoon" and llm_model == "claude-sonnet-4-6":

--- a/tests/test_llm_thesis/test_thesis_config.py
+++ b/tests/test_llm_thesis/test_thesis_config.py
@@ -1,0 +1,58 @@
+"""Config tests for the xhigh extended-thinking knobs on LLMThesisConfig.
+
+Guards: the thinking budget default + positive-int validation, the raised
+per-scan kill-switch cap, and that the committed settings.yaml block actually
+reaches the typed config (YAML-reload path the scheduler uses).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from rainier.core.config import LLMThesisConfig, load_settings
+
+
+def test_thinking_budget_and_cap_defaults():
+    cfg = LLMThesisConfig()
+    # "xhigh" tier.
+    assert cfg.thinking_budget_tokens == 24000
+    # Cap raised 1.0 -> 2.5 so a 5-ticker xhigh scan doesn't trip the kill switch.
+    assert cfg.max_usd_per_scan == 2.5
+
+
+@pytest.mark.parametrize("bad", [0, -1, -24000])
+def test_thinking_budget_rejects_non_positive(bad: int):
+    with pytest.raises(ValidationError):
+        LLMThesisConfig(thinking_budget_tokens=bad)
+
+
+def test_thinking_budget_accepts_positive_override():
+    cfg = LLMThesisConfig(thinking_budget_tokens=8000)
+    assert cfg.thinking_budget_tokens == 8000
+
+
+def test_yaml_block_reaches_thesis_config(monkeypatch, tmp_path):
+    yaml_path = tmp_path / "settings.yaml"
+    yaml_path.write_text(
+        "llm_thesis:\n"
+        "  model: \"claude-sonnet-4-6\"\n"
+        "  max_usd_per_scan: 2.5\n"
+        "  thinking_budget_tokens: 30000\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    s = load_settings(config_path=yaml_path)
+    assert s.llm_thesis.thinking_budget_tokens == 30000
+    assert s.llm_thesis.max_usd_per_scan == 2.5
+
+
+def test_committed_settings_yaml_uses_xhigh_budget_and_raised_cap():
+    """The real config must ship the xhigh budget + raised cap (yaml/model
+    lockstep) so the live cron actually runs the intended spend profile."""
+    repo_root = Path(__file__).resolve().parents[2]
+    s = load_settings(config_path=repo_root / "config" / "settings.yaml")
+    assert s.llm_thesis.thinking_budget_tokens == 24000
+    assert s.llm_thesis.max_usd_per_scan == 2.5

--- a/tests/test_llm_thesis/test_thesis_config.py
+++ b/tests/test_llm_thesis/test_thesis_config.py
@@ -23,15 +23,18 @@ def test_thinking_budget_and_cap_defaults():
     assert cfg.max_usd_per_scan == 2.5
 
 
-@pytest.mark.parametrize("bad", [0, -1, -24000])
-def test_thinking_budget_rejects_non_positive(bad: int):
+# 0/-1 are non-positive; 500/1023 are positive but below Anthropic's 1024
+# minimum thinking budget — both must fail fast at config load rather than
+# reach the provider and 400 every thesis call.
+@pytest.mark.parametrize("bad", [0, -1, -24000, 500, 1023])
+def test_thinking_budget_rejects_below_minimum(bad: int):
     with pytest.raises(ValidationError):
         LLMThesisConfig(thinking_budget_tokens=bad)
 
 
-def test_thinking_budget_accepts_positive_override():
-    cfg = LLMThesisConfig(thinking_budget_tokens=8000)
-    assert cfg.thinking_budget_tokens == 8000
+def test_thinking_budget_accepts_at_and_above_minimum():
+    assert LLMThesisConfig(thinking_budget_tokens=1024).thinking_budget_tokens == 1024
+    assert LLMThesisConfig(thinking_budget_tokens=8000).thinking_budget_tokens == 8000
 
 
 def test_yaml_block_reaches_thesis_config(monkeypatch, tmp_path):

--- a/tests/test_paper/test_reflections.py
+++ b/tests/test_paper/test_reflections.py
@@ -823,10 +823,11 @@ def test_input_hash_unaffected_by_reflections_text():
         signals={},
     )
     # Structural guarantee: the Tier-2 hash is computed from the EvidencePack +
-    # image bytes ONLY — prompt text (calibration/reflections blocks) cannot
-    # enter it because the function takes no prompt-text parameter and the pack
-    # carries no reflection field. (PROMPT_VERSION busts Tier-1 instead.)
+    # image bytes (+ the numeric thinking budget) ONLY — prompt text
+    # (calibration/reflections blocks) cannot enter it because the function takes
+    # no prompt-text parameter and the pack carries no reflection field.
+    # (PROMPT_VERSION busts Tier-1 instead.)
     params = list(inspect.signature(compute_input_hash).parameters)
-    assert params == ["pack", "image_bytes"]
+    assert params == ["pack", "image_bytes", "thinking_budget_tokens"]
     assert "reflection" not in pack.model_dump()
     assert compute_input_hash(pack, b"img") == compute_input_hash(pack, b"img")

--- a/tests/test_paper/test_reflections.py
+++ b/tests/test_paper/test_reflections.py
@@ -222,7 +222,8 @@ class _StubLLM:
         self.fail = fail
         self.calls: list[dict] = []
 
-    def __call__(self, *, model, system_prompt, user_prompt, image_bytes):
+    def __call__(self, *, model, system_prompt, user_prompt, image_bytes,
+                 **_kwargs):
         self.calls.append(
             {
                 "model": model,
@@ -685,7 +686,8 @@ async def _run_thesis_capture(monkeypatch) -> tuple:
 
     captured: dict = {}
 
-    def fake_call_llm(*, model, system_prompt, user_prompt, image_bytes):
+    def fake_call_llm(*, model, system_prompt, user_prompt, image_bytes,
+                      **_kwargs):
         captured["user_prompt"] = user_prompt
         return valid, 10, 20
 


### PR DESCRIPTION
## Scope

Switch the **daily LLM thesis** generation (`llm_thesis/service.py`) to **Claude Sonnet 4.6 with xhigh extended thinking**. No A/B harness (operator waived it — direct change). Model stays `claude-sonnet-4-6`; the weekly `research/` pipeline is untouched.

### What changed
- **`_call_llm`**: attaches `thinking={"type":"enabled","budget_tokens":24000}` (deterministic xhigh — litellm's `reasoning_effort` maps to much smaller anthropic budgets), forces `temperature=1.0` (anthropic rejects `!=1` with thinking), and sets `max_tokens = budget + 2000` answer headroom. Gated on the resolved provider being **anthropic** AND `litellm.supports_reasoning(model)` — if the configured model can't enable thinking (non-anthropic provider or a litellm registry drop), `_call_llm` **raises** rather than silently producing a cheap no-thinking thesis that would be persisted/cached as a valid xhigh result (cache-poisoning vector caught in review).
- **Response parsing** unchanged: reads `message["content"]` (the JSON thesis); reasoning stays on a separate key and never leaks into the parsed thesis.
- **Cost accounting** stays correct: anthropic bills thinking as OUTPUT tokens folded into `completion_tokens`, which the per-scan kill switch already bills at \$15/M. No double-count.
- **Config** (`LLMThesisConfig` + `settings.yaml`): new `thinking_budget_tokens` (default 24000, validated `ge=1024` = anthropic's minimum), and `max_usd_per_scan` raised `1.0 -> 2.5` (a 5-ticker xhigh scan runs ~\$1.0-1.9; the old cap would trip the kill switch mid-scan).
- **Cache correctness**: switching to thinking is a behavioral change invisible to `compute_input_hash`, so `PROMPT_VERSION` bumped `v3 -> v4` (busts Tier-1 on the switch). Retuning `thinking_budget_tokens` is handled automatically: the budget is folded into the Tier-2 `input_hash` and stamped for the Tier-1 drift check, so a retune persists as its own row instead of colliding with / re-reading the stale row.
- **CLI**: `thesis daily` / `thesis ticker` `--max-usd` now defaults to the config cap (inherits 2.5) instead of a hardcoded 1.0 that silently overrode config on manual runs.

### Cost impact
~\$0.018/ticker -> ~\$0.15-0.40/ticker (thinking billed as output). Per-scan cap 2.5 covers a 5-ticker scan.

## Review
- **codex review**: 8 fix iterations (iter-1..iter-8), 14 total review runs. Final gate: **PASS** (runs 13 & 14 both fully clean, two consecutive; codex ran the full suite: 1775 passed, 354 skipped).
- **/review** (gstack skill): 1 invocation + independent Claude adversarial subagent. Actionable P2s fixed (fail-loud/raise on thinking fallback; un-mocked live-model thinking guard test). Gate: **PASS**.

### Deferred (non-blocking)
- **[P2]** Reactive kill switch discards a paid-for thesis on cumulative overrun — pre-existing design, out of this task's scope. xhigh amplifies the per-ticker waste; worth a follow-up pre-call worst-case gate.
- **[P2]** Optional live e2e (`rainier thesis daily --dry-run`) to confirm the real API accepts the thinking params at `max_tokens=26000` non-streamed — skipped to avoid spending API credit + sharing the live local DB; unit tests are the gate per the task brief. Low risk (litellm client, 600s timeout).
- **[P3]** No upper ceiling on `thinking_budget_tokens` (would need an absurd >126k value to exceed the model's 128k output cap; the `ge=1024` floor covers the realistic mistake).

## Test plan
- [x] `_call_llm` invoked with thinking enabled at the configured budget, `temperature=1.0`, `max_tokens > budget_tokens`
- [x] `_call_llm` raises (no completion) for non-anthropic / non-reasoning models
- [x] Un-mocked guard: committed config model resolves to anthropic + supports reasoning
- [x] Config: `thinking_budget_tokens` loads from yaml, rejects `<1024`; `max_usd_per_scan` reads 2.5; committed settings.yaml uses 24000 + 2.5
- [x] Cost estimate bills thinking/output tokens at \$15/M
- [x] Response parsing: JSON thesis parses from `content`; reasoning text doesn't leak
- [x] Cache: budget change busts Tier-1 (stamp) and Tier-2 (`input_hash`); None budget keeps the legacy 2-arg hash byte-identical
- [x] CLI: `thesis daily` inherits config cap when `--max-usd` omitted; explicit override respected
- [x] `uv run pytest tests/ -q` green; `uv run ruff check src/ tests/` clean

https://claude.ai/code/session_01QvtzXcVVxuJ4Gahk6M6zjo