### PR TITLE
fix: WHY bullets no longer truncated mid-sentence at 60 chars

### DIFF
--- a/src/rainier/alerts/discord.py
+++ b/src/rainier/alerts/discord.py
@@ -400,6 +400,13 @@ _EMBED_FOOTER_MAX = 2048
 # in the middle of a chip.
 _CHIP_LINE_MAX = 200
 
+# Per-bullet cap for the WHY field. Full thesis sentences run ~80-160 chars;
+# 220 shows them whole instead of chopping mid-sentence (the old 60-char cap
+# truncated nearly every real bullet). With <=4 bullets, 4 * 220 = 880 < 1024,
+# so the field-level _EMBED_FIELD_VALUE_MAX backstop at the call site still
+# guarantees Discord compliance without a mid-word chop in the common case.
+_WHY_BULLET_MAX = 220
+
 
 def _truncate_at_word(text: str, max_chars: int) -> str:
     """Word-boundary safe truncation. Appends ``…`` when shortened.
@@ -541,8 +548,8 @@ def _why_bullets(thesis: dict) -> list[str]:
     """Top 3-4 short bullets pulled from the thesis prose.
 
     Strategy: split paragraph_radar + paragraph_evidence on sentence
-    boundaries, drop blanks, keep the first 4, cap each at 60 chars
-    (word-boundary safe).
+    boundaries, drop blanks, keep the first 4, cap each at
+    ``_WHY_BULLET_MAX`` chars (word-boundary safe).
 
     PR5 review iter-1: LLM-generated paragraphs flow into Discord text;
     scrub ``@everyone`` / ``@here`` / backticks before emitting so an
@@ -561,7 +568,7 @@ def _why_bullets(thesis: dict) -> list[str]:
             piece = piece.strip().rstrip(".;")
             if piece:
                 chunks.append(piece)
-    bullets = [_truncate_at_word(c, 60) for c in chunks[:4] if c]
+    bullets = [_truncate_at_word(c, _WHY_BULLET_MAX) for c in chunks[:4] if c]
     return bullets
 
 

--- a/tests/test_alerts/test_discord_embed.py
+++ b/tests/test_alerts/test_discord_embed.py
@@ -8,13 +8,16 @@ HTTP, no DB. Multipart attachment + DB chart-load happens in
 from __future__ import annotations
 
 from rainier.alerts.discord import (
+    _EMBED_FIELD_VALUE_MAX,
     _VERDICT_COLORS,
+    _WHY_BULLET_MAX,
     _build_chip_line,
     _levels_block,
     _llm_noticed,
     _risks_lines,
     _truncate_at_word,
     _watch_line,
+    _why_bullets,
     format_thesis_embed,
 )
 from rainier.core.types import StockCandidate
@@ -421,7 +424,6 @@ class TestLLMTextScrubbing:
         assert "`" not in out
 
     def test_why_bullets_scrub_paragraph_radar(self):
