### PR TITLE
feat: fng-backtest — F&G + QQQ-MA signal, train/OOS split, auto-verdict

### DIFF
--- a/src/rainier/backtest/fear_greed_signal.py
+++ b/src/rainier/backtest/fear_greed_signal.py
@@ -1,0 +1,494 @@
+"""Fear & Greed + QQQ-MA market-entry backtest (Phase 2, offline analysis).
+
+Combines a trend filter (QQQ vs its own SMA) with the CNN Fear & Greed Index
+under three level-state combine logics and asks ONE question: does adding F&G
+beat a QQQ-MA-only baseline out-of-sample? No live surface — this gates Phase 3.
+
+Execution convention (no lookahead), mirroring ``tqqq_sma_sweep.py``'s
+carry-then-apply order: the mask value for day ``D`` — computed from ``F&G[D]``
+and ``close[D]``, both known only after ``D``'s close — gates the position that
+earns ``return[D+1]``. Day D itself earns nothing from a signal that turns on at
+D. The one-day lag lives in :func:`equity_curve`::
+
+    for d in 1..n-1:
+        if mask[d-1]:  equity *= 1 + ret[d]     # position set yesterday
+        if mask[d] != mask[d-1]:  equity *= 1 - slip   # trade at today's close
+
+The three logics (all require ``QQQ > SMA(window)`` AND):
+    CONTRARIAN    F&G <= low_thresh      (buy fear in an uptrend)
+    MOMENTUM      F&G >= high_thresh     (sentiment confirms trend)
+    GREED_AVOID   F&G <  extreme_thresh  (step aside only on froth)
+
+Selection is train-only; the gate metric is read from a single untouched OOS
+holdout (NOT the full-sample selection ``walk_forward_top_n`` does). Masks are
+built on the FULL price history so an SMA(200) has proper warmup in the OOS
+slice; the split only partitions which return periods score into which window.
+
+Data reads: prices via ``tqqq_sma_sweep.fetch_prices`` (adjusted-close parquet,
+deep history); F&G via the legacy ``core.database`` engine. All current F&G rows
+are ``source_version=backfill`` (revised values) so the whole span is
+research-grade — surfaced in the report, never silently.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from datetime import date, datetime
+from enum import Enum
+
+import numpy as np
+import pandas as pd
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from rainier.core.database import get_session
+from rainier.core.models import FearGreedIndex
+
+_TRADING_DAYS_PER_YEAR = 252.0
+
+
+class Logic(str, Enum):
+    """The three level-state combine logics (all gated on ``QQQ > SMA``)."""
+
+    CONTRARIAN = "contrarian"     # in when F&G <= threshold
+    MOMENTUM = "momentum"         # in when F&G >= threshold
+    GREED_AVOID = "greed_avoid"   # in when F&G <  threshold
+
+
+# Pre-registered grid (task plan). Kept small on purpose — the OOS/overfitting
+# bar in the design gates on a clear (x1.15) edge, not a marginal one.
+MA_WINDOWS: tuple[int, ...] = (20, 50, 100, 200)
+THRESHOLD_GRID: dict[Logic, tuple[float, ...]] = {
+    Logic.CONTRARIAN: (20.0, 25.0, 30.0),
+    Logic.MOMENTUM: (55.0, 60.0, 65.0, 75.0),
+    Logic.GREED_AVOID: (75.0, 80.0),
+}
+
+
+@dataclass(frozen=True)
+class Combo:
+    """One (logic, MA window, F&G threshold) point in the grid."""
+
+    logic: Logic
+    ma: int
+    threshold: float
+
+
+@dataclass(frozen=True)
+class ArmMetrics:
+    """Performance summary for one backtest arm over one date window."""
+
+    final_value: float
+    total_return: float
+    cagr: float
+    max_dd: float
+    calmar: float
+    sharpe: float
+    exposure: float
+    switches: int
+    hit_rate: float
+    n_days: int
+
+
+@dataclass(frozen=True)
+class ComboResult:
+    """A grid combo evaluated on the train slice, the OOS slice, and full span."""
+
+    combo: Combo
+    train: ArmMetrics
+    oos: ArmMetrics
+    full: ArmMetrics
+
+
+@dataclass(frozen=True)
+class BenchArm:
+    """A benchmark arm (buy-and-hold or MA-only) across the three windows."""
+
+    label: str
+    train: ArmMetrics
+    oos: ArmMetrics
+    full: ArmMetrics
+
+
+@dataclass(frozen=True)
+class BacktestResult:
+    """Everything the report renders + the auto-verdict inputs."""
+
+    symbol: str
+    start: date
+    end: date
+    split_date: date
+    research_grade: bool
+    daily_boundary: datetime | None
+    slippage_bp: float
+    combo_results: list[ComboResult]
+    ma_only: dict[int, BenchArm]          # keyed by MA window
+    buy_and_hold: BenchArm
+    selections: dict[Logic, ComboResult]  # train-selected, per logic
+    verdicts: dict[Logic, bool]           # OOS gate outcome, per logic
+    eligible_logics: list[Logic]
+
+
+# --------------------------------------------------------------------------
+# Signal masks
+# --------------------------------------------------------------------------
+
+
+def sma(close: np.ndarray, window: int) -> np.ndarray:
+    """Simple moving average; ``NaN`` for the first ``window-1`` warmup days."""
+    close = np.asarray(close, dtype=np.float64)
+    n = close.shape[0]
+    out = np.full(n, np.nan)
+    if window < 1 or window > n:
+        return out
+    csum = np.concatenate([[0.0], np.cumsum(close)])
+    out[window - 1:] = (csum[window:] - csum[:-window]) / window
+    return out
+
+
+def ma_mask(close: np.ndarray, window: int) -> np.ndarray:
+    """Trend filter: ``True`` where ``close > SMA(window)`` (warmup days False)."""
+    close = np.asarray(close, dtype=np.float64)
+    ma = sma(close, window)
+    mask = np.zeros(close.shape[0], dtype=bool)
+    valid = ~np.isnan(ma)
+    mask[valid] = close[valid] > ma[valid]
+    return mask
+
+
+def logic_mask(
+    close: np.ndarray, fng: np.ndarray, logic: Logic, threshold: float, window: int
+) -> np.ndarray:
+    """Combined in/out mask: trend filter AND the logic's F&G condition."""
+    fng = np.asarray(fng, dtype=np.float64)
+    trend = ma_mask(close, window)
+    if logic is Logic.CONTRARIAN:
+        cond = fng <= threshold
+    elif logic is Logic.MOMENTUM:
+        cond = fng >= threshold
+    elif logic is Logic.GREED_AVOID:
+        cond = fng < threshold
+    else:  # pragma: no cover - exhaustive enum
+        raise ValueError(f"unknown logic {logic!r}")
+    # A NaN F&G reading is "no signal" -> stay out.
+    cond = np.where(np.isnan(fng), False, cond)
+    return trend & cond
+
+
+def buy_and_hold_mask(n: int) -> np.ndarray:
+    """Always-in mask (the buy-and-hold benchmark)."""
+    return np.ones(n, dtype=bool)
+
+
+# --------------------------------------------------------------------------
+# Equity + metrics
+# --------------------------------------------------------------------------
+
+
+def equity_curve(
+    trade_close: np.ndarray, mask: np.ndarray, slippage_bp: float = 5.0
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(equity, strat_ret)`` applying the D->D+1 lag + per-transition slip.
+
+    ``equity[0] = 1.0``. The position earning ``ret[d]`` is ``mask[d-1]`` (set at
+    the prior close). Slippage is charged once per adjacent state change; an
+    all-in mask (buy-and-hold) therefore pays nothing and equals ``close`` scaled
+    to 1.0 at the start.
+    """
+    trade_close = np.asarray(trade_close, dtype=np.float64)
+    mask = np.asarray(mask, dtype=bool)
+    n = trade_close.shape[0]
+    ret = np.zeros(n)
+    ret[1:] = trade_close[1:] / trade_close[:-1] - 1.0
+    slip = slippage_bp * 1e-4
+
+    equity = np.empty(n)
+    equity[0] = 1.0
+    e = 1.0
+    for d in range(1, n):
+        if mask[d - 1]:
+            e *= 1.0 + ret[d]
+        if mask[d] != mask[d - 1]:
+            e *= 1.0 - slip
+        equity[d] = e
+
+    strat_ret = np.zeros(n)
+    strat_ret[1:] = equity[1:] / equity[:-1] - 1.0
+    return equity, strat_ret
+
+
+def compute_metrics(
+    trade_close: np.ndarray, mask: np.ndarray, slippage_bp: float = 5.0
+) -> ArmMetrics:
+    """Full metric summary for one arm (annualized at 252 days, rf=0)."""
+    trade_close = np.asarray(trade_close, dtype=np.float64)
+    mask = np.asarray(mask, dtype=bool)
+    n = trade_close.shape[0]
+    equity, strat_ret = equity_curve(trade_close, mask, slippage_bp)
+
+    final_value = float(equity[-1])
+    total_return = final_value - 1.0
+
+    years = n / _TRADING_DAYS_PER_YEAR
+    if final_value > 0.0 and years > 0.0:
+        cagr = final_value ** (1.0 / years) - 1.0
+    else:
+        cagr = -1.0
+
+    peak = np.maximum.accumulate(equity)
+    max_dd = float((1.0 - equity / peak).max())
+
+    std = float(strat_ret.std(ddof=1)) if n > 1 else 0.0
+    sharpe = float(strat_ret.mean() / std * np.sqrt(_TRADING_DAYS_PER_YEAR)) if std > 0.0 else 0.0
+
+    calmar = cagr / max_dd if max_dd > 0.0 else float("nan")
+
+    exposure = float(mask.mean()) if n > 0 else 0.0
+    switches = int(np.count_nonzero(mask[1:] != mask[:-1])) if n > 1 else 0
+
+    # Hit-rate: of the return periods the arm actually held a position, the
+    # fraction where the price moved up. In-position for ret[d] is mask[d-1].
+    ret = np.zeros(n)
+    ret[1:] = trade_close[1:] / trade_close[:-1] - 1.0
+    in_pos = mask[:-1]
+    held = int(np.count_nonzero(in_pos))
+    hit_rate = float(np.count_nonzero((ret[1:] > 0.0) & in_pos) / held) if held else float("nan")
+
+    return ArmMetrics(
+        final_value=final_value,
+        total_return=total_return,
+        cagr=cagr,
+        max_dd=max_dd,
+        calmar=calmar,
+        sharpe=sharpe,
+        exposure=exposure,
+        switches=switches,
+        hit_rate=hit_rate,
+        n_days=n,
+    )
+
+
+# --------------------------------------------------------------------------
+# Selection + verdict
+# --------------------------------------------------------------------------
+
+
+def _train_rank_key(cr: ComboResult) -> float:
+    """Rank key for train selection: Calmar, with NaN (no-drawdown) as worst.
+
+    A NaN Calmar means no drawdown was observed on the train slice — usually a
+    near-always-cash degenerate combo, not a robust winner — so it sorts last.
+    """
+    c = cr.train.calmar
+    return c if np.isfinite(c) else float("-inf")
+
+
+def select_best_on_train(
+    combo_results: Sequence[ComboResult], logic: Logic
+) -> ComboResult | None:
+    """Pick the combo of ``logic`` with the highest TRAIN Calmar (OOS untouched)."""
+    candidates = [cr for cr in combo_results if cr.combo.logic is logic]
+    if not candidates:
+        return None
+    return max(candidates, key=_train_rank_key)
+
+
+def logic_eligible(
+    logic_oos: ArmMetrics, ma_only_oos: ArmMetrics, calmar_mult: float = 1.15
+) -> bool:
+    """The pre-registered 3-inequality promote bar, on the OOS holdout.
+
+    Eligible iff ALL THREE hold vs the paired MA-only arm:
+        (i)   OOS Calmar  >= MA-only OOS Calmar * 1.15
+        (ii)  OOS Sharpe  >= MA-only OOS Sharpe
+        (iii) OOS MaxDD   <= MA-only OOS MaxDD   (no deeper drawdown)
+    A non-finite Calmar on either side fails (i) — Calmar is too unstable to
+    stake a promotion on when a denominator vanished.
+    """
+    calmar_ok = (
+        np.isfinite(logic_oos.calmar)
+        and np.isfinite(ma_only_oos.calmar)
+        and logic_oos.calmar >= ma_only_oos.calmar * calmar_mult
+    )
+    sharpe_ok = logic_oos.sharpe >= ma_only_oos.sharpe
+    maxdd_ok = logic_oos.max_dd <= ma_only_oos.max_dd
+    return bool(calmar_ok and sharpe_ok and maxdd_ok)
+
+
+# --------------------------------------------------------------------------
+# Data loading
+# --------------------------------------------------------------------------
+
+
+SessionFactory = Callable[[], AbstractContextManager[Session]]
+
+
+def load_fng_series(
+    session_factory: SessionFactory = get_session,
+) -> tuple[pd.Series, datetime | None]:
+    """Read the point-in-time F&G composite as a date-indexed score series.
+
+    Per the Phase-1 contract: for each ``date`` take the EARLIEST observation
+    (min ``observed_at``, then min ``id``) — closest to real-time knowledge. The
+    live-capture boundary is DERIVED as ``MIN(observed_at) WHERE
+    source_version='daily'`` (``None`` when no live rows exist yet — the whole
+    span is then research-grade). Returns ``(score_series, daily_boundary)``.
+    """
+    with session_factory() as session:
+        rows = session.execute(
+            select(FearGreedIndex.date, FearGreedIndex.score)
+            .order_by(
+                FearGreedIndex.date,
+                FearGreedIndex.observed_at.asc(),
+                FearGreedIndex.id.asc(),
+            )
+        ).all()
+        boundary = session.execute(
+            select(func.min(FearGreedIndex.observed_at))
+            .where(FearGreedIndex.source_version == "daily")
+        ).scalar_one_or_none()
+
+    by_date: dict[date, float] = {}
+    for d, score in rows:
+        if d not in by_date:  # first row per date == earliest observation
+            by_date[d] = float(score)
+
+    series = pd.Series(by_date, dtype=float).sort_index()
+    series.index = pd.to_datetime(series.index)
+    return series, boundary
+
+
+def align_prices_and_fng(
+    prices: pd.DataFrame, fng: pd.Series, symbol: str
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, pd.DatetimeIndex]:
+    """Align prices to the F&G span, forward-filling F&G onto trading days.
+
+    Returns ``(signal_close, trade_close, fng_values, dates)``. ``signal_close``
+    is always QQQ (the trend + F&G are market-level per the design); ``trade_close``
+    is the traded instrument. F&G is forward-filled onto any trading day the
+    endpoint skipped — a stale (past) reading, never a future one, so the fill
+    cannot reintroduce lookahead. Rows before F&G's first date are dropped.
+    """
+    sym = symbol.lower()
+    if sym not in prices.columns:
+        raise ValueError(f"prices frame has no column {sym!r} (have {list(prices.columns)})")
+    if "qqq" not in prices.columns:
+        raise ValueError("prices frame must include a 'qqq' column for the signal")
+
+    idx = prices.index
+    fng_aligned = fng.reindex(idx.union(fng.index)).sort_index().ffill().reindex(idx)
+    joined = pd.DataFrame(
+        {
+            "qqq": prices["qqq"],
+            "trade": prices[sym],
+            "fng": fng_aligned,
+        },
+        index=idx,
+    ).dropna()
+
+    return (
+        joined["qqq"].to_numpy(dtype=np.float64),
+        joined["trade"].to_numpy(dtype=np.float64),
+        joined["fng"].to_numpy(dtype=np.float64),
+        joined.index,
+    )
+
+
+# --------------------------------------------------------------------------
+# Backtest driver
+# --------------------------------------------------------------------------
+
+
+def _all_combos() -> list[Combo]:
+    return [
+        Combo(logic, ma, thr)
+        for logic in Logic
+        for ma in MA_WINDOWS
+        for thr in THRESHOLD_GRID[logic]
+    ]
+
+
+def _split_index(dates: pd.DatetimeIndex, split_date) -> int:
+    return int(np.searchsorted(dates.values, np.datetime64(pd.Timestamp(split_date))))
+
+
+def _eval_windows(
+    trade_close: np.ndarray, mask: np.ndarray, split: int, slippage_bp: float
+) -> tuple[ArmMetrics, ArmMetrics, ArmMetrics]:
+    """(train, oos, full) metrics — masks come from full history, sliced here."""
+    train = compute_metrics(trade_close[:split], mask[:split], slippage_bp)
+    oos = compute_metrics(trade_close[split:], mask[split:], slippage_bp)
+    full = compute_metrics(trade_close, mask, slippage_bp)
+    return train, oos, full
+
+
+def run_backtest(
+    signal_close: np.ndarray,
+    trade_close: np.ndarray,
+    fng: np.ndarray,
+    dates: pd.DatetimeIndex,
+    split_date,
+    slippage_bp: float = 5.0,
+    combos: Sequence[Combo] | None = None,
+    ma_windows: Sequence[int] | None = None,
+    symbol: str = "QQQ",
+    research_grade: bool = True,
+    daily_boundary: datetime | None = None,
+) -> BacktestResult:
+    """Run the grid + benchmarks with a single untouched OOS holdout.
+
+    Selection is train-only (:func:`select_best_on_train`); the gate metric per
+    logic is read from the OOS slice and scored against the MA-only arm sharing
+    the selected combo's MA window (:func:`logic_eligible`).
+    """
+    combos = list(combos) if combos is not None else _all_combos()
+    ma_windows = list(ma_windows) if ma_windows is not None else list(MA_WINDOWS)
+    split = _split_index(dates, split_date)
+
+    combo_results: list[ComboResult] = []
+    for combo in combos:
+        mask = logic_mask(signal_close, fng, combo.logic, combo.threshold, combo.ma)
+        train, oos, full = _eval_windows(trade_close, mask, split, slippage_bp)
+        combo_results.append(ComboResult(combo=combo, train=train, oos=oos, full=full))
+
+    ma_only: dict[int, BenchArm] = {}
+    for w in ma_windows:
+        mask = ma_mask(signal_close, w)
+        train, oos, full = _eval_windows(trade_close, mask, split, slippage_bp)
+        ma_only[w] = BenchArm(label=f"MA-only({w})", train=train, oos=oos, full=full)
+
+    bh_mask = buy_and_hold_mask(trade_close.shape[0])
+    bh_train, bh_oos, bh_full = _eval_windows(trade_close, bh_mask, split, slippage_bp)
+    buy_and_hold = BenchArm(label="buy-and-hold", train=bh_train, oos=bh_oos, full=bh_full)
+
+    selections: dict[Logic, ComboResult] = {}
+    verdicts: dict[Logic, bool] = {}
+    for logic in Logic:
+        picked = select_best_on_train(combo_results, logic)
+        if picked is None:
+            continue
+        selections[logic] = picked
+        paired = ma_only.get(picked.combo.ma)
+        verdicts[logic] = (
+            logic_eligible(picked.oos, paired.oos) if paired is not None else False
+        )
+
+    eligible = [logic for logic, ok in verdicts.items() if ok]
+
+    return BacktestResult(
+        symbol=symbol,
+        start=dates[0].date(),
+        end=dates[-1].date(),
+        split_date=pd.Timestamp(split_date).date(),
+        research_grade=research_grade,
+        daily_boundary=daily_boundary,
+        slippage_bp=slippage_bp,
+        combo_results=combo_results,
+        ma_only=ma_only,
+        buy_and_hold=buy_and_hold,
+        selections=selections,
+        verdicts=verdicts,
+        eligible_logics=eligible,
+    )

--- a/src/rainier/backtest/fear_greed_signal.py
+++ b/src/rainier/backtest/fear_greed_signal.py
@@ -447,6 +447,17 @@ def run_backtest(
     ma_windows = list(ma_windows) if ma_windows is not None else list(MA_WINDOWS)
     split = _split_index(dates, split_date)
 
+    # A degenerate split (0 or n) leaves one window empty, which would crash
+    # compute_metrics on a size-0 slice. Fail loudly with an actionable message.
+    n = int(trade_close.shape[0])
+    if not 0 < split < n:
+        raise ValueError(
+            f"split_date {pd.Timestamp(split_date).date()} yields a degenerate "
+            f"train/OOS split (index {split} of {n}); it must fall strictly "
+            f"inside the aligned span {dates[0].date()}..{dates[-1].date()} "
+            "(check --split-date / --oos-months vs the data range)."
+        )
+
     combo_results: list[ComboResult] = []
     for combo in combos:
         mask = logic_mask(signal_close, fng, combo.logic, combo.threshold, combo.ma)

--- a/src/rainier/backtest/fng_report.py
+++ b/src/rainier/backtest/fng_report.py
@@ -1,0 +1,238 @@
+"""Self-contained HTML report for the F&G + QQQ-MA backtest.
+
+One file, embedded CSS, no JS, no external asset fetches (viewable offline).
+Renders: framing + research-grade banner, the auto-verdict, the per-logic
+train-selected combo scored against its paired MA-only arm on the OOS holdout,
+the full combo ranking (train vs OOS Calmar/Sharpe/MaxDD), and the benchmarks.
+
+The report is a regenerable render (``docs/*-backtest-*.html`` is gitignored);
+the committed source-of-truth is this code + ``rainier fng-backtest``.
+"""
+
+from __future__ import annotations
+
+import html
+from datetime import datetime, timezone
+from pathlib import Path
+
+from rainier.backtest.fear_greed_signal import (
+    ArmMetrics,
+    BacktestResult,
+    Logic,
+)
+
+_LOGIC_RULE = {
+    Logic.CONTRARIAN: "QQQ &gt; MA and F&amp;G &le; low",
+    Logic.MOMENTUM: "QQQ &gt; MA and F&amp;G &ge; high",
+    Logic.GREED_AVOID: "QQQ &gt; MA and F&amp;G &lt; extreme",
+}
+
+
+def _fmt(x: float, pct: bool = False, nd: int = 2) -> str:
+    if x is None or (isinstance(x, float) and x != x):  # NaN
+        return "&mdash;"
+    if pct:
+        return f"{x * 100:.{nd}f}%"
+    return f"{x:.{nd}f}"
+
+
+def _metric_cells(m: ArmMetrics) -> str:
+    return (
+        f"<td>{_fmt(m.cagr, pct=True)}</td>"
+        f"<td>{_fmt(m.max_dd, pct=True)}</td>"
+        f"<td>{_fmt(m.calmar)}</td>"
+        f"<td>{_fmt(m.sharpe)}</td>"
+        f"<td>{_fmt(m.exposure, pct=True, nd=1)}</td>"
+        f"<td>{m.switches}</td>"
+        f"<td>{_fmt(m.hit_rate, pct=True, nd=1)}</td>"
+    )
+
+
+def _verdict_block(result: BacktestResult) -> str:
+    eligible = result.eligible_logics
+    if eligible:
+        names = ", ".join(l.value for l in eligible)
+        cls, headline = "verdict-pass", f"ELIGIBLE for a Phase-3 gate: {names}"
+        sub = (
+            "At least one logic cleared all three OOS inequalities vs its paired "
+            "MA-only arm. Phase 3 remains a separate gated decision (shadow first)."
+        )
+    else:
+        cls, headline = "verdict-fail", "F&amp;G stays context-only (dashboard 4c)"
+        sub = (
+            "No logic cleared the pre-registered bar out-of-sample. Do NOT gate "
+            "entries on F&amp;G; keep it as a read-only dashboard/context signal."
+        )
+    rows = []
+    for logic in Logic:
+        sel = result.selections.get(logic)
+        if sel is None:
+            continue
+        paired = result.ma_only.get(sel.combo.ma)
+        ok = result.verdicts.get(logic, False)
+        c = sel.oos
+        b = paired.oos if paired else None
+        calmar_ratio = (
+            _fmt(c.calmar / b.calmar) if (b and b.calmar and b.calmar == b.calmar and b.calmar != 0) else "&mdash;"
+        )
+        rows.append(
+            f"<tr><td>{logic.value}</td>"
+            f"<td>MA={sel.combo.ma}, thr={sel.combo.threshold:g}</td>"
+            f"<td>{_fmt(c.calmar)}</td><td>{_fmt(b.calmar) if b else '&mdash;'}</td>"
+            f"<td>{calmar_ratio}&times;</td>"
+            f"<td>{_fmt(c.sharpe)} / {_fmt(b.sharpe) if b else '&mdash;'}</td>"
+            f"<td>{_fmt(c.max_dd, pct=True)} / {_fmt(b.max_dd, pct=True) if b else '&mdash;'}</td>"
+            f"<td class='{'ok' if ok else 'no'}'>{'PASS' if ok else 'fail'}</td></tr>"
+        )
+    table = (
+        "<table><thead><tr><th>Logic</th><th>Train-selected combo</th>"
+        "<th>OOS Calmar</th><th>MA-only Calmar</th><th>ratio (bar &ge;1.15&times;)</th>"
+        "<th>Sharpe (logic/MA)</th><th>MaxDD (logic/MA)</th><th>Verdict</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table>"
+    )
+    return (
+        f"<div class='verdict {cls}'><div class='v-head'>{headline}</div>"
+        f"<div class='v-sub'>{sub}</div></div>"
+        "<p>Bar (all three, OOS, vs the MA-only arm sharing the selected MA): "
+        "Calmar &ge; 1.15&times;, Sharpe &ge;, MaxDD &le; (annualized 252, rf=0).</p>"
+        f"{table}"
+    )
+
+
+def _combo_rows(result: BacktestResult) -> str:
+    # Rank by OOS Calmar desc (NaN last) for the headline ranking.
+    def key(cr):
+        c = cr.oos.calmar
+        return c if c == c else float("-inf")
+
+    rows = []
+    for cr in sorted(result.combo_results, key=key, reverse=True):
+        selected = result.selections.get(cr.combo.logic)
+        star = " &#9733;" if selected is not None and selected.combo == cr.combo else ""
+        rows.append(
+            f"<tr><td>{cr.combo.logic.value}{star}</td>"
+            f"<td>{cr.combo.ma}</td><td>{cr.combo.threshold:g}</td>"
+            f"<td>{_fmt(cr.train.calmar)}</td><td>{_fmt(cr.oos.calmar)}</td>"
+            f"<td>{_fmt(cr.train.sharpe)}</td><td>{_fmt(cr.oos.sharpe)}</td>"
+            f"<td>{_fmt(cr.oos.max_dd, pct=True)}</td>"
+            f"<td>{_fmt(cr.oos.cagr, pct=True)}</td>"
+            f"<td>{_fmt(cr.oos.exposure, pct=True, nd=1)}</td>"
+            f"<td>{cr.oos.switches}</td></tr>"
+        )
+    return (
+        "<table><thead><tr><th>Logic</th><th>MA</th><th>Thr</th>"
+        "<th>Train Calmar</th><th>OOS Calmar</th><th>Train Sharpe</th>"
+        "<th>OOS Sharpe</th><th>OOS MaxDD</th><th>OOS CAGR</th>"
+        "<th>OOS Expo</th><th>OOS Sw</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table>"
+    )
+
+
+def _bench_rows(result: BacktestResult) -> str:
+    arms = [result.buy_and_hold] + [result.ma_only[w] for w in sorted(result.ma_only)]
+    body = []
+    for arm in arms:
+        body.append(
+            f"<tr><td>{arm.label}</td>{_metric_cells(arm.full)}{_metric_cells(arm.oos)}</tr>"
+        )
+    head = (
+        "<tr><th rowspan=2>Arm</th>"
+        "<th colspan=7>Full span</th><th colspan=7>OOS holdout</th></tr>"
+        "<tr>"
+        + "".join(f"<th>{h}</th>" for h in ("CAGR", "MaxDD", "Calmar", "Sharpe", "Expo", "Sw", "Hit")) * 2
+        + "</tr>"
+    )
+    return f"<table><thead>{head}</thead><tbody>{''.join(body)}</tbody></table>"
+
+
+_CSS = """
+:root{color-scheme:light dark}
+body{font:15px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+ margin:0;padding:2rem;max-width:1100px;margin-inline:auto;color:#1a1a1a;background:#fafafa}
+h1{font-size:1.6rem;margin:0 0 .2rem}h2{font-size:1.15rem;margin:2rem 0 .6rem;border-bottom:1px solid #ddd;padding-bottom:.2rem}
+.meta{color:#666;font-size:.85rem}
+.banner{background:#fff8e1;border:1px solid #f0d98a;border-radius:6px;padding:.7rem 1rem;margin:1rem 0;font-size:.9rem}
+.verdict{border-radius:8px;padding:1rem 1.2rem;margin:1rem 0}
+.verdict-pass{background:#e6f6e9;border:1px solid #8ccf9a}
+.verdict-fail{background:#fdecec;border:1px solid #e0a3a3}
+.v-head{font-size:1.15rem;font-weight:700}.v-sub{color:#444;margin-top:.3rem;font-size:.9rem}
+table{border-collapse:collapse;width:100%;font-size:.82rem;margin:.6rem 0;overflow-x:auto;display:block}
+th,td{border:1px solid #ddd;padding:.3rem .5rem;text-align:right;white-space:nowrap}
+th:first-child,td:first-child{text-align:left}
+thead th{background:#f0f0f0}
+td.ok{color:#1b7a2e;font-weight:700}td.no{color:#a12}
+tbody tr:nth-child(even){background:#f6f6f6}
+.foot{color:#888;font-size:.78rem;margin-top:2rem}
+@media(prefers-color-scheme:dark){body{background:#16181c;color:#e6e6e6}
+ h2{border-color:#333}.meta,.foot{color:#999}thead th{background:#22252b}
+ th,td{border-color:#333}tbody tr:nth-child(even){background:#1c1f24}
+ .banner{background:#2b2617;border-color:#5a4d1f}
+ .verdict-pass{background:#16301c;border-color:#2e5d38}.verdict-fail{background:#341a1a;border-color:#5d2e2e}
+ .v-sub{color:#bbb}}
+"""
+
+
+def render_report(result: BacktestResult, output_path: Path) -> Path:
+    """Write the self-contained HTML report; return the path."""
+    output_path = Path(output_path)
+    now = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    if result.research_grade:
+        banner = (
+            "<div class='banner'><b>Research-grade data.</b> Every F&amp;G row is "
+            "<code>source_version=backfill</code> (CNN's revised series) &mdash; no live "
+            "point-in-time capture exists yet (derived boundary "
+            "<code>MIN(observed_at) WHERE source_version='daily'</code> is empty). "
+            "These are the endpoint's restated values, not what was knowable in real time. "
+            "Treat OOS numbers as indicative, not a live track record.</div>"
+        )
+    else:
+        banner = (
+            f"<div class='banner'>Live-capture boundary: "
+            f"<code>{html.escape(str(result.daily_boundary))}</code>. Rows before it are "
+            "research-grade backfill (revised); rows on/after are true point-in-time.</div>"
+        )
+
+    rules = "".join(
+        f"<li><b>{l.value}</b>: {_LOGIC_RULE[l]}</li>" for l in Logic
+    )
+
+    doc = f"""<!doctype html><html lang=en><head><meta charset=utf-8>
+<meta name=viewport content="width=device-width,initial-scale=1">
+<title>F&amp;G + QQQ-MA backtest &mdash; {html.escape(result.symbol)}</title>
+<style>{_CSS}</style></head><body>
+<h1>Fear &amp; Greed + QQQ-MA market-entry backtest</h1>
+<div class=meta>Traded symbol <b>{html.escape(result.symbol)}</b> &middot;
+span {result.start} &rarr; {result.end} &middot;
+train/OOS split {result.split_date} &middot;
+slippage {result.slippage_bp:g} bp/transition &middot; rendered {now}</div>
+{banner}
+<p>Trend + sentiment are market-level (always QQQ vs its own SMA + the composite
+F&amp;G). The traded instrument is <b>{html.escape(result.symbol)}</b>. Execution is
+one-day-lagged: the mask from <code>F&amp;G[D]</code>+<code>close[D]</code> earns
+<code>return[D+1]</code>. Selection is train-only; the gate is the untouched OOS
+holdout. Logics:</p>
+<ul>{rules}</ul>
+
+<h2>1. Verdict (auto-computed, OOS holdout)</h2>
+{_verdict_block(result)}
+
+<h2>2. All combos ranked (by OOS Calmar)</h2>
+<p>&#9733; marks each logic's train-selected combo. Compare train vs OOS columns
+to see how much of the edge survives out-of-sample.</p>
+{_combo_rows(result)}
+
+<h2>3. Benchmarks</h2>
+<p>Buy-and-hold and the MA-only arms (QQQ&gt;MA, no F&amp;G), on the traded symbol.
+The verdict pairs each logic against the MA-only arm sharing its MA window.</p>
+{_bench_rows(result)}
+
+<div class=foot>Regenerable render &mdash; reproduce with
+<code>rainier fng-backtest --symbol {html.escape(result.symbol)}</code>.
+Prices: yfinance adjusted-close parquet cache. F&amp;G: legacy
+<code>fear_greed_index</code> table (earliest observation per date).</div>
+</body></html>"""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(doc)
+    return output_path

--- a/src/rainier/backtest/fng_report.py
+++ b/src/rainier/backtest/fng_report.py
@@ -82,19 +82,25 @@ def _verdict_block(result: BacktestResult) -> str:
             f"<td>{calmar_ratio}&times;</td>"
             f"<td>{_fmt(c.sharpe)} / {_fmt(b.sharpe) if b else '&mdash;'}</td>"
             f"<td>{_fmt(c.max_dd, pct=True)} / {_fmt(b.max_dd, pct=True) if b else '&mdash;'}</td>"
+            f"<td>{_fmt(c.exposure, pct=True, nd=1)}</td>"
             f"<td class='{'ok' if ok else 'no'}'>{'PASS' if ok else 'fail'}</td></tr>"
         )
     table = (
         "<table><thead><tr><th>Logic</th><th>Train-selected combo</th>"
         "<th>OOS Calmar</th><th>MA-only Calmar</th><th>ratio (bar &ge;1.15&times;)</th>"
-        "<th>Sharpe (logic/MA)</th><th>MaxDD (logic/MA)</th><th>Verdict</th></tr></thead>"
+        "<th>Sharpe (logic/MA)</th><th>MaxDD (logic/MA)</th>"
+        "<th>OOS Expo</th><th>Verdict</th></tr></thead>"
         f"<tbody>{''.join(rows)}</tbody></table>"
     )
     return (
         f"<div class='verdict {cls}'><div class='v-head'>{headline}</div>"
         f"<div class='v-sub'>{sub}</div></div>"
         "<p>Bar (all three, OOS, vs the MA-only arm sharing the selected MA): "
-        "Calmar &ge; 1.15&times;, Sharpe &ge;, MaxDD &le; (annualized 252, rf=0).</p>"
+        "Calmar &ge; 1.15&times;, Sharpe &ge;, MaxDD &le; (annualized 252, rf=0). "
+        "<b>Read Calmar with the exposure column:</b> a very-low-exposure combo "
+        "sits in cash most of the OOS window, so its tiny drawdown can inflate "
+        "Calmar off a near-zero denominator &mdash; a PASS at &lt;~15% exposure is "
+        "fragile, not a robust edge (the design's Calmar-instability caveat).</p>"
         f"{table}"
     )
 

--- a/src/rainier/cli.py
+++ b/src/rainier/cli.py
@@ -4296,6 +4296,105 @@ def sma_sweep(
 
 
 # ---------------------------------------------------------------------------
+# fng-backtest — Fear & Greed + QQQ-MA market-entry signal (offline analysis)
+# ---------------------------------------------------------------------------
+
+
+@cli.command("fng-backtest")
+@click.option("--symbol", type=click.Choice(["QQQ", "TQQQ"]), default="QQQ",
+              show_default=True, help="Traded instrument. Trend + F&G are always QQQ-level.")
+@click.option("--slippage-bp", type=float, default=5.0, show_default=True,
+              help="Round-trip slippage per state transition, basis points.")
+@click.option("--oos-months", type=int, default=18, show_default=True,
+              help="Length of the untouched OOS holdout at the end of the span (months).")
+@click.option("--split-date", type=str, default=None,
+              help="Explicit train/OOS split date (YYYY-MM-DD). Overrides --oos-months.")
+@click.option("--report-path", type=click.Path(), default=None,
+              help="HTML report output path. Default: docs/fng-<symbol>-backtest-report.html")
+@click.option("--refresh-data", is_flag=True, default=False,
+              help="Force a fresh yfinance price download even if the cache is valid.")
+def fng_backtest(
+    symbol: str,
+    slippage_bp: float,
+    oos_months: int,
+    split_date: str | None,
+    report_path: str | None,
+    refresh_data: bool,
+) -> None:
+    """Backtest the F&G + QQQ-MA entry signal vs buy-and-hold AND an MA-only arm.
+
+    Selects the best (logic, MA, threshold) on the TRAIN window only and gates
+    on a single untouched OOS holdout; the auto-verdict answers "does F&G beat
+    the MA-only baseline out-of-sample?". Offline — no live surface.
+    """
+    from rainier.backtest.fear_greed_signal import (
+        align_prices_and_fng,
+        load_fng_series,
+        run_backtest,
+    )
+    from rainier.backtest.fng_report import render_report
+    from rainier.backtest.tqqq_sma_sweep import fetch_prices
+
+    if report_path is None:
+        report_path = f"docs/fng-{symbol.lower()}-backtest-report.html"
+
+    click.echo("Loading F&G series (legacy fear_greed_index)…")
+    fng, boundary = load_fng_series()
+    if fng.empty:
+        raise click.ClickException(
+            "fear_greed_index is empty — run `rainier fear-greed backfill` first."
+        )
+    research_grade = boundary is None
+    click.echo(f"  F&G rows: {len(fng)}  {fng.index[0].date()} → {fng.index[-1].date()}  "
+               f"({'research-grade (all backfill)' if research_grade else f'live boundary {boundary}'})")
+
+    click.echo("Fetching prices (QQQ/TQQQ)…")
+    prices = fetch_prices(refresh=refresh_data)
+
+    signal_close, trade_close, fng_vals, dates = align_prices_and_fng(prices, fng, symbol)
+    click.echo(f"  aligned bars: {len(dates)}  {dates[0].date()} → {dates[-1].date()}")
+
+    if split_date is not None:
+        split_ts = pd.Timestamp(split_date)
+    else:
+        split_ts = pd.Timestamp(dates[-1]) - pd.DateOffset(months=oos_months)
+    click.echo(f"Train/OOS split: {split_ts.date()} (OOS = final ~{oos_months} months)")
+
+    result = run_backtest(
+        signal_close=signal_close,
+        trade_close=trade_close,
+        fng=fng_vals,
+        dates=dates,
+        split_date=split_ts,
+        slippage_bp=slippage_bp,
+        symbol=symbol,
+        research_grade=research_grade,
+        daily_boundary=boundary,
+    )
+
+    click.echo("")
+    click.echo("Per-logic OOS verdict (vs paired MA-only arm):")
+    for logic, sel in result.selections.items():
+        ok = result.verdicts.get(logic, False)
+        paired = result.ma_only.get(sel.combo.ma)
+        mac = paired.oos.calmar if paired else float("nan")
+        click.echo(
+            f"  {logic.value:<12} combo(MA={sel.combo.ma}, thr={sel.combo.threshold:g})  "
+            f"OOS Calmar {sel.oos.calmar:.2f} vs MA-only {mac:.2f}  "
+            f"Sharpe {sel.oos.sharpe:.2f}  MaxDD {sel.oos.max_dd*100:.1f}%  "
+            f"→ {'ELIGIBLE' if ok else 'fail'}"
+        )
+    if result.eligible_logics:
+        names = ", ".join(l.value for l in result.eligible_logics)
+        click.echo(f"\nVERDICT: ELIGIBLE for Phase-3 gate (shadow first) — {names}")
+    else:
+        click.echo("\nVERDICT: F&G stays context-only (dashboard 4c) — no OOS edge.")
+
+    out = render_report(result, Path(report_path))
+    click.echo(f"\nReport → {out}")
+
+
+# ---------------------------------------------------------------------------
 # cache — manage regenerable on-disk caches
 # ---------------------------------------------------------------------------
 

--- a/tests/test_fng_backtest/test_fear_greed_signal.py
+++ b/tests/test_fng_backtest/test_fear_greed_signal.py
@@ -1,0 +1,235 @@
+"""Core-use-case tests for the Fear & Greed + QQQ-MA market-entry backtest.
+
+Lean suite (operator standard: test the contracts users depend on, not a
+matrix). The core user function is ``rainier fng-backtest``; the load-bearing
+contracts are:
+
+1. No lookahead — a signal from ``F&G[D]`` + ``close[D]`` earns ``return[D+1]``
+   and ZERO on day D (carry-then-apply, one-day lag).
+2. Each combine logic's in/out mask matches its rule.
+3. Benchmarks (buy-and-hold + MA-only) present + correct — primitives asserted
+   directly against the named toy series; annualized metrics against an inline
+   numpy reference snippet.
+4. Train-only selection / OOS gate — selection reads the train window only; the
+   gate metric is read from the untouched OOS slice.
+5. Auto-verdict — the 3-inequality rule returns eligible / context-only
+   deterministically.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from rainier.backtest.fear_greed_signal import (
+    ArmMetrics,
+    Combo,
+    ComboResult,
+    Logic,
+    buy_and_hold_mask,
+    compute_metrics,
+    equity_curve,
+    logic_eligible,
+    logic_mask,
+    ma_mask,
+    run_backtest,
+    select_best_on_train,
+)
+
+# --------------------------------------------------------------------------
+# 1. No lookahead — the load-bearing correctness property
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("d_signal", [1, 2, 3])
+def test_no_lookahead_signal_earns_next_day_return(d_signal: int) -> None:
+    """A mask that is 'in' only on day ``D`` captures ``return[D+1]`` and 0 on D."""
+    close = np.array([100.0, 110.0, 90.0, 95.0, 105.0])
+    mask = np.zeros(len(close), dtype=bool)
+    mask[d_signal] = True  # decision at close[D] gates the NEXT return
+
+    _equity, strat_ret = equity_curve(close, mask, slippage_bp=0.0)
+
+    ret = np.zeros(len(close))
+    ret[1:] = close[1:] / close[:-1] - 1.0
+
+    # Zero on day D (the same-day return period is NOT captured — no lookahead).
+    assert strat_ret[d_signal] == pytest.approx(0.0)
+    # return[D+1] IS captured by the position set at day D.
+    assert strat_ret[d_signal + 1] == pytest.approx(ret[d_signal + 1])
+    # Nothing else is captured.
+    captured = {d_signal + 1}
+    for i in range(1, len(close)):
+        if i not in captured:
+            assert strat_ret[i] == pytest.approx(0.0)
+
+
+# --------------------------------------------------------------------------
+# 2. Each combine logic's in/out matches its rule
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "logic,threshold,expected",
+    [
+        # trend (close>SMA2) = [F,T,T,T,T]; fng = [50,10,60,80,25]
+        (Logic.CONTRARIAN, 30.0, [False, True, False, False, True]),   # fng<=30
+        (Logic.MOMENTUM, 60.0, [False, False, True, True, False]),     # fng>=60
+        (Logic.GREED_AVOID, 75.0, [False, True, True, False, True]),   # fng<75
+    ],
+)
+def test_logic_mask_matches_rule(
+    logic: Logic, threshold: float, expected: list[bool]
+) -> None:
+    close = np.array([10.0, 11.0, 12.0, 13.0, 14.0])
+    fng = np.array([50.0, 10.0, 60.0, 80.0, 25.0])
+    # Sanity: the shared trend filter is close>SMA(2), valid from index 1.
+    assert list(ma_mask(close, 2)) == [False, True, True, True, True]
+
+    mask = logic_mask(close, fng, logic, threshold, window=2)
+    assert list(mask) == expected
+
+
+# --------------------------------------------------------------------------
+# 3. Benchmarks present + correct — toy-series primitives + annualized ref
+# --------------------------------------------------------------------------
+
+# Named toy series (task-plan oracle): buy-and-hold, always in.
+_BH_CLOSE = np.array([100.0, 101.0, 100.0, 103.0, 102.0, 105.0])
+
+
+def test_buy_and_hold_primitives_match_toy_oracle() -> None:
+    m = compute_metrics(_BH_CLOSE, buy_and_hold_mask(len(_BH_CLOSE)), slippage_bp=5.0)
+
+    assert m.total_return == pytest.approx(0.05)          # 105/100 - 1
+    assert m.final_value == pytest.approx(1.05)
+    assert m.max_dd == pytest.approx(1.0 / 101.0)         # peak 1.01 -> 1.00
+    assert m.exposure == pytest.approx(1.0)
+    assert m.switches == 0
+    assert m.hit_rate == pytest.approx(3.0 / 5.0)         # 3 up of 5 return periods
+
+    equity, _ = equity_curve(_BH_CLOSE, buy_and_hold_mask(len(_BH_CLOSE)), 5.0)
+    np.testing.assert_allclose(equity, [1.0, 1.01, 1.0, 1.03, 1.02, 1.05])
+
+
+def test_annualized_metrics_match_reference_snippet() -> None:
+    """CAGR/Calmar/Sharpe pinned to an inline numpy reference (252, rf=0)."""
+    m = compute_metrics(_BH_CLOSE, buy_and_hold_mask(len(_BH_CLOSE)), slippage_bp=0.0)
+
+    # --- reference computation (the formula the implementation must match) ---
+    equity = np.array([1.0, 1.01, 1.0, 1.03, 1.02, 1.05])
+    n = len(equity)
+    strat_ret = np.zeros(n)
+    strat_ret[1:] = equity[1:] / equity[:-1] - 1.0
+    years = n / 252.0
+    ref_cagr = equity[-1] ** (1.0 / years) - 1.0
+    peak = np.maximum.accumulate(equity)
+    ref_max_dd = float((1.0 - equity / peak).max())
+    ref_calmar = ref_cagr / ref_max_dd
+    ref_sharpe = strat_ret.mean() / strat_ret.std(ddof=1) * np.sqrt(252.0)
+
+    assert m.cagr == pytest.approx(ref_cagr)
+    assert m.calmar == pytest.approx(ref_calmar)
+    assert m.sharpe == pytest.approx(ref_sharpe)
+
+
+def test_exposure_switches_and_slippage_per_transition() -> None:
+    """Second toy: hand-specified mask pins exposure, switch count, and that
+    slippage is charged once per transition."""
+    close = np.array([100.0, 101.0, 102.0, 101.0, 102.0, 103.0])
+    mask = np.array([True, True, False, False, True, True])
+
+    m0 = compute_metrics(close, mask, slippage_bp=0.0)
+    assert m0.exposure == pytest.approx(4.0 / 6.0)
+    assert m0.switches == 2  # in->out at idx2, out->in at idx4
+
+    # Strategy return off the mask (slippage=0): captures ret[1], ret[2], ret[5].
+    ret = np.zeros(len(close))
+    ret[1:] = close[1:] / close[:-1] - 1.0
+    expected = (1 + ret[1]) * (1 + ret[2]) * (1 + ret[5])
+    assert m0.final_value == pytest.approx(expected)
+
+    # Two transitions -> equity scaled by (1 - slip)^2.
+    slip = 10.0 * 1e-4
+    m1 = compute_metrics(close, mask, slippage_bp=10.0)
+    assert m1.final_value == pytest.approx(m0.final_value * (1 - slip) ** 2)
+
+
+# --------------------------------------------------------------------------
+# 4. Train-only selection / OOS gate — assert the split
+# --------------------------------------------------------------------------
+
+
+def _arm(calmar: float, sharpe: float = 0.0, max_dd: float = 0.1) -> ArmMetrics:
+    return ArmMetrics(
+        final_value=1.0, total_return=0.0, cagr=0.0, max_dd=max_dd,
+        calmar=calmar, sharpe=sharpe, exposure=1.0, switches=0,
+        hit_rate=0.0, n_days=10,
+    )
+
+
+def test_selection_reads_train_only() -> None:
+    """The train-selected combo maximizes TRAIN Calmar; its gate metric is OOS."""
+    logic = Logic.CONTRARIAN
+    # row_a is best on TRAIN but worst on OOS; row_b is the reverse.
+    row_a = ComboResult(
+        combo=Combo(logic, 20, 20.0), train=_arm(2.0), oos=_arm(0.1), full=_arm(1.0)
+    )
+    row_b = ComboResult(
+        combo=Combo(logic, 20, 30.0), train=_arm(1.0), oos=_arm(5.0), full=_arm(1.0)
+    )
+
+    picked = select_best_on_train([row_a, row_b], logic)
+    assert picked is row_a                      # selection ignored OOS
+    assert picked.oos.calmar == pytest.approx(0.1)  # gate reads OOS, not train
+
+
+def test_run_backtest_slices_train_and_oos_without_leakage() -> None:
+    """Per-combo OOS/train metrics equal ``compute_metrics`` on the raw slices,
+    with masks derived from full history (no seam warmup loss, no leakage)."""
+    rng = np.random.default_rng(0)
+    n = 80
+    dates = pd.bdate_range("2021-01-01", periods=n)
+    qqq = 100.0 * np.cumprod(1 + rng.normal(0.001, 0.01, n))
+    fng = np.clip(50 + rng.normal(0, 15, n), 0, 100)
+    combo = Combo(Logic.CONTRARIAN, 5, 30.0)
+    split_date = dates[50]
+
+    result = run_backtest(
+        signal_close=qqq, trade_close=qqq, fng=fng, dates=dates,
+        split_date=split_date, slippage_bp=5.0, combos=[combo], ma_windows=[5],
+    )
+    split = int(np.searchsorted(dates.values, np.datetime64(split_date)))
+    mask = logic_mask(qqq, fng, combo.logic, combo.threshold, combo.ma)
+
+    cr = result.combo_results[0]
+    assert cr.oos == compute_metrics(qqq[split:], mask[split:], 5.0)
+    assert cr.train == compute_metrics(qqq[:split], mask[:split], 5.0)
+    # Benchmarks present for the report.
+    assert 5 in result.ma_only
+    assert result.buy_and_hold.full.final_value > 0
+
+
+# --------------------------------------------------------------------------
+# 5. Auto-verdict — 3-inequality rule
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "logic_oos,ma_oos,expected",
+    [
+        # all three clear: Calmar >= 1.15x, Sharpe >=, MaxDD <=
+        (_arm(1.20, sharpe=1.1, max_dd=0.20), _arm(1.00, sharpe=1.0, max_dd=0.20), True),
+        # Calmar edge too small (1.10 < 1.15x)
+        (_arm(1.10, sharpe=1.1, max_dd=0.20), _arm(1.00, sharpe=1.0, max_dd=0.20), False),
+        # Sharpe worse
+        (_arm(1.50, sharpe=0.9, max_dd=0.20), _arm(1.00, sharpe=1.0, max_dd=0.20), False),
+        # MaxDD worse (deeper)
+        (_arm(1.50, sharpe=1.1, max_dd=0.30), _arm(1.00, sharpe=1.0, max_dd=0.20), False),
+    ],
+)
+def test_logic_eligible_three_inequalities(
+    logic_oos: ArmMetrics, ma_oos: ArmMetrics, expected: bool
+) -> None:
+    assert logic_eligible(logic_oos, ma_oos) is expected

--- a/tests/test_fng_backtest/test_fear_greed_signal.py
+++ b/tests/test_fng_backtest/test_fear_greed_signal.py
@@ -211,6 +211,23 @@ def test_run_backtest_slices_train_and_oos_without_leakage() -> None:
     assert result.buy_and_hold.full.final_value > 0
 
 
+@pytest.mark.parametrize("bad_split", ["2000-01-01", "2099-01-01"])
+def test_run_backtest_rejects_degenerate_split(bad_split: str) -> None:
+    """A split outside the aligned span (empty train or OOS window) raises a
+    clear ValueError, not a bare IndexError from a size-0 metric slice."""
+    n = 40
+    dates = pd.bdate_range("2021-01-01", periods=n)
+    qqq = 100.0 * np.cumprod(1 + np.full(n, 0.001))
+    fng = np.full(n, 50.0)
+
+    with pytest.raises(ValueError, match="degenerate"):
+        run_backtest(
+            signal_close=qqq, trade_close=qqq, fng=fng, dates=dates,
+            split_date=pd.Timestamp(bad_split), combos=[Combo(Logic.CONTRARIAN, 5, 30.0)],
+            ma_windows=[5],
+        )
+
+
 # --------------------------------------------------------------------------
 # 5. Auto-verdict — 3-inequality rule
 # --------------------------------------------------------------------------

--- a/tests/test_fng_backtest/test_fear_greed_signal.py
+++ b/tests/test_fng_backtest/test_fear_greed_signal.py
@@ -2,16 +2,17 @@
 
 Lean suite (operator standard: test the contracts users depend on, not a
 matrix). The core user function is ``rainier fng-backtest``; the load-bearing
-contracts are:
+contracts are one test each:
 
 1. No lookahead — a signal from ``F&G[D]`` + ``close[D]`` earns ``return[D+1]``
    and ZERO on day D (carry-then-apply, one-day lag).
 2. Each combine logic's in/out mask matches its rule.
-3. Benchmarks (buy-and-hold + MA-only) present + correct — primitives asserted
-   directly against the named toy series; annualized metrics against an inline
-   numpy reference snippet.
-4. Train-only selection / OOS gate — selection reads the train window only; the
-   gate metric is read from the untouched OOS slice.
+3. Metrics are correct — buy-and-hold primitives + annualized CAGR/Calmar/Sharpe
+   against an inline numpy reference, plus exposure / switch count / per-transition
+   slippage on a hand-specified switching mask.
+4. Train/OOS split integrity — selection reads the train window only, per-combo
+   OOS/train metrics equal ``compute_metrics`` on the raw slices (no leakage), and
+   a degenerate split raises a clear ``ValueError``.
 5. Auto-verdict — the 3-inequality rule returns eligible / context-only
    deterministically.
 """
@@ -36,6 +37,15 @@ from rainier.backtest.fear_greed_signal import (
     run_backtest,
     select_best_on_train,
 )
+
+
+def _arm(calmar: float, sharpe: float = 0.0, max_dd: float = 0.1) -> ArmMetrics:
+    return ArmMetrics(
+        final_value=1.0, total_return=0.0, cagr=0.0, max_dd=max_dd,
+        calmar=calmar, sharpe=sharpe, exposure=1.0, switches=0,
+        hit_rate=0.0, n_days=10,
+    )
+
 
 # --------------------------------------------------------------------------
 # 1. No lookahead — the load-bearing correctness property
@@ -92,16 +102,20 @@ def test_logic_mask_matches_rule(
 
 
 # --------------------------------------------------------------------------
-# 3. Benchmarks present + correct — toy-series primitives + annualized ref
+# 3. Metrics are correct — primitives + annualized ref + slippage/switches
 # --------------------------------------------------------------------------
 
 # Named toy series (task-plan oracle): buy-and-hold, always in.
 _BH_CLOSE = np.array([100.0, 101.0, 100.0, 103.0, 102.0, 105.0])
 
 
-def test_buy_and_hold_primitives_match_toy_oracle() -> None:
+def test_metrics_match_toy_oracle_and_reference() -> None:
+    """Every metric on the named toy series: buy-and-hold primitives, the equity
+    curve, the annualized CAGR/Calmar/Sharpe pinned to an inline numpy reference,
+    and — on a second hand-specified switching mask — exposure, switch count, and
+    that slippage is charged once per transition."""
+    # --- buy-and-hold primitives on the named oracle (slippage charged 0 here) ---
     m = compute_metrics(_BH_CLOSE, buy_and_hold_mask(len(_BH_CLOSE)), slippage_bp=5.0)
-
     assert m.total_return == pytest.approx(0.05)          # 105/100 - 1
     assert m.final_value == pytest.approx(1.05)
     assert m.max_dd == pytest.approx(1.0 / 101.0)         # peak 1.01 -> 1.00
@@ -112,31 +126,23 @@ def test_buy_and_hold_primitives_match_toy_oracle() -> None:
     equity, _ = equity_curve(_BH_CLOSE, buy_and_hold_mask(len(_BH_CLOSE)), 5.0)
     np.testing.assert_allclose(equity, [1.0, 1.01, 1.0, 1.03, 1.02, 1.05])
 
-
-def test_annualized_metrics_match_reference_snippet() -> None:
-    """CAGR/Calmar/Sharpe pinned to an inline numpy reference (252, rf=0)."""
-    m = compute_metrics(_BH_CLOSE, buy_and_hold_mask(len(_BH_CLOSE)), slippage_bp=0.0)
-
-    # --- reference computation (the formula the implementation must match) ---
-    equity = np.array([1.0, 1.01, 1.0, 1.03, 1.02, 1.05])
-    n = len(equity)
-    strat_ret = np.zeros(n)
-    strat_ret[1:] = equity[1:] / equity[:-1] - 1.0
+    # --- annualized metrics vs the reference formula (252, rf=0), no slippage ---
+    m_ann = compute_metrics(_BH_CLOSE, buy_and_hold_mask(len(_BH_CLOSE)), slippage_bp=0.0)
+    ref_equity = np.array([1.0, 1.01, 1.0, 1.03, 1.02, 1.05])
+    n = len(ref_equity)
+    ref_strat_ret = np.zeros(n)
+    ref_strat_ret[1:] = ref_equity[1:] / ref_equity[:-1] - 1.0
     years = n / 252.0
-    ref_cagr = equity[-1] ** (1.0 / years) - 1.0
-    peak = np.maximum.accumulate(equity)
-    ref_max_dd = float((1.0 - equity / peak).max())
+    ref_cagr = ref_equity[-1] ** (1.0 / years) - 1.0
+    peak = np.maximum.accumulate(ref_equity)
+    ref_max_dd = float((1.0 - ref_equity / peak).max())
     ref_calmar = ref_cagr / ref_max_dd
-    ref_sharpe = strat_ret.mean() / strat_ret.std(ddof=1) * np.sqrt(252.0)
+    ref_sharpe = ref_strat_ret.mean() / ref_strat_ret.std(ddof=1) * np.sqrt(252.0)
+    assert m_ann.cagr == pytest.approx(ref_cagr)
+    assert m_ann.calmar == pytest.approx(ref_calmar)
+    assert m_ann.sharpe == pytest.approx(ref_sharpe)
 
-    assert m.cagr == pytest.approx(ref_cagr)
-    assert m.calmar == pytest.approx(ref_calmar)
-    assert m.sharpe == pytest.approx(ref_sharpe)
-
-
-def test_exposure_switches_and_slippage_per_transition() -> None:
-    """Second toy: hand-specified mask pins exposure, switch count, and that
-    slippage is charged once per transition."""
+    # --- exposure / switch count / per-transition slippage (switching mask) ---
     close = np.array([100.0, 101.0, 102.0, 101.0, 102.0, 103.0])
     mask = np.array([True, True, False, False, True, True])
 
@@ -157,21 +163,17 @@ def test_exposure_switches_and_slippage_per_transition() -> None:
 
 
 # --------------------------------------------------------------------------
-# 4. Train-only selection / OOS gate — assert the split
+# 4. Train/OOS split integrity — train-only selection, no leakage, fail-loud
 # --------------------------------------------------------------------------
 
 
-def _arm(calmar: float, sharpe: float = 0.0, max_dd: float = 0.1) -> ArmMetrics:
-    return ArmMetrics(
-        final_value=1.0, total_return=0.0, cagr=0.0, max_dd=max_dd,
-        calmar=calmar, sharpe=sharpe, exposure=1.0, switches=0,
-        hit_rate=0.0, n_days=10,
-    )
-
-
-def test_selection_reads_train_only() -> None:
-    """The train-selected combo maximizes TRAIN Calmar; its gate metric is OOS."""
+def test_train_oos_split_integrity() -> None:
+    """Selection reads the TRAIN window only; per-combo OOS/train metrics equal
+    ``compute_metrics`` on the raw slices (masks from full history, no seam warmup
+    loss, no leakage); a degenerate split (empty train or OOS) fails loudly."""
     logic = Logic.CONTRARIAN
+
+    # --- selection maximizes TRAIN Calmar, ignoring OOS; gate metric reads OOS ---
     # row_a is best on TRAIN but worst on OOS; row_b is the reverse.
     row_a = ComboResult(
         combo=Combo(logic, 20, 20.0), train=_arm(2.0), oos=_arm(0.1), full=_arm(1.0)
@@ -179,15 +181,11 @@ def test_selection_reads_train_only() -> None:
     row_b = ComboResult(
         combo=Combo(logic, 20, 30.0), train=_arm(1.0), oos=_arm(5.0), full=_arm(1.0)
     )
-
     picked = select_best_on_train([row_a, row_b], logic)
-    assert picked is row_a                      # selection ignored OOS
+    assert picked is row_a                          # selection ignored OOS
     assert picked.oos.calmar == pytest.approx(0.1)  # gate reads OOS, not train
 
-
-def test_run_backtest_slices_train_and_oos_without_leakage() -> None:
-    """Per-combo OOS/train metrics equal ``compute_metrics`` on the raw slices,
-    with masks derived from full history (no seam warmup loss, no leakage)."""
+    # --- run_backtest slices train/OOS off full-history masks without leakage ---
     rng = np.random.default_rng(0)
     n = 80
     dates = pd.bdate_range("2021-01-01", periods=n)
@@ -210,22 +208,18 @@ def test_run_backtest_slices_train_and_oos_without_leakage() -> None:
     assert 5 in result.ma_only
     assert result.buy_and_hold.full.final_value > 0
 
-
-@pytest.mark.parametrize("bad_split", ["2000-01-01", "2099-01-01"])
-def test_run_backtest_rejects_degenerate_split(bad_split: str) -> None:
-    """A split outside the aligned span (empty train or OOS window) raises a
-    clear ValueError, not a bare IndexError from a size-0 metric slice."""
-    n = 40
-    dates = pd.bdate_range("2021-01-01", periods=n)
-    qqq = 100.0 * np.cumprod(1 + np.full(n, 0.001))
-    fng = np.full(n, 50.0)
-
-    with pytest.raises(ValueError, match="degenerate"):
-        run_backtest(
-            signal_close=qqq, trade_close=qqq, fng=fng, dates=dates,
-            split_date=pd.Timestamp(bad_split), combos=[Combo(Logic.CONTRARIAN, 5, 30.0)],
-            ma_windows=[5],
-        )
+    # --- degenerate split (outside the aligned span) raises a clear ValueError ---
+    bad_n = 40
+    bad_dates = pd.bdate_range("2021-01-01", periods=bad_n)
+    bad_qqq = 100.0 * np.cumprod(1 + np.full(bad_n, 0.001))
+    bad_fng = np.full(bad_n, 50.0)
+    for bad_split in ("2000-01-01", "2099-01-01"):  # empty train, then empty OOS
+        with pytest.raises(ValueError, match="degenerate"):
+            run_backtest(
+                signal_close=bad_qqq, trade_close=bad_qqq, fng=bad_fng, dates=bad_dates,
+                split_date=pd.Timestamp(bad_split),
+                combos=[Combo(Logic.CONTRARIAN, 5, 30.0)], ma_windows=[5],
+            )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 1. Why we need this
Phase 2 of docs/DESIGN-fear-greed-signal.md: before wiring Fear & Greed into any live entry decision, we must know whether it actually adds value over a plain QQQ-MA trend filter. This is the offline backtest that answers that — the gate for Phase 3.

## 2. What was missing
No way to test "trend + sentiment" entry rules. Rainier's existing sweep selects winners in-sample, so it couldn't serve as an honest gate.

## 3. What we did
- Signal engine (`backtest/fear_greed_signal.py`): 3 level-state logics (contrarian/momentum/greed-avoidance) × MA grid × F&G thresholds, D→D+1 execution lag (no lookahead), carry-then-apply equity/metrics, benchmarks (buy-and-hold AND MA-only), train-only selection + a single untouched OOS holdout, and a 3-inequality auto-verdict (Calmar ≥ MA-only ×1.15 AND Sharpe ≥ AND MaxDD ≤).
- HTML report (`backtest/fng_report.py`) + `rainier fng-backtest` CLI.
- **Finding (the deliverable):** on the backfilled data, the only "eligible" result (contrarian) is a low-exposure Calmar artifact — ~4% OOS exposure (in cash ~96% of the window), 4% CAGR vs buy-and-hold's 20%, tiny drawdown inflating Calmar off a near-zero base. Not a robust edge. The report surfaces an explicit low-exposure warning. Honest read: **F&G stays a context/dashboard signal; do not gate entries on it** — the pre-registered bar doing its job. (Verified NOT lookahead: D→D+1 lag unit-tested; masks/ffill use only ≤D data.)

## 4. Tests added
`tests/test_fng_backtest/test_fear_greed_signal.py` — 5 contract-level tests (12 cases via parametrization), table-driven, one coarse test per load-bearing contract (no matrix):
1. **No lookahead** (3 cases) — a signal from `F&G[D]`+`close[D]` earns `return[D+1]` and zero on day D.
2. **Combine-logic masks** (3 cases) — each of the 3 logics' in/out mask matches its rule.
3. **Metrics correct** (1 test) — on the named toy oracle: total return, MaxDD, exposure, switch count, hit-rate, the equity curve, annualized CAGR/Calmar/Sharpe vs an inline numpy reference, plus per-transition slippage on a hand-specified switching mask.
4. **Train/OOS split integrity** (1 test) — selection reads the train window only, per-combo OOS/train metrics equal `compute_metrics` on the raw slices (no leakage), benchmarks present, and a degenerate split raises `ValueError`.
5. **Auto-verdict** (4 cases) — the 3-inequality rule returns eligible / context-only deterministically.

Regrouped from the prior 9-function suite (merged the 3 metric tests → 1, and train-only-selection + no-leakage + degenerate-guard → 1); every assertion preserved (verified assertion-by-assertion + mutation-tested).

## Test plan
- [ ] CI green
- [ ] verify locally: rainier fng-backtest --symbol QQQ

## Review
- alpha (codex/gpt-5.5-codex): passed (2 rounds)
- beta (claude/claude-opus-4-8): passed (2 rounds)

## Deferred (P2/P3, documented, no P0/P1)
- [P2] fng-backtest doesn't honor --config for the F&G load (uses default get_session)
- [P2] verdict ×1.15 Calmar leg loosens when OOS Calmar negative — matches the pre-registered spec, guarded by Sharpe/MaxDD legs
- [P2/P3] unbounded F&G ffill has no staleness cap; minor P3s (min-OOS-window, seam period, exposure off-by-one cosmetic)

https://claude.ai/code/session_01QvtzXcVVxuJ4Gahk6M6zjo