-        from rainier.alerts.discord import _why_bullets
         bullets = _why_bullets(
             _thesis(
                 paragraph_radar="@everyone strong setup. Volume confirms."
@@ -429,6 +431,49 @@ class TestLLMTextScrubbing:
         )
         for b in bullets:
             assert "@everyone" not in b
+
+    def test_why_bullet_full_sentence_survives_whole(self):
+        # Regression: the operator saw real ~150-char thesis sentences chopped
+        # mid-word by the old 60-char cap ("...pattern_type is…"). A full
+        # sentence shorter than _WHY_BULLET_MAX must render intact — no ellipsis.
+        sentence = (
+            "Entry 670.60 sits 1.07 percent below the current price 677.79 "
+            "and the stop rests just under the prior swing low which leaves "
+            "a clean measured move higher"
+        )
+        assert len(sentence) < _WHY_BULLET_MAX  # guards the fixture premise
+        bullets = _why_bullets(_thesis(paragraph_radar=sentence + "."))
+        assert bullets[0] == sentence
+        assert not bullets[0].endswith("…")
+
+    def test_why_bullet_over_cap_truncated_at_word_boundary(self):
+        # Boundary: a sentence longer than _WHY_BULLET_MAX is still truncated,
+        # now at the higher cap, and lands on a word break with the ellipsis.
+        words = ["measured"] * 60  # 60 * 9 - 1 = 539 chars, well over the cap
+        sentence = " ".join(words)
+        assert len(sentence) > _WHY_BULLET_MAX  # guards the fixture premise
+        bullets = _why_bullets(_thesis(paragraph_radar=sentence + "."))
+        assert bullets[0].endswith("…")
+        assert len(bullets[0]) <= _WHY_BULLET_MAX
+        # Word-boundary safe: dropping the ellipsis leaves whole words only.
+        assert bullets[0][:-1].strip() == bullets[0][:-1]
+        for token in bullets[0][:-1].split():
+            assert token == "measured"
+
+    def test_why_field_value_within_discord_field_cap(self):
+        # Field-cap safety: four long bullets (2 sentences each in radar +
+        # evidence) still fit Discord's 1024-char field-value limit because the
+        # call site backstops the joined WHY value at _EMBED_FIELD_VALUE_MAX.
+        long_sentence = " ".join(["breakout"] * 40)  # ~319 chars, over the cap
+        embed = format_thesis_embed(
+            _thesis(
+                paragraph_radar=f"{long_sentence}. {long_sentence}.",
+                paragraph_evidence=f"{long_sentence}. {long_sentence}.",
+            ),
+            _candidate(),
+        )
+        why = next(f for f in embed["fields"] if f["name"] == "WHY")
+        assert len(why["value"]) <= _EMBED_FIELD_VALUE_MAX
 
 
 class TestFooterAndImage:

--- a/tests/test_alerts/test_discord_embed.py
+++ b/tests/test_alerts/test_discord_embed.py
@@ -460,6 +460,26 @@ class TestLLMTextScrubbing:
         for token in bullets[0][:-1].split():
             assert token == "measured"
 
+    def test_why_bullet_exact_boundary_transition(self):
+        # Off-by-one: a bullet of exactly _WHY_BULLET_MAX chars survives whole;
+        # one char over gains the ellipsis. Guards the constant's transition.
+        # "aa " repeats with period 3; slicing to these lengths never lands on
+        # a trailing space (which _why_bullets would strip), so the fixture
+        # lengths are exact.
+        filler = ("aa " * 100).strip()
+        at_cap = filler[:_WHY_BULLET_MAX]
+        over_cap = filler[: _WHY_BULLET_MAX + 1]
+        assert len(at_cap) == _WHY_BULLET_MAX
+        assert not at_cap.endswith(" ") and not over_cap.endswith(" ")
+
+        at = _why_bullets(_thesis(paragraph_radar=at_cap, paragraph_evidence=""))
+        assert at[0] == at_cap
+        assert not at[0].endswith("…")
+
+        over = _why_bullets(_thesis(paragraph_radar=over_cap, paragraph_evidence=""))
+        assert over[0].endswith("…")
+        assert len(over[0]) <= _WHY_BULLET_MAX
+
     def test_why_field_value_within_discord_field_cap(self):
         # Field-cap safety: four long bullets (2 sentences each in radar +
         # evidence) still fit Discord's 1024-char field-value limit because the


### PR DESCRIPTION
## Scope
The QU100-LLM Discord thesis embed truncated every WHY-section bullet at a magic **60 chars**, chopping full thesis sentences mid-word with a trailing `…` (operator screenshot: "…pattern_type is…", "…stop,", "…near 695-700 on chart,…").

Fix: replace the magic `60` in `_why_bullets` with a named module constant `_WHY_BULLET_MAX = 220`, placed beside the other `_EMBED_*` limits. Real thesis sentences run ~80-160 chars, so 220 shows them whole. With ≤4 bullets, 4 × 220 = 880 < 1024, so the existing field-level `_EMBED_FIELD_VALUE_MAX` (1024) backstop at the call site still guarantees Discord compliance without a mid-word chop in the common case.

No change to bullet count (still first 4), sentence-splitting, or the `_scrub_discord_text` mention/backtick scrubbing. The 1024 field-level backstop is left intact.

## Tests added (`tests/test_alerts/test_discord_embed.py`)
- `test_why_bullet_full_sentence_survives_whole` — regression: a realistic ~150-char sentence renders intact, no `…`.
- `test_why_bullet_over_cap_truncated_at_word_boundary` — a sentence over the cap still truncates at a word boundary with `…`, len ≤ cap.
- `test_why_bullet_exact_boundary_transition` — off-by-one: exactly `_WHY_BULLET_MAX` survives whole; one char over gains the ellipsis (added per /review testing specialist).
- `test_why_field_value_within_discord_field_cap` — 4 long bullets keep the WHY field `value` ≤ 1024 via `format_thesis_embed`.

## Reviews
- Codex review: 4 runs, all clean (final two consecutive clean on the final diff), no P0/P1.
- /review (gstack): 1 invocation. Testing specialist raised 1 INFORMATIONAL (missing exact-boundary test) — fixed. Maintainability specialist: clean.

## Test plan
- [x] `uv run pytest tests/test_alerts/ -q` — 123 passed, 1 skipped
- [x] `uv run ruff check src/ tests/` — clean

## Deferred [P2]/[P3]
None.

https://claude.ai/code/session_01QvtzXcVVxuJ4Gahk6M6zjo